### PR TITLE
Properly handle EOF in varint-rs

### DIFF
--- a/varint-rs/src/lib.rs
+++ b/varint-rs/src/lib.rs
@@ -378,8 +378,12 @@ impl<T: Default + DecoderHelper> Decoder for VarintDecoder<T> {
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         loop {
-            if src.is_empty() && self.state.is_some() {
-                break Err(io::Error::from(io::ErrorKind::UnexpectedEof));
+            if src.is_empty() {
+                if self.state.is_some() {
+                    break Err(io::Error::from(io::ErrorKind::UnexpectedEof));
+                } else {
+                    break Ok(None);
+                }
             } else {
                 // We know that the length is not 0, so this cannot fail.
                 let first_byte = src.split_to(1)[0];
@@ -632,5 +636,13 @@ mod tests {
             .wait();
 
         assert_eq!(result.unwrap_err().kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn no_panic_after_eof() {
+        FramedRead::new(&[1, 1][..], VarintDecoder::<usize>::new())
+            .collect()
+            .wait()
+            .unwrap();
     }
 }


### PR DESCRIPTION
Right now `varint-rs` will panic when it reaches EOF.