### PR TITLE
connection_reuse: drop dead connections.

### DIFF
--- a/mplex/src/lib.rs
+++ b/mplex/src/lib.rs
@@ -170,7 +170,7 @@ pub struct InboundFuture<T, Buf: Array> {
 }
 
 impl<T: AsyncRead, Buf: Array<Item = u8>> Future for InboundFuture<T, Buf> {
-    type Item = Substream<T, Buf>;
+    type Item = Option<Substream<T, Buf>>;
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
@@ -178,6 +178,10 @@ impl<T: AsyncRead, Buf: Array<Item = u8>> Future for InboundFuture<T, Buf> {
             Async::Ready(lock) => lock,
             Async::NotReady => return Ok(Async::NotReady),
         };
+
+        if lock.is_closed() {
+            return Ok(Async::Ready(None));
+        }
 
         // Attempt to make progress, but don't block if we can't
         match read_stream(&mut lock, None) {
@@ -198,12 +202,12 @@ impl<T: AsyncRead, Buf: Array<Item = u8>> Future for InboundFuture<T, Buf> {
 
         lock.open_stream(id);
 
-        Ok(Async::Ready(Substream::new(
+        Ok(Async::Ready(Some(Substream::new(
             id,
             self.end,
             name,
             Arc::clone(&self.state),
-        )))
+        ))))
     }
 }
 
@@ -228,7 +232,7 @@ fn nonce_to_id(id: usize, end: Endpoint) -> u32 {
 }
 
 impl<T: AsyncWrite, Buf: Array> Future for OutboundFuture<T, Buf> {
-    type Item = Substream<T, Buf>;
+    type Item = Option<Substream<T, Buf>>;
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
@@ -236,6 +240,10 @@ impl<T: AsyncWrite, Buf: Array> Future for OutboundFuture<T, Buf> {
             Async::Ready(lock) => lock,
             Async::NotReady => return Ok(Async::NotReady),
         };
+
+        if lock.is_closed() {
+            return Ok(Async::Ready(None));
+        }
 
         loop {
             let (mut id_str, id) = self.current_id.take().unwrap_or_else(|| {
@@ -258,12 +266,12 @@ impl<T: AsyncWrite, Buf: Array> Future for OutboundFuture<T, Buf> {
                     debug_assert!(id_str.position() <= id_str.get_ref().len() as u64);
                     if id_str.position() == id_str.get_ref().len() as u64 {
                         if lock.open_stream(id) {
-                            return Ok(Async::Ready(Substream::new(
+                            return Ok(Async::Ready(Some(Substream::new(
                                 id,
                                 self.meta.end,
                                 Bytes::from(&id_str.get_ref()[..]),
                                 Arc::clone(&self.state),
-                            )));
+                            ))));
                         }
                     } else {
                         self.current_id = Some((id_str, id));
@@ -391,7 +399,12 @@ mod tests {
 
         let mplex = Multiplex::dial(stream);
 
-        let mut substream = mplex.clone().outbound().wait().unwrap();
+        let mut substream = mplex
+            .clone()
+            .outbound()
+            .wait()
+            .unwrap()
+            .expect("outbound substream");
 
         assert!(tokio::write_all(&mut substream, message).wait().is_ok());
 
@@ -408,7 +421,7 @@ mod tests {
 
         let mplex = Multiplex::listen(stream);
 
-        let mut substream = mplex.inbound().wait().unwrap();
+        let mut substream = mplex.inbound().wait().unwrap().expect("inbound substream");
 
         assert_eq!(id, substream.id());
         assert_eq!(
@@ -433,7 +446,14 @@ mod tests {
         let mut outbound: Vec<Substream<_>> = vec![];
 
         for _ in 0..5 {
-            outbound.push(mplex.clone().outbound().wait().unwrap());
+            outbound.push(
+                mplex
+                    .clone()
+                    .outbound()
+                    .wait()
+                    .unwrap()
+                    .expect("outbound substream"),
+            );
         }
 
         outbound.sort_by_key(|a| a.id());
@@ -453,7 +473,14 @@ mod tests {
         let mut inbound: Vec<Substream<_>> = vec![];
 
         for _ in 0..5 {
-            inbound.push(mplex.clone().inbound().wait().unwrap());
+            inbound.push(
+                mplex
+                    .clone()
+                    .inbound()
+                    .wait()
+                    .unwrap()
+                    .expect("inbound substream"),
+            );
         }
 
         inbound.sort_by_key(|a| a.id());
@@ -513,7 +540,7 @@ mod tests {
 
         let mplex = Multiplex::listen(io::Cursor::new(input));
 
-        let mut substream = mplex.inbound().wait().unwrap();
+        let mut substream = mplex.inbound().wait().unwrap().expect("inbound substream");
 
         assert_eq!(substream.id(), 0);
         assert_eq!(substream.name(), None);
@@ -565,7 +592,7 @@ mod tests {
 
         let mplex = Multiplex::listen(io::Cursor::new(input));
 
-        let mut substream = mplex.inbound().wait().unwrap();
+        let mut substream = mplex.inbound().wait().unwrap().expect("inbound substream");
 
         assert_eq!(substream.id(), 0);
         assert_eq!(substream.name(), None);
@@ -613,7 +640,7 @@ mod tests {
 
         let mplex = Multiplex::listen(io::Cursor::new(data));
 
-        let mut substream = mplex.inbound().wait().unwrap();
+        let mut substream = mplex.inbound().wait().unwrap().expect("inbound substream");
 
         assert_eq!(substream.id(), 1);
 
@@ -648,7 +675,14 @@ mod tests {
         let mut outbound: Vec<Substream<_, Buffer>> = vec![];
 
         for _ in 0..5 {
-            outbound.push(mplex.clone().outbound().wait().unwrap());
+            outbound.push(
+                mplex
+                    .clone()
+                    .outbound()
+                    .wait()
+                    .unwrap()
+                    .expect("outbound substream"),
+            );
         }
 
         outbound.sort_by_key(|a| a.id());
@@ -668,7 +702,12 @@ mod tests {
         let mut inbound: Vec<Substream<_, Buffer>> = vec![];
 
         for _ in 0..5 {
-            let inb: Substream<_, Buffer> = mplex.clone().inbound().wait().unwrap();
+            let inb: Substream<_, Buffer> = mplex
+                .clone()
+                .inbound()
+                .wait()
+                .unwrap()
+                .expect("inbound substream");
             inbound.push(inb);
         }
 

--- a/mplex/src/read.rs
+++ b/mplex/src/read.rs
@@ -224,6 +224,7 @@ fn read_stream_internal<T: AsyncRead, Buf: Array<Item = u8>>(
                         let header = if let Some(header) = header {
                             header
                         } else {
+                            lock.close();
                             return Ok(on_block.unwrap_or(0));
                         };
 
@@ -291,6 +292,7 @@ fn read_stream_internal<T: AsyncRead, Buf: Array<Item = u8>>(
                         let length = if let Some(length) = length {
                             length
                         } else {
+                            lock.close();
                             return Ok(on_block.unwrap_or(0));
                         };
 
@@ -356,6 +358,10 @@ fn read_stream_internal<T: AsyncRead, Buf: Array<Item = u8>>(
 
                     match consumed {
                         Ok(consumed) => {
+                            if consumed == 0 {
+                                lock.close()
+                            }
+
                             let new_remaining = remaining_bytes - consumed;
 
                             lock.read_state = Some(NewStream {
@@ -422,6 +428,10 @@ fn read_stream_internal<T: AsyncRead, Buf: Array<Item = u8>>(
 
                         match read_result {
                             Ok(consumed) => {
+                                if consumed == 0 {
+                                    lock.close()
+                                }
+
                                 let new_remaining = remaining_bytes - consumed;
 
                                 lock.read_state = Some(ParsingMessageBody {
@@ -464,6 +474,9 @@ fn read_stream_internal<T: AsyncRead, Buf: Array<Item = u8>>(
                         let new_len = ignore_buf.len().min(remaining_bytes);
                         match lock.stream.read(&mut ignore_buf[..new_len]) {
                             Ok(consumed) => {
+                                if consumed == 0 {
+                                    lock.close()
+                                }
                                 remaining_bytes -= consumed;
                                 lock.read_state = Some(Ignore {
                                     remaining_bytes: remaining_bytes,

--- a/mplex/src/shared.rs
+++ b/mplex/src/shared.rs
@@ -75,7 +75,7 @@ pub struct MultiplexShared<T, Buf: Array> {
     pub read_state: Option<MultiplexReadState>,
     pub write_state: Option<MultiplexWriteState>,
     pub stream: T,
-    // true if the stream is open, false otherwise
+    eof: bool, // true, if `stream` has been exhausted
     pub open_streams: HashMap<u32, SubstreamMetadata<Buf>>,
     pub meta_write_tasks: Vec<Task>,
     // TODO: Should we use a version of this with a fixed size that doesn't allocate and return
@@ -93,6 +93,7 @@ impl<T, Buf: Array> MultiplexShared<T, Buf> {
             meta_write_tasks: Default::default(),
             to_open: Default::default(),
             stream: stream,
+            eof: false,
         }
     }
 
@@ -105,6 +106,14 @@ impl<T, Buf: Array> MultiplexShared<T, Buf> {
 
     pub fn close_stream(&mut self, id: u32) {
         self.open_streams.insert(id, SubstreamMetadata::Closed);
+    }
+
+    pub fn close(&mut self) {
+        self.eof = true
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.eof
     }
 }
 

--- a/mplex/tests/two_peers.rs
+++ b/mplex/tests/two_peers.rs
@@ -56,7 +56,7 @@ fn client_to_server_outbound() {
             .map_err(|(err, _)| err)
             .and_then(|(client, _)| client.unwrap().map(|v| v.0))
             .and_then(|client| client.outbound())
-            .map(|client| Framed::<_, bytes::BytesMut>::new(client))
+            .map(|client| Framed::<_, bytes::BytesMut>::new(client.unwrap()))
             .and_then(|client| {
                 client
                     .into_future()
@@ -79,7 +79,7 @@ fn client_to_server_outbound() {
         .dial(rx.recv().unwrap())
         .unwrap()
         .and_then(|client| client.0.inbound())
-        .map(|server| Framed::<_, bytes::BytesMut>::new(server))
+        .map(|server| Framed::<_, bytes::BytesMut>::new(server.unwrap()))
         .and_then(|server| server.send("hello world".into()))
         .map(|_| ());
 
@@ -108,7 +108,7 @@ fn client_to_server_inbound() {
             .map_err(|(err, _)| err)
             .and_then(|(client, _)| client.unwrap().map(|v| v.0))
             .and_then(|client| client.inbound())
-            .map(|client| Framed::<_, bytes::BytesMut>::new(client))
+            .map(|client| Framed::<_, bytes::BytesMut>::new(client.unwrap()))
             .and_then(|client| {
                 client
                     .into_future()
@@ -131,7 +131,7 @@ fn client_to_server_inbound() {
         .dial(rx.recv().unwrap())
         .unwrap()
         .and_then(|(client, _)| client.outbound())
-        .map(|server| Framed::<_, bytes::BytesMut>::new(server))
+        .map(|server| Framed::<_, bytes::BytesMut>::new(server.unwrap()))
         .and_then(|server| server.send("hello world".into()))
         .map(|_| ());
 

--- a/swarm/src/muxing.rs
+++ b/swarm/src/muxing.rs
@@ -29,10 +29,18 @@ use tokio_io::{AsyncRead, AsyncWrite};
 pub trait StreamMuxer {
     /// Type of the object that represents the raw substream where data can be read and written.
     type Substream: AsyncRead + AsyncWrite;
+
     /// Future that will be resolved when a new incoming substream is open.
-    type InboundSubstream: Future<Item = Self::Substream, Error = IoError>;
+    ///
+    /// A `None` item signals that the underlying resource has been exhausted and
+    /// no more substreams can be created.
+    type InboundSubstream: Future<Item = Option<Self::Substream>, Error = IoError>;
+
     /// Future that will be resolved when the outgoing substream is open.
-    type OutboundSubstream: Future<Item = Self::Substream, Error = IoError>;
+    ///
+    /// A `None` item signals that the underlying resource has been exhausted and
+    /// no more substreams can be created.
+    type OutboundSubstream: Future<Item = Option<Self::Substream>, Error = IoError>;
 
     /// Produces a future that will be resolved when a new incoming substream arrives.
     fn inbound(self) -> Self::InboundSubstream;

--- a/swarm/tests/multiplex.rs
+++ b/swarm/tests/multiplex.rs
@@ -115,7 +115,7 @@ fn client_to_server_outbound() {
         .dial(rx.recv().unwrap())
         .unwrap()
         .and_then(|client| client.0.outbound())
-        .map(|server| Framed::<_, BytesMut>::new(server))
+        .map(|server| Framed::<_, BytesMut>::new(server.unwrap()))
         .and_then(|server| server.send("hello world".into()))
         .map(|_| ());
 
@@ -229,7 +229,7 @@ fn use_opened_listen_to_dial() {
                 let c2 = c.clone();
                 c.clone().inbound().map(move |i| (c2, i))
             })
-            .map(|(muxer, client)| (muxer, Framed::<_, BytesMut>::new(client)))
+            .map(|(muxer, client)| (muxer, Framed::<_, BytesMut>::new(client.unwrap())))
             .and_then(|(muxer, client)| {
                 client
                     .into_future()
@@ -241,7 +241,7 @@ fn use_opened_listen_to_dial() {
                 assert_eq!(msg, "hello world");
                 muxer.outbound()
             })
-            .map(|client| Framed::<_, BytesMut>::new(client))
+            .map(|client| Framed::<_, BytesMut>::new(client.unwrap()))
             .and_then(|client| client.into_future().map_err(|(err, _)| err))
             .and_then(|(msg, _)| {
                 let msg = msg.unwrap();


### PR DESCRIPTION
Currently, connection substreams are added to `connection_reuse::Shared::active_connections`, but never removed. This is not least because the `StreamMuxer` trait defines its inbound and outbound substream futures to always yield a substream and contains no provision to signal that no more substreams can be created, which would allow client code (e.g. `ConnectionReuse`) to detect this and purge its caches.

This PR defines the `StreamMuxer` trait to optionally yield inbound/outbound substreams and changes `libp2p-mplex` to handle stream EOFs by marking the underlying resource as closed. `ConnectionReuse` will remove stream muxers from its active connections cache if a `None` substream is returned.