### PR TITLE
Add a rustfmt.toml file to the repo

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,16 @@
+verbose=false
+max_width=100
+comment_width=100
+tab_spaces=4
+fn_call_width=100
+struct_lit_width=32
+fn_call_style="Visual"
+single_line_if_else_max_width=100
+trailing_comma="Vertical"
+chain_indent="Visual"
+chain_one_line_max=100
+reorder_imports=true
+format_strings=false
+hard_tabs=true
+wrap_match_arms=false
+error_on_line_overflow=false


### PR DESCRIPTION
I copied the rustfmt.toml from the main parity repo.