### PR TITLE
Start writing about the architecture of the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,16 @@ This repository is the central place for rust development of the
 This readme along with many others will be more fleshed out the closer
 the project gets to completion. Right now everything including the crate
 organization is very much Work in Progress.
+
+## General overview of the architecture
+
+Architecture of the crates of this repository:
+
+- `datastore`: Utility library whose API provides a key-value storage with multiple possible
+  backends.
+- `libp2p-host`: Stub. Will probably get reworked or removed.
+- `libp2p-tcp-transport`: Implementation of the `Transport` trait for TCP/IP.
+- `libp2p-transport`: Contains the `Transport` trait. Will probably get reworked or removed.
+- `multistream-select`: Implementation of the `multistream-select` protocol, which is used to
+  negotiate a protocol over a newly-established connection with a peer, or after a connection
+  upgrade.


### PR DESCRIPTION
Adds a small paragraph in the README describing the architecture of the repository.
I didn't want to talk about the changes introduced by any of the unmerged pull requests, so it's not very useful for now but will definitely become very useful later.
