### PR TITLE
Remove the top-level library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,3 @@
-[package]
-name = "libp2p"
-version = "0.1.0"
-authors = ["Parity Technologies <admin@parity.io>"]
-
 [workspace]
 members = [
     "libp2p-host",


### PR DESCRIPTION
Another quick PR.

Cargo doesn't like the top-level library, which prevents `cargo test --all` from working at the root level, so let's remove it.
