### PR TITLE
Fix protoc warnings

### DIFF
--- a/libp2p-secio/keys.proto
+++ b/libp2p-secio/keys.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 enum KeyType {
   RSA = 0;
   Ed25519 = 1;

--- a/libp2p-secio/structs.proto
+++ b/libp2p-secio/structs.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package spipe.pb;
 
 message Propose {


### PR DESCRIPTION
This PR fixes the following ```protoc``` warnings by specifying ```proto version``` 
```bash
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: structs.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
./src/./: No such file or directory
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: keys.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
```