### PR TITLE
Integrate a local copy of rust-multiaddr for development

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "multistream-select",
     "datastore",
     "futures-mutex",
+    "rust-multiaddr",
     "rw-stream-sink",
     "circular-buffer",
     "varint-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ members = [
 [replace]
 # Ring has a feature merged in master that hasn't been published yet ; remove this after 0.12.2
 "ring:0.12.1" = { git = "https://github.com/briansmith/ring" }
-# Multiaddr has a feature merged in master that hasn't been published yet ; remove this after 0.2.1
-"multiaddr:0.2.0" = { git = "https://github.com/multiformats/rust-multiaddr" }
+# Using a local improved version of multiaddr for now
+"multiaddr:0.2.0" = { path = "./rust-multiaddr" }

--- a/rust-multiaddr/.gitignore
+++ b/rust-multiaddr/.gitignore
@@ -1,0 +1,3 @@
+target
+Cargo.lock
+*.rs.bk

--- a/rust-multiaddr/.travis.yml
+++ b/rust-multiaddr/.travis.yml
@@ -1,0 +1,31 @@
+sudo: false
+language: rust
+addons:
+  apt:
+    packages:
+    - libcurl4-openssl-dev
+    - libelf-dev
+    - libdw-dev
+    - binutils-dev
+rust:
+# - nightly # enable when passing
+- beta
+- stable
+
+before_script:
+- |
+  pip install 'travis-cargo<0.2' --user &&
+  export PATH=$HOME/.local/bin:$PATH
+script:
+- |
+  travis-cargo build &&
+  travis-cargo test &&
+  travis-cargo bench &&
+  travis-cargo --only stable doc
+after_success:
+- travis-cargo --only stable doc-upload
+- travis-cargo coveralls --no-sudo --verify
+env:
+  global:
+  - TRAVIS_CARGO_NIGHTLY_FEATURE=nightly
+  - secure: f/VDWCDpQazAB1TX4QlwGDumT7ft4uip5isALquR3TUT/WyKScnXe9JCAMp5/kJaVzSUeQgbqbBXsNmkzMpqBGj5Cu8GqUDIPf2TbqfFJ/wNzzQXrvwB2n3fA5affbSLBvLBw1R9Jonv14tPduYgnfkGDi89UbxMhXDRhpmwrFlKxHLcbz36+pYG5Qg3ftAGDrNDWprh5W0J1RgwyXGj56fUKLcHDzZoyvNEEzkSM3WV4OdWixCDESrS3SZLaYCjLNHLbCsbaa6AWUlGZMJXj5mrNDDxeCFU6Z9euUWG9ypJkiRA6eMo1zqXZrHYvPJM2ivqWqEYUXtKGHpugH2Sa34C/PvXOiuYkC2yXLO6TmSaAYWo5x6z1I2WrgMKSbhpqsrV0ZRKywCBuMooyQw85tQJRFPqSxbaJYPjsVhZ4yZEDnbsCvr8puhKtWAYOhz/0d15Pyom+yJ3roT4eSt4VyPVifEFAKC4/tLxbXkzB44PvOg0Ur+HxUUoAxi0dgrb1MTOwgkDxUl3iIdQtn6bAjM2D84ciCtYvlcTQAp7Rohgoda3FU99Hoxujj7YJ3eRLfBpLOclXTqUFBU0JFRDlec1xcD4MnwsLz9oWdw/hIhyh4PGfm6wuvfBKkJdQ4JhzIS7UcDCUdrsTx7LqMtA5M1CkN53mw+HNXfUncOOyLw=

--- a/rust-multiaddr/Cargo.toml
+++ b/rust-multiaddr/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+authors = ["dignifiedquire <dignifiedquire@gmail.com>"]
+description = "Implementation of the multiaddr format"
+homepage = "https://github.com/multiformats/rust-multiaddr"
+keywords = ["multiaddr", "ipfs"]
+license = "MIT"
+name = "multiaddr"
+readme = "README.md"
+version = "0.2.0"
+
+[dependencies]
+byteorder = "~0.4"
+cid = "~0.2"
+integer-encoding = "~1.0.3"
+
+[dev-dependencies]
+data-encoding = "~1.1.2"

--- a/rust-multiaddr/LICENSE
+++ b/rust-multiaddr/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (C) 2015-2016 Friedel Ziegelmayer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Status API Training Shop Blog About Pricing

--- a/rust-multiaddr/README.md
+++ b/rust-multiaddr/README.md
@@ -1,0 +1,63 @@
+# rust-multiaddr
+
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
+[![](https://img.shields.io/badge/project-multiformats-blue.svg?style=flat-square)](https://github.com/multiformats/multiformats)
+[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](https://webchat.freenode.net/?channels=%23ipfs)
+[![Travis CI](https://img.shields.io/travis/multiformats/rust-multiaddr.svg?style=flat-square&branch=master)](https://travis-ci.org/multiformats/rust-multiaddr)
+[![codecov.io](https://img.shields.io/codecov/c/github/multiformats/rust-multiaddr.svg?style=flat-square&branch=master)](https://codecov.io/github/multiformats/rust-multiaddr?branch=master)
+[![](https://img.shields.io/badge/rust-docs-blue.svg?style=flat-square)](https://docs.rs/crate/multiaddr)
+[![crates.io](https://img.shields.io/badge/crates.io-v0.2.0-orange.svg?style=flat-square )](https://crates.io/crates/multiaddr)
+[![](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+
+
+> [multiaddr](https://github.com/multiformats/multiaddr) implementation in Rust.
+
+## Table of Contents
+
+- [Install](#install)
+- [Usage](#usage)
+- [Maintainers](#maintainers)
+- [Contribute](#contribute)
+- [License](#license)
+
+## Install
+
+First add this to your `Cargo.toml`
+
+```toml
+[dependencies]
+multiaddr = "*"
+```
+
+then run `cargo build`.
+
+## Usage
+
+```rust
+extern crate multiaddr;
+
+use multiaddr::{Multiaddr, ToMultiaddr};
+
+let address = Multiaddr::new("/ip4/127.0.0.1/udp/1234").unwrap();
+// or directly from a string
+let other = "/ip4/127.0.0.1".to_multiaddr().unwrap();
+
+assert_eq!(address.to_string(), "/ip4/127.0.0.1/udp/1234");
+assert_eq!(other.to_string(), "/ip4/127.0.0.1");
+```
+
+## Maintainers
+
+Captain: [@dignifiedquire](https://github.com/dignifiedquire).
+
+## Contribute
+
+Contributions welcome. Please check out [the issues](https://github.com/multiformats/rust-multiaddr/issues).
+
+Check out our [contributing document](https://github.com/multiformats/multiformats/blob/master/contributing.md) for more information on how we work, and about contributing in general. Please be aware that all interactions related to multiformats are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+
+Small note: If editing the README, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
+
+## License
+
+[MIT](LICENSE) © 2015-2017 Friedel Ziegelmeyer

--- a/rust-multiaddr/src/errors.rs
+++ b/rust-multiaddr/src/errors.rs
@@ -1,0 +1,71 @@
+use std::{net, fmt, error, io, num};
+use cid;
+use byteorder;
+
+pub type Result<T> = ::std::result::Result<T, Error>;
+
+/// Error types
+#[derive(Debug)]
+pub enum Error {
+    UnknownProtocol,
+    UnknownProtocolString,
+    InvalidMultiaddr,
+    MissingAddress,
+    ParsingError(Box<error::Error + Send + Sync>),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(error::Error::description(self))
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::UnknownProtocol => "unknown protocol",
+            Error::UnknownProtocolString => "unknown protocol string",
+            Error::InvalidMultiaddr => "invalid multiaddr",
+            Error::MissingAddress => "protocol requires address, none given",
+            Error::ParsingError(_) => "failed to parse",
+        }
+    }
+
+    #[inline]
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::ParsingError(ref err) => Some(&**err),
+            _ => None
+        }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error {
+        Error::ParsingError(err.into())
+    }
+}
+
+impl From<cid::Error> for Error {
+    fn from(err: cid::Error) -> Error {
+        Error::ParsingError(err.into())
+    }
+}
+
+impl From<net::AddrParseError> for Error {
+    fn from(err: net::AddrParseError) -> Error {
+        Error::ParsingError(err.into())
+    }
+}
+
+impl From<byteorder::Error> for Error {
+    fn from(err: byteorder::Error) -> Error {
+        Error::ParsingError(err.into())
+    }
+}
+
+impl From<num::ParseIntError> for Error {
+    fn from(err: num::ParseIntError) -> Error {
+        Error::ParsingError(err.into())
+    }
+}

--- a/rust-multiaddr/src/lib.rs
+++ b/rust-multiaddr/src/lib.rs
@@ -1,0 +1,375 @@
+///! # multiaddr
+///!
+///! Implementation of [multiaddr](https://github.com/jbenet/multiaddr)
+///! in Rust.
+extern crate byteorder;
+extern crate cid;
+extern crate integer_encoding;
+
+mod protocol;
+mod errors;
+
+pub use errors::{Result, Error};
+pub use protocol::{ProtocolId, ProtocolArgSize, AddrComponent};
+
+use std::fmt;
+use std::iter::FromIterator;
+use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6, IpAddr, Ipv4Addr, Ipv6Addr};
+use std::str::FromStr;
+
+/// Representation of a Multiaddr.
+#[derive(PartialEq, Eq, Clone, Hash)]
+pub struct Multiaddr {
+    bytes: Vec<u8>,
+}
+
+impl ToString for Multiaddr {
+    /// Convert a Multiaddr to a string
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use multiaddr::Multiaddr;
+    ///
+    /// let address = Multiaddr::new("/ip4/127.0.0.1/udt").unwrap();
+    /// assert_eq!(address.to_string(), "/ip4/127.0.0.1/udt");
+    /// ```
+    ///
+    fn to_string(&self) -> String {
+        let mut out = String::new();
+        for s in self.iter() {
+            out.push_str(&s.to_string());
+        }
+        out
+    }
+}
+
+impl fmt::Debug for Multiaddr {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.to_string().fmt(f)
+    }
+}
+
+impl Multiaddr {
+    /// Create a new multiaddr based on a string representation, like
+    /// `/ip4/127.0.0.1/udp/1234`.
+    ///
+    /// # Examples
+    ///
+    /// Simple construction
+    ///
+    /// ```
+    /// use multiaddr::Multiaddr;
+    ///
+    /// let address = Multiaddr::new("/ip4/127.0.0.1/udp/1234").unwrap();
+    /// assert_eq!(address.to_bytes(), [
+    ///     4, 127, 0, 0, 1,
+    ///     17, 4, 210
+    /// ]);
+    /// ```
+    ///
+    pub fn new(input: &str) -> Result<Multiaddr> {
+        let mut bytes = Vec::new();
+
+        let mut parts = input.split('/');
+        if !parts.next().ok_or(Error::InvalidMultiaddr)?.is_empty() {
+            return Err(Error::InvalidMultiaddr);
+        }
+
+        while let Some(part) = parts.next() {
+            let protocol: ProtocolId = part.parse()?;
+            let addr_component = match protocol.size() {
+                ProtocolArgSize::Fixed { bytes: 0 } => {
+                    protocol.parse_data("")?     // TODO: bad design
+                },
+                _ => {
+                    let data = parts.next().ok_or(Error::MissingAddress)?;
+                    protocol.parse_data(data)?
+                },
+            };
+
+            addr_component.write_bytes(&mut bytes).expect("writing to a Vec never fails");
+        }
+
+        Ok(Multiaddr { bytes: bytes })
+    }
+
+    /// Return a copy to disallow changing the bytes directly
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.bytes.to_owned()
+    }
+
+    /// Extracts a slice containing the entire underlying vector.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Return a list of protocols
+    ///
+    /// # Examples
+    ///
+    /// A single protocol
+    ///
+    /// ```
+    /// use multiaddr::{Multiaddr, ProtocolId};
+    ///
+    /// let address = Multiaddr::new("/ip4/127.0.0.1").unwrap();
+    /// assert_eq!(address.protocol(), vec![ProtocolId::IP4]);
+    /// ```
+    ///
+    #[inline]
+    pub fn protocol(&self) -> Vec<ProtocolId> {
+        self.iter().map(|addr| addr.protocol_id()).collect()
+    }
+
+    /// Wrap a given Multiaddr and return the combination.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use multiaddr::Multiaddr;
+    ///
+    /// let address = Multiaddr::new("/ip4/127.0.0.1").unwrap();
+    /// let nested = address.encapsulate("/udt").unwrap();
+    /// assert_eq!(nested, Multiaddr::new("/ip4/127.0.0.1/udt").unwrap());
+    /// ```
+    ///
+    pub fn encapsulate<T: ToMultiaddr>(&self, input: T) -> Result<Multiaddr> {
+        let new = input.to_multiaddr()?;
+        let mut bytes = self.bytes.clone();
+
+        bytes.extend(new.to_bytes());
+
+        Ok(Multiaddr { bytes: bytes })
+    }
+
+    /// Remove the outer most address from itself.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use multiaddr::{Multiaddr, ToMultiaddr};
+    ///
+    /// let address = Multiaddr::new("/ip4/127.0.0.1/udt/sctp/5678").unwrap();
+    /// let unwrapped = address.decapsulate("/udt").unwrap();
+    /// assert_eq!(unwrapped, Multiaddr::new("/ip4/127.0.0.1").unwrap());
+    ///
+    /// assert_eq!(
+    ///     address.decapsulate("/udt").unwrap(),
+    ///     "/ip4/127.0.0.1".to_multiaddr().unwrap()
+    /// );
+    /// ```
+    ///
+    /// Returns the original if the passed in address is not found
+    ///
+    /// ```
+    /// use multiaddr::ToMultiaddr;
+    ///
+    /// let address = "/ip4/127.0.0.1/udt/sctp/5678".to_multiaddr().unwrap();
+    /// let unwrapped = address.decapsulate("/ip4/127.0.1.1").unwrap();
+    /// assert_eq!(unwrapped, address);
+    /// ```
+    ///
+    pub fn decapsulate<T: ToMultiaddr>(&self, input: T) -> Result<Multiaddr> {
+        let input = input.to_multiaddr()?.to_bytes();
+
+        let bytes_len = self.bytes.len();
+        let input_length = input.len();
+
+        let mut input_pos = 0;
+        let mut matches = false;
+
+        for (i, _) in self.bytes.iter().enumerate() {
+            let next = i + input_length;
+
+            if next > bytes_len {
+                continue;
+            }
+
+            if &self.bytes[i..next] == input.as_slice() {
+                matches = true;
+                input_pos = i;
+                break;
+            }
+        }
+
+        if !matches {
+            return Ok(Multiaddr { bytes: self.bytes.clone() });
+        }
+
+        let mut bytes = self.bytes.clone();
+        bytes.truncate(input_pos);
+
+        Ok(Multiaddr { bytes: bytes })
+    }
+
+    /// Returns the components of this multiaddress.
+    /// 
+    /// ```
+    /// use std::net::Ipv4Addr;
+    /// use multiaddr::AddrComponent;
+    /// use multiaddr::Multiaddr;
+    ///
+    /// let address: Multiaddr = "/ip4/127.0.0.1/udt/sctp/5678".parse().unwrap();
+    /// 
+    /// let components = address.iter().collect::<Vec<_>>();
+    /// assert_eq!(components[0], AddrComponent::IP4(Ipv4Addr::new(127, 0, 0, 1)));
+    /// assert_eq!(components[1], AddrComponent::UDT);
+    /// assert_eq!(components[2], AddrComponent::SCTP(5678));
+    /// ```
+    ///
+    #[inline]
+    pub fn iter(&self) -> Iter {
+        Iter(&self.bytes)
+    }
+
+    /// Pops the last `AddrComponent` of this multiaddr, or `None` if the multiaddr is empty. 
+    /// ```
+    /// use multiaddr::AddrComponent;
+    /// use multiaddr::Multiaddr;
+    ///
+    /// let address: Multiaddr = "/ip4/127.0.0.1/udt/sctp/5678".parse().unwrap();
+    /// 
+    /// assert_eq!(address.pop().unwrap(), AddrComponent::SCTP(5678));
+    /// assert_eq!(address.pop().unwrap(), AddrComponent::UDT);
+    /// ```
+    ///
+    pub fn pop(&mut self) -> Option<AddrComponent> {
+        // Note: could be more optimized
+        let mut list = self.iter().collect::<Vec<_>>();
+        let last_elem = list.pop();
+        *self = list.into_iter().collect();
+        last_elem
+    }
+}
+
+impl From<AddrComponent> for Multiaddr {
+    fn from(addr: AddrComponent) -> Multiaddr {
+        let mut out = Vec::new();
+        addr.write_bytes(&mut out).expect("writing to a Vec never fails");
+        Multiaddr { bytes: out }
+    }
+}
+
+impl FromIterator<AddrComponent> for Multiaddr {
+    fn from_iter<T>(iter: T) -> Self
+        where T: IntoIterator<Item = AddrComponent>
+    {
+        let mut bytes = Vec::new();
+        for cmp in iter {
+            cmp.write_bytes(&mut bytes).expect("writing to a Vec never fails");
+        }
+        Multiaddr { bytes: bytes }
+    }
+}
+
+impl FromStr for Multiaddr {
+    type Err = Error;
+
+    #[inline]
+    fn from_str(s: &str) -> Result<Self> {
+        Multiaddr::new(s)
+    }
+}
+
+/// Iterator for the address components in a multiaddr.
+pub struct Iter<'a>(&'a [u8]);
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = AddrComponent;
+
+    fn next(&mut self) -> Option<AddrComponent> {
+        if self.0.is_empty() {
+            return None;
+        }
+
+        let (component, next_data) = AddrComponent::from_bytes(self.0)
+                                                        .expect("multiaddr is known to be valid");
+        self.0 = next_data;
+        Some(component)
+    }
+}
+
+/// A trait for objects which can be converted to a
+/// Multiaddr.
+///
+/// This trait is implemented by default for
+///
+/// * `SocketAddr`, `SocketAddrV4` and `SocketAddrV6`, assuming that the
+///   the given port is a tcp port.
+///
+/// * `Ipv4Addr`, `Ipv6Addr`
+///
+/// * `String` and `&str`, requiring the default string format for a Multiaddr.
+///
+pub trait ToMultiaddr {
+    /// Converts this object to a Multiaddr
+    ///
+    /// # Errors
+    ///
+    /// Any errors encountered during parsing will be returned
+    /// as an `Err`.
+    fn to_multiaddr(&self) -> Result<Multiaddr>;
+}
+
+impl ToMultiaddr for SocketAddr {
+    fn to_multiaddr(&self) -> Result<Multiaddr> {
+        match *self {
+            SocketAddr::V4(ref a) => (*a).to_multiaddr(),
+            SocketAddr::V6(ref a) => (*a).to_multiaddr(),
+        }
+    }
+}
+
+impl ToMultiaddr for SocketAddrV4 {
+    fn to_multiaddr(&self) -> Result<Multiaddr> {
+        Multiaddr::new(&format!("/ip4/{}/tcp/{}", self.ip(), self.port()))
+    }
+}
+
+impl ToMultiaddr for SocketAddrV6 {
+    fn to_multiaddr(&self) -> Result<Multiaddr> {
+        // TODO: Should how should we handle `flowinfo` and `scope_id`?
+        Multiaddr::new(&format!("/ip6/{}/tcp/{}", self.ip(), self.port()))
+    }
+}
+
+impl ToMultiaddr for IpAddr {
+    fn to_multiaddr(&self) -> Result<Multiaddr> {
+        match *self {
+            IpAddr::V4(ref a) => (*a).to_multiaddr(),
+            IpAddr::V6(ref a) => (*a).to_multiaddr(),
+        }
+    }
+}
+
+impl ToMultiaddr for Ipv4Addr {
+    fn to_multiaddr(&self) -> Result<Multiaddr> {
+        Multiaddr::new(&format!("/ip4/{}", &self))
+    }
+}
+
+impl ToMultiaddr for Ipv6Addr {
+    fn to_multiaddr(&self) -> Result<Multiaddr> {
+        Multiaddr::new(&format!("/ip6/{}", &self))
+    }
+}
+
+impl ToMultiaddr for String {
+    fn to_multiaddr(&self) -> Result<Multiaddr> {
+        Multiaddr::new(self)
+    }
+}
+
+impl<'a> ToMultiaddr for &'a str {
+    fn to_multiaddr(&self) -> Result<Multiaddr> {
+        Multiaddr::new(self)
+    }
+}
+
+impl ToMultiaddr for Multiaddr {
+    fn to_multiaddr(&self) -> Result<Multiaddr> {
+        Ok(self.clone())
+    }
+}

--- a/rust-multiaddr/src/lib.rs
+++ b/rust-multiaddr/src/lib.rs
@@ -23,7 +23,14 @@ pub struct Multiaddr {
     bytes: Vec<u8>,
 }
 
-impl ToString for Multiaddr {
+impl fmt::Debug for Multiaddr {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.to_string().fmt(f)
+    }
+}
+
+impl fmt::Display for Multiaddr {
     /// Convert a Multiaddr to a string
     ///
     /// # Examples
@@ -35,19 +42,12 @@ impl ToString for Multiaddr {
     /// assert_eq!(address.to_string(), "/ip4/127.0.0.1/udt");
     /// ```
     ///
-    fn to_string(&self) -> String {
-        let mut out = String::new();
-        for s in self.iter() {
-            out.push_str(&s.to_string());
-        }
-        out
-    }
-}
-
-impl fmt::Debug for Multiaddr {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.to_string().fmt(f)
+        for s in self.iter() {
+            s.to_string().fmt(f)?;
+        }
+        Ok(())
     }
 }
 

--- a/rust-multiaddr/src/lib.rs
+++ b/rust-multiaddr/src/lib.rs
@@ -69,10 +69,12 @@ impl Multiaddr {
     /// ]);
     /// ```
     ///
+    #[deprecated(note = "Use `string.parse()` instead")]
     pub fn new(input: &str) -> Result<Multiaddr> {
         let mut bytes = Vec::new();
 
         let mut parts = input.split('/');
+        // A multiaddr must start with `/`
         if !parts.next().ok_or(Error::InvalidMultiaddr)?.is_empty() {
             return Err(Error::InvalidMultiaddr);
         }
@@ -119,6 +121,7 @@ impl Multiaddr {
     /// ```
     ///
     #[inline]
+    #[deprecated(note = "Use `self.iter().map(|addr| addr.protocol_id())` instead")]
     pub fn protocol(&self) -> Vec<ProtocolId> {
         self.iter().map(|addr| addr.protocol_id()).collect()
     }
@@ -144,7 +147,7 @@ impl Multiaddr {
         Ok(Multiaddr { bytes: bytes })
     }
 
-    /// Remove the outer most address from itself.
+    /// Remove the outermost address.
     ///
     /// # Examples
     ///
@@ -249,6 +252,16 @@ impl From<AddrComponent> for Multiaddr {
         let mut out = Vec::new();
         addr.write_bytes(&mut out).expect("writing to a Vec never fails");
         Multiaddr { bytes: out }
+    }
+}
+
+impl<'a> IntoIterator for &'a Multiaddr {
+    type Item = AddrComponent;
+    type IntoIter = Iter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Iter<'a> {
+        Iter(&self.bytes)
     }
 }
 

--- a/rust-multiaddr/src/protocol.rs
+++ b/rust-multiaddr/src/protocol.rs
@@ -1,0 +1,427 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::str::FromStr;
+use std::convert::From;
+use std::io::{Cursor, Write, Result as IoResult};
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use cid::Cid;
+use integer_encoding::{VarInt, VarIntWriter};
+
+use {Result, Error};
+
+///! # ProtocolId
+///!
+///! A type to describe the possible protocol used in a
+///! Multiaddr.
+
+/// ProtocolId is the list of all possible protocols.
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+#[repr(u32)]
+pub enum ProtocolId {
+    IP4 = 4,
+    TCP = 6,
+    UDP = 17,
+    DCCP = 33,
+    IP6 = 41,
+    SCTP = 132,
+    UDT = 301,
+    UTP = 302,
+    IPFS = 421,
+    HTTP = 480,
+    HTTPS = 443,
+    ONION = 444,
+    WS = 477,
+    WSS = 478,
+    Libp2pWebrtcStar = 275,
+    Libp2pWebrtcDirect = 276,
+    P2pCircuit = 290,
+}
+
+impl From<ProtocolId> for u32 {
+    fn from(proto: ProtocolId) -> u32 {
+        proto as u32
+    }
+}
+
+impl From<ProtocolId> for u64 {
+    fn from(proto: ProtocolId) -> u64 {
+        proto as u32 as u64
+    }
+}
+
+impl ToString for ProtocolId {
+    fn to_string(&self) -> String {
+        match *self {
+            ProtocolId::IP4 => "ip4".to_owned(),
+            ProtocolId::TCP => "tcp".to_owned(),
+            ProtocolId::UDP => "udp".to_owned(),
+            ProtocolId::DCCP => "dccp".to_owned(),
+            ProtocolId::IP6 => "ip6".to_owned(),
+            ProtocolId::SCTP => "sctp".to_owned(),
+            ProtocolId::UDT => "udt".to_owned(),
+            ProtocolId::UTP => "utp".to_owned(),
+            ProtocolId::IPFS => "ipfs".to_owned(),
+            ProtocolId::HTTP => "http".to_owned(),
+            ProtocolId::HTTPS => "https".to_owned(),
+            ProtocolId::ONION => "onion".to_owned(),
+            ProtocolId::WS => "ws".to_owned(),
+            ProtocolId::WSS => "wss".to_owned(),
+            ProtocolId::Libp2pWebrtcStar => "libp2p-webrtc-star".to_owned(),
+            ProtocolId::Libp2pWebrtcDirect => "libp2p-webrtc-direct".to_owned(),
+            ProtocolId::P2pCircuit => "p2p-circuit".to_owned(),
+        }
+    }
+}
+
+impl FromStr for ProtocolId {
+    type Err = Error;
+
+    fn from_str(raw: &str) -> Result<Self> {
+        match raw {
+            "ip4" => Ok(ProtocolId::IP4),
+            "tcp" => Ok(ProtocolId::TCP),
+            "udp" => Ok(ProtocolId::UDP),
+            "dccp" => Ok(ProtocolId::DCCP),
+            "ip6" => Ok(ProtocolId::IP6),
+            "sctp" => Ok(ProtocolId::SCTP),
+            "udt" => Ok(ProtocolId::UDT),
+            "utp" => Ok(ProtocolId::UTP),
+            "ipfs" => Ok(ProtocolId::IPFS),
+            "http" => Ok(ProtocolId::HTTP),
+            "https" => Ok(ProtocolId::HTTPS),
+            "onion" => Ok(ProtocolId::ONION),
+            "ws" => Ok(ProtocolId::WS),
+            "wss" => Ok(ProtocolId::WSS),
+            "libp2p-webrtc-star" => Ok(ProtocolId::Libp2pWebrtcStar),
+            "libp2p-webrtc-direct" => Ok(ProtocolId::Libp2pWebrtcDirect),
+            "p2p-circuit" => Ok(ProtocolId::P2pCircuit),
+            _ => Err(Error::UnknownProtocolString),
+        }
+    }
+}
+
+
+impl ProtocolId {
+    /// Convert a `u64` based code to a `ProtocolId`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use multiaddr::ProtocolId;
+    ///
+    /// assert_eq!(ProtocolId::from(6).unwrap(), ProtocolId::TCP);
+    /// assert!(ProtocolId::from(455).is_err());
+    /// ```
+    pub fn from(raw: u64) -> Result<ProtocolId> {
+        match raw {
+            4 => Ok(ProtocolId::IP4),
+            6 => Ok(ProtocolId::TCP),
+            17 => Ok(ProtocolId::UDP),
+            33 => Ok(ProtocolId::DCCP),
+            41 => Ok(ProtocolId::IP6),
+            132 => Ok(ProtocolId::SCTP),
+            301 => Ok(ProtocolId::UDT),
+            302 => Ok(ProtocolId::UTP),
+            421 => Ok(ProtocolId::IPFS),
+            480 => Ok(ProtocolId::HTTP),
+            443 => Ok(ProtocolId::HTTPS),
+            444 => Ok(ProtocolId::ONION),
+            477 => Ok(ProtocolId::WS),
+            478 => Ok(ProtocolId::WSS),
+            275 => Ok(ProtocolId::Libp2pWebrtcStar),
+            276 => Ok(ProtocolId::Libp2pWebrtcDirect),
+            290 => Ok(ProtocolId::P2pCircuit),
+            _ => Err(Error::UnknownProtocol),
+        }
+    }
+
+    /// Get the size from a `ProtocolId`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use multiaddr::ProtocolId;
+    /// use multiaddr::ProtocolArgSize;
+    ///
+    /// assert_eq!(ProtocolId::TCP.size(), ProtocolArgSize::Fixed { bytes: 2 });
+    /// ```
+    ///
+    pub fn size(&self) -> ProtocolArgSize {
+        match *self {
+            ProtocolId::IP4 => ProtocolArgSize::Fixed { bytes: 4 },
+            ProtocolId::TCP => ProtocolArgSize::Fixed { bytes: 2 },
+            ProtocolId::UDP => ProtocolArgSize::Fixed { bytes: 2 },
+            ProtocolId::DCCP => ProtocolArgSize::Fixed { bytes: 2 },
+            ProtocolId::IP6 => ProtocolArgSize::Fixed { bytes: 16 },
+            ProtocolId::SCTP => ProtocolArgSize::Fixed { bytes: 2 },
+            ProtocolId::UDT => ProtocolArgSize::Fixed { bytes: 0 },
+            ProtocolId::UTP => ProtocolArgSize::Fixed { bytes: 0 },
+            ProtocolId::IPFS => ProtocolArgSize::Variable,
+            ProtocolId::HTTP => ProtocolArgSize::Fixed { bytes: 0 },
+            ProtocolId::HTTPS => ProtocolArgSize::Fixed { bytes: 0 },
+            ProtocolId::ONION => ProtocolArgSize::Fixed { bytes: 10 },
+            ProtocolId::WS => ProtocolArgSize::Fixed { bytes: 0 },
+            ProtocolId::WSS => ProtocolArgSize::Fixed { bytes: 0 },
+            ProtocolId::Libp2pWebrtcStar => ProtocolArgSize::Fixed { bytes: 0 },
+            ProtocolId::Libp2pWebrtcDirect => ProtocolArgSize::Fixed { bytes: 0 },
+            ProtocolId::P2pCircuit => ProtocolArgSize::Fixed { bytes: 0 },
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ProtocolArgSize {
+    /// The size of the argument is of fixed length. The length can be 0, in which case there is no
+    /// argument.
+    Fixed { bytes: usize },
+    /// The size of the argument is of variable length.
+    Variable,
+}
+
+impl ProtocolId {
+    /// Convert an array slice to the string representation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::net::Ipv4Addr;
+    /// use multiaddr::AddrComponent;
+    /// use multiaddr::ProtocolId;
+    ///
+    /// let proto = ProtocolId::IP4;
+    /// assert_eq!(proto.parse_data("127.0.0.1").unwrap(),
+    ///            AddrComponent::IP4(Ipv4Addr::new(127, 0, 0, 1)));
+    /// ```
+    ///
+    pub fn parse_data(&self, a: &str) -> Result<AddrComponent> {
+        match *self {
+            ProtocolId::IP4 => {
+                let addr = Ipv4Addr::from_str(a)?;
+                Ok(AddrComponent::IP4(addr))
+            }
+            ProtocolId::IP6 => {
+                let addr = Ipv6Addr::from_str(a)?;
+                Ok(AddrComponent::IP6(addr))
+            }
+            ProtocolId::TCP => {
+                let parsed: u16 = a.parse()?;
+                Ok(AddrComponent::TCP(parsed))
+            }
+            ProtocolId::UDP => {
+                let parsed: u16 = a.parse()?;
+                Ok(AddrComponent::UDP(parsed))
+            }
+            ProtocolId::DCCP => {
+                let parsed: u16 = a.parse()?;
+                Ok(AddrComponent::DCCP(parsed))
+            }
+            ProtocolId::SCTP => {
+                let parsed: u16 = a.parse()?;
+                Ok(AddrComponent::SCTP(parsed))
+            }
+            ProtocolId::IPFS => {
+                let bytes = Cid::from(a)?.to_bytes();
+                Ok(AddrComponent::IPFS(bytes))
+            }
+            ProtocolId::ONION => unimplemented!(),              // TODO:
+            ProtocolId::UTP => Ok(AddrComponent::UTP),
+            ProtocolId::UDT => Ok(AddrComponent::UDT),
+            ProtocolId::HTTP => Ok(AddrComponent::HTTP),
+            ProtocolId::HTTPS => Ok(AddrComponent::HTTPS),
+            ProtocolId::WS => Ok(AddrComponent::WS),
+            ProtocolId::WSS => Ok(AddrComponent::WSS),
+            ProtocolId::Libp2pWebrtcStar => Ok(AddrComponent::Libp2pWebrtcStar),
+            ProtocolId::Libp2pWebrtcDirect => Ok(AddrComponent::Libp2pWebrtcDirect),
+            ProtocolId::P2pCircuit => Ok(AddrComponent::P2pCircuit),
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum AddrComponent {
+    IP4(Ipv4Addr),
+    TCP(u16),
+    UDP(u16),
+    DCCP(u16),
+    IP6(Ipv6Addr),
+    SCTP(u16),
+    UDT,
+    UTP,
+    IPFS(Vec<u8>),
+    HTTP,
+    HTTPS,
+    ONION(Vec<u8>),
+    WS,
+    WSS,
+    Libp2pWebrtcStar,
+    Libp2pWebrtcDirect,
+    P2pCircuit,
+}
+
+impl AddrComponent {
+    /// Returns the `ProtocolId` corresponding to this `AddrComponent`.
+    #[inline]
+    pub fn protocol_id(&self) -> ProtocolId {
+        match *self {
+            AddrComponent::IP4(_) => ProtocolId::IP4,
+            AddrComponent::TCP(_) => ProtocolId::TCP,
+            AddrComponent::UDP(_) => ProtocolId::UDP,
+            AddrComponent::DCCP(_) => ProtocolId::DCCP,
+            AddrComponent::IP6(_) => ProtocolId::IP6,
+            AddrComponent::SCTP(_) => ProtocolId::SCTP,
+            AddrComponent::UDT => ProtocolId::UDT,
+            AddrComponent::UTP => ProtocolId::UTP,
+            AddrComponent::IPFS(_) => ProtocolId::IPFS,
+            AddrComponent::HTTP => ProtocolId::HTTP,
+            AddrComponent::HTTPS => ProtocolId::HTTPS,
+            AddrComponent::ONION(_) => ProtocolId::ONION,
+            AddrComponent::WS => ProtocolId::WS,
+            AddrComponent::WSS => ProtocolId::WSS,
+            AddrComponent::Libp2pWebrtcStar => ProtocolId::Libp2pWebrtcStar,
+            AddrComponent::Libp2pWebrtcDirect => ProtocolId::Libp2pWebrtcDirect,
+            AddrComponent::P2pCircuit => ProtocolId::P2pCircuit,
+        }
+    }
+
+    pub fn from_bytes(input: &[u8]) -> Result<(AddrComponent, &[u8])> {
+        let (proto_num, proto_id_len) = u64::decode_var(input);   // TODO: will panic if ID too large
+
+        let protocol_id = ProtocolId::from(proto_num)?;
+        let (data_offset, data_size) = match protocol_id.size() {
+            ProtocolArgSize::Fixed { bytes } => {
+                (0, bytes)
+            },
+            ProtocolArgSize::Variable => {
+                let (data_size, varint_len) = u64::decode_var(&input[proto_id_len..]);      // TODO: will panic if ID too large
+                (varint_len, data_size as usize)
+            },
+        };
+
+        let (data, rest) = input[proto_id_len..][data_offset..].split_at(data_size);
+
+        let addr_component = match protocol_id {
+            ProtocolId::IP4 => {
+                AddrComponent::IP4(Ipv4Addr::new(data[0], data[1], data[2], data[3]))
+            },
+            ProtocolId::IP6 => {
+                let mut rdr = Cursor::new(data);
+                let mut seg = vec![];
+
+                for _ in 0..8 {
+                    seg.push(rdr.read_u16::<BigEndian>()?);
+                }
+
+                let addr = Ipv6Addr::new(seg[0],
+                                         seg[1],
+                                         seg[2],
+                                         seg[3],
+                                         seg[4],
+                                         seg[5],
+                                         seg[6],
+                                         seg[7]);
+                AddrComponent::IP6(addr)
+            }
+            ProtocolId::TCP => {
+                let mut rdr = Cursor::new(data);
+                let num = rdr.read_u16::<BigEndian>()?;
+                AddrComponent::TCP(num)
+            }
+            ProtocolId::UDP => {
+                let mut rdr = Cursor::new(data);
+                let num = rdr.read_u16::<BigEndian>()?;
+                AddrComponent::UDP(num)
+            }
+            ProtocolId::DCCP => {
+                let mut rdr = Cursor::new(data);
+                let num = rdr.read_u16::<BigEndian>()?;
+                AddrComponent::DCCP(num)
+            }
+            ProtocolId::SCTP => {
+                let mut rdr = Cursor::new(data);
+                let num = rdr.read_u16::<BigEndian>()?;
+                AddrComponent::SCTP(num)
+            }
+            ProtocolId::IPFS => {
+                let bytes = Cid::from(data)?.to_bytes();
+                AddrComponent::IPFS(bytes)
+            }
+            ProtocolId::ONION => unimplemented!(),      // TODO:
+            ProtocolId::UTP => AddrComponent::UTP,
+            ProtocolId::UDT => AddrComponent::UDT,
+            ProtocolId::HTTP => AddrComponent::HTTP,
+            ProtocolId::HTTPS => AddrComponent::HTTPS,
+            ProtocolId::WS => AddrComponent::WS,
+            ProtocolId::WSS => AddrComponent::WSS,
+            ProtocolId::Libp2pWebrtcStar => AddrComponent::Libp2pWebrtcStar,
+            ProtocolId::Libp2pWebrtcDirect => AddrComponent::Libp2pWebrtcDirect,
+            ProtocolId::P2pCircuit => AddrComponent::P2pCircuit,
+        };
+
+        Ok((addr_component, rest))
+    }
+
+    /// Turns this address component into bytes by writing it to a `Write`.
+    pub fn write_bytes<W: Write>(self, out: &mut W) -> IoResult<()> {
+        out.write_varint(Into::<u64>::into(self.protocol_id()))?;
+
+        match self {
+            AddrComponent::IP4(addr) => {
+                out.write_all(&addr.octets())?;
+            }
+            AddrComponent::IP6(addr) => {
+                for &segment in &addr.segments() {
+                    out.write_u16::<BigEndian>(segment)?;
+                }
+            }
+            AddrComponent::TCP(port) | AddrComponent::UDP(port) | AddrComponent::DCCP(port) |
+            AddrComponent::SCTP(port) => {
+                out.write_u16::<BigEndian>(port)?;
+            }
+            AddrComponent::IPFS(bytes) => {
+                out.write_varint(bytes.len())?;
+                out.write_all(&bytes)?;
+            }
+            AddrComponent::ONION(_) => {
+                unimplemented!()  // TODO:
+            },
+            AddrComponent::UTP |
+            AddrComponent::UDT |
+            AddrComponent::HTTP |
+            AddrComponent::HTTPS |
+            AddrComponent::WS |
+            AddrComponent::WSS |
+            AddrComponent::Libp2pWebrtcStar |
+            AddrComponent::Libp2pWebrtcDirect |
+            AddrComponent::P2pCircuit => {}
+        };
+
+        Ok(())
+    }
+}
+
+impl ToString for AddrComponent {
+    fn to_string(&self) -> String {
+        match *self {
+            AddrComponent::IP4(ref addr) => format!("/ip4/{}", addr),
+            AddrComponent::TCP(port) => format!("/tcp/{}", port),
+            AddrComponent::UDP(port) => format!("/udp/{}", port),
+            AddrComponent::DCCP(port) => format!("/dccp/{}", port),
+            AddrComponent::IP6(ref addr) => format!("/ip6/{}", addr),
+            AddrComponent::SCTP(port) => format!("/sctp/{}", port),
+            AddrComponent::UDT => format!("/udt"),
+            AddrComponent::UTP => format!("/utp"),
+            AddrComponent::IPFS(ref bytes) => {
+                // TODO: meh for cloning
+                let c = Cid::from(bytes.clone()).expect("cid is known to be valid");
+                format!("/ipfs/{}", c)
+            },
+            AddrComponent::HTTP => format!("/http"),
+            AddrComponent::HTTPS => format!("/https"),
+            AddrComponent::ONION(_) => unimplemented!(),//format!("/onion"),        // TODO:
+            AddrComponent::WS => format!("/ws"),
+            AddrComponent::WSS => format!("/wss"),
+            AddrComponent::Libp2pWebrtcStar => format!("/libp2p-webrtc-star"),
+            AddrComponent::Libp2pWebrtcDirect => format!("/libp2p-webrtc-direct"),
+            AddrComponent::P2pCircuit => format!("/p2p-circuit"),
+        }
+    }
+}

--- a/rust-multiaddr/tests/lib.rs
+++ b/rust-multiaddr/tests/lib.rs
@@ -1,0 +1,171 @@
+extern crate multiaddr;
+extern crate data_encoding;
+
+use data_encoding::hex;
+use multiaddr::*;
+use std::net::{SocketAddrV4, SocketAddrV6, Ipv4Addr, Ipv6Addr};
+
+#[test]
+fn protocol_to_code() {
+    assert_eq!(ProtocolId::IP4 as usize, 4);
+}
+
+#[test]
+fn protocol_to_name() {
+    assert_eq!(ProtocolId::TCP.to_string(), "tcp");
+}
+
+
+fn assert_bytes(source: &str, target: &str, protocols: Vec<ProtocolId>) -> () {
+    let address = Multiaddr::new(source).unwrap();
+    assert_eq!(hex::encode(address.to_bytes().as_slice()), target);
+    assert_eq!(address.protocol(), protocols);
+}
+fn ma_valid(source: &str, target: &str, protocols: Vec<ProtocolId>) -> () {
+    assert_bytes(source, target, protocols);
+    assert_eq!(Multiaddr::new(source).unwrap().to_string(), source);
+}
+
+#[test]
+fn multiaddr_eq() {
+    let m1 = Multiaddr::new("/ip4/127.0.0.1/udp/1234").unwrap();
+    let m2 = Multiaddr::new("/ip4/127.0.0.1/tcp/1234").unwrap();
+    let m3 = Multiaddr::new("/ip4/127.0.0.1/tcp/1234").unwrap();
+
+    assert_ne!(m1, m2);
+    assert_ne!(m2, m1);
+    assert_eq!(m2, m3);
+    assert_eq!(m1, m1);
+}
+
+#[test]
+fn construct_success() {
+    use ProtocolId::*;
+
+    ma_valid("/ip4/1.2.3.4", "0401020304", vec![IP4]);
+    ma_valid("/ip4/0.0.0.0", "0400000000", vec![IP4]);
+    ma_valid("/ip6/::1", "2900000000000000000000000000000001", vec![IP6]);
+    ma_valid("/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21",
+             "29260100094F819700803ECA6566E80C21",
+             vec![IP6]);
+    ma_valid("/udp/0", "110000", vec![UDP]);
+    ma_valid("/tcp/0", "060000", vec![TCP]);
+    ma_valid("/sctp/0", "84010000", vec![SCTP]);
+    ma_valid("/udp/1234", "1104D2", vec![UDP]);
+    ma_valid("/tcp/1234", "0604D2", vec![TCP]);
+    ma_valid("/sctp/1234", "840104D2", vec![SCTP]);
+    ma_valid("/udp/65535", "11FFFF", vec![UDP]);
+    ma_valid("/tcp/65535", "06FFFF", vec![TCP]);
+    ma_valid("/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+             "A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
+             vec![IPFS]);
+    ma_valid("/udp/1234/sctp/1234", "1104D2840104D2", vec![UDP, SCTP]);
+    ma_valid("/udp/1234/udt", "1104D2AD02", vec![UDP, UDT]);
+    ma_valid("/udp/1234/utp", "1104D2AE02", vec![UDP, UTP]);
+    ma_valid("/tcp/1234/http", "0604D2E003", vec![TCP, HTTP]);
+    ma_valid("/tcp/1234/https", "0604D2BB03", vec![TCP, HTTPS]);
+    ma_valid("/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+             "A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B0604D2",
+             vec![IPFS, TCP]);
+    ma_valid("/ip4/127.0.0.1/udp/1234",
+             "047F0000011104D2",
+             vec![IP4, UDP]);
+    ma_valid("/ip4/127.0.0.1/udp/0", "047F000001110000", vec![IP4, UDP]);
+    ma_valid("/ip4/127.0.0.1/tcp/1234",
+             "047F0000010604D2",
+             vec![IP4, TCP]);
+    ma_valid("/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+             "047F000001A503221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
+             vec![IP4, IPFS]);
+    ma_valid("/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+             "047F000001A503221220D52EBB89D85B02A284948203A\
+62FF28389C57C9F42BEEC4EC20DB76A68911C0B0604D2",
+             vec![IP4, IPFS, TCP]);
+    // /unix/a/b/c/d/e,
+    // /unix/stdio,
+    // /ip4/1.2.3.4/tcp/80/unix/a/b/c/d/e/f,
+    // /ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio
+    ma_valid("/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:\
+              7095/tcp/8000/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+             "29200108A07AC542013AC986FFFE317095061F40DD03A5\
+03221220D52EBB89D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
+             vec![IP6, TCP, WS, IPFS]);
+    ma_valid("/libp2p-webrtc-star/ip4/127.0.0.\
+              1/tcp/9090/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+             "9302047F000001062382DD03A503221220D52EBB89D85B\
+02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
+             vec![Libp2pWebrtcStar, IP4, TCP, WS, IPFS]);
+    ma_valid("/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:\
+              7095/tcp/8000/wss/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+             "29200108A07AC542013AC986FFFE317095061F40DE03A503221220D52EBB8\
+9D85B02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
+             vec![IP6, TCP, WSS, IPFS]);
+    ma_valid("/ip4/127.0.0.1/tcp/9090/p2p-circuit/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+             "047F000001062382A202A503221220D52EBB89D85B\
+02A284948203A62FF28389C57C9F42BEEC4EC20DB76A68911C0B",
+             vec![IP4, TCP, P2pCircuit, IPFS]);
+}
+
+#[test]
+fn construct_fail() {
+    let addresses = ["/ip4",
+                     "/ip4/::1",
+                     "/ip4/fdpsofodsajfdoisa",
+                     "/ip6",
+                     "/udp",
+                     "/tcp",
+                     "/sctp",
+                     "/udp/65536",
+                     "/tcp/65536",
+                     // "/onion/9imaq4ygg2iegci7:80",
+                     // "/onion/aaimaq4ygg2iegci7:80",
+                     // "/onion/timaq4ygg2iegci7:0",
+                     // "/onion/timaq4ygg2iegci7:-1",
+                     // "/onion/timaq4ygg2iegci7",
+                     // "/onion/timaq4ygg2iegci@:666",
+                     "/udp/1234/sctp",
+                     "/udp/1234/udt/1234",
+                     "/udp/1234/utp/1234",
+                     "/ip4/127.0.0.1/udp/jfodsajfidosajfoidsa",
+                     "/ip4/127.0.0.1/udp",
+                     "/ip4/127.0.0.1/tcp/jfodsajfidosajfoidsa",
+                     "/ip4/127.0.0.1/tcp",
+                     "/ip4/127.0.0.1/ipfs",
+                     "/ip4/127.0.0.1/ipfs/tcp",
+                     "/p2p-circuit/50"];
+
+    for address in &addresses {
+        assert!(Multiaddr::new(address).is_err(), address.to_string());
+    }
+}
+
+
+#[test]
+fn to_multiaddr() {
+    assert_eq!(Ipv4Addr::new(127, 0, 0, 1).to_multiaddr().unwrap(),
+               Multiaddr::new("/ip4/127.0.0.1").unwrap());
+    assert_eq!(Ipv6Addr::new(0x2601, 0x9, 0x4f81, 0x9700, 0x803e, 0xca65, 0x66e8, 0xc21)
+                   .to_multiaddr()
+                   .unwrap(),
+               Multiaddr::new("/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21").unwrap());
+    assert_eq!("/ip4/127.0.0.1/tcp/1234".to_string().to_multiaddr().unwrap(),
+               Multiaddr::new("/ip4/127.0.0.1/tcp/1234").unwrap());
+    assert_eq!("/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21".to_multiaddr().unwrap(),
+               Multiaddr::new("/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21").unwrap());
+    assert_eq!(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 1234).to_multiaddr().unwrap(),
+               Multiaddr::new("/ip4/127.0.0.1/tcp/1234").unwrap());
+    assert_eq!(SocketAddrV6::new(Ipv6Addr::new(0x2601,
+                                               0x9,
+                                               0x4f81,
+                                               0x9700,
+                                               0x803e,
+                                               0xca65,
+                                               0x66e8,
+                                               0xc21),
+                                 1234,
+                                 0,
+                                 0)
+                   .to_multiaddr()
+                   .unwrap(),
+               Multiaddr::new("/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21/tcp/1234").unwrap());
+}


### PR DESCRIPTION
I've been working on improving `rust-multiaddr`, and have opened [an upstream PR](https://github.com/multiformats/rust-multiaddr/pull/28).
However:
- This PR is likely going to take a long time to get reviewed, as it contains big design changes.
- Some necessary changes and improvements may have been missed.

Therefore this PR integrates `rust-multiaddr` to the current repository, with the intent to remove it in the future after its design has been fleshed out.

Also modifies `tcp-transport` to use the new design.
