### PR TITLE
Simplify the swarm by not requiring `AsyncRead + AsyncWrite`

### DIFF
--- a/example/examples/echo-server.rs
+++ b/example/examples/echo-server.rs
@@ -74,25 +74,24 @@ fn main() {
         // `Transport` because the output of the upgrade is not a stream but a controller for
         // muxing. We have to explicitly call `into_connection_reuse()` in order to turn this into
         // a `Transport`.
-        .into_connection_reuse();
+        .into_connection_reuse()
+
+        // On top of this, use a custom "echo" protocol.
+        .with_upgrade(SimpleProtocol::new("/echo/1.0.0", |socket| {
+            // This closure is called whenever a stream using the "echo" protocol has been
+            // successfully negotiated. The parameter is the raw socket (implements the AsyncRead
+            // and AsyncWrite traits), and the closure must return an implementation of
+            // `IntoFuture` that can yield any type of object.
+            Ok(length_delimited::Framed::<_, bytes::BytesMut>::new(socket))
+        }));
 
     // We now have a `transport` variable that can be used either to dial nodes or listen to
     // incoming connections, and that will automatically apply secio and multiplex on top
     // of any opened stream.
 
-    // We now prepare the protocol that we are going to negotiate with nodes that open a connection
-    // or substream to our server.
-    let proto = SimpleProtocol::new("/echo/1.0.0", |socket| {
-        // This closure is called whenever a stream using the "echo" protocol has been
-        // successfully negotiated. The parameter is the raw socket (implements the AsyncRead
-        // and AsyncWrite traits), and the closure must return an implementation of
-        // `IntoFuture` that can yield any type of object.
-        Ok(length_delimited::Framed::<_, bytes::BytesMut>::new(socket))
-    });
-
     // Let's put this `transport` into a *swarm*. The swarm will handle all the incoming and
     // outgoing connections for us.
-    let (swarm_controller, swarm_future) = swarm::swarm(transport, proto, |socket, client_addr| {
+    let (swarm_controller, swarm_future) = swarm::swarm(transport, |socket, client_addr| {
         println!("Successfully negotiated protocol with {}", client_addr);
 
         // The type of `socket` is exactly what the closure of `SimpleProtocol` returns.

--- a/libp2p-swarm/src/connection_reuse.rs
+++ b/libp2p-swarm/src/connection_reuse.rs
@@ -66,7 +66,7 @@ use transport::{ConnectionUpgrade, MuxedTransport, Transport, UpgradedNode};
 pub struct ConnectionReuse<T, C>
 where
 	T: Transport,
-	C: ConnectionUpgrade<T::RawConn>,
+	C: ConnectionUpgrade<T::Output>,
 {
 	// Underlying transport and connection upgrade for when we need to dial or listen.
 	inner: UpgradedNode<T, C>,
@@ -83,7 +83,7 @@ struct Shared<O> {
 impl<T, C> From<UpgradedNode<T, C>> for ConnectionReuse<T, C>
 where
 	T: Transport,
-	C: ConnectionUpgrade<T::RawConn>,
+	C: ConnectionUpgrade<T::Output>,
 {
 	#[inline]
 	fn from(node: UpgradedNode<T, C>) -> ConnectionReuse<T, C> {
@@ -100,16 +100,16 @@ where
 impl<T, C> Transport for ConnectionReuse<T, C>
 where
 	T: Transport + 'static,                     // TODO: 'static :(
-	T::RawConn: AsyncRead + AsyncWrite,
-	C: ConnectionUpgrade<T::RawConn> + 'static, // TODO: 'static :(
+	T::Output: AsyncRead + AsyncWrite,
+	C: ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :(
 	C: Clone,
 	C::Output: StreamMuxer + Clone,
 	C::NamesIter: Clone, // TODO: not elegant
 {
-	type RawConn = <C::Output as StreamMuxer>::Substream;
+	type Output = <C::Output as StreamMuxer>::Substream;
 	type Listener = Box<Stream<Item = (Self::ListenerUpgrade, Multiaddr), Error = IoError>>;
-	type ListenerUpgrade = FutureResult<Self::RawConn, IoError>;
-	type Dial = Box<Future<Item = Self::RawConn, Error = IoError>>;
+	type ListenerUpgrade = FutureResult<Self::Output, IoError>;
+	type Dial = Box<Future<Item = Self::Output, Error = IoError>>;
 
 	fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
 		let (listener, new_addr) = match self.inner.listen_on(addr.clone()) {
@@ -160,8 +160,8 @@ where
 impl<T, C> MuxedTransport for ConnectionReuse<T, C>
 where
 	T: Transport + 'static,                     // TODO: 'static :(
-	T::RawConn: AsyncRead + AsyncWrite,
-	C: ConnectionUpgrade<T::RawConn> + 'static, // TODO: 'static :(
+	T::Output: AsyncRead + AsyncWrite,
+	C: ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :(
 	C: Clone,
 	C::Output: StreamMuxer + Clone,
 	C::NamesIter: Clone, // TODO: not elegant

--- a/libp2p-swarm/src/connection_reuse.rs
+++ b/libp2p-swarm/src/connection_reuse.rs
@@ -54,6 +54,7 @@ use parking_lot::Mutex;
 use smallvec::SmallVec;
 use std::io::Error as IoError;
 use std::sync::Arc;
+use tokio_io::{AsyncRead, AsyncWrite};
 use transport::{ConnectionUpgrade, MuxedTransport, Transport, UpgradedNode};
 
 /// Allows reusing the same muxed connection multiple times.
@@ -99,6 +100,7 @@ where
 impl<T, C> Transport for ConnectionReuse<T, C>
 where
 	T: Transport + 'static,                     // TODO: 'static :(
+	T::RawConn: AsyncRead + AsyncWrite,
 	C: ConnectionUpgrade<T::RawConn> + 'static, // TODO: 'static :(
 	C: Clone,
 	C::Output: StreamMuxer + Clone,
@@ -158,6 +160,7 @@ where
 impl<T, C> MuxedTransport for ConnectionReuse<T, C>
 where
 	T: Transport + 'static,                     // TODO: 'static :(
+	T::RawConn: AsyncRead + AsyncWrite,
 	C: ConnectionUpgrade<T::RawConn> + 'static, // TODO: 'static :(
 	C: Clone,
 	C::Output: StreamMuxer + Clone,

--- a/libp2p-swarm/src/lib.rs
+++ b/libp2p-swarm/src/lib.rs
@@ -186,9 +186,10 @@
 //! let mut core = tokio_core::reactor::Core::new().unwrap();
 //! 
 //! let transport = libp2p_tcp_transport::TcpConfig::new(core.handle())
-//!     .with_dummy_muxing();
+//!     .with_dummy_muxing()
+//!     .with_upgrade(Ping);
 //! 
-//! let (swarm_controller, swarm_future) = libp2p_swarm::swarm(transport, Ping, |(mut pinger, service), client_addr| {
+//! let (swarm_controller, swarm_future) = libp2p_swarm::swarm(transport, |(mut pinger, service), client_addr| {
 //!     pinger.ping().map_err(|_| panic!())
 //!         .select(service).map_err(|_| panic!())
 //!         .map(|_| ())

--- a/libp2p-swarm/src/swarm.rs
+++ b/libp2p-swarm/src/swarm.rs
@@ -34,7 +34,7 @@ use {Multiaddr, MuxedTransport};
 pub fn swarm<T, H, F>(transport: T, handler: H)
                       -> (SwarmController<T>, SwarmFuture<T, H, F::Future>)
     where T: MuxedTransport + Clone + 'static,      // TODO: 'static :-/
-          H: FnMut(T::RawConn, Multiaddr) -> F,
+          H: FnMut(T::Output, Multiaddr) -> F,
           F: IntoFuture<Item = (), Error = IoError>,
 {
     let (new_dialers_tx, new_dialers_rx) = mpsc::unbounded();
@@ -103,7 +103,7 @@ impl<T> SwarmController<T>
     // TODO: consider returning a future so that errors can be processed?
     pub fn dial_custom_handler<Df, Dfu>(&self, multiaddr: Multiaddr, and_then: Df)
                                         -> Result<(), Multiaddr>
-        where Df: FnOnce(T::RawConn) -> Dfu + 'static,          // TODO: 'static :-/
+        where Df: FnOnce(T::Output) -> Dfu + 'static,          // TODO: 'static :-/
               Dfu: IntoFuture<Item = (), Error = IoError> + 'static,        // TODO: 'static :-/
     {
         match self.transport.clone().dial(multiaddr) {
@@ -155,7 +155,7 @@ pub struct SwarmFuture<T, H, F>
 
 impl<T, H, If, F> Future for SwarmFuture<T, H, F>
     where T: MuxedTransport + Clone + 'static,      // TODO: 'static :-/,
-          H: FnMut(T::RawConn, Multiaddr) -> If,
+          H: FnMut(T::Output, Multiaddr) -> If,
           If: IntoFuture<Future = F, Item = (), Error = IoError>,
           F: Future<Item = (), Error = IoError>,
 {

--- a/libp2p-swarm/src/swarm.rs
+++ b/libp2p-swarm/src/swarm.rs
@@ -66,12 +66,25 @@ pub fn swarm<T, H, F>(transport: T, handler: H)
 
 /// Allows control of what the swarm is doing.
 pub struct SwarmController<T>
-    where T: MuxedTransport + 'static,      // TODO: 'static :-/
+    where T: MuxedTransport
 {
     transport: T,
     new_listeners: mpsc::UnboundedSender<T::Listener>,
     new_dialers: mpsc::UnboundedSender<(T::Dial, Multiaddr)>,
     new_toprocess: mpsc::UnboundedSender<Box<Future<Item = (), Error = IoError>>>,
+}
+
+impl<T> Clone for SwarmController<T>
+    where T: MuxedTransport + Clone
+{
+    fn clone(&self) -> SwarmController<T> {
+        SwarmController {
+            transport: self.transport.clone(),
+            new_listeners: self.new_listeners.clone(),
+            new_dialers: self.new_dialers.clone(),
+            new_toprocess: self.new_toprocess.clone(),
+        }
+    }
 }
 
 impl<T> SwarmController<T>

--- a/libp2p-tcp-transport/src/lib.rs
+++ b/libp2p-tcp-transport/src/lib.rs
@@ -84,9 +84,9 @@ impl TcpConfig {
 }
 
 impl Transport for TcpConfig {
-    type RawConn = TcpStream;
+    type Output = TcpStream;
     type Listener = Box<Stream<Item = (Self::ListenerUpgrade, Multiaddr), Error = IoError>>;
-    type ListenerUpgrade = FutureResult<Self::RawConn, IoError>;
+    type ListenerUpgrade = FutureResult<Self::Output, IoError>;
     type Dial = TcpStreamNew;
 
     /// Listen on the given multi-addr.

--- a/libp2p-websocket/src/browser.rs
+++ b/libp2p-websocket/src/browser.rs
@@ -47,9 +47,9 @@ impl BrowserWsConfig {
 }
 
 impl Transport for BrowserWsConfig {
-	type RawConn = BrowserWsConn;
+	type Output = BrowserWsConn;
 	type Listener = Box<Stream<Item = (Self::ListenerUpgrade, Multiaddr), Error = IoError>>; // TODO: use `!`
-	type ListenerUpgrade = Box<Future<Item = Self::RawConn, Error = IoError>>; // TODO: use `!`
+	type ListenerUpgrade = Box<Future<Item = Self::Output, Error = IoError>>; // TODO: use `!`
 	type Dial = FutureThen<
 		oneshot::Receiver<Result<BrowserWsConn, IoError>>,
 		Result<BrowserWsConn, IoError>,

--- a/libp2p-websocket/src/desktop.rs
+++ b/libp2p-websocket/src/desktop.rs
@@ -53,7 +53,7 @@ impl<T> WsConfig<T> {
 impl<T> Transport for WsConfig<T>
 where
 	T: Transport + 'static, // TODO: this 'static is pretty arbitrary and is necessary because of the websocket library
-	T::RawConn: Send, // TODO: this Send is pretty arbitrary and is necessary because of the websocket library
+	T::RawConn: AsyncStream + Send, // TODO: this Send is pretty arbitrary and is necessary because of the websocket library
 {
 	type RawConn = Box<AsyncStream>;
 	type Listener = stream::Map<

--- a/libp2p-websocket/src/desktop.rs
+++ b/libp2p-websocket/src/desktop.rs
@@ -53,15 +53,15 @@ impl<T> WsConfig<T> {
 impl<T> Transport for WsConfig<T>
 where
 	T: Transport + 'static, // TODO: this 'static is pretty arbitrary and is necessary because of the websocket library
-	T::RawConn: AsyncStream + Send, // TODO: this Send is pretty arbitrary and is necessary because of the websocket library
+	T::Output: AsyncStream + Send, // TODO: this Send is pretty arbitrary and is necessary because of the websocket library
 {
-	type RawConn = Box<AsyncStream>;
+	type Output = Box<AsyncStream>;
 	type Listener = stream::Map<
 		T::Listener,
 		fn((<T as Transport>::ListenerUpgrade, Multiaddr)) -> (Self::ListenerUpgrade, Multiaddr),
 	>;
-	type ListenerUpgrade = Box<Future<Item = Self::RawConn, Error = IoError>>;
-	type Dial = Box<Future<Item = Self::RawConn, Error = IoError>>;
+	type ListenerUpgrade = Box<Future<Item = Self::Output, Error = IoError>>;
+	type Dial = Box<Future<Item = Self::Output, Error = IoError>>;
 
 	fn listen_on(
 		self,


### PR DESCRIPTION
Right now the output (the `RawConn`) of a `Transport` requires the `AsyncRead` and `AsyncWrite` traits, and acts as a stream of data. Consequently the `swarm` builder requires a `ConnectionUpgrade` in order to turn the transport into the object that controls the protocol.

This PR removes this requirement, so that dialing or listening through a `Transport` can produce any kind of object. Consequently, it also renames `RawConn` to `Output`.

This greatly simplifies the API and implementation of `swarm`.
