### PR TITLE
Add an ipfs_bootstrap function to fill the peer store

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -6,7 +6,9 @@ authors = ["pierre <pierre.krieger1708@gmail.com>"]
 [dependencies]
 bytes = "0.4"
 futures = "0.1"
+multiaddr = { path = "../rust-multiaddr" }
 multiplex = { path = "../multiplex-rs" }
+libp2p-peerstore = { path = "../libp2p-peerstore" }
 libp2p-secio = { path = "../libp2p-secio" }
 libp2p-swarm = { path = "../libp2p-swarm" }
 libp2p-tcp-transport = { path = "../libp2p-tcp-transport" }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -1,0 +1,64 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+extern crate libp2p_peerstore;
+extern crate libp2p_swarm;
+extern crate multiaddr;
+
+use libp2p_peerstore::{PeerAccess, Peerstore};
+use libp2p_swarm::Multiaddr;
+use std::time::Duration;
+
+/// Stores initial addresses on the given peer store. Uses a very large timeout.
+pub fn ipfs_bootstrap<P>(peer_store: P)
+where
+	P: Peerstore + Clone,
+{
+	const ADDRESSES: [&'static str; 9] = [
+        "/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
+        "/ip4/104.236.179.241/tcp/4001/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM",
+        "/ip4/162.243.248.213/tcp/4001/ipfs/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm",
+        "/ip4/128.199.219.111/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu",
+        "/ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64",
+        "/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
+        "/ip4/178.62.61.185/tcp/4001/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3",
+        "/dns4/wss0.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmZMxNdpMkewiVZLMRxaNxUeZpDUb34pWjZ1kZvsd16Zic",
+        "/dns4/wss1.bootstrap.libp2p.io/tcp/443/wss/ipfs/Qmbut9Ywz9YEDrz8ySBSgWyJk41Uvm2QJPhwDJzJyGFsD6"
+    ];
+
+	let ttl = Duration::from_secs(100 * 365 * 24 * 3600);
+
+	for address in ADDRESSES.iter() {
+		let mut multiaddr = address
+			.parse::<Multiaddr>()
+			.expect("failed to parse hard-coded multiaddr");
+
+		let ipfs_component = multiaddr.pop().expect("hard-coded multiaddr isn't empty");
+		let public_key = match ipfs_component {
+			multiaddr::AddrComponent::IPFS(key) => key,
+			_ => panic!("hard-coded multiaddr didn't end with /ipfs/"),
+		};
+
+		peer_store
+			.clone()
+			.peer_or_create(&public_key)
+			.add_addr(multiaddr, ttl.clone());
+	}
+}

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -31,7 +31,7 @@ pub fn ipfs_bootstrap<P>(peer_store: P)
 where
 	P: Peerstore + Clone,
 {
-	const ADDRESSES: [&'static str; 9] = [
+	const ADDRESSES: &[&str] = &[
         "/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
         "/ip4/104.236.179.241/tcp/4001/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM",
         "/ip4/162.243.248.213/tcp/4001/ipfs/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm",

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -23,7 +23,7 @@ extern crate libp2p_swarm;
 extern crate multiaddr;
 
 use libp2p_peerstore::{PeerAccess, Peerstore};
-use libp2p_swarm::Multiaddr;
+use multiaddr::Multiaddr;
 use std::time::Duration;
 
 /// Stores initial addresses on the given peer store. Uses a very large timeout.
@@ -50,7 +50,7 @@ where
 			.parse::<Multiaddr>()
 			.expect("failed to parse hard-coded multiaddr");
 
-		let ipfs_component = multiaddr.pop().expect("hard-coded multiaddr isn't empty");
+		let ipfs_component = multiaddr.pop().expect("hard-coded multiaddr is empty");
 		let public_key = match ipfs_component {
 			multiaddr::AddrComponent::IPFS(key) => key,
 			_ => panic!("hard-coded multiaddr didn't end with /ipfs/"),


### PR DESCRIPTION
Fills a peer store with the default bootstrap nodes of IPFS. For example purposes.