### PR TITLE
Update .editorconfig to align with rustfmt.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,10 +1,9 @@
 root = true
 [*]
-indent_style=tab
-indent_size=tab
-tab_width=4
+indent_style=space
+indent_size=4
 end_of_line=lf
 charset=utf-8
 trim_trailing_whitespace=true
-max_line_length=120
-insert_final_newline=true
+max_line_length=100
+insert_final_newline=false


### PR DESCRIPTION
The current settings differ from rustfmt which is used during CI runs to check the source code format. In particular, rustfmt will replace tabs with spaces, therefore this commit attempts to use the same settings already for editing.