### PR TITLE
Implement libp2p-dns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "multistream-select",
     "datastore",
     "example",
+    "libp2p-dns",
     "libp2p-identify",
     "libp2p-peerstore",
     "libp2p-ping",

--- a/libp2p-dns/Cargo.toml
+++ b/libp2p-dns/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "libp2p-dns"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+
+[dependencies]
+libp2p-swarm = { path = "../libp2p-swarm" }
+log = "0.4.1"
+futures = "0.1"
+multiaddr = "0.2.0"
+tokio-dns-unofficial = "0.1"
+tokio-io = "0.1"

--- a/libp2p-dns/Cargo.toml
+++ b/libp2p-dns/Cargo.toml
@@ -10,3 +10,6 @@ futures = "0.1"
 multiaddr = "0.2.0"
 tokio-dns-unofficial = "0.1"
 tokio-io = "0.1"
+
+[dev-dependencies]
+libp2p-tcp-transport = { path = "../libp2p-tcp-transport" }

--- a/libp2p-dns/README.md
+++ b/libp2p-dns/README.md
@@ -1,0 +1,27 @@
+# TCP transport
+
+Implementation of the libp2p `Transport` trait for TCP/IP.
+
+Uses [the *tokio* library](https://tokio.rs).
+
+## Usage
+
+Create [a tokio `Core`](https://docs.rs/tokio-core/0.1/tokio_core/reactor/struct.Core.html),
+then grab a handle by calling the `handle()` method on it, then create a `TcpConfig` and pass
+the handle.
+
+Example:
+
+```rust
+extern crate libp2p_tcp_transport;
+extern crate tokio_core;
+
+use libp2p_tcp_transport::TcpConfig;
+use tokio_core::reactor::Core;
+
+let mut core = Core::new().unwrap();
+let tcp = TcpConfig::new(core.handle());
+```
+
+The `TcpConfig` structs implements the `Transport` trait of the `swarm` library. See the
+documentation of `swarm` and of libp2p in general to learn how to use the `Transport` trait.

--- a/libp2p-dns/README.md
+++ b/libp2p-dns/README.md
@@ -1,27 +1,13 @@
-# TCP transport
+# libp2p-dns
 
-Implementation of the libp2p `Transport` trait for TCP/IP.
-
-Uses [the *tokio* library](https://tokio.rs).
+This crate provides the type `DnsConfig` that allows one to resolve the `/dns4/` and `/dns6/`
+components of multiaddresses.
 
 ## Usage
 
-Create [a tokio `Core`](https://docs.rs/tokio-core/0.1/tokio_core/reactor/struct.Core.html),
-then grab a handle by calling the `handle()` method on it, then create a `TcpConfig` and pass
-the handle.
+In order to use this crate, create a `DnsConfig` with one of its constructors and pass it an
+implementation of the `Transport` trait.
 
-Example:
-
-```rust
-extern crate libp2p_tcp_transport;
-extern crate tokio_core;
-
-use libp2p_tcp_transport::TcpConfig;
-use tokio_core::reactor::Core;
-
-let mut core = Core::new().unwrap();
-let tcp = TcpConfig::new(core.handle());
-```
-
-The `TcpConfig` structs implements the `Transport` trait of the `swarm` library. See the
-documentation of `swarm` and of libp2p in general to learn how to use the `Transport` trait.
+Whenever we want to dial an address through the `DnsConfig` and that address contains a
+`/dns4/` or `/dns6/` component, a DNS resolve will be performed and the component will be
+replaced with respectively an `/ip4/` or an `/ip6/` component.

--- a/libp2p-dns/src/lib.rs
+++ b/libp2p-dns/src/lib.rs
@@ -21,6 +21,21 @@
 // TODO: use this once stable ; for now we just copy-paste the content of the README.md
 //#![doc(include = "../README.md")]
 
+//! # libp2p-dns
+//!
+//! This crate provides the type `DnsConfig` that allows one to resolve the `/dns4/` and `/dns6/`
+//! components of multiaddresses.
+//!
+//! ## Usage
+//!
+//! In order to use this crate, create a `DnsConfig` with one of its constructors and pass it an
+//! implementation of the `Transport` trait.
+//!
+//! Whenever we want to dial an address through the `DnsConfig` and that address contains a
+//! `/dns4/` or `/dns6/` component, a DNS resolve will be performed and the component will be
+//! replaced with respectively an `/ip4/` or an `/ip6/` component.
+//!
+
 #[macro_use]
 extern crate log;
 extern crate libp2p_swarm as swarm;
@@ -48,11 +63,17 @@ impl<T> DnsConfig<T> {
     /// Creates a new configuration object for DNS.
     #[inline]
     pub fn new(inner: T) -> DnsConfig<T> {
+        DnsConfig::with_resolve_threads(inner, 1)
+    }
+
+    /// Same as `new`, but allows specifying a number of threads for the resolving.
+    #[inline]
+    pub fn with_resolve_threads(inner: T, num_threads: usize) -> DnsConfig<T> {
         trace!(target: "libp2p-dns", "Created a CpuPoolResolver");
 
         DnsConfig {
             inner,
-            resolver: CpuPoolResolver::new(8),      // TODO: arbitrary
+            resolver: CpuPoolResolver::new(num_threads),
         }
     }
 }

--- a/libp2p-dns/src/lib.rs
+++ b/libp2p-dns/src/lib.rs
@@ -86,14 +86,13 @@ impl<T> DnsConfig<T> {
 }
 
 impl<T> fmt::Debug for DnsConfig<T>
-	where T: fmt::Debug
+where
+	T: fmt::Debug,
 {
 	#[inline]
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_tuple("DnsConfig")
-            .field(&self.inner)
-            .finish()
-    }
+	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+		fmt.debug_tuple("DnsConfig").field(&self.inner).finish()
+	}
 }
 
 impl<T> Transport for DnsConfig<T>
@@ -254,12 +253,12 @@ mod tests {
 				assert_eq!(addr.len(), 2);
 				match addr[1] {
 					AddrComponent::TCP(_) => (),
-					_ => panic!()
+					_ => panic!(),
 				};
 				match addr[0] {
 					AddrComponent::DNS4(_) => (),
 					AddrComponent::DNS6(_) => (),
-					_ => panic!()
+					_ => panic!(),
 				};
 				Ok(Box::new(future::empty()) as Box<_>)
 			}

--- a/libp2p-dns/src/lib.rs
+++ b/libp2p-dns/src/lib.rs
@@ -1,21 +1,21 @@
 // Copyright 2018 Parity Technologies (UK) Ltd.
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a 
-// copy of this software and associated documentation files (the "Software"), 
-// to deal in the Software without restriction, including without limitation 
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-// and/or sell copies of the Software, and to permit persons to whom the 
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
 //
-// The above copyright notice and this permission notice shall be included in 
+// The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
 //
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
 // TODO: use this once stable ; for now we just copy-paste the content of the README.md
@@ -36,219 +36,224 @@
 //! replaced with respectively an `/ip4/` or an `/ip6/` component.
 //!
 
+extern crate futures;
+extern crate libp2p_swarm as swarm;
 #[macro_use]
 extern crate log;
-extern crate libp2p_swarm as swarm;
+extern crate multiaddr;
 extern crate tokio_dns;
 extern crate tokio_io;
-extern crate multiaddr;
-extern crate futures;
 
-use std::io::{Error as IoError, ErrorKind as IoErrorKind};
-use std::net::IpAddr;
 use futures::future::{self, Future, IntoFuture};
 use log::Level;
-use multiaddr::{Multiaddr, AddrComponent};
+use multiaddr::{AddrComponent, Multiaddr};
+use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+use std::net::IpAddr;
 use swarm::Transport;
 use tokio_dns::{CpuPoolResolver, Resolver};
 
 /// Represents the configuration for a DNS transport capability of libp2p.
-#[derive(Clone)]        // TODO: Debug
+#[derive(Clone)] // TODO: Debug
 pub struct DnsConfig<T> {
-    inner: T,
-    resolver: CpuPoolResolver,
+	inner: T,
+	resolver: CpuPoolResolver,
 }
 
 impl<T> DnsConfig<T> {
-    /// Creates a new configuration object for DNS.
-    #[inline]
-    pub fn new(inner: T) -> DnsConfig<T> {
-        DnsConfig::with_resolve_threads(inner, 1)
-    }
+	/// Creates a new configuration object for DNS.
+	#[inline]
+	pub fn new(inner: T) -> DnsConfig<T> {
+		DnsConfig::with_resolve_threads(inner, 1)
+	}
 
-    /// Same as `new`, but allows specifying a number of threads for the resolving.
-    #[inline]
-    pub fn with_resolve_threads(inner: T, num_threads: usize) -> DnsConfig<T> {
-        trace!(target: "libp2p-dns", "Created a CpuPoolResolver");
+	/// Same as `new`, but allows specifying a number of threads for the resolving.
+	#[inline]
+	pub fn with_resolve_threads(inner: T, num_threads: usize) -> DnsConfig<T> {
+		trace!(target: "libp2p-dns", "Created a CpuPoolResolver");
 
-        DnsConfig {
-            inner,
-            resolver: CpuPoolResolver::new(num_threads),
-        }
-    }
+		DnsConfig {
+			inner,
+			resolver: CpuPoolResolver::new(num_threads),
+		}
+	}
 }
 
 impl<T> Transport for DnsConfig<T>
-    where T: Transport + 'static,           // TODO: 'static :-/
+where
+	T: Transport + 'static, // TODO: 'static :-/
 {
-    type RawConn = T::RawConn;
-    type Listener = T::Listener;
-    type ListenerUpgrade = T::ListenerUpgrade;
-    type Dial = Box<Future<Item = Self::RawConn, Error = IoError>>;
+	type RawConn = T::RawConn;
+	type Listener = T::Listener;
+	type ListenerUpgrade = T::ListenerUpgrade;
+	type Dial = Box<Future<Item = Self::RawConn, Error = IoError>>;
 
-    #[inline]
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
-        match self.inner.listen_on(addr) {
-            Ok(r) => Ok(r),
-            Err((inner, addr)) => {
-                Err((DnsConfig { inner, resolver: self.resolver }, addr))
-            }
-        }
-    }
+	#[inline]
+	fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
+		match self.inner.listen_on(addr) {
+			Ok(r) => Ok(r),
+			Err((inner, addr)) => Err((
+				DnsConfig {
+					inner,
+					resolver: self.resolver,
+				},
+				addr,
+			)),
+		}
+	}
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
-        let contains_dns = addr
-            .iter()
-            .any(|cmp| {
-                match cmp {
-                    AddrComponent::DNS4(_) => true,
-                    AddrComponent::DNS6(_) => true,
-                    _ => false
-                }
-            });
+	fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
+		let contains_dns = addr.iter().any(|cmp| match cmp {
+			AddrComponent::DNS4(_) => true,
+			AddrComponent::DNS6(_) => true,
+			_ => false,
+		});
 
-        if !contains_dns {
-            trace!(target: "libp2p-dns", "Pass-through address without DNS: {}", addr);
-            return match self.inner.dial(addr) {
-                Ok(d) => Ok(Box::new(d.into_future()) as Box<_>),
-                Err((inner, addr)) => Err((DnsConfig { inner, resolver: self.resolver }, addr)),
-            };
-        }
+		if !contains_dns {
+			trace!(target: "libp2p-dns", "Pass-through address without DNS: {}", addr);
+			return match self.inner.dial(addr) {
+				Ok(d) => Ok(Box::new(d.into_future()) as Box<_>),
+				Err((inner, addr)) => Err((
+					DnsConfig {
+						inner,
+						resolver: self.resolver,
+					},
+					addr,
+				)),
+			};
+		}
 
-        let resolver = self.resolver;
+		let resolver = self.resolver;
 
-        trace!(target: "libp2p-dns", "Dialing address with DNS: {}", addr);
-        let resolve_iters = addr
-            .iter()
-            .map(move |cmp| {
-                match cmp {
-                    AddrComponent::DNS4(ref name) => {
-                        future::Either::A(resolve_dns(name, resolver.clone(), ResolveTy::Dns4))
-                    },
-                    AddrComponent::DNS6(ref name) => {
-                        future::Either::A(resolve_dns(name, resolver.clone(), ResolveTy::Dns6))
-                    },
-                    cmp => {
-                        future::Either::B(future::ok(cmp))
-                    },
-                }
-            })
-            .collect::<Vec<_>>()
-            .into_iter();
+		trace!(target: "libp2p-dns", "Dialing address with DNS: {}", addr);
+		let resolve_iters = addr.iter()
+			.map(move |cmp| match cmp {
+				AddrComponent::DNS4(ref name) => {
+					future::Either::A(resolve_dns(name, resolver.clone(), ResolveTy::Dns4))
+				}
+				AddrComponent::DNS6(ref name) => {
+					future::Either::A(resolve_dns(name, resolver.clone(), ResolveTy::Dns6))
+				}
+				cmp => future::Either::B(future::ok(cmp)),
+			})
+			.collect::<Vec<_>>()
+			.into_iter();
 
-        let new_addr = future::join_all(resolve_iters)
-            .map(move |outcome| {
-                let outcome: Multiaddr = outcome.into_iter().collect();
-                debug!(target: "libp2p-dns", "DNS resolution outcome: {} => {}", addr, outcome);
-                outcome
-            });
+		let new_addr = future::join_all(resolve_iters).map(move |outcome| {
+			let outcome: Multiaddr = outcome.into_iter().collect();
+			debug!(target: "libp2p-dns", "DNS resolution outcome: {} => {}", addr, outcome);
+			outcome
+		});
 
-        let inner = self.inner;
-        let future = new_addr
-            .and_then(move |addr| {
-                inner.dial(addr).map_err(|_| {
-                    IoError::new(IoErrorKind::Other, "multiaddr not supported")
-                })
-            })
-            .flatten();
+		let inner = self.inner;
+		let future = new_addr
+			.and_then(move |addr| {
+				inner
+					.dial(addr)
+					.map_err(|_| IoError::new(IoErrorKind::Other, "multiaddr not supported"))
+			})
+			.flatten();
 
-        Ok(Box::new(future) as Box<_>)
-    }
+		Ok(Box::new(future) as Box<_>)
+	}
 
-    #[inline]
-    fn nat_traversal(&self, server: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
-        // Since `listen_on` doesn't perform any resolution, we just pass through `nat_traversal`
-        // as well.
-        self.inner.nat_traversal(server, observed)
-    }
+	#[inline]
+	fn nat_traversal(&self, server: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
+		// Since `listen_on` doesn't perform any resolution, we just pass through `nat_traversal`
+		// as well.
+		self.inner.nat_traversal(server, observed)
+	}
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum ResolveTy {
-    Dns4,
-    Dns6,
+	Dns4,
+	Dns6,
 }
 
-fn resolve_dns(name: &str, resolver: CpuPoolResolver, ty: ResolveTy)
-    -> Box<Future<Item = AddrComponent, Error = IoError>>
-{
-    let debug_name = if log_enabled!(target: "libp2p-dns", Level::Trace) {
-        Some(name.to_owned())
-    } else {
-        None
-    };
+fn resolve_dns(
+	name: &str,
+	resolver: CpuPoolResolver,
+	ty: ResolveTy,
+) -> Box<Future<Item = AddrComponent, Error = IoError>> {
+	let debug_name = if log_enabled!(target: "libp2p-dns", Level::Trace) {
+		Some(name.to_owned())
+	} else {
+		None
+	};
 
-    let future = resolver
-        .resolve(name)
-        .and_then(move |addrs| {
-            trace!(target: "libp2p-dns", "DNS component resolution: {} => {:?}",
+	let future = resolver.resolve(name).and_then(move |addrs| {
+		trace!(target: "libp2p-dns", "DNS component resolution: {} => {:?}",
                    debug_name.expect("trace log level was enabled"), addrs);
-            addrs.into_iter()
-                .filter_map(move |addr| {
-                    match (addr, ty) {
-                        (IpAddr::V4(addr), ResolveTy::Dns4) => Some(AddrComponent::IP4(addr)),
-                        (IpAddr::V6(addr), ResolveTy::Dns6) => Some(AddrComponent::IP6(addr)),
-                        _ => None,
-                    }
-                })
-                .next()
-                .ok_or(IoError::new(IoErrorKind::Other, "couldn't find any relevant IP address"))
-        });
-    
-    Box::new(future)
+		addrs
+			.into_iter()
+			.filter_map(move |addr| match (addr, ty) {
+				(IpAddr::V4(addr), ResolveTy::Dns4) => Some(AddrComponent::IP4(addr)),
+				(IpAddr::V6(addr), ResolveTy::Dns6) => Some(AddrComponent::IP6(addr)),
+				_ => None,
+			})
+			.next()
+			.ok_or(IoError::new(
+				IoErrorKind::Other,
+				"couldn't find any relevant IP address",
+			))
+	});
+
+	Box::new(future)
 }
 
 #[cfg(test)]
 mod tests {
-    extern crate libp2p_tcp_transport;
-    use self::libp2p_tcp_transport::TcpConfig;
-    use multiaddr::{Multiaddr, AddrComponent};
-    use swarm::Transport;
-    use std::io::Error as IoError;
-    use futures::{future, Future};
-    use DnsConfig;
+	extern crate libp2p_tcp_transport;
+	use self::libp2p_tcp_transport::TcpConfig;
+	use DnsConfig;
+	use futures::{future, Future};
+	use multiaddr::{AddrComponent, Multiaddr};
+	use std::io::Error as IoError;
+	use swarm::Transport;
 
-    #[test]
-    fn basic_resolve() {
-        #[derive(Clone)]
-        struct CustomTransport;
-        impl Transport for CustomTransport {
-            type RawConn = <TcpConfig as Transport>::RawConn;
-            type Listener = <TcpConfig as Transport>::Listener;
-            type ListenerUpgrade = <TcpConfig as Transport>::ListenerUpgrade;
-            type Dial = Box<Future<Item = Self::RawConn, Error = IoError>>;
+	#[test]
+	fn basic_resolve() {
+		#[derive(Clone)]
+		struct CustomTransport;
+		impl Transport for CustomTransport {
+			type RawConn = <TcpConfig as Transport>::RawConn;
+			type Listener = <TcpConfig as Transport>::Listener;
+			type ListenerUpgrade = <TcpConfig as Transport>::ListenerUpgrade;
+			type Dial = Box<Future<Item = Self::RawConn, Error = IoError>>;
 
-            #[inline]
-            fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
-                unreachable!()
-            }
+			#[inline]
+			fn listen_on(
+				self,
+				addr: Multiaddr,
+			) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
+				unreachable!()
+			}
 
-            fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
-                let contains_dns = addr
-                    .iter()
-                    .any(|cmp| {
-                        match cmp {
-                            AddrComponent::DNS4(_) => true,
-                            AddrComponent::DNS6(_) => true,
-                            _ => false
-                        }
-                    });
+			fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
+				let contains_dns = addr.iter().any(|cmp| match cmp {
+					AddrComponent::DNS4(_) => true,
+					AddrComponent::DNS6(_) => true,
+					_ => false,
+				});
 
-                assert!(!contains_dns);
-                Ok(Box::new(future::empty()) as Box<_>)
-            }
+				assert!(!contains_dns);
+				Ok(Box::new(future::empty()) as Box<_>)
+			}
 
-            #[inline]
-            fn nat_traversal(&self, server: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
-                panic!()
-            }
-        }
+			#[inline]
+			fn nat_traversal(&self, server: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
+				panic!()
+			}
+		}
 
-        let transport = DnsConfig::new(CustomTransport);
+		let transport = DnsConfig::new(CustomTransport);
 
-        let _ = transport.clone().dial("/dns4/example.com/tcp/20000".parse().unwrap())
-            .unwrap_or_else(|_| panic!());
-        let _ = transport.dial("/dns6/example.com/tcp/20000".parse().unwrap())
-            .unwrap_or_else(|_| panic!());
-    }
+		let _ = transport
+			.clone()
+			.dial("/dns4/example.com/tcp/20000".parse().unwrap())
+			.unwrap_or_else(|_| panic!());
+		let _ = transport
+			.dial("/dns6/example.com/tcp/20000".parse().unwrap())
+			.unwrap_or_else(|_| panic!());
+	}
 }

--- a/libp2p-dns/src/lib.rs
+++ b/libp2p-dns/src/lib.rs
@@ -1,0 +1,183 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a 
+// copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the 
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+
+// TODO: use this once stable ; for now we just copy-paste the content of the README.md
+//#![doc(include = "../README.md")]
+
+#[macro_use]
+extern crate log;
+extern crate libp2p_swarm as swarm;
+extern crate tokio_dns;
+extern crate tokio_io;
+extern crate multiaddr;
+extern crate futures;
+
+use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+use std::net::IpAddr;
+use futures::future::{self, Future, IntoFuture};
+use log::Level;
+use multiaddr::{Multiaddr, AddrComponent};
+use swarm::Transport;
+use tokio_dns::{CpuPoolResolver, Resolver};
+
+/// Represents the configuration for a DNS transport capability of libp2p.
+#[derive(Clone)]        // TODO: Debug
+pub struct DnsConfig<T> {
+    inner: T,
+    resolver: CpuPoolResolver,
+}
+
+impl<T> DnsConfig<T> {
+    /// Creates a new configuration object for DNS.
+    #[inline]
+    pub fn new(inner: T) -> DnsConfig<T> {
+        trace!(target: "libp2p-dns", "Created a CpuPoolResolver");
+
+        DnsConfig {
+            inner,
+            resolver: CpuPoolResolver::new(8),      // TODO: arbitrary
+        }
+    }
+}
+
+impl<T> Transport for DnsConfig<T>
+    where T: Transport + 'static,           // TODO: 'static :-/
+{
+    type RawConn = T::RawConn;
+    type Listener = T::Listener;
+    type ListenerUpgrade = T::ListenerUpgrade;
+    type Dial = Box<Future<Item = Self::RawConn, Error = IoError>>;
+
+    #[inline]
+    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
+        match self.inner.listen_on(addr) {
+            Ok(r) => Ok(r),
+            Err((inner, addr)) => {
+                Err((DnsConfig { inner, resolver: self.resolver }, addr))
+            }
+        }
+    }
+
+    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
+        let contains_dns = addr
+            .iter()
+            .any(|cmp| {
+                match cmp {
+                    AddrComponent::DNS4(_) => true,
+                    AddrComponent::DNS6(_) => true,
+                    _ => false
+                }
+            });
+
+        if !contains_dns {
+            trace!(target: "libp2p-dns", "Pass-through address without DNS: {}", addr);
+            return match self.inner.dial(addr) {
+                Ok(d) => Ok(Box::new(d.into_future()) as Box<_>),
+                Err((inner, addr)) => Err((DnsConfig { inner, resolver: self.resolver }, addr)),
+            };
+        }
+
+        let resolver = self.resolver;
+
+        trace!(target: "libp2p-dns", "Dialing address with DNS: {}", addr);
+        let resolve_iters = addr
+            .iter()
+            .map(move |cmp| {
+                match cmp {
+                    AddrComponent::DNS4(ref name) => {
+                        future::Either::A(resolve_dns(name, resolver.clone(), ResolveTy::Dns4))
+                    },
+                    AddrComponent::DNS6(ref name) => {
+                        future::Either::A(resolve_dns(name, resolver.clone(), ResolveTy::Dns6))
+                    },
+                    cmp => {
+                        future::Either::B(future::ok(cmp))
+                    },
+                }
+            })
+            .collect::<Vec<_>>()
+            .into_iter();
+
+        let new_addr = future::join_all(resolve_iters)
+            .map(move |outcome| {
+                let outcome: Multiaddr = outcome.into_iter().collect();
+                debug!(target: "libp2p-dns", "DNS resolution outcome: {} => {}", addr, outcome);
+                outcome
+            });
+
+        let inner = self.inner;
+        let future = new_addr
+            .and_then(move |addr| {
+                inner.dial(addr).map_err(|_| {
+                    IoError::new(IoErrorKind::Other, "multiaddr not supported")
+                })
+            })
+            .flatten();
+
+        Ok(Box::new(future) as Box<_>)
+    }
+
+    #[inline]
+    fn nat_traversal(&self, server: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
+        // Since `listen_on` doesn't perform any resolution, we just pass through `nat_traversal`
+        // as well.
+        self.inner.nat_traversal(server, observed)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum ResolveTy {
+    Dns4,
+    Dns6,
+}
+
+fn resolve_dns(name: &str, resolver: CpuPoolResolver, ty: ResolveTy)
+    -> Box<Future<Item = AddrComponent, Error = IoError>>
+{
+    let debug_name = if log_enabled!(target: "libp2p-dns", Level::Trace) {
+        Some(name.to_owned())
+    } else {
+        None
+    };
+
+    let future = resolver
+        .resolve(name)
+        .and_then(move |addrs| {
+            trace!(target: "libp2p-dns", "DNS component resolution: {} => {:?}",
+                   debug_name.expect("trace log level was enabled"), addrs);
+            addrs.into_iter()
+                .filter_map(move |addr| {
+                    match (addr, ty) {
+                        (IpAddr::V4(addr), ResolveTy::Dns4) => Some(AddrComponent::IP4(addr)),
+                        (IpAddr::V6(addr), ResolveTy::Dns6) => Some(AddrComponent::IP6(addr)),
+                        _ => None,
+                    }
+                })
+                .next()
+                .ok_or(IoError::new(IoErrorKind::Other, "couldn't find any relevant IP address"))
+        });
+    
+    Box::new(future)
+}
+
+#[cfg(test)]
+mod tests {
+    use DnsConfig;
+}

--- a/libp2p-dns/src/lib.rs
+++ b/libp2p-dns/src/lib.rs
@@ -60,7 +60,7 @@ use tokio_dns::{CpuPoolResolver, Resolver};
 /// passed to the underlying transport.
 ///
 /// Listening is unaffected.
-#[derive(Clone)] // TODO: Debug
+#[derive(Clone)]
 pub struct DnsConfig<T> {
 	inner: T,
 	resolver: CpuPoolResolver,
@@ -202,7 +202,7 @@ fn resolve_dns(
 
 	let future = resolver.resolve(name).and_then(move |addrs| {
 		trace!(target: "libp2p-dns", "DNS component resolution: {} => {:?}",
-                   debug_name.expect("trace log level was enabled"), addrs);
+				   debug_name.expect("trace log level was enabled"), addrs);
 		addrs
 			.into_iter()
 			.filter_map(move |addr| match (addr, ty) {


### PR DESCRIPTION
Adds `libp2p-dns`. Provides the `DnsConfig` type which implements `Transport` and wraps around another implementation of `Transport`.

Any attempt to dial to a multiaddr which contains `tcp4` or `tcp6` that goes through `DnsConfig` will be resolved.