### PR TITLE
Correctly report the address of the dialer in the identify protocol

### DIFF
--- a/libp2p-secio/src/lib.rs
+++ b/libp2p-secio/src/lib.rs
@@ -95,6 +95,7 @@ pub use self::error::SecioError;
 use bytes::{Bytes, BytesMut};
 use futures::{Future, Poll, StartSend, Sink, Stream};
 use futures::stream::MapErr as StreamMapErr;
+use libp2p_swarm::Multiaddr;
 use ring::signature::RSAKeyPair;
 use rw_stream_sink::RwStreamSink;
 use std::error::Error;
@@ -197,7 +198,7 @@ impl<S> libp2p_swarm::ConnectionUpgrade<S> for SecioConfig
 	}
 
 	#[inline]
-	fn upgrade(self, incoming: S, _: (), _: libp2p_swarm::Endpoint) -> Self::Future {
+	fn upgrade(self, incoming: S, _: (), _: libp2p_swarm::Endpoint, _: &Multiaddr) -> Self::Future {
 		let fut = SecioMiddleware::handshake(
 			incoming,
 			self.key,

--- a/multiplex-rs/src/lib.rs
+++ b/multiplex-rs/src/lib.rs
@@ -42,7 +42,7 @@ use futures::{Async, Future, Poll};
 use futures::future::{self, FutureResult};
 use header::MultiplexHeader;
 use swarm::muxing::StreamMuxer;
-use swarm::{ConnectionUpgrade, Endpoint};
+use swarm::{ConnectionUpgrade, Endpoint, Multiaddr};
 use futures_mutex::Mutex;
 use read::{read_stream, MultiplexReadState};
 use shared::{buf_from_slice, ByteBuf, MultiplexShared};
@@ -348,7 +348,7 @@ where
     type NamesIter = iter::Once<(Bytes, ())>;
 
     #[inline]
-    fn upgrade(self, i: C, _: (), end: Endpoint) -> Self::Future {
+    fn upgrade(self, i: C, _: (), end: Endpoint, _: &Multiaddr) -> Self::Future {
         future::ok(Multiplex::new(i, end))
     }
 


### PR DESCRIPTION
Right now the user of the library has to specify in advance the value of `observed_addr` that will be sent to the remotes that connect to us, which doesn't make sense as the `observed_addr` is supposed to the address that the server sees for the dialer.

This PR modifies the API of `ConnectionUpgrade` and adds a parameter to `upgrade` indicating the address of the remote. This is then used by the identify protocol in order to send the correct value.