### PR TITLE
Add a datastore library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "multistream-select",
+    "datastore",
     "libp2p-host",
     "libp2p-transport",
     "libp2p-tcp-transport",

--- a/datastore/Cargo.toml
+++ b/datastore/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "datastore"
 version = "0.1.0"
-authors = ["pierre <pierre.krieger1708@gmail.com>"]
+authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 base64 = "0.7"
 futures = "0.1"
+parking_lot = "0.4"
 serde_json = "1.0"
 tempfile = "2.2"

--- a/datastore/Cargo.toml
+++ b/datastore/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "datastore"
+version = "0.1.0"
+authors = ["pierre <pierre.krieger1708@gmail.com>"]
+
+[dependencies]
+base64 = "0.7"
+futures = "0.1"
+serde_json = "1.0"
+tempfile = "2.2"

--- a/datastore/src/json_file.rs
+++ b/datastore/src/json_file.rs
@@ -87,14 +87,10 @@ impl JsonFileDatastore {
         to_writer(&mut temporary_file, &*content)?;
         temporary_file.sync_data()?;
 
-        // It is possible that `persist` fails for a legitimate reason (eg. persisting across
-        // filesystems won't work).
-        let temporary_file = match temporary_file.persist(&self.path) {
-            Ok(_) => return Ok(()),
-            Err(err) => err.file,
-        };
-
-        fs::copy(temporary_file.path(), &self.path)?;
+        // Note that `persist` will fail if we try to persist across filesystems. However that
+        // shouldn't happen since we created the temporary file in the same directory as the final
+        // path.
+        temporary_file.persist(&self.path)?;
         Ok(())
     }
 }

--- a/datastore/src/json_file.rs
+++ b/datastore/src/json_file.rs
@@ -1,0 +1,236 @@
+
+use Datastore;
+use base64;
+use futures::Future;
+use futures::stream::{Stream, iter_ok};
+use query::{Query, naive_apply_query};
+use serde_json::{from_reader, to_writer};
+use serde_json::map::Map;
+use serde_json::value::Value;
+use std::borrow::Cow;
+use std::fs;
+use std::io::Cursor;
+use std::io::Error as IoError;
+use std::io::ErrorKind as IoErrorKind;
+use std::io::Read;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use tempfile::NamedTempFile;
+
+/// Implementation of `Datastore` that uses a single plain JSON file.
+pub struct JsonFileDatastore {
+    path: PathBuf,
+    content: Mutex<Map<String, Value>>,
+}
+
+impl JsonFileDatastore {
+    /// Opens or creates the datastore. If the path refers to an existing path, then this function
+    /// will attempt to load an existing set of values from it (which can result in an error).
+    /// Otherwise if the path doesn't exist, a new empty datastore will be created.
+    pub fn new<P>(path: P) -> Result<JsonFileDatastore, IoError>
+    where
+        P: Into<PathBuf>,
+    {
+        let path = path.into();
+
+        if !path.exists() {
+            return Ok(JsonFileDatastore {
+                path: path,
+                content: Mutex::new(Map::new()),
+            });
+        }
+
+        let content = {
+            let mut file = fs::File::open(&path)?;
+
+            // We want to support empty files (and treat them as an empty recordset). Unfortunately
+            // `serde_json` will always produce an error if we do this ("unexpected EOF at line 0
+            // column 0"). Therefore we start by reading one byte from the file in order to check
+            // for EOF.
+
+            let mut first_byte = [0];
+            if file.read(&mut first_byte)? == 0 {
+                // File is empty.
+                Map::new()
+            } else {
+                match from_reader::<_, Value>(Cursor::new(first_byte).chain(file)) {
+                    Ok(Value::Null) => Map::new(),
+                    Ok(Value::Object(map)) => map,
+                    Ok(_) => {
+                        return Err(IoError::new(
+                            IoErrorKind::InvalidData,
+                            "expected JSON object",
+                        ));
+                    }
+                    Err(err) => return Err(IoError::new(IoErrorKind::InvalidData, err)),
+                }
+            }
+        };
+
+        Ok(JsonFileDatastore {
+            path: path,
+            content: Mutex::new(content),
+        })
+    }
+
+    /// Flushes the content of the datastore to the disk.
+    pub fn flush(&self) -> Result<(), IoError> {
+        // Create a temporary file in the same directory as the destination, which avoids the
+        // problem of having a file cleaner delete our file while we use it.
+        let self_path_parent = self.path.parent().ok_or(IoError::new(
+            IoErrorKind::Other,
+            "couldn't get parent directory of destination",
+        ))?;
+        let mut temporary_file = NamedTempFile::new_in(self_path_parent)?;
+
+        let content = self.content.lock().unwrap();
+        to_writer(&mut temporary_file, &*content)?;
+        temporary_file.sync_data()?;
+
+        // It is possible that `persist` fails for a legitimate reason (eg. persisting across
+        // filesystems won't work).
+        let temporary_file = match temporary_file.persist(&self.path) {
+            Ok(_) => return Ok(()),
+            Err(err) => err.file,
+        };
+
+        fs::copy(temporary_file.path(), &self.path)?;
+        Ok(())
+    }
+}
+
+impl Datastore for JsonFileDatastore {
+    fn put(&self, key: Cow<str>, value: Vec<u8>) {
+        let mut content = self.content.lock().unwrap();
+        content.insert(key.into_owned(), Value::String(base64::encode(&value)));
+    }
+
+    fn get(&self, key: &str) -> Option<Vec<u8>> {
+        let content = self.content.lock().unwrap();
+        // If the JSON is malformed, we just ignore the value.
+        content.get(key).and_then(|val| match val {
+            &Value::String(ref s) => base64::decode(s).ok(),
+            _ => None,
+        })
+    }
+
+    fn has(&self, key: &str) -> bool {
+        let content = self.content.lock().unwrap();
+        content.contains_key(key)
+    }
+
+    fn delete(&self, key: &str) -> bool {
+        let mut content = self.content.lock().unwrap();
+        content.remove(key).is_some()
+    }
+
+    fn query<'a>(
+        &'a self,
+        query: Query,
+    ) -> Box<Stream<Item = (String, Vec<u8>), Error = IoError> + 'a> {
+        let content = self.content.lock().unwrap();
+
+        let keys_only = query.keys_only;
+
+        let content_stream = iter_ok(content.iter().filter_map(|(key, value)| {
+            // Skip values that are malformed.
+            let value = if keys_only {
+                Vec::with_capacity(0)
+            } else {
+                match value {
+                    &Value::String(ref s) => {
+                        match base64::decode(s) {
+                            Ok(s) => s,
+                            Err(_) => return None,
+                        }
+                    }
+                    _ => return None,
+                }
+            };
+
+            Some((key.clone(), value))
+        }));
+
+        let collected = naive_apply_query(content_stream, query)
+            .collect()
+            .wait()
+            .unwrap();
+        let output_stream = iter_ok(collected.into_iter());
+        Box::new(output_stream) as Box<_>
+    }
+}
+
+impl Drop for JsonFileDatastore {
+    #[inline]
+    fn drop(&mut self) {
+        let _ = self.flush(); // What do we do in case of error? :-/
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {Query, Order, Filter, FilterTy, FilterOp};
+    use Datastore;
+    use JsonFileDatastore;
+    use futures::{Future, Stream};
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn open_and_flush() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let datastore = JsonFileDatastore::new(temp_file.path()).unwrap();
+        datastore.flush().unwrap();
+    }
+
+    #[test]
+    fn values_store_and_reload() {
+        let temp_file = NamedTempFile::new().unwrap();
+
+        let datastore = JsonFileDatastore::new(temp_file.path()).unwrap();
+        datastore.put("foo".into(), vec![1, 2, 3]);
+        datastore.put("bar".into(), vec![0, 255, 127]);
+        datastore.flush().unwrap();
+        drop(datastore);
+
+        let reload = JsonFileDatastore::new(temp_file.path()).unwrap();
+        assert_eq!(reload.get("bar").unwrap(), &[0, 255, 127]);
+        assert_eq!(reload.get("foo").unwrap(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn query_basic() {
+        let temp_file = NamedTempFile::new().unwrap();
+
+        let datastore = JsonFileDatastore::new(temp_file.path()).unwrap();
+        datastore.put("foo1".into(), vec![1, 2, 3]);
+        datastore.put("foo2".into(), vec![4, 5, 6]);
+        datastore.put("foo3".into(), vec![7, 8, 9]);
+        datastore.put("foo4".into(), vec![10, 11, 12]);
+        datastore.put("foo5".into(), vec![13, 14, 15]);
+        datastore.put("bar1".into(), vec![0, 255, 127]);
+        datastore.flush().unwrap();
+
+        let query = datastore
+            .query(Query {
+                prefix: "fo".into(),
+                filters: vec![
+                    Filter {
+                        ty: FilterTy::ValueCompare(vec![6, 7, 8].into()),
+                        operation: FilterOp::Greater,
+                    },
+                ],
+                orders: vec![Order::ByKeyDesc],
+                skip: 1,
+                limit: u64::max_value(),
+                keys_only: false,
+            })
+            .collect()
+            .wait()
+            .unwrap();
+
+        assert_eq!(query[0].0, "foo4");
+        assert_eq!(query[0].1, &[10, 11, 12]);
+        assert_eq!(query[1].0, "foo3");
+        assert_eq!(query[1].1, &[7, 8, 9]);
+    }
+}

--- a/datastore/src/lib.rs
+++ b/datastore/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate base64;
 #[macro_use]
 extern crate futures;
+extern crate parking_lot;
 extern crate serde_json;
 extern crate tempfile;
 

--- a/datastore/src/lib.rs
+++ b/datastore/src/lib.rs
@@ -1,3 +1,23 @@
+// Copyright 2017 Parity Technologies (UK) Ltd.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
 extern crate base64;
 #[macro_use]
 extern crate futures;

--- a/datastore/src/lib.rs
+++ b/datastore/src/lib.rs
@@ -1,0 +1,40 @@
+extern crate base64;
+#[macro_use]
+extern crate futures;
+extern crate serde_json;
+extern crate tempfile;
+
+use futures::Stream;
+use std::borrow::Cow;
+use std::io::Error as IoError;
+
+mod query;
+mod json_file;
+
+pub use self::json_file::JsonFileDatastore;
+pub use self::query::{Query, Order, Filter, FilterTy, FilterOp};
+
+/// Abstraction over any struct that can store `(key, value)` pairs.
+pub trait Datastore {
+    /// Sets the value of a key.
+    fn put(&self, key: Cow<str>, value: Vec<u8>);
+
+    /// Returns the value corresponding to this key.
+    // TODO: use higher-kinded stuff once stable to provide a more generic "accessor" for the data
+    fn get(&self, key: &str) -> Option<Vec<u8>>;
+
+    /// Returns true if the datastore contains the given key.
+    fn has(&self, key: &str) -> bool;
+
+    /// Removes the given key from the datastore. Returns true if the key existed.
+    fn delete(&self, key: &str) -> bool;
+
+    /// Executes a query on the key-value store.
+    ///
+    /// This operation is expensive on some implementations and cheap on others. It is your
+    /// responsibility to pick the right implementation for the right job.
+    fn query<'a>(
+        &'a self,
+        query: Query,
+    ) -> Box<Stream<Item = (String, Vec<u8>), Error = IoError> + 'a>;
+}

--- a/datastore/src/query.rs
+++ b/datastore/src/query.rs
@@ -1,3 +1,22 @@
+// Copyright 2017 Parity Technologies (UK) Ltd.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
 
 use futures::{Stream, Future, Async, Poll};
 use futures::stream::{iter_ok, Take as StreamTake, Skip as StreamSkip};

--- a/datastore/src/query.rs
+++ b/datastore/src/query.rs
@@ -1,0 +1,311 @@
+
+use futures::{Stream, Future, Async, Poll};
+use futures::stream::{iter_ok, Take as StreamTake, Skip as StreamSkip};
+use std::borrow::Cow;
+use std::cmp::Ordering;
+use std::io::Error as IoError;
+use std::marker::PhantomData;
+use std::vec::IntoIter as VecIntoIter;
+
+/// Description of a query to apply on a datastore.
+///
+/// The various modifications of the dataset are applied in the same order as the fields (prefix,
+/// filters, orders, skip, limit).
+#[derive(Debug, Clone)]
+pub struct Query<'a> {
+    /// Only the keys that start with `prefix` will be returned.
+    pub prefix: Cow<'a, str>,
+    /// Filters to apply on the results.
+    pub filters: Vec<Filter<'a>>,
+    /// How to order the keys. Applied sequentially.
+    pub orders: Vec<Order>,
+    /// Number of elements to skip from at the start of the results.
+    pub skip: u64,
+    /// Maximum number of elements in the results.
+    pub limit: u64,
+    /// Only return keys. If true, then all the `Vec`s of the data will be empty.
+    pub keys_only: bool,
+}
+
+/// A filter to apply to the results set.
+#[derive(Debug, Clone)]
+pub struct Filter<'a> {
+    /// Type of filter and value to compare with.
+    pub ty: FilterTy<'a>,
+    /// Comparison operation.
+    pub operation: FilterOp,
+}
+
+/// Type of filter and value to compare with.
+#[derive(Debug, Clone)]
+pub enum FilterTy<'a> {
+    /// Compare the key with a reference value.
+    KeyCompare(Cow<'a, str>),
+    /// Compare the value with a reference value.
+    ValueCompare(Cow<'a, [u8]>),
+}
+
+/// Filtering operation. Keep in mind that anything else than `Equal` and `NotEqual` is a bit
+/// blurry.
+#[derive(Debug, Copy, Clone)]
+pub enum FilterOp {
+    Less,
+    LessOrEqual,
+    Equal,
+    NotEqual,
+    Greater,
+    GreaterOrEqual,
+}
+
+/// Order in which to sort the results of a query.
+#[derive(Debug, Copy, Clone)]
+pub enum Order {
+    /// Put the values in ascending order.
+    ByValueAsc,
+    /// Put the values in descending order.
+    ByValueDesc,
+    /// Put the keys in ascending order.
+    ByKeyAsc,
+    /// Put the keys in descending order.
+    ByKeyDesc,
+}
+
+/// Naively applies a query on a set of results.
+pub fn naive_apply_query<'a, S>(stream: S, query: Query<'a>)
+        -> StreamTake<StreamSkip<NaiveKeysOnlyApply<NaiveApplyOrdered<NaiveFiltersApply<'a, NaivePrefixApply<'a, S>, VecIntoIter<Filter<'a>>>>>>>
+    where S: Stream<Item = (String, Vec<u8>), Error = IoError> + 'a
+{
+    let prefixed = naive_apply_prefix(stream, query.prefix);
+    let filtered = naive_apply_filters(prefixed, query.filters.into_iter());
+    let ordered = naive_apply_ordered(filtered, query.orders);
+    let keys_only = naive_apply_keys_only(ordered, query.keys_only);
+    naive_apply_skip_limit(keys_only, query.skip, query.limit)
+}
+
+/// Skips the `skip` first element of a stream and only returns `limit` elements.
+#[inline]
+pub fn naive_apply_skip_limit<S>(stream: S, skip: u64, limit: u64) -> StreamTake<StreamSkip<S>>
+where
+    S: Stream<Item = (String, Vec<u8>), Error = IoError>,
+{
+    stream.skip(skip).take(limit)
+}
+
+/// Filters the result of a stream to empty values if `keys_only` is true.
+#[inline]
+pub fn naive_apply_keys_only<S>(stream: S, keys_only: bool) -> NaiveKeysOnlyApply<S>
+where
+    S: Stream<Item = (String, Vec<u8>), Error = IoError>,
+{
+    NaiveKeysOnlyApply {
+        keys_only: keys_only,
+        stream: stream,
+    }
+}
+
+/// Returned by `naive_apply_keys_only`.
+#[derive(Debug, Clone)]
+pub struct NaiveKeysOnlyApply<S> {
+    keys_only: bool,
+    stream: S,
+}
+
+impl<S> Stream for NaiveKeysOnlyApply<S>
+where
+    S: Stream<Item = (String, Vec<u8>), Error = IoError>,
+{
+    type Item = (String, Vec<u8>);
+    type Error = IoError;
+
+    #[inline]
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        if self.keys_only {
+            Ok(Async::Ready(try_ready!(self.stream.poll()).map(|mut v| {
+                v.1 = Vec::new();
+                v
+            })))
+        } else {
+            self.stream.poll()
+        }
+    }
+}
+
+/// Filters the result of a stream to only keep the results with a prefix.
+#[inline]
+pub fn naive_apply_prefix<'a, S>(stream: S, prefix: Cow<'a, str>) -> NaivePrefixApply<'a, S>
+where
+    S: Stream<Item = (String, Vec<u8>), Error = IoError>,
+{
+    NaivePrefixApply {
+        prefix: prefix,
+        stream: stream,
+    }
+}
+
+/// Returned by `naive_apply_prefix`.
+#[derive(Debug, Clone)]
+pub struct NaivePrefixApply<'a, S> {
+    prefix: Cow<'a, str>,
+    stream: S,
+}
+
+impl<'a, S> Stream for NaivePrefixApply<'a, S>
+where
+    S: Stream<Item = (String, Vec<u8>), Error = IoError>,
+{
+    type Item = (String, Vec<u8>);
+    type Error = IoError;
+
+    #[inline]
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        loop {
+            let item = try_ready!(self.stream.poll());
+            match item {
+                Some(i) => {
+                    if i.0.starts_with(&*self.prefix) {
+                        return Ok(Async::Ready(Some(i)));
+                    }
+                }
+                None => return Ok(Async::Ready(None)),
+            }
+        }
+    }
+}
+
+/// Applies orderings on the stream data. Will simply pass data through if the list of orderings
+/// is empty. Otherwise will need to collect.
+pub fn naive_apply_ordered<'a, S, I>(stream: S, orders_iter: I) -> NaiveApplyOrdered<'a, S>
+where
+    S: Stream<Item = (String, Vec<u8>), Error = IoError> + 'a,
+    I: IntoIterator<Item = Order>,
+    I::IntoIter: 'a,
+{
+    let orders_iter = orders_iter.into_iter();
+    if orders_iter.size_hint().1 == Some(0) {
+        return NaiveApplyOrdered { inner: NaiveApplyOrderedInner::PassThrough(stream) };
+    }
+
+    let collected = stream
+        .collect()
+        .and_then(move |mut collected| {
+            for order in orders_iter {
+                match order {
+                    Order::ByValueAsc => {
+                        collected.sort_by(|a, b| a.1.cmp(&b.1));
+                    }
+                    Order::ByValueDesc => {
+                        collected.sort_by(|a, b| b.1.cmp(&a.1));
+                    }
+                    Order::ByKeyAsc => {
+                        collected.sort_by(|a, b| a.0.cmp(&b.0));
+                    }
+                    Order::ByKeyDesc => {
+                        collected.sort_by(|a, b| b.0.cmp(&a.0));
+                    }
+                }
+            }
+            Ok(iter_ok(collected.into_iter()))
+        })
+        .flatten_stream();
+
+    NaiveApplyOrdered { inner: NaiveApplyOrderedInner::Collected(Box::new(collected)) }
+}
+
+/// Returned by `naive_apply_ordered`.
+pub struct NaiveApplyOrdered<'a, S> {
+    inner: NaiveApplyOrderedInner<'a, S>,
+}
+
+enum NaiveApplyOrderedInner<'a, S> {
+    PassThrough(S),
+    Collected(Box<Stream<Item = (String, Vec<u8>), Error = IoError> + 'a>),
+}
+
+impl<'a, S> Stream for NaiveApplyOrdered<'a, S>
+where
+    S: Stream<Item = (String, Vec<u8>), Error = IoError>,
+{
+    type Item = (String, Vec<u8>);
+    type Error = IoError;
+
+    #[inline]
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        match self.inner {
+            NaiveApplyOrderedInner::PassThrough(ref mut s) => s.poll(),
+            NaiveApplyOrderedInner::Collected(ref mut s) => s.poll(),
+        }
+    }
+}
+
+/// Filters the result of a stream to apply a set of filters.
+#[inline]
+pub fn naive_apply_filters<'a, S, I>(stream: S, filters: I) -> NaiveFiltersApply<'a, S, I>
+where
+    S: Stream<Item = (String, Vec<u8>), Error = IoError>,
+    I: Iterator<Item = Filter<'a>> + Clone,
+{
+    NaiveFiltersApply {
+        filters: filters,
+        stream: stream,
+        marker: PhantomData,
+    }
+}
+
+/// Returned by `naive_apply_prefix`.
+#[derive(Debug, Clone)]
+pub struct NaiveFiltersApply<'a, S, I> {
+    filters: I,
+    stream: S,
+    marker: PhantomData<&'a ()>,
+}
+
+impl<'a, S, I> Stream for NaiveFiltersApply<'a, S, I>
+where
+    S: Stream<
+        Item = (String, Vec<u8>),
+        Error = IoError,
+    >,
+    I: Iterator<Item = Filter<'a>> + Clone,
+{
+    type Item = (String, Vec<u8>);
+    type Error = IoError;
+
+    #[inline]
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        'outer: loop {
+            let item = try_ready!(self.stream.poll());
+            match item {
+                Some(i) => {
+                    for filter in self.filters.clone() {
+                        if !naive_filter_test(&i, &filter) {
+                            continue 'outer;
+                        }
+                    }
+                    return Ok(Async::Ready(Some(i)));
+                }
+                None => return Ok(Async::Ready(None)),
+            }
+        }
+    }
+}
+
+#[inline]
+fn naive_filter_test(entry: &(String, Vec<u8>), filter: &Filter) -> bool {
+    let (expected_ordering, revert_expected) = match filter.operation {
+        FilterOp::Less => (Ordering::Less, false),
+        FilterOp::LessOrEqual => (Ordering::Greater, true),
+        FilterOp::Equal => (Ordering::Less, false),
+        FilterOp::NotEqual => (Ordering::Less, true),
+        FilterOp::Greater => (Ordering::Greater, false),
+        FilterOp::GreaterOrEqual => (Ordering::Less, true),
+    };
+
+    match filter.ty {
+        FilterTy::KeyCompare(ref ref_value) => {
+            ((&*entry.0).cmp(&**ref_value) == expected_ordering) != revert_expected
+        }
+        FilterTy::ValueCompare(ref ref_value) => {
+            ((&*entry.1).cmp(&**ref_value) == expected_ordering) != revert_expected
+        }
+    }
+}


### PR DESCRIPTION
Similar to https://github.com/ipfs/go-datastore, itself inspired from https://github.com/datastore/datastore.
To be used internally by record_store and peer_store.

Contrary to its Go counterpart which is generic, this library only allows string keys and byte array values. Being generic would not only be very difficult but would also add a big overhead.

Right now only has a single backend, which uses a single JSON file on the disk.

I implemented the same querying API as the one in Go, but I'm not sure how much we need it. For example filtering entries whose value is superior or inferior to a reference value may not make much sense, considering that values are byte arrays.