### PR TITLE
Implement the identify protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [workspace]
 members = [
+    "multistream-select",
+    "datastore",
+    "example",
+    "libp2p-identify",
     "libp2p-peerstore",
     "libp2p-ping",
     "libp2p-secio",

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Architecture of the crates of this repository:
 - `datastore`: Utility library whose API provides a key-value storage with multiple possible
   backends. Used by `peerstore`.
 - `example`: Example usages of this library.
+- `libp2p-identify`: Protocol implementation that allows a node A to query another node B what
+  information B knows about A. Implements the `ConnectionUpgrade` trait of `libp2p-swarm`.
 - `libp2p-peerstore`: Generic storage for information about remote peers (their multiaddresses and
   their public key), with multiple possible backends. Each multiaddress also has a time-to-live.
   Used by `libp2p-swarm`.

--- a/libp2p-identify/Cargo.toml
+++ b/libp2p-identify/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "libp2p-identify"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+
+[dependencies]
+bytes = "0.4"
+futures = "0.1"
+libp2p-peerstore = { path = "../libp2p-peerstore" }
+libp2p-swarm = { path = "../libp2p-swarm" }
+multiaddr = "0.2.0"
+protobuf = "1.4.2"
+tokio-io = "0.1.0"
+
+[dev-dependencies]
+libp2p-tcp-transport = { path = "../libp2p-tcp-transport" }
+tokio-core = "0.1.0"

--- a/libp2p-identify/regen_structs_proto.sh
+++ b/libp2p-identify/regen_structs_proto.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# This script regenerates the `src/structs_proto.rs` and `src/keys_proto.rs` files from
+# `structs.proto` and `keys.proto`.
+
+sudo docker run --rm -v `pwd`:/usr/code:z -w /usr/code rust /bin/bash -c " \
+    apt-get update; \
+    apt-get install -y protobuf-compiler; \
+    cargo install protobuf; \
+    protoc --rust_out . structs.proto"
+
+mv -f structs.rs ./src/structs_proto.rs

--- a/libp2p-identify/src/lib.rs
+++ b/libp2p-identify/src/lib.rs
@@ -1,0 +1,215 @@
+// Copyright 2017 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Implementation of the `/ipfs/id/1.0.0` protocol. Allows a node A to query another node B which
+//! information B knows about A. Also includes the addresses B is listening on.
+//!
+//! When two nodes connect to each other, the listening half sends a message to the dialing half,
+//! indicating the information, and then the protocol stops.
+
+extern crate bytes;
+extern crate futures;
+extern crate multiaddr;
+extern crate libp2p_peerstore;
+extern crate libp2p_swarm;
+extern crate protobuf;
+extern crate tokio_io;
+
+use bytes::{Bytes, BytesMut};
+use futures::{Future, Stream, Sink};
+use libp2p_swarm::{ConnectionUpgrade, Endpoint};
+use multiaddr::Multiaddr;
+use protobuf::Message as ProtobufMessage;
+use protobuf::core::parse_from_bytes as protobuf_parse_from_bytes;
+use protobuf::repeated::RepeatedField;
+use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+use std::iter;
+use tokio_io::{AsyncRead, AsyncWrite};
+use tokio_io::codec::length_delimited;
+
+mod structs_proto;
+
+/// Prototype for an upgrade to the identity protocol.
+#[derive(Debug, Clone)]
+pub struct IdentifyProtocol {
+	pub information: IdentifyInfo,
+}
+
+/// Information sent from the listener to the dialer.
+#[derive(Debug, Clone)]
+pub struct IdentifyInfo {
+	/// Public key of the node.
+	pub public_key: Vec<u8>,
+	/// Version of the "global" protocol, eg. `ipfs/1.0.0`.
+	pub protocol_version: String,
+	/// Name and version. Can be thought as similar to the `User-Agent` header of HTTP.
+	pub agent_version: String,
+	/// Addresses that are listened on.
+	pub listen_addrs: Vec<Multiaddr>,
+	/// Address that the server uses to communicate with the dialer.
+	pub observed_addr: Multiaddr,
+	/// Protocols supported by the remote.
+	pub protocols: Vec<String>,
+}
+
+impl<C> ConnectionUpgrade<C> for IdentifyProtocol
+    where C: AsyncRead + AsyncWrite + 'static
+{
+	type NamesIter = iter::Once<(Bytes, Self::UpgradeIdentifier)>;
+	type UpgradeIdentifier = ();
+
+	#[inline]
+	fn protocol_names(&self) -> Self::NamesIter {
+		iter::once((Bytes::from("/ipfs/id/1.0.0"), ()))
+	}
+
+	type Output = Option<IdentifyInfo>;
+	type Future = Box<Future<Item = Self::Output, Error = IoError>>;
+
+	fn upgrade(self, socket: C, _: (), ty: Endpoint) -> Self::Future {
+		// TODO: use jack's varint library instead
+		let socket = length_delimited::Builder::new().length_field_length(1).new_framed(socket);
+
+		match ty {
+			Endpoint::Dialer => {
+				let future = socket.into_future()
+				                   .map(|(msg, _)| msg)
+				                   .map_err(|(err, _)| err)
+				                   .and_then(|msg| if let Some(msg) = msg {
+					Ok(Some(parse_proto_msg(msg)?))
+				} else {
+					Ok(None)
+				});
+
+				Box::new(future) as Box<_>
+			}
+
+			Endpoint::Listener => {
+				let info = self.information;
+
+				let listen_addrs = info.listen_addrs
+				                       .into_iter()
+				                       .map(|addr| addr.to_string().into_bytes())
+				                       .collect();
+
+				let mut message = structs_proto::Identify::new();
+				message.set_agentVersion(info.agent_version);
+				message.set_protocolVersion(info.protocol_version);
+				message.set_publicKey(info.public_key);
+				message.set_listenAddrs(listen_addrs);
+				message.set_observedAddr(info.observed_addr.to_string().into_bytes());
+				message.set_protocols(RepeatedField::from_vec(info.protocols));
+
+				let bytes = message.write_to_bytes().expect("we control the protobuf message");
+				let future = socket.send(bytes).map(|_| None);
+				Box::new(future) as Box<_>
+			}
+		}
+	}
+}
+
+// Turns a protobuf message into an `IdentifyInfo`. If something bad happens, turn it into
+// an `IoError`.
+fn parse_proto_msg(msg: BytesMut) -> Result<IdentifyInfo, IoError> {
+	match protobuf_parse_from_bytes::<structs_proto::Identify>(&msg) {
+		Ok(mut msg) => {
+			let listen_addrs = {
+				let mut addrs = Vec::new();
+				for addr in msg.take_listenAddrs().into_iter() {
+					addrs.push(bytes_to_multiaddr(addr)?);
+				}
+				addrs
+			};
+
+			let observed_addr = bytes_to_multiaddr(msg.take_observedAddr())?;
+
+			Ok(IdentifyInfo {
+				public_key: msg.take_publicKey(),
+				protocol_version: msg.take_protocolVersion(),
+				agent_version: msg.take_agentVersion(),
+				listen_addrs: listen_addrs,
+				observed_addr: observed_addr,
+				protocols: msg.take_protocols().into_vec(),
+			})
+		}
+
+		Err(err) => {
+			Err(IoError::new(IoErrorKind::InvalidData, err))
+		}
+	}
+}
+
+// Turn a `Vec<u8>` into a `Multiaddr`. If something bad happens, turn it into an `IoError`.
+fn bytes_to_multiaddr(bytes: Vec<u8>) -> Result<Multiaddr, IoError> {
+	let string = match String::from_utf8(bytes) {
+		Ok(b) => b,
+		Err(err) => return Err(IoError::new(IoErrorKind::InvalidData, err)),
+	};
+
+	match Multiaddr::new(&string) {
+		Ok(b) => Ok(b),
+		Err(err) => return Err(IoError::new(IoErrorKind::InvalidData, err)),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	extern crate libp2p_tcp_transport;
+	extern crate tokio_core;
+
+	use self::libp2p_tcp_transport::TcpConfig;
+	use self::tokio_core::reactor::Core;
+	use IdentifyInfo;
+	use IdentifyProtocol;
+	use futures::{IntoFuture, Future, Stream};
+	use libp2p_swarm::Transport;
+	use libp2p_swarm::multiaddr::Multiaddr;
+
+	#[test]
+	fn basic() {
+		let mut core = Core::new().unwrap();
+		let tcp = TcpConfig::new(core.handle());
+		let with_proto = tcp.with_upgrade(IdentifyProtocol {
+			information: IdentifyInfo {
+				public_key: vec![1, 2, 3, 4],
+				protocol_version: "ipfs/1.0.0".to_owned(),
+				agent_version: "agent/version".to_owned(),
+				listen_addrs: vec![Multiaddr::new("/ip4/5.6.7.8/tcp/12345").unwrap()],
+				observed_addr: Multiaddr::new("/ip4/1.2.3.4/tcp/9876").unwrap(),
+				protocols: vec!["ping".to_owned(), "kad".to_owned()],
+			},
+		});
+
+		let (server, addr) = with_proto.clone()
+		                  		       .listen_on(Multiaddr::new("/ip4/127.0.0.1/tcp/0").unwrap())
+		                       		   .unwrap();
+		let server = server.into_future()
+		                   .map(|(n, _)| n)
+		                   .map_err(|(err, _)| err);
+		let dialer = with_proto.dial(addr)
+		                       .unwrap()
+		                       .into_future();
+
+		let (recv, should_be_empty) = core.run(dialer.join(server)).unwrap();
+		assert!(should_be_empty.unwrap().0.unwrap().is_none());
+		let recv = recv.unwrap();
+		assert_eq!(recv.public_key, &[1, 2, 3, 4]);
+	}
+}

--- a/libp2p-identify/src/lib.rs
+++ b/libp2p-identify/src/lib.rs
@@ -74,14 +74,13 @@ impl<C> ConnectionUpgrade<C> for IdentifyProtocol
 {
 	type NamesIter = iter::Once<(Bytes, Self::UpgradeIdentifier)>;
 	type UpgradeIdentifier = ();
+	type Output = Option<IdentifyInfo>;
+	type Future = Box<Future<Item = Self::Output, Error = IoError>>;
 
 	#[inline]
 	fn protocol_names(&self) -> Self::NamesIter {
 		iter::once((Bytes::from("/ipfs/id/1.0.0"), ()))
 	}
-
-	type Output = Option<IdentifyInfo>;
-	type Future = Box<Future<Item = Self::Output, Error = IoError>>;
 
 	fn upgrade(self, socket: C, _: (), ty: Endpoint) -> Self::Future {
 		// TODO: use jack's varint library instead

--- a/libp2p-identify/src/structs_proto.rs
+++ b/libp2p-identify/src/structs_proto.rs
@@ -1,0 +1,550 @@
+// This file is generated. Do not edit
+// @generated
+
+// https://github.com/Manishearth/rust-clippy/issues/702
+#![allow(unknown_lints)]
+#![allow(clippy)]
+
+#![cfg_attr(rustfmt, rustfmt_skip)]
+
+#![allow(box_pointers)]
+#![allow(dead_code)]
+#![allow(missing_docs)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(trivial_casts)]
+#![allow(unsafe_code)]
+#![allow(unused_imports)]
+#![allow(unused_results)]
+
+use protobuf::Message as Message_imported_for_functions;
+use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
+
+#[derive(PartialEq,Clone,Default)]
+pub struct Identify {
+    // message fields
+    protocolVersion: ::protobuf::SingularField<::std::string::String>,
+    agentVersion: ::protobuf::SingularField<::std::string::String>,
+    publicKey: ::protobuf::SingularField<::std::vec::Vec<u8>>,
+    listenAddrs: ::protobuf::RepeatedField<::std::vec::Vec<u8>>,
+    observedAddr: ::protobuf::SingularField<::std::vec::Vec<u8>>,
+    protocols: ::protobuf::RepeatedField<::std::string::String>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::protobuf::CachedSize,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for Identify {}
+
+impl Identify {
+    pub fn new() -> Identify {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static Identify {
+        static mut instance: ::protobuf::lazy::Lazy<Identify> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const Identify,
+        };
+        unsafe {
+            instance.get(Identify::new)
+        }
+    }
+
+    // optional string protocolVersion = 5;
+
+    pub fn clear_protocolVersion(&mut self) {
+        self.protocolVersion.clear();
+    }
+
+    pub fn has_protocolVersion(&self) -> bool {
+        self.protocolVersion.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_protocolVersion(&mut self, v: ::std::string::String) {
+        self.protocolVersion = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_protocolVersion(&mut self) -> &mut ::std::string::String {
+        if self.protocolVersion.is_none() {
+            self.protocolVersion.set_default();
+        }
+        self.protocolVersion.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_protocolVersion(&mut self) -> ::std::string::String {
+        self.protocolVersion.take().unwrap_or_else(|| ::std::string::String::new())
+    }
+
+    pub fn get_protocolVersion(&self) -> &str {
+        match self.protocolVersion.as_ref() {
+            Some(v) => &v,
+            None => "",
+        }
+    }
+
+    fn get_protocolVersion_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.protocolVersion
+    }
+
+    fn mut_protocolVersion_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.protocolVersion
+    }
+
+    // optional string agentVersion = 6;
+
+    pub fn clear_agentVersion(&mut self) {
+        self.agentVersion.clear();
+    }
+
+    pub fn has_agentVersion(&self) -> bool {
+        self.agentVersion.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_agentVersion(&mut self, v: ::std::string::String) {
+        self.agentVersion = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_agentVersion(&mut self) -> &mut ::std::string::String {
+        if self.agentVersion.is_none() {
+            self.agentVersion.set_default();
+        }
+        self.agentVersion.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_agentVersion(&mut self) -> ::std::string::String {
+        self.agentVersion.take().unwrap_or_else(|| ::std::string::String::new())
+    }
+
+    pub fn get_agentVersion(&self) -> &str {
+        match self.agentVersion.as_ref() {
+            Some(v) => &v,
+            None => "",
+        }
+    }
+
+    fn get_agentVersion_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.agentVersion
+    }
+
+    fn mut_agentVersion_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.agentVersion
+    }
+
+    // optional bytes publicKey = 1;
+
+    pub fn clear_publicKey(&mut self) {
+        self.publicKey.clear();
+    }
+
+    pub fn has_publicKey(&self) -> bool {
+        self.publicKey.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_publicKey(&mut self, v: ::std::vec::Vec<u8>) {
+        self.publicKey = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_publicKey(&mut self) -> &mut ::std::vec::Vec<u8> {
+        if self.publicKey.is_none() {
+            self.publicKey.set_default();
+        }
+        self.publicKey.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_publicKey(&mut self) -> ::std::vec::Vec<u8> {
+        self.publicKey.take().unwrap_or_else(|| ::std::vec::Vec::new())
+    }
+
+    pub fn get_publicKey(&self) -> &[u8] {
+        match self.publicKey.as_ref() {
+            Some(v) => &v,
+            None => &[],
+        }
+    }
+
+    fn get_publicKey_for_reflect(&self) -> &::protobuf::SingularField<::std::vec::Vec<u8>> {
+        &self.publicKey
+    }
+
+    fn mut_publicKey_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::vec::Vec<u8>> {
+        &mut self.publicKey
+    }
+
+    // repeated bytes listenAddrs = 2;
+
+    pub fn clear_listenAddrs(&mut self) {
+        self.listenAddrs.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_listenAddrs(&mut self, v: ::protobuf::RepeatedField<::std::vec::Vec<u8>>) {
+        self.listenAddrs = v;
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_listenAddrs(&mut self) -> &mut ::protobuf::RepeatedField<::std::vec::Vec<u8>> {
+        &mut self.listenAddrs
+    }
+
+    // Take field
+    pub fn take_listenAddrs(&mut self) -> ::protobuf::RepeatedField<::std::vec::Vec<u8>> {
+        ::std::mem::replace(&mut self.listenAddrs, ::protobuf::RepeatedField::new())
+    }
+
+    pub fn get_listenAddrs(&self) -> &[::std::vec::Vec<u8>] {
+        &self.listenAddrs
+    }
+
+    fn get_listenAddrs_for_reflect(&self) -> &::protobuf::RepeatedField<::std::vec::Vec<u8>> {
+        &self.listenAddrs
+    }
+
+    fn mut_listenAddrs_for_reflect(&mut self) -> &mut ::protobuf::RepeatedField<::std::vec::Vec<u8>> {
+        &mut self.listenAddrs
+    }
+
+    // optional bytes observedAddr = 4;
+
+    pub fn clear_observedAddr(&mut self) {
+        self.observedAddr.clear();
+    }
+
+    pub fn has_observedAddr(&self) -> bool {
+        self.observedAddr.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_observedAddr(&mut self, v: ::std::vec::Vec<u8>) {
+        self.observedAddr = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_observedAddr(&mut self) -> &mut ::std::vec::Vec<u8> {
+        if self.observedAddr.is_none() {
+            self.observedAddr.set_default();
+        }
+        self.observedAddr.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_observedAddr(&mut self) -> ::std::vec::Vec<u8> {
+        self.observedAddr.take().unwrap_or_else(|| ::std::vec::Vec::new())
+    }
+
+    pub fn get_observedAddr(&self) -> &[u8] {
+        match self.observedAddr.as_ref() {
+            Some(v) => &v,
+            None => &[],
+        }
+    }
+
+    fn get_observedAddr_for_reflect(&self) -> &::protobuf::SingularField<::std::vec::Vec<u8>> {
+        &self.observedAddr
+    }
+
+    fn mut_observedAddr_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::vec::Vec<u8>> {
+        &mut self.observedAddr
+    }
+
+    // repeated string protocols = 3;
+
+    pub fn clear_protocols(&mut self) {
+        self.protocols.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_protocols(&mut self, v: ::protobuf::RepeatedField<::std::string::String>) {
+        self.protocols = v;
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_protocols(&mut self) -> &mut ::protobuf::RepeatedField<::std::string::String> {
+        &mut self.protocols
+    }
+
+    // Take field
+    pub fn take_protocols(&mut self) -> ::protobuf::RepeatedField<::std::string::String> {
+        ::std::mem::replace(&mut self.protocols, ::protobuf::RepeatedField::new())
+    }
+
+    pub fn get_protocols(&self) -> &[::std::string::String] {
+        &self.protocols
+    }
+
+    fn get_protocols_for_reflect(&self) -> &::protobuf::RepeatedField<::std::string::String> {
+        &self.protocols
+    }
+
+    fn mut_protocols_for_reflect(&mut self) -> &mut ::protobuf::RepeatedField<::std::string::String> {
+        &mut self.protocols
+    }
+}
+
+impl ::protobuf::Message for Identify {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
+            match field_number {
+                5 => {
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.protocolVersion)?;
+                },
+                6 => {
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.agentVersion)?;
+                },
+                1 => {
+                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.publicKey)?;
+                },
+                2 => {
+                    ::protobuf::rt::read_repeated_bytes_into(wire_type, is, &mut self.listenAddrs)?;
+                },
+                4 => {
+                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.observedAddr)?;
+                },
+                3 => {
+                    ::protobuf::rt::read_repeated_string_into(wire_type, is, &mut self.protocols)?;
+                },
+                _ => {
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        if let Some(ref v) = self.protocolVersion.as_ref() {
+            my_size += ::protobuf::rt::string_size(5, &v);
+        }
+        if let Some(ref v) = self.agentVersion.as_ref() {
+            my_size += ::protobuf::rt::string_size(6, &v);
+        }
+        if let Some(ref v) = self.publicKey.as_ref() {
+            my_size += ::protobuf::rt::bytes_size(1, &v);
+        }
+        for value in &self.listenAddrs {
+            my_size += ::protobuf::rt::bytes_size(2, &value);
+        };
+        if let Some(ref v) = self.observedAddr.as_ref() {
+            my_size += ::protobuf::rt::bytes_size(4, &v);
+        }
+        for value in &self.protocols {
+            my_size += ::protobuf::rt::string_size(3, &value);
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(ref v) = self.protocolVersion.as_ref() {
+            os.write_string(5, &v)?;
+        }
+        if let Some(ref v) = self.agentVersion.as_ref() {
+            os.write_string(6, &v)?;
+        }
+        if let Some(ref v) = self.publicKey.as_ref() {
+            os.write_bytes(1, &v)?;
+        }
+        for v in &self.listenAddrs {
+            os.write_bytes(2, &v)?;
+        };
+        if let Some(ref v) = self.observedAddr.as_ref() {
+            os.write_bytes(4, &v)?;
+        }
+        for v in &self.protocols {
+            os.write_string(3, &v)?;
+        };
+        os.write_unknown_fields(self.get_unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for Identify {
+    fn new() -> Identify {
+        Identify::new()
+    }
+
+    fn descriptor_static(_: ::std::option::Option<Identify>) -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
+                    "protocolVersion",
+                    Identify::get_protocolVersion_for_reflect,
+                    Identify::mut_protocolVersion_for_reflect,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
+                    "agentVersion",
+                    Identify::get_agentVersion_for_reflect,
+                    Identify::mut_agentVersion_for_reflect,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
+                    "publicKey",
+                    Identify::get_publicKey_for_reflect,
+                    Identify::mut_publicKey_for_reflect,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
+                    "listenAddrs",
+                    Identify::get_listenAddrs_for_reflect,
+                    Identify::mut_listenAddrs_for_reflect,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
+                    "observedAddr",
+                    Identify::get_observedAddr_for_reflect,
+                    Identify::mut_observedAddr_for_reflect,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
+                    "protocols",
+                    Identify::get_protocols_for_reflect,
+                    Identify::mut_protocols_for_reflect,
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<Identify>(
+                    "Identify",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+}
+
+impl ::protobuf::Clear for Identify {
+    fn clear(&mut self) {
+        self.clear_protocolVersion();
+        self.clear_agentVersion();
+        self.clear_publicKey();
+        self.clear_listenAddrs();
+        self.clear_observedAddr();
+        self.clear_protocols();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::fmt::Debug for Identify {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for Identify {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+static file_descriptor_proto_data: &'static [u8] = b"\
+    \n\rstructs.proto\"\xda\x01\n\x08Identify\x12(\n\x0fprotocolVersion\x18\
+    \x05\x20\x01(\tR\x0fprotocolVersion\x12\"\n\x0cagentVersion\x18\x06\x20\
+    \x01(\tR\x0cagentVersion\x12\x1c\n\tpublicKey\x18\x01\x20\x01(\x0cR\tpub\
+    licKey\x12\x20\n\x0blistenAddrs\x18\x02\x20\x03(\x0cR\x0blistenAddrs\x12\
+    \"\n\x0cobservedAddr\x18\x04\x20\x01(\x0cR\x0cobservedAddr\x12\x1c\n\tpr\
+    otocols\x18\x03\x20\x03(\tR\tprotocolsJ\xc2\t\n\x06\x12\x04\0\0\x16\x01\
+    \n\n\n\x02\x04\0\x12\x04\0\0\x16\x01\n\n\n\x03\x04\0\x01\x12\x03\0\x08\
+    \x10\nX\n\x04\x04\0\x02\0\x12\x03\x02\x02&\x1a8\x20protocolVersion\x20de\
+    termines\x20compatibility\x20between\x20peers\n\"\x11\x20e.g.\x20ipfs/1.\
+    0.0\n\n\x0c\n\x05\x04\0\x02\0\x04\x12\x03\x02\x02\n\n\x0c\n\x05\x04\0\
+    \x02\0\x05\x12\x03\x02\x0b\x11\n\x0c\n\x05\x04\0\x02\0\x01\x12\x03\x02\
+    \x12!\n\x0c\n\x05\x04\0\x02\0\x03\x12\x03\x02$%\n\x9f\x01\n\x04\x04\0\
+    \x02\x01\x12\x03\x06\x02#\x1a|\x20agentVersion\x20is\x20like\x20a\x20Use\
+    rAgent\x20string\x20in\x20browsers,\x20or\x20client\x20version\x20in\x20\
+    bittorrent\n\x20includes\x20the\x20client\x20name\x20and\x20client.\n\"\
+    \x14\x20e.g.\x20go-ipfs/0.1.0\n\n\x0c\n\x05\x04\0\x02\x01\x04\x12\x03\
+    \x06\x02\n\n\x0c\n\x05\x04\0\x02\x01\x05\x12\x03\x06\x0b\x11\n\x0c\n\x05\
+    \x04\0\x02\x01\x01\x12\x03\x06\x12\x1e\n\x0c\n\x05\x04\0\x02\x01\x03\x12\
+    \x03\x06!\"\n\xe3\x01\n\x04\x04\0\x02\x02\x12\x03\x0b\x02\x1f\x1a\xd5\
+    \x01\x20publicKey\x20is\x20this\x20node's\x20public\x20key\x20(which\x20\
+    also\x20gives\x20its\x20node.ID)\n\x20-\x20may\x20not\x20need\x20to\x20b\
+    e\x20sent,\x20as\x20secure\x20channel\x20implies\x20it\x20has\x20been\
+    \x20sent.\n\x20-\x20then\x20again,\x20if\x20we\x20change\x20/\x20disable\
+    \x20secure\x20channel,\x20may\x20still\x20want\x20it.\n\n\x0c\n\x05\x04\
+    \0\x02\x02\x04\x12\x03\x0b\x02\n\n\x0c\n\x05\x04\0\x02\x02\x05\x12\x03\
+    \x0b\x0b\x10\n\x0c\n\x05\x04\0\x02\x02\x01\x12\x03\x0b\x11\x1a\n\x0c\n\
+    \x05\x04\0\x02\x02\x03\x12\x03\x0b\x1d\x1e\n]\n\x04\x04\0\x02\x03\x12\
+    \x03\x0e\x02!\x1aP\x20listenAddrs\x20are\x20the\x20multiaddrs\x20the\x20\
+    sender\x20node\x20listens\x20for\x20open\x20connections\x20on\n\n\x0c\n\
+    \x05\x04\0\x02\x03\x04\x12\x03\x0e\x02\n\n\x0c\n\x05\x04\0\x02\x03\x05\
+    \x12\x03\x0e\x0b\x10\n\x0c\n\x05\x04\0\x02\x03\x01\x12\x03\x0e\x11\x1c\n\
+    \x0c\n\x05\x04\0\x02\x03\x03\x12\x03\x0e\x1f\x20\n\x81\x02\n\x04\x04\0\
+    \x02\x04\x12\x03\x13\x02\"\x1a\xf3\x01\x20oservedAddr\x20is\x20the\x20mu\
+    ltiaddr\x20of\x20the\x20remote\x20endpoint\x20that\x20the\x20sender\x20n\
+    ode\x20perceives\n\x20this\x20is\x20useful\x20information\x20to\x20conve\
+    y\x20to\x20the\x20other\x20side,\x20as\x20it\x20helps\x20the\x20remote\
+    \x20endpoint\n\x20determine\x20whether\x20its\x20connection\x20to\x20the\
+    \x20local\x20peer\x20goes\x20through\x20NAT.\n\n\x0c\n\x05\x04\0\x02\x04\
+    \x04\x12\x03\x13\x02\n\n\x0c\n\x05\x04\0\x02\x04\x05\x12\x03\x13\x0b\x10\
+    \n\x0c\n\x05\x04\0\x02\x04\x01\x12\x03\x13\x11\x1d\n\x0c\n\x05\x04\0\x02\
+    \x04\x03\x12\x03\x13\x20!\n\x0b\n\x04\x04\0\x02\x05\x12\x03\x15\x02\x20\
+    \n\x0c\n\x05\x04\0\x02\x05\x04\x12\x03\x15\x02\n\n\x0c\n\x05\x04\0\x02\
+    \x05\x05\x12\x03\x15\x0b\x11\n\x0c\n\x05\x04\0\x02\x05\x01\x12\x03\x15\
+    \x12\x1b\n\x0c\n\x05\x04\0\x02\x05\x03\x12\x03\x15\x1e\x1f\
+";
+
+static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {
+    lock: ::protobuf::lazy::ONCE_INIT,
+    ptr: 0 as *const ::protobuf::descriptor::FileDescriptorProto,
+};
+
+fn parse_descriptor_proto() -> ::protobuf::descriptor::FileDescriptorProto {
+    ::protobuf::parse_from_bytes(file_descriptor_proto_data).unwrap()
+}
+
+pub fn file_descriptor_proto() -> &'static ::protobuf::descriptor::FileDescriptorProto {
+    unsafe {
+        file_descriptor_proto_lazy.get(|| {
+            parse_descriptor_proto()
+        })
+    }
+}

--- a/libp2p-identify/structs.proto
+++ b/libp2p-identify/structs.proto
@@ -1,0 +1,23 @@
+message Identify {
+  // protocolVersion determines compatibility between peers
+  optional string protocolVersion = 5; // e.g. ipfs/1.0.0
+
+  // agentVersion is like a UserAgent string in browsers, or client version in bittorrent
+  // includes the client name and client.
+  optional string agentVersion = 6; // e.g. go-ipfs/0.1.0
+
+  // publicKey is this node's public key (which also gives its node.ID)
+  // - may not need to be sent, as secure channel implies it has been sent.
+  // - then again, if we change / disable secure channel, may still want it.
+  optional bytes publicKey = 1;
+
+  // listenAddrs are the multiaddrs the sender node listens for open connections on
+  repeated bytes listenAddrs = 2;
+
+  // oservedAddr is the multiaddr of the remote endpoint that the sender node perceives
+  // this is useful information to convey to the other side, as it helps the remote endpoint
+  // determine whether its connection to the local peer goes through NAT.
+  optional bytes observedAddr = 4;
+
+  repeated string protocols = 3;
+}


### PR DESCRIPTION
Based over #75 

The `identify` protocol is a way for a dialer to know who it is. Once the protocol has been negotiated, the listener side immediately sends a message to the dialer side indicating various information such as the addresses by which the dialer is observed.
