### PR TITLE
Fix the build by pinning a commit of ring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [replace]
-# Ring has a feature merged in master that hasn't been published yet ; remove this after 0.12.2
-"ring:0.12.1" = { git = "https://github.com/briansmith/ring" }
+# TODO: Update ring and solve conflicts
+"ring:0.12.1" = { git = "https://github.com/briansmith/ring", rev = "3a14ef619559f7d4b69e2286d49c833409eef34a" }
 # Using a local improved version of multiaddr for now
 "multiaddr:0.2.0" = { path = "./rust-multiaddr" }


### PR DESCRIPTION
Fixes the compilation.

Now that a new version of `ring` has been released, it should be possible to upgrade to version 0.13. However this is far from being straight-forward because you cannot have two versions of ring in parallel in the same project.

Therefore for now this PR takes the most straight-forward approach, and uses version 0.12.1.