### PR TITLE
Add a with_simple_protocol_upgrade alternative to with_upgrade

### DIFF
--- a/example/examples/echo-dialer.rs
+++ b/example/examples/echo-dialer.rs
@@ -28,7 +28,7 @@ extern crate tokio_io;
 
 use bytes::BytesMut;
 use futures::{Stream, Sink, Future};
-use swarm::Transport;
+use swarm::{Transport, SimpleProtocol};
 use tcp::TcpConfig;
 use tokio_core::reactor::Core;
 use tokio_io::codec::length_delimited;
@@ -47,9 +47,9 @@ fn main() {
             }
         });
 
-    let with_echo = with_secio.with_simple_protocol_upgrade("/echo/1.0.0", |socket| {
+    let with_echo = with_secio.with_upgrade(SimpleProtocol::new("/echo/1.0.0", |socket| {
         Ok(length_delimited::Framed::<_, BytesMut>::new(socket))
-    });
+    }));
 
     let dialer = with_echo.dial(swarm::multiaddr::Multiaddr::new("/ip4/127.0.0.1/tcp/10333").unwrap())
         .unwrap_or_else(|_| panic!())

--- a/example/examples/echo-dialer.rs
+++ b/example/examples/echo-dialer.rs
@@ -26,15 +26,11 @@ extern crate libp2p_tcp_transport as tcp;
 extern crate tokio_core;
 extern crate tokio_io;
 
-use bytes::Bytes;
-use futures::future::{Future, FutureResult, IntoFuture};
-use futures::{Stream, Sink};
-use std::io::Error as IoError;
-use std::iter;
-use swarm::{Transport, ConnectionUpgrade};
+use bytes::BytesMut;
+use futures::{Stream, Sink, Future};
+use swarm::Transport;
 use tcp::TcpConfig;
 use tokio_core::reactor::Core;
-use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_io::codec::length_delimited;
 
 fn main() {
@@ -51,11 +47,12 @@ fn main() {
             }
         });
 
-    let with_echo = with_secio.with_upgrade(Echo);
+    let with_echo = with_secio.with_simple_protocol_upgrade("/echo/1.0.0", |socket| {
+        Ok(length_delimited::Framed::<_, BytesMut>::new(socket))
+    });
 
     let dialer = with_echo.dial(swarm::multiaddr::Multiaddr::new("/ip4/127.0.0.1/tcp/10333").unwrap())
-        .map_err(|_| panic!())
-        .unwrap()
+        .unwrap_or_else(|_| panic!())
         .and_then(|f| {
             f.send("hello world".into())
         })
@@ -69,27 +66,4 @@ fn main() {
         });
 
     core.run(dialer).unwrap();
-}
-
-// TODO: copy-pasted from echo-server
-#[derive(Debug, Copy, Clone)]
-pub struct Echo;
-impl<C> ConnectionUpgrade<C> for Echo
-    where C: AsyncRead + AsyncWrite
-{
-    type NamesIter = iter::Once<(Bytes, Self::UpgradeIdentifier)>;
-    type UpgradeIdentifier = ();
-
-    #[inline]
-    fn protocol_names(&self) -> Self::NamesIter {
-        iter::once(("/echo/1.0.0".into(), ()))
-    }
-
-    type Output = length_delimited::Framed<C>;
-    type Future = FutureResult<Self::Output, IoError>;
-
-    #[inline]
-    fn upgrade(self, socket: C, _: Self::UpgradeIdentifier) -> Self::Future {
-        Ok(length_delimited::Framed::new(socket)).into_future()
-    }
 }

--- a/example/examples/echo-server.rs
+++ b/example/examples/echo-server.rs
@@ -26,15 +26,14 @@ extern crate libp2p_tcp_transport as tcp;
 extern crate tokio_core;
 extern crate tokio_io;
 
-use bytes::Bytes;
-use futures::future::{Future, FutureResult, IntoFuture, loop_fn, Loop};
+use bytes::BytesMut;
+use futures::future::{Future, IntoFuture, loop_fn, Loop};
 use futures::{Stream, Sink};
 use std::io::Error as IoError;
 use std::iter;
 use swarm::{Transport, ConnectionUpgrade};
 use tcp::TcpConfig;
 use tokio_core::reactor::Core;
-use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_io::codec::length_delimited;
 
 fn main() {
@@ -51,11 +50,12 @@ fn main() {
             }
         });
 
-    let with_echo = with_secio.with_upgrade(Echo);
+    let with_echo = with_secio.with_simple_protocol_upgrade("/echo/1.0.0", |socket| {
+        Ok(length_delimited::Framed::<_, BytesMut>::new(socket))
+    });
 
     let future = with_echo.listen_on(swarm::multiaddr::Multiaddr::new("/ip4/0.0.0.0/tcp/10333").unwrap())
-        .map_err(|_| panic!())
-        .unwrap().0
+        .unwrap_or_else(|_| panic!()).0
         .for_each(|(socket, _)| {
             loop_fn(socket, |socket| {
                 socket.into_future()
@@ -71,27 +71,4 @@ fn main() {
         });
 
     core.run(future).unwrap();
-}
-
-// TODO: copy-pasted from echo-dialer
-#[derive(Debug, Copy, Clone)]
-pub struct Echo;
-impl<C> ConnectionUpgrade<C> for Echo
-    where C: AsyncRead + AsyncWrite
-{
-    type NamesIter = iter::Once<(Bytes, Self::UpgradeIdentifier)>;
-    type UpgradeIdentifier = ();
-
-    #[inline]
-    fn protocol_names(&self) -> Self::NamesIter {
-        iter::once(("/echo/1.0.0".into(), ()))
-    }
-
-    type Output = length_delimited::Framed<C>;
-    type Future = FutureResult<Self::Output, IoError>;
-
-    #[inline]
-    fn upgrade(self, socket: C, _: Self::UpgradeIdentifier) -> Self::Future {
-        Ok(length_delimited::Framed::new(socket)).into_future()
-    }
 }

--- a/example/examples/echo-server.rs
+++ b/example/examples/echo-server.rs
@@ -26,12 +26,9 @@ extern crate libp2p_tcp_transport as tcp;
 extern crate tokio_core;
 extern crate tokio_io;
 
-use bytes::BytesMut;
 use futures::future::{Future, IntoFuture, loop_fn, Loop};
 use futures::{Stream, Sink};
-use std::io::Error as IoError;
-use std::iter;
-use swarm::{Transport, ConnectionUpgrade};
+use swarm::{Transport, SimpleProtocol};
 use tcp::TcpConfig;
 use tokio_core::reactor::Core;
 use tokio_io::codec::length_delimited;
@@ -50,9 +47,9 @@ fn main() {
             }
         });
 
-    let with_echo = with_secio.with_simple_protocol_upgrade("/echo/1.0.0", |socket| {
-        Ok(length_delimited::Framed::<_, BytesMut>::new(socket))
-    });
+    let with_echo = with_secio.with_upgrade(SimpleProtocol::new("/echo/1.0.0", |socket| {
+        Ok(length_delimited::Framed::new(socket))
+    }));
 
     let future = with_echo.listen_on(swarm::multiaddr::Multiaddr::new("/ip4/0.0.0.0/tcp/10333").unwrap())
         .unwrap_or_else(|_| panic!()).0

--- a/libp2p-swarm/src/lib.rs
+++ b/libp2p-swarm/src/lib.rs
@@ -149,3 +149,4 @@ pub use self::connection_reuse::ConnectionReuse;
 pub use self::multiaddr::Multiaddr;
 pub use self::muxing::StreamMuxer;
 pub use self::transport::{ConnectionUpgrade, PlainTextConfig, Transport, UpgradedNode, OrUpgrade};
+pub use self::transport::SimpleProtocol;

--- a/libp2p-swarm/src/transport.rs
+++ b/libp2p-swarm/src/transport.rs
@@ -207,7 +207,7 @@ impl<C, F, O> ConnectionUpgrade<C> for SimpleProtocol<F>
 
     #[inline]
     fn protocol_names(&self) -> Self::NamesIter {
-        iter::once(("/echo/1.0.0".into(), ()))
+        iter::once((self.name.clone(), ()))
     }
 
     type Output = O::Item;


### PR DESCRIPTION
Simplifies the echo dialer and listener, and will probably also be useful later when Kademlia is implemented.

(Note: I suggest to merge the other PRs first, because they conflict with this one and are more important)
