### PR TITLE
Change the MuxedTransport trait 

### DIFF
--- a/libp2p-swarm/Cargo.toml
+++ b/libp2p-swarm/Cargo.toml
@@ -8,6 +8,7 @@ bytes = "0.4"
 multiaddr = "0.2.0"
 multistream-select = { path = "../multistream-select" }
 futures = { version = "0.1", features = ["use_std"] }
+parking_lot = "0.5.3"
 smallvec = "0.5"
 tokio-io = "0.1"
 

--- a/libp2p-swarm/src/lib.rs
+++ b/libp2p-swarm/src/lib.rs
@@ -48,11 +48,12 @@
 //! The `MuxedTransport` trait is an extension to the `Transport` trait, and is implemented on
 //! transports that can receive incoming connections on streams that have been opened with `dial()`.
 //! 
-//! The trait provides the `dial_and_listen()` method, which returns both a dialer and a stream of
-//! incoming connections.
+//! The trait provides the `next_incoming()` method, which returns a future that will resolve to
+//! the next substream that arrives from a dialed node.
 //! 
 //! > **Note**: This trait is mainly implemented for transports that provide stream muxing
-//! >           capabilities.
+//! >           capabilities, but it can also be implemented in a dummy way by returning an empty
+//! >           iterator.
 //! 
 //! # Connection upgrades
 //! 
@@ -78,7 +79,7 @@
 //! `Transport` trait. The return value of this method also implements the `Transport` trait, which
 //! means that you can call `dial()` and `listen_on()` on it in order to directly obtain an
 //! upgraded connection or a listener that will yield upgraded connections. Similarly, the
-//! `dial_and_listen()` method will automatically apply the upgrade on both the dialer and the
+//! `next_incoming()` method will automatically apply the upgrade on both the dialer and the
 //! listener. An error is produced if the remote doesn't support the protocol corresponding to the
 //! connection upgrade.
 //! 
@@ -123,7 +124,7 @@
 //! transport.
 //! 
 //! However the `UpgradedNode` struct returned by `with_upgrade` still provides methods named
-//! `dial`, `listen_on`, and `dial_and_listen`, which will yield you a `Future` or a `Stream`,
+//! `dial`, `listen_on`, and `next_incoming`, which will yield you a `Future` or a `Stream`,
 //! which you can use to obtain the `Output`. This `Output` can then be used in a protocol-specific
 //! way to use the protocol.
 //! 

--- a/libp2p-swarm/src/lib.rs
+++ b/libp2p-swarm/src/lib.rs
@@ -167,6 +167,7 @@ extern crate bytes;
 #[macro_use]
 extern crate futures;
 extern crate multistream_select;
+extern crate parking_lot;
 extern crate smallvec;
 extern crate tokio_io;
 


### PR DESCRIPTION
Based over #80 

Right now the `MuxedTransport` trait provides three methods: `dial`, `listen_on` and `dial_and_listen`. The difference between `dial` and `dial_and_listen` is that the latter allows you to handle the substreams that are opened by the node you dialed.
Whenever you use a muxed transport, you are strongly encouraged to use `dial_and_listen` instead of just `dial`.

This PR simplifies this design by removing `dial_and_listen` entirely, and replacing it with a `next_incoming` method that will consume the transport and return the next opened substream. Since the transport is generally clonable, you can easily turn that into a stream of incoming connections.
