### PR TITLE
Swarm rework

### DIFF
--- a/circular-buffer/src/lib.rs
+++ b/circular-buffer/src/lib.rs
@@ -29,8 +29,8 @@
 
 extern crate smallvec;
 
-use std::ops::Drop;
 use std::mem::ManuallyDrop;
+use std::ops::Drop;
 
 pub use smallvec::Array;
 
@@ -41,8 +41,8 @@ use owned_slice::OwnedSlice;
 /// elements of these slices would be leaked after the slice goes out of scope. `OwnedSlice` simply
 /// manually drops all its elements when it goes out of scope.
 pub mod owned_slice {
-    use std::ops::{Deref, DerefMut, Drop};
     use std::mem::ManuallyDrop;
+    use std::ops::{Deref, DerefMut, Drop};
 
     /// A slice that owns its elements, but not their storage. This is useful for things like
     /// `Vec::retain` and `CircularBuffer::pop_slice`, since these functions can return a slice but

--- a/datastore/src/json_file.rs
+++ b/datastore/src/json_file.rs
@@ -27,8 +27,8 @@ use futures::stream::{iter_ok, Stream};
 use query::{naive_apply_query, Query};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use serde_json::{from_reader, from_value, to_value, to_writer, Map};
 use serde_json::value::Value;
+use serde_json::{from_reader, from_value, to_value, to_writer, Map};
 use std::borrow::Cow;
 use std::fs;
 use std::io::Cursor;
@@ -264,11 +264,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use {Filter, FilterOp, FilterTy, Order, Query};
     use Datastore;
     use JsonFileDatastore;
     use futures::{Future, Stream};
     use tempfile::NamedTempFile;
+    use {Filter, FilterOp, FilterTy, Order, Query};
 
     #[test]
     fn open_and_flush() {

--- a/datastore/src/lib.rs
+++ b/datastore/src/lib.rs
@@ -113,8 +113,8 @@ use std::borrow::Cow;
 use std::io::Error as IoError;
 use std::ops::DerefMut;
 
-mod query;
 mod json_file;
+mod query;
 
 pub use self::json_file::{JsonFileDatastore, JsonFileDatastoreEntry};
 pub use self::query::{Filter, FilterOp, FilterTy, Order, Query};

--- a/datastore/src/query.rs
+++ b/datastore/src/query.rs
@@ -18,8 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures::{Async, Future, Poll, Stream};
 use futures::stream::{iter_ok, Skip as StreamSkip, Take as StreamTake};
+use futures::{Async, Future, Poll, Stream};
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::io::Error as IoError;

--- a/dns/src/lib.rs
+++ b/dns/src/lib.rs
@@ -99,10 +99,10 @@ impl<T> Transport for DnsConfig<T>
 where
     T: Transport + 'static, // TODO: 'static :-/
 {
-    type RawConn = T::RawConn;
+    type Output = T::Output;
     type Listener = T::Listener;
     type ListenerUpgrade = T::ListenerUpgrade;
-    type Dial = Box<Future<Item = (Self::RawConn, Multiaddr), Error = IoError>>;
+    type Dial = Box<Future<Item = (Self::Output, Multiaddr), Error = IoError>>;
 
     #[inline]
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
@@ -238,10 +238,10 @@ mod tests {
         #[derive(Clone)]
         struct CustomTransport;
         impl Transport for CustomTransport {
-            type RawConn = <TcpConfig as Transport>::RawConn;
+            type Output = <TcpConfig as Transport>::Output;
             type Listener = <TcpConfig as Transport>::Listener;
             type ListenerUpgrade = <TcpConfig as Transport>::ListenerUpgrade;
-            type Dial = Box<Future<Item = (Self::RawConn, Multiaddr), Error = IoError>>;
+            type Dial = Box<Future<Item = (Self::Output, Multiaddr), Error = IoError>>;
 
             #[inline]
             fn listen_on(

--- a/example/examples/echo-dialer.rs
+++ b/example/examples/echo-dialer.rs
@@ -73,7 +73,7 @@ fn main() {
                 }
             };
 
-            upgrade::or(plain_text, secio)
+            upgrade::or(plain_text, upgrade::map(secio, |(socket, _)| socket))
         })
 
         // On top of plaintext or secio, we will use the multiplex protocol.

--- a/example/examples/echo-dialer.rs
+++ b/example/examples/echo-dialer.rs
@@ -89,8 +89,7 @@ fn main() {
     // by the listening part. We don't want to accept anything, so we pass a dummy object that
     // represents a connection that is always denied.
     let (swarm_controller, swarm_future) = swarm::swarm(
-        transport,
-        DeniedConnectionUpgrade,
+        transport.clone().with_upgrade(DeniedConnectionUpgrade),
         |_socket, _client_addr| -> Result<(), _> {
             unreachable!("All incoming connections should have been denied")
         },
@@ -108,7 +107,7 @@ fn main() {
     // We now use the controller to dial to the address.
     let (finished_tx, finished_rx) = oneshot::channel();
     swarm_controller
-        .dial_custom_handler(target_addr.parse().expect("invalid multiaddr"), proto, |echo, _| {
+        .dial_custom_handler(target_addr.parse().expect("invalid multiaddr"), transport.with_upgrade(proto), |echo, _| {
             // `echo` is what the closure used when initializing `proto` returns.
             // Consequently, please note that the `send` method is available only because the type
             // `length_delimited::Framed` has a `send` method.

--- a/example/examples/echo-dialer.rs
+++ b/example/examples/echo-dialer.rs
@@ -29,8 +29,8 @@ extern crate libp2p_websocket as websocket;
 extern crate tokio_core;
 extern crate tokio_io;
 
-use futures::{Future, Sink, Stream};
 use futures::sync::oneshot;
+use futures::{Future, Sink, Stream};
 use std::env;
 use swarm::Transport;
 use swarm::upgrade::{self, DeniedConnectionUpgrade, SimpleProtocol};

--- a/example/examples/echo-dialer.rs
+++ b/example/examples/echo-dialer.rs
@@ -33,7 +33,7 @@ use futures::{Future, Sink, Stream};
 use futures::sync::oneshot;
 use std::env;
 use swarm::Transport;
-use swarm::upgrade::{self, DeniedConnectionUpgrade, SimpleProtocol, UpgradeExt};
+use swarm::upgrade::{self, DeniedConnectionUpgrade, SimpleProtocol};
 use tcp::TcpConfig;
 use tokio_core::reactor::Core;
 use tokio_io::AsyncRead;
@@ -73,7 +73,7 @@ fn main() {
                 }
             };
 
-            plain_text.or_upgrade(secio)
+            upgrade::or(plain_text, secio)
         })
 
         // On top of plaintext or secio, we will use the multiplex protocol.

--- a/example/examples/echo-server.rs
+++ b/example/examples/echo-server.rs
@@ -99,7 +99,8 @@ fn main() {
 
     // Let's put this `transport` into a *swarm*. The swarm will handle all the incoming and
     // outgoing connections for us.
-    let (swarm_controller, swarm_future) = swarm::swarm(transport, proto, |socket, client_addr| {
+    let (swarm_controller, swarm_future) = swarm::swarm(transport.clone().with_upgrade(proto),
+    |socket, client_addr| {
         println!("Successfully negotiated protocol with {}", client_addr);
 
         // The type of `socket` is exactly what the closure of `SimpleProtocol` returns.

--- a/example/examples/echo-server.rs
+++ b/example/examples/echo-server.rs
@@ -33,7 +33,7 @@ use futures::future::{loop_fn, Future, IntoFuture, Loop};
 use futures::{Sink, Stream};
 use std::env;
 use swarm::Transport;
-use swarm::upgrade::{self, SimpleProtocol, UpgradeExt};
+use swarm::upgrade::{self, SimpleProtocol};
 use tcp::TcpConfig;
 use tokio_core::reactor::Core;
 use tokio_io::AsyncRead;
@@ -72,7 +72,7 @@ fn main() {
                 }
             };
 
-            plain_text.or_upgrade(secio)
+            upgrade::or(plain_text, secio)
         })
 
         // On top of plaintext or secio, we will use the multiplex protocol.

--- a/example/examples/echo-server.rs
+++ b/example/examples/echo-server.rs
@@ -72,7 +72,7 @@ fn main() {
                 }
             };
 
-            upgrade::or(plain_text, secio)
+            upgrade::or(plain_text, upgrade::map(secio, |(socket, _)| socket))
         })
 
         // On top of plaintext or secio, we will use the multiplex protocol.

--- a/example/examples/echo-server.rs
+++ b/example/examples/echo-server.rs
@@ -99,37 +99,39 @@ fn main() {
 
     // Let's put this `transport` into a *swarm*. The swarm will handle all the incoming and
     // outgoing connections for us.
-    let (swarm_controller, swarm_future) = swarm::swarm(transport.clone().with_upgrade(proto),
-    |socket, client_addr| {
-        println!("Successfully negotiated protocol with {}", client_addr);
+    let (swarm_controller, swarm_future) = swarm::swarm(
+        transport.clone().with_upgrade(proto),
+        |socket, client_addr| {
+            println!("Successfully negotiated protocol with {}", client_addr);
 
-        // The type of `socket` is exactly what the closure of `SimpleProtocol` returns.
+            // The type of `socket` is exactly what the closure of `SimpleProtocol` returns.
 
-        // We loop forever in order to handle all the messages sent by the client.
-        loop_fn(socket, move |socket| {
-            let client_addr = client_addr.clone();
-            socket
-                .into_future()
-                .map_err(|(e, _)| e)
-                .and_then(move |(msg, rest)| {
-                    if let Some(msg) = msg {
-                        // One message has been received. We send it back to the client.
-                        println!(
-                            "Received a message from {}: {:?}\n => Sending back \
-                             identical message to remote",
-                            client_addr, msg
-                        );
-                        Box::new(rest.send(msg.freeze()).map(|m| Loop::Continue(m)))
-                            as Box<Future<Item = _, Error = _>>
-                    } else {
-                        // End of stream. Connection closed. Breaking the loop.
-                        println!("Received EOF from {}\n => Dropping connection", client_addr);
-                        Box::new(Ok(Loop::Break(())).into_future())
-                            as Box<Future<Item = _, Error = _>>
-                    }
-                })
-        })
-    });
+            // We loop forever in order to handle all the messages sent by the client.
+            loop_fn(socket, move |socket| {
+                let client_addr = client_addr.clone();
+                socket
+                    .into_future()
+                    .map_err(|(e, _)| e)
+                    .and_then(move |(msg, rest)| {
+                        if let Some(msg) = msg {
+                            // One message has been received. We send it back to the client.
+                            println!(
+                                "Received a message from {}: {:?}\n => Sending back \
+                                 identical message to remote",
+                                client_addr, msg
+                            );
+                            Box::new(rest.send(msg.freeze()).map(|m| Loop::Continue(m)))
+                                as Box<Future<Item = _, Error = _>>
+                        } else {
+                            // End of stream. Connection closed. Breaking the loop.
+                            println!("Received EOF from {}\n => Dropping connection", client_addr);
+                            Box::new(Ok(Loop::Break(())).into_future())
+                                as Box<Future<Item = _, Error = _>>
+                        }
+                    })
+            })
+        },
+    );
 
     // We now use the controller to listen on the address.
     let address = swarm_controller

--- a/example/examples/floodsub.rs
+++ b/example/examples/floodsub.rs
@@ -38,7 +38,7 @@ use futures::Stream;
 use peerstore::PeerId;
 use std::{env, mem};
 use swarm::{Multiaddr, Transport};
-use swarm::upgrade::{self, UpgradeExt};
+use swarm::upgrade;
 use tcp::TcpConfig;
 use tokio_core::reactor::Core;
 use websocket::WsConfig;
@@ -75,7 +75,7 @@ fn main() {
                 }
             };
 
-            plain_text.or_upgrade(secio)
+            upgrade::or(plain_text, secio)
         })
 
         // On top of plaintext or secio, we will use the multiplex protocol.

--- a/example/examples/floodsub.rs
+++ b/example/examples/floodsub.rs
@@ -33,12 +33,12 @@ extern crate tokio_core;
 extern crate tokio_io;
 extern crate tokio_stdin;
 
-use futures::future::Future;
 use futures::Stream;
+use futures::future::Future;
 use peerstore::PeerId;
 use std::{env, mem};
-use swarm::{Multiaddr, Transport};
 use swarm::upgrade;
+use swarm::{Multiaddr, Transport};
 use tcp::TcpConfig;
 use tokio_core::reactor::Core;
 use websocket::WsConfig;
@@ -141,7 +141,10 @@ fn main() {
                 let target: Multiaddr = msg[6..].parse().unwrap();
                 println!("*Dialing {}*", target);
                 swarm_controller
-                    .dial_to_handler(target, transport.clone().with_upgrade(floodsub_upgrade.clone()))
+                    .dial_to_handler(
+                        target,
+                        transport.clone().with_upgrade(floodsub_upgrade.clone()),
+                    )
                     .unwrap();
             } else {
                 floodsub_ctl.publish(&topic, msg.into_bytes());

--- a/example/examples/floodsub.rs
+++ b/example/examples/floodsub.rs
@@ -102,8 +102,7 @@ fn main() {
     // Let's put this `transport` into a *swarm*. The swarm will handle all the incoming and
     // outgoing connections for us.
     let (swarm_controller, swarm_future) = swarm::swarm(
-        transport,
-        floodsub_upgrade.clone(),
+        transport.clone().with_upgrade(floodsub_upgrade.clone()),
         |socket, client_addr| {
             println!("Successfully negotiated protocol with {}", client_addr);
             socket
@@ -142,7 +141,7 @@ fn main() {
                 let target: Multiaddr = msg[6..].parse().unwrap();
                 println!("*Dialing {}*", target);
                 swarm_controller
-                    .dial_to_handler(target, floodsub_upgrade.clone())
+                    .dial_to_handler(target, transport.clone().with_upgrade(floodsub_upgrade.clone()))
                     .unwrap();
             } else {
                 floodsub_ctl.publish(&topic, msg.into_bytes());

--- a/example/examples/floodsub.rs
+++ b/example/examples/floodsub.rs
@@ -75,7 +75,7 @@ fn main() {
                 }
             };
 
-            upgrade::or(plain_text, secio)
+            upgrade::or(plain_text, upgrade::map(secio, |(socket, _)| socket))
         })
 
         // On top of plaintext or secio, we will use the multiplex protocol.

--- a/example/examples/kademlia.rs
+++ b/example/examples/kademlia.rs
@@ -116,9 +116,13 @@ fn main() {
 
     // Let's put this `transport` into a *swarm*. The swarm will handle all the incoming and
     // outgoing connections for us.
-    let (swarm_controller, swarm_future) = swarm::swarm(transport.clone().with_upgrade(proto.clone()), |upgrade, _| upgrade);
+    let (swarm_controller, swarm_future) = swarm::swarm(
+        transport.clone().with_upgrade(proto.clone()),
+        |upgrade, _| upgrade,
+    );
 
-    let (kad_controller, _kad_init) = kad_ctl_proto.start(swarm_controller.clone(), transport.with_upgrade(proto));
+    let (kad_controller, _kad_init) =
+        kad_ctl_proto.start(swarm_controller.clone(), transport.with_upgrade(proto));
 
     for listen_addr in listen_addrs {
         let addr = swarm_controller

--- a/example/examples/kademlia.rs
+++ b/example/examples/kademlia.rs
@@ -80,7 +80,7 @@ fn main() {
                 }
             };
 
-            upgrade::or(plain_text, secio)
+            upgrade::or(plain_text, upgrade::map(secio, |(socket, _)| socket))
         })
 
         // On top of plaintext or secio, we will use the multiplex protocol.

--- a/example/examples/kademlia.rs
+++ b/example/examples/kademlia.rs
@@ -116,9 +116,9 @@ fn main() {
 
     // Let's put this `transport` into a *swarm*. The swarm will handle all the incoming and
     // outgoing connections for us.
-    let (swarm_controller, swarm_future) = swarm::swarm(transport, proto, |upgrade, _| upgrade);
+    let (swarm_controller, swarm_future) = swarm::swarm(transport.clone().with_upgrade(proto.clone()), |upgrade, _| upgrade);
 
-    let (kad_controller, _kad_init) = kad_ctl_proto.start(swarm_controller.clone());
+    let (kad_controller, _kad_init) = kad_ctl_proto.start(swarm_controller.clone(), transport.with_upgrade(proto));
 
     for listen_addr in listen_addrs {
         let addr = swarm_controller

--- a/example/examples/kademlia.rs
+++ b/example/examples/kademlia.rs
@@ -40,7 +40,7 @@ use std::env;
 use std::sync::Arc;
 use std::time::Duration;
 use swarm::Transport;
-use swarm::upgrade::{self, UpgradeExt};
+use swarm::upgrade;
 use tcp::TcpConfig;
 use tokio_core::reactor::Core;
 
@@ -80,7 +80,7 @@ fn main() {
                 }
             };
 
-            plain_text.or_upgrade(secio)
+            upgrade::or(plain_text, secio)
         })
 
         // On top of plaintext or secio, we will use the multiplex protocol.

--- a/example/examples/ping-client.rs
+++ b/example/examples/ping-client.rs
@@ -65,7 +65,7 @@ fn main() {
                 }
             };
 
-            upgrade::or(plain_text, secio)
+            upgrade::or(plain_text, upgrade::map(secio, |(socket, _)| socket))
         })
 
         // On top of plaintext or secio, we will use the multiplex protocol.

--- a/example/examples/ping-client.rs
+++ b/example/examples/ping-client.rs
@@ -33,7 +33,7 @@ use futures::Future;
 use futures::sync::oneshot;
 use std::env;
 use swarm::Transport;
-use swarm::upgrade::{self, DeniedConnectionUpgrade, UpgradeExt};
+use swarm::upgrade::{self, DeniedConnectionUpgrade};
 use tcp::TcpConfig;
 use tokio_core::reactor::Core;
 
@@ -65,7 +65,7 @@ fn main() {
                 }
             };
 
-            plain_text.or_upgrade(secio)
+            upgrade::or(plain_text, secio)
         })
 
         // On top of plaintext or secio, we will use the multiplex protocol.

--- a/floodsub/src/lib.rs
+++ b/floodsub/src/lib.rs
@@ -39,17 +39,11 @@ mod topic;
 
 pub use self::topic::{Topic, TopicBuilder, TopicHash};
 
-use std::fmt;
-use std::hash::{Hash, Hasher};
-use std::io::{Error as IoError, ErrorKind as IoErrorKind};
-use std::iter;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use bytes::{Bytes, BytesMut};
 use byteorder::{BigEndian, WriteBytesExt};
+use bytes::{Bytes, BytesMut};
 use fnv::{FnvHashMap, FnvHashSet, FnvHasher};
-use futures::{future, Future, Poll, Sink, Stream};
 use futures::sync::mpsc;
+use futures::{future, Future, Poll, Sink, Stream};
 use libp2p_peerstore::PeerId;
 use libp2p_swarm::{ConnectionUpgrade, Endpoint};
 use log::Level;
@@ -57,6 +51,12 @@ use multiaddr::{AddrComponent, Multiaddr};
 use parking_lot::{Mutex, RwLock};
 use protobuf::Message as ProtobufMessage;
 use smallvec::SmallVec;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+use std::iter;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio_io::{AsyncRead, AsyncWrite};
 use varint::VarintCodec;
 

--- a/identify/src/protocol.rs
+++ b/identify/src/protocol.rs
@@ -29,8 +29,8 @@ use protobuf::repeated::RepeatedField;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::iter;
 use structs_proto;
-use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_io::codec::Framed;
+use tokio_io::{AsyncRead, AsyncWrite};
 use varint::VarintCodec;
 
 /// Configuration for an upgrade to the identity protocol.
@@ -238,11 +238,11 @@ mod tests {
 
     use self::libp2p_tcp_transport::TcpConfig;
     use self::tokio_core::reactor::Core;
-    use {IdentifyInfo, IdentifyOutput, IdentifyProtocolConfig};
     use futures::{Future, Stream};
     use libp2p_swarm::Transport;
     use std::sync::mpsc;
     use std::thread;
+    use {IdentifyInfo, IdentifyOutput, IdentifyProtocolConfig};
 
     #[test]
     fn correct_transfer() {

--- a/identify/src/transport.rs
+++ b/identify/src/transport.rs
@@ -26,6 +26,7 @@ use protocol::{IdentifyInfo, IdentifyOutput, IdentifyProtocolConfig};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::ops::Deref;
 use std::time::Duration;
+use tokio_io::{AsyncRead, AsyncWrite};
 
 /// Implementation of `Transport`. See [the crate root description](index.html).
 #[derive(Debug, Clone)]
@@ -59,6 +60,7 @@ impl<Trans, PStoreRef> IdentifyTransport<Trans, PStoreRef> {
 impl<Trans, PStore, PStoreRef> Transport for IdentifyTransport<Trans, PStoreRef>
 where
     Trans: Transport + Clone + 'static, // TODO: 'static :(
+    Trans::Output: AsyncRead + AsyncWrite,
     PStoreRef: Deref<Target = PStore> + Clone + 'static, // TODO: 'static :(
     for<'r> &'r PStore: Peerstore,
 {
@@ -275,6 +277,7 @@ where
 impl<Trans, PStore, PStoreRef> MuxedTransport for IdentifyTransport<Trans, PStoreRef>
 where
     Trans: MuxedTransport + Clone + 'static,
+    Trans::Output: AsyncRead + AsyncWrite,
     PStoreRef: Deref<Target = PStore> + Clone + 'static,
     for<'r> &'r PStore: Peerstore,
 {

--- a/identify/src/transport.rs
+++ b/identify/src/transport.rs
@@ -62,10 +62,10 @@ where
     PStoreRef: Deref<Target = PStore> + Clone + 'static, // TODO: 'static :(
     for<'r> &'r PStore: Peerstore,
 {
-    type RawConn = Trans::RawConn;
+    type Output = Trans::Output;
     type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = IoError>>;
-    type ListenerUpgrade = Box<Future<Item = (Trans::RawConn, Multiaddr), Error = IoError>>;
-    type Dial = Box<Future<Item = (Trans::RawConn, Multiaddr), Error = IoError>>;
+    type ListenerUpgrade = Box<Future<Item = (Trans::Output, Multiaddr), Error = IoError>>;
+    type Dial = Box<Future<Item = (Trans::Output, Multiaddr), Error = IoError>>;
 
     #[inline]
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
@@ -279,7 +279,7 @@ where
     for<'r> &'r PStore: Peerstore,
 {
     type Incoming = Box<Future<Item = Self::IncomingUpgrade, Error = IoError>>;
-    type IncomingUpgrade = Box<Future<Item = (Trans::RawConn, Multiaddr), Error = IoError>>;
+    type IncomingUpgrade = Box<Future<Item = (Trans::Output, Multiaddr), Error = IoError>>;
 
     #[inline]
     fn next_incoming(self) -> Self::Incoming {
@@ -410,9 +410,9 @@ mod tests {
             inner: TcpConfig,
         }
         impl Transport for UnderlyingTrans {
-            type RawConn = <TcpConfig as Transport>::RawConn;
+            type Output = <TcpConfig as Transport>::Output;
             type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = IoError>>;
-            type ListenerUpgrade = Box<Future<Item = (Self::RawConn, Multiaddr), Error = IoError>>;
+            type ListenerUpgrade = Box<Future<Item = (Self::Output, Multiaddr), Error = IoError>>;
             type Dial = <TcpConfig as Transport>::Dial;
             #[inline]
             fn listen_on(

--- a/identify/src/transport.rs
+++ b/identify/src/transport.rs
@@ -394,8 +394,8 @@ mod tests {
     use self::tokio_core::reactor::Core;
     use IdentifyTransport;
     use futures::{Future, Stream};
-    use libp2p_peerstore::{PeerAccess, PeerId, Peerstore};
     use libp2p_peerstore::memory_peerstore::MemoryPeerstore;
+    use libp2p_peerstore::{PeerAccess, PeerId, Peerstore};
     use libp2p_swarm::Transport;
     use multiaddr::{AddrComponent, Multiaddr};
     use std::io::Error as IoError;

--- a/kad/src/high_level.rs
+++ b/kad/src/high_level.rs
@@ -107,6 +107,7 @@ where
         for<'r> &'r Pc: Peerstore,
         R: Clone + 'static,                                 // TODO: 'static :-/
         T: Clone + MuxedTransport + 'static,                // TODO: 'static :-/
+        T::Output: AsyncRead + AsyncWrite,
         C: Clone + ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
         C::NamesIter: Clone,
         C::Output: From<KademliaProcessingFuture>,
@@ -145,6 +146,7 @@ where
 pub struct KademliaController<P, R, T, C>
 where
     T: MuxedTransport + 'static,                // TODO: 'static :-/
+    T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
 {
     inner: Arc<Inner<P, R>>,
@@ -154,6 +156,7 @@ where
 impl<P, R, T, C> Clone for KademliaController<P, R, T, C>
 where
     T: Clone + MuxedTransport + 'static, // TODO: 'static :-/
+    T::Output: AsyncRead + AsyncWrite,
     C: Clone + ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
 {
     #[inline]
@@ -171,11 +174,12 @@ where
     for<'r> &'r Pc: Peerstore,
     R: Clone,
     T: Clone + MuxedTransport + 'static, // TODO: 'static :-/
+    T::Output: AsyncRead + AsyncWrite,
     C: Clone + ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
 {
     /// Performs an iterative find node query on the network.
     ///
-    /// Will query the network for the peers that are the closest to `searched_key` and return
+    /// Will query the network for the peers that4 are the closest to `searched_key` and return
     /// the results.
     ///
     /// The algorithm used is a standard Kademlia algorithm. The details are not documented, so
@@ -217,6 +221,7 @@ impl<P, R> KademliaUpgrade<P, R> {
     pub fn from_controller<T, C>(ctl: &KademliaController<P, R, T, C>) -> Self
     where
         T: MuxedTransport,
+        T::Output: AsyncRead + AsyncWrite,
         C: ConnectionUpgrade<T::Output>,
     {
         KademliaUpgrade {
@@ -414,6 +419,7 @@ where
     for<'r> &'r Pc: Peerstore,
     R: Clone + 'static,                                 // TODO: 'static :-/
     T: Clone + MuxedTransport + 'static,                // TODO: 'static :-/
+    T::Output: AsyncRead + AsyncWrite,
     C: Clone + ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
     C::NamesIter: Clone,
     C::Output: From<KademliaProcessingFuture>,

--- a/kad/src/high_level.rs
+++ b/kad/src/high_level.rs
@@ -107,7 +107,7 @@ where
         for<'r> &'r Pc: Peerstore,
         R: Clone + 'static,                                 // TODO: 'static :-/
         T: Clone + MuxedTransport + 'static,                // TODO: 'static :-/
-        C: Clone + ConnectionUpgrade<T::RawConn> + 'static, // TODO: 'static :-/
+        C: Clone + ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
         C::NamesIter: Clone,
         C::Output: From<KademliaProcessingFuture>,
     {
@@ -145,7 +145,7 @@ where
 pub struct KademliaController<P, R, T, C>
 where
     T: MuxedTransport + 'static,                // TODO: 'static :-/
-    C: ConnectionUpgrade<T::RawConn> + 'static, // TODO: 'static :-/
+    C: ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
 {
     inner: Arc<Inner<P, R>>,
     swarm_controller: SwarmController<T, C>,
@@ -154,7 +154,7 @@ where
 impl<P, R, T, C> Clone for KademliaController<P, R, T, C>
 where
     T: Clone + MuxedTransport + 'static, // TODO: 'static :-/
-    C: Clone + ConnectionUpgrade<T::RawConn> + 'static, // TODO: 'static :-/
+    C: Clone + ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
 {
     #[inline]
     fn clone(&self) -> Self {
@@ -171,7 +171,7 @@ where
     for<'r> &'r Pc: Peerstore,
     R: Clone,
     T: Clone + MuxedTransport + 'static, // TODO: 'static :-/
-    C: Clone + ConnectionUpgrade<T::RawConn> + 'static, // TODO: 'static :-/
+    C: Clone + ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
 {
     /// Performs an iterative find node query on the network.
     ///
@@ -217,7 +217,7 @@ impl<P, R> KademliaUpgrade<P, R> {
     pub fn from_controller<T, C>(ctl: &KademliaController<P, R, T, C>) -> Self
     where
         T: MuxedTransport,
-        C: ConnectionUpgrade<T::RawConn>,
+        C: ConnectionUpgrade<T::Output>,
     {
         KademliaUpgrade {
             inner: ctl.inner.clone(),
@@ -414,7 +414,7 @@ where
     for<'r> &'r Pc: Peerstore,
     R: Clone + 'static,                                 // TODO: 'static :-/
     T: Clone + MuxedTransport + 'static,                // TODO: 'static :-/
-    C: Clone + ConnectionUpgrade<T::RawConn> + 'static, // TODO: 'static :-/
+    C: Clone + ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
     C::NamesIter: Clone,
     C::Output: From<KademliaProcessingFuture>,
 {

--- a/kad/src/high_level.rs
+++ b/kad/src/high_level.rs
@@ -24,12 +24,12 @@
 
 use bytes::Bytes;
 use fnv::FnvHashMap;
-use futures::{self, future, Future};
 use futures::sync::oneshot;
+use futures::{self, future, Future};
 use kad_server::{KadServerInterface, KademliaServerConfig, KademliaServerController};
 use kbucket::{KBucketsPeerId, KBucketsTable, UpdateOutcome};
 use libp2p_peerstore::{PeerAccess, PeerId, Peerstore};
-use libp2p_swarm::{Transport, Endpoint, MuxedTransport, SwarmController, ConnectionUpgrade};
+use libp2p_swarm::{ConnectionUpgrade, Endpoint, MuxedTransport, SwarmController, Transport};
 use multiaddr::Multiaddr;
 use parking_lot::Mutex;
 use protocol::ConnectionType;
@@ -105,10 +105,10 @@ where
     where
         P: Clone + Deref<Target = Pc> + 'static, // TODO: 'static :-/
         for<'r> &'r Pc: Peerstore,
-        R: Clone + 'static,                                 // TODO: 'static :-/
-        T: Clone + MuxedTransport + 'static,                // TODO: 'static :-/
+        R: Clone + 'static,                  // TODO: 'static :-/
+        T: Clone + MuxedTransport + 'static, // TODO: 'static :-/
         T::Output: From<KademliaProcessingFuture>,
-        K: Transport<Output = KademliaProcessingFuture> + Clone + 'static,         // TODO: 'static :-/
+        K: Transport<Output = KademliaProcessingFuture> + Clone + 'static, // TODO: 'static :-/
     {
         // TODO: initialization
 
@@ -144,7 +144,7 @@ where
 #[derive(Debug)]
 pub struct KademliaController<P, R, T, K>
 where
-    T: MuxedTransport + 'static,                // TODO: 'static :-/
+    T: MuxedTransport + 'static, // TODO: 'static :-/
 {
     inner: Arc<Inner<P, R>>,
     swarm_controller: SwarmController<T>,
@@ -411,8 +411,8 @@ impl<R, P, Pc, T, K> query::QueryInterface for KademliaController<P, R, T, K>
 where
     P: Clone + Deref<Target = Pc> + 'static, // TODO: 'static :-/
     for<'r> &'r Pc: Peerstore,
-    R: Clone + 'static,                                 // TODO: 'static :-/
-    T: Clone + MuxedTransport + 'static,                // TODO: 'static :-/
+    R: Clone + 'static,                  // TODO: 'static :-/
+    T: Clone + MuxedTransport + 'static, // TODO: 'static :-/
     T::Output: From<KademliaProcessingFuture>,
     K: Transport<Output = KademliaProcessingFuture> + Clone + 'static,
 {
@@ -467,7 +467,9 @@ where
             }
             Entry::Vacant(entry) => {
                 // Need to open a connection.
-                match self.swarm_controller.dial_to_handler(addr, self.kademlia_transport.clone()) {
+                match self.swarm_controller
+                    .dial_to_handler(addr, self.kademlia_transport.clone())
+                {
                     Ok(()) => (),
                     Err(_addr) => {
                         let fut = future::err(IoError::new(

--- a/kad/src/kad_server.rs
+++ b/kad/src/kad_server.rs
@@ -36,8 +36,8 @@
 //! `Arc` in order to be available whenever we need to request something from a node.
 
 use bytes::Bytes;
-use futures::{future, Future, Sink, Stream};
 use futures::sync::{mpsc, oneshot};
+use futures::{future, Future, Sink, Stream};
 use libp2p_peerstore::PeerId;
 use libp2p_swarm::ConnectionUpgrade;
 use libp2p_swarm::Endpoint;

--- a/kad/src/protocol.rs
+++ b/kad/src/protocol.rs
@@ -26,8 +26,8 @@
 //! used to send messages.
 
 use bytes::Bytes;
-use futures::{Sink, Stream};
 use futures::future;
+use futures::{Sink, Stream};
 use libp2p_peerstore::PeerId;
 use libp2p_swarm::{ConnectionUpgrade, Endpoint, Multiaddr};
 use protobuf::{self, Message};
@@ -162,9 +162,9 @@ where
 }
 
 /// Custom trait that derives `Sink` and `Stream`, so that we can box it.
-pub trait KadStreamSink
-    : Stream<Item = KadMsg, Error = IoError> + Sink<SinkItem = KadMsg, SinkError = IoError>
-    {
+pub trait KadStreamSink:
+    Stream<Item = KadMsg, Error = IoError> + Sink<SinkItem = KadMsg, SinkError = IoError>
+{
 }
 impl<T> KadStreamSink for T
 where

--- a/mplex/src/lib.rs
+++ b/mplex/src/lib.rs
@@ -35,25 +35,25 @@ extern crate rand;
 extern crate tokio_io;
 extern crate varint;
 
-mod read;
-mod write;
-mod shared;
 mod header;
+mod read;
+mod shared;
+mod write;
 
 use bytes::Bytes;
 use circular_buffer::Array;
-use futures::{Async, Future, Poll};
 use futures::future::{self, FutureResult};
-use header::MultiplexHeader;
-use swarm::muxing::StreamMuxer;
-use swarm::{ConnectionUpgrade, Endpoint, Multiaddr};
+use futures::{Async, Future, Poll};
 use futures_mutex::Mutex;
+use header::MultiplexHeader;
 use read::{read_stream, MultiplexReadState};
 use shared::{buf_from_slice, ByteBuf, MultiplexShared};
-use std::iter;
 use std::io::{self, Read, Write};
+use std::iter;
 use std::sync::Arc;
 use std::sync::atomic::{self, AtomicUsize};
+use swarm::muxing::StreamMuxer;
+use swarm::{ConnectionUpgrade, Endpoint, Multiaddr};
 use tokio_io::{AsyncRead, AsyncWrite};
 use write::write_stream;
 

--- a/mplex/src/read.rs
+++ b/mplex/src/read.rs
@@ -18,14 +18,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use {bytes, varint};
+use circular_buffer::Array;
 use futures::Async;
 use futures::task;
 use header::{MultiplexHeader, PacketType};
+use shared::SubstreamMetadata;
 use std::io;
 use tokio_io::AsyncRead;
-use shared::SubstreamMetadata;
-use circular_buffer::Array;
+use {bytes, varint};
 
 pub enum NextMultiplexState {
     NewStream(u32),

--- a/mplex/src/shared.rs
+++ b/mplex/src/shared.rs
@@ -21,11 +21,11 @@
 use read::MultiplexReadState;
 use write::MultiplexWriteState;
 
-use circular_buffer::{Array, CircularBuffer};
-use std::collections::HashMap;
-use bytes::Bytes;
 use arrayvec::ArrayVec;
+use bytes::Bytes;
+use circular_buffer::{Array, CircularBuffer};
 use futures::task::Task;
+use std::collections::HashMap;
 
 const BUF_SIZE: usize = 1024;
 

--- a/mplex/src/write.rs
+++ b/mplex/src/write.rs
@@ -18,14 +18,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use shared::{ByteBuf, MultiplexShared, SubstreamMetadata};
 use header::MultiplexHeader;
+use shared::{ByteBuf, MultiplexShared, SubstreamMetadata};
 
 use circular_buffer;
-use varint;
 use futures::task;
 use std::io;
 use tokio_io::AsyncWrite;
+use varint;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum RequestType {

--- a/multistream-select/src/dialer_select.rs
+++ b/multistream-select/src/dialer_select.rs
@@ -23,8 +23,8 @@
 
 use ProtocolChoiceError;
 use bytes::Bytes;
-use futures::{Future, Sink, Stream};
 use futures::future::{loop_fn, result, Loop};
+use futures::{Future, Sink, Stream};
 
 use protocol::Dialer;
 use protocol::DialerToListenerMessage;

--- a/multistream-select/src/length_delimited.rs
+++ b/multistream-select/src/length_delimited.rs
@@ -26,10 +26,10 @@
 //! We purposely only support a frame length of under 64kiB. Frames most consist in a short
 //! protocol name, which is highly unlikely to be more than 64kiB long.
 
-use std::io::{Error as IoError, ErrorKind as IoErrorKind};
-use std::marker::PhantomData;
 use futures::{Async, Poll, Sink, StartSend, Stream};
 use smallvec::SmallVec;
+use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+use std::marker::PhantomData;
 use tokio_io::AsyncRead;
 
 /// Wraps around a `AsyncRead` and implements `Stream`.
@@ -232,10 +232,10 @@ fn decode_length_prefix(buf: &[u8]) -> u16 {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
-    use std::io::ErrorKind;
     use futures::{Future, Stream};
     use length_delimited::LengthDelimitedFramedRead;
+    use std::io::Cursor;
+    use std::io::ErrorKind;
 
     #[test]
     fn basic_read() {

--- a/multistream-select/src/listener_select.rs
+++ b/multistream-select/src/listener_select.rs
@@ -23,8 +23,8 @@
 
 use ProtocolChoiceError;
 use bytes::Bytes;
-use futures::{Future, Sink, Stream};
 use futures::future::{err, loop_fn, Loop};
+use futures::{Future, Sink, Stream};
 
 use protocol::DialerToListenerMessage;
 use protocol::Listener;

--- a/multistream-select/src/protocol/dialer.rs
+++ b/multistream-select/src/protocol/dialer.rs
@@ -28,9 +28,9 @@ use protocol::ListenerToDialerMessage;
 use protocol::MULTISTREAM_PROTOCOL_WITH_LF;
 use protocol::MultistreamSelectError;
 use std::io::{BufRead, Cursor, Read};
-use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_io::codec::length_delimited::Builder as LengthDelimitedBuilder;
 use tokio_io::codec::length_delimited::FramedWrite as LengthDelimitedFramedWrite;
+use tokio_io::{AsyncRead, AsyncWrite};
 use varint;
 
 /// Wraps around a `AsyncRead+AsyncWrite`. Assumes that we're on the dialer's side. Produces and
@@ -191,12 +191,12 @@ where
 #[cfg(test)]
 mod tests {
     extern crate tokio_core;
-    use bytes::Bytes;
-    use futures::{Sink, Stream};
-    use futures::Future;
-    use protocol::{Dialer, DialerToListenerMessage, MultistreamSelectError};
     use self::tokio_core::net::{TcpListener, TcpStream};
     use self::tokio_core::reactor::Core;
+    use bytes::Bytes;
+    use futures::Future;
+    use futures::{Sink, Stream};
+    use protocol::{Dialer, DialerToListenerMessage, MultistreamSelectError};
 
     #[test]
     fn wrong_proto_name() {

--- a/multistream-select/src/protocol/listener.rs
+++ b/multistream-select/src/protocol/listener.rs
@@ -27,9 +27,9 @@ use protocol::DialerToListenerMessage;
 use protocol::ListenerToDialerMessage;
 use protocol::MULTISTREAM_PROTOCOL_WITH_LF;
 use protocol::MultistreamSelectError;
-use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_io::codec::length_delimited::Builder as LengthDelimitedBuilder;
 use tokio_io::codec::length_delimited::FramedWrite as LengthDelimitedFramedWrite;
+use tokio_io::{AsyncRead, AsyncWrite};
 use varint;
 
 /// Wraps around a `AsyncRead+AsyncWrite`. Assumes that we're on the listener's side. Produces and
@@ -186,12 +186,12 @@ where
 #[cfg(test)]
 mod tests {
     extern crate tokio_core;
-    use bytes::Bytes;
-    use futures::{Sink, Stream};
-    use futures::Future;
-    use protocol::{Dialer, Listener, ListenerToDialerMessage, MultistreamSelectError};
     use self::tokio_core::net::{TcpListener, TcpStream};
     use self::tokio_core::reactor::Core;
+    use bytes::Bytes;
+    use futures::Future;
+    use futures::{Sink, Stream};
+    use protocol::{Dialer, Listener, ListenerToDialerMessage, MultistreamSelectError};
 
     #[test]
     fn wrong_proto_name() {

--- a/multistream-select/src/tests.rs
+++ b/multistream-select/src/tests.rs
@@ -24,16 +24,16 @@
 
 extern crate tokio_core;
 
-use {dialer_select_proto, listener_select_proto};
-use ProtocolChoiceError;
-use bytes::Bytes;
-use dialer_select::{dialer_select_proto_parallel, dialer_select_proto_serial};
-use futures::{Sink, Stream};
-use futures::Future;
-use protocol::{Dialer, DialerToListenerMessage, Listener, ListenerToDialerMessage};
 use self::tokio_core::net::TcpListener;
 use self::tokio_core::net::TcpStream;
 use self::tokio_core::reactor::Core;
+use ProtocolChoiceError;
+use bytes::Bytes;
+use dialer_select::{dialer_select_proto_parallel, dialer_select_proto_serial};
+use futures::Future;
+use futures::{Sink, Stream};
+use protocol::{Dialer, DialerToListenerMessage, Listener, ListenerToDialerMessage};
+use {dialer_select_proto, listener_select_proto};
 
 #[test]
 fn negotiate_with_self_succeeds() {

--- a/peerstore/src/json_peerstore.rs
+++ b/peerstore/src/json_peerstore.rs
@@ -22,6 +22,7 @@
 
 use super::TTL;
 use PeerId;
+use bs58;
 use datastore::{Datastore, JsonFileDatastore, JsonFileDatastoreEntry, Query};
 use futures::{Future, Stream};
 use multiaddr::Multiaddr;
@@ -31,7 +32,6 @@ use std::io::Error as IoError;
 use std::iter;
 use std::path::PathBuf;
 use std::vec::IntoIter as VecIntoIter;
-use bs58;
 
 /// Peerstore backend that uses a Json file.
 pub struct JsonPeerstore {

--- a/peerstore/src/peer_info.rs
+++ b/peerstore/src/peer_info.rs
@@ -28,9 +28,9 @@
 
 use TTL;
 use multiaddr::Multiaddr;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde::de::Error as DeserializerError;
 use serde::ser::SerializeStruct;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cmp::Ordering;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 

--- a/peerstore/src/peerstore.rs
+++ b/peerstore/src/peerstore.rs
@@ -18,8 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use {PeerId, TTL};
 use multiaddr::Multiaddr;
+use {PeerId, TTL};
 
 /// Implemented on objects that store peers.
 ///

--- a/ping/src/lib.rs
+++ b/ping/src/lib.rs
@@ -89,9 +89,9 @@ extern crate rand;
 extern crate tokio_io;
 
 use bytes::{BufMut, Bytes, BytesMut};
-use futures::{Future, Sink, Stream};
 use futures::future::{loop_fn, FutureResult, IntoFuture, Loop};
 use futures::sync::{mpsc, oneshot};
+use futures::{Future, Sink, Stream};
 use libp2p_swarm::{ConnectionUpgrade, Endpoint, Multiaddr};
 use log::Level;
 use parking_lot::Mutex;
@@ -102,8 +102,8 @@ use std::error::Error;
 use std::io::Error as IoError;
 use std::iter;
 use std::sync::Arc;
-use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_io::codec::{Decoder, Encoder};
+use tokio_io::{AsyncRead, AsyncWrite};
 
 /// Represents a prototype for an upgrade to handle the ping protocol.
 ///
@@ -306,9 +306,9 @@ mod tests {
     use self::tokio_core::net::TcpStream;
     use self::tokio_core::reactor::Core;
     use super::Ping;
-    use futures::future::join_all;
     use futures::Future;
     use futures::Stream;
+    use futures::future::join_all;
     use libp2p_swarm::{ConnectionUpgrade, Endpoint};
 
     #[test]

--- a/ratelimit/src/lib.rs
+++ b/ratelimit/src/lib.rs
@@ -140,6 +140,7 @@ pub struct ListenerUpgrade<T: Transport>(RateLimited<T::ListenerUpgrade>);
 impl<T> Future for ListenerUpgrade<T>
 where
     T: Transport + 'static,
+    T::Output: AsyncRead + AsyncWrite,
 {
     type Item = (Connection<T::Output>, Multiaddr);
     type Error = io::Error;
@@ -157,6 +158,7 @@ pub struct Dial<T: Transport>(RateLimited<T::Dial>);
 impl<T> IntoFuture for Dial<T>
 where
     T: Transport + 'static,
+    T::Output: AsyncRead + AsyncWrite,
 {
     type Future = Box<Future<Item = Self::Item, Error = Self::Error>>;
     type Item = (Connection<T::Output>, Multiaddr);
@@ -176,6 +178,7 @@ where
 impl<T> Transport for RateLimited<T>
 where
     T: Transport + 'static,
+    T::Output: AsyncRead + AsyncWrite,
 {
     type Output = Connection<T::Output>;
     type Listener = Listener<T>;

--- a/ratelimit/src/lib.rs
+++ b/ratelimit/src/lib.rs
@@ -141,7 +141,7 @@ impl<T> Future for ListenerUpgrade<T>
 where
     T: Transport + 'static,
 {
-    type Item = (Connection<T::RawConn>, Multiaddr);
+    type Item = (Connection<T::Output>, Multiaddr);
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
@@ -159,7 +159,7 @@ where
     T: Transport + 'static,
 {
     type Future = Box<Future<Item = Self::Item, Error = Self::Error>>;
-    type Item = (Connection<T::RawConn>, Multiaddr);
+    type Item = (Connection<T::Output>, Multiaddr);
     type Error = io::Error;
 
     fn into_future(self) -> Self::Future {
@@ -177,7 +177,7 @@ impl<T> Transport for RateLimited<T>
 where
     T: Transport + 'static,
 {
-    type RawConn = Connection<T::RawConn>;
+    type Output = Connection<T::Output>;
     type Listener = Listener<T>;
     type ListenerUpgrade = ListenerUpgrade<T>;
     type Dial = Dial<T>;

--- a/rw-stream-sink/src/lib.rs
+++ b/rw-stream-sink/src/lib.rs
@@ -34,12 +34,12 @@ extern crate bytes;
 extern crate futures;
 extern crate tokio_io;
 
+use bytes::{Buf, IntoBuf};
+use futures::{Async, AsyncSink, Poll, Sink, Stream};
 use std::cmp;
 use std::io::Error as IoError;
 use std::io::ErrorKind as IoErrorKind;
 use std::io::{Read, Write};
-use bytes::{Buf, IntoBuf};
-use futures::{Async, AsyncSink, Poll, Sink, Stream};
 use tokio_io::{AsyncRead, AsyncWrite};
 
 /// Wraps around a `Stream + Sink` whose items are buffers. Implements `AsyncRead` and `AsyncWrite`.
@@ -164,11 +164,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use bytes::Bytes;
-    use futures::{Future, Poll, Sink, StartSend, Stream};
-    use futures::sync::mpsc::channel;
-    use std::io::Read;
     use RwStreamSink;
+    use bytes::Bytes;
+    use futures::sync::mpsc::channel;
+    use futures::{Future, Poll, Sink, StartSend, Stream};
+    use std::io::Read;
 
     // This struct merges a stream and a sink and is quite useful for tests.
     struct Wrapper<St, Si>(St, Si);

--- a/secio/src/codec/mod.rs
+++ b/secio/src/codec/mod.rs
@@ -26,8 +26,8 @@ use self::encode::EncoderMiddleware;
 
 use crypto::symmetriccipher::SynchronousStreamCipher;
 use ring::hmac;
-use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_io::codec::length_delimited;
+use tokio_io::{AsyncRead, AsyncWrite};
 
 mod decode;
 mod encode;
@@ -59,6 +59,9 @@ where
 #[cfg(test)]
 mod tests {
     extern crate tokio_core;
+    use self::tokio_core::net::TcpListener;
+    use self::tokio_core::net::TcpStream;
+    use self::tokio_core::reactor::Core;
     use super::DecoderMiddleware;
     use super::EncoderMiddleware;
     use super::full_codec;
@@ -66,16 +69,13 @@ mod tests {
     use crypto::aessafe::AesSafe256Encryptor;
     use crypto::blockmodes::CtrMode;
     use error::SecioError;
-    use futures::{Future, Sink, Stream};
     use futures::sync::mpsc::channel;
+    use futures::{Future, Sink, Stream};
     use rand;
     use ring::digest::SHA256;
     use ring::hmac::SigningKey;
     use ring::hmac::VerificationKey;
     use std::io::Error as IoError;
-    use self::tokio_core::net::TcpListener;
-    use self::tokio_core::net::TcpStream;
-    use self::tokio_core::reactor::Core;
     use tokio_io::codec::length_delimited::Framed;
 
     #[test]

--- a/secio/src/handshake.rs
+++ b/secio/src/handshake.rs
@@ -30,19 +30,19 @@ use futures::stream::Stream;
 use keys_proto::{KeyType as KeyTypeProtobuf, PublicKey as PublicKeyProtobuf};
 use protobuf::Message as ProtobufMessage;
 use protobuf::core::parse_from_bytes as protobuf_parse_from_bytes;
-use ring::{agreement, digest, rand};
 use ring::agreement::EphemeralPrivateKey;
 use ring::hmac::{SigningContext, SigningKey, VerificationKey};
 use ring::rand::SecureRandom;
-use ring::signature::{RSAKeyPair, RSASigningState, RSA_PKCS1_2048_8192_SHA256, RSA_PKCS1_SHA256};
 use ring::signature::verify as signature_verify;
+use ring::signature::{RSAKeyPair, RSASigningState, RSA_PKCS1_2048_8192_SHA256, RSA_PKCS1_SHA256};
+use ring::{agreement, digest, rand};
 use std::cmp::{self, Ordering};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::mem;
 use std::sync::Arc;
 use structs_proto::{Exchange, Propose};
-use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_io::codec::length_delimited;
+use tokio_io::{AsyncRead, AsyncWrite};
 use untrusted::Input as UntrustedInput;
 
 /// Performs a handshake on the given socket.
@@ -526,6 +526,9 @@ fn stretch_key(key: &SigningKey, result: &mut [u8]) {
 #[cfg(test)]
 mod tests {
     extern crate tokio_core;
+    use self::tokio_core::net::TcpListener;
+    use self::tokio_core::net::TcpStream;
+    use self::tokio_core::reactor::Core;
     use super::handshake;
     use super::stretch_key;
     use futures::Future;
@@ -534,9 +537,6 @@ mod tests {
     use ring::hmac::SigningKey;
     use ring::signature::RSAKeyPair;
     use std::sync::Arc;
-    use self::tokio_core::net::TcpListener;
-    use self::tokio_core::net::TcpStream;
-    use self::tokio_core::reactor::Core;
     use untrusted::Input;
 
     #[test]

--- a/secio/src/lib.rs
+++ b/secio/src/lib.rs
@@ -39,7 +39,7 @@
 //! # fn main() {
 //! use futures::Future;
 //! use libp2p_secio::{SecioConfig, SecioKeyPair};
-//! use libp2p_swarm::{Multiaddr, Transport};
+//! use libp2p_swarm::{Multiaddr, Transport, upgrade};
 //! use libp2p_tcp_transport::TcpConfig;
 //! use tokio_core::reactor::Core;
 //! use tokio_io::io::write_all;
@@ -52,10 +52,12 @@
 //!         //let private_key = include_bytes!("test-private-key.pk8");
 //!         # let public_key = vec![];
 //!         //let public_key = include_bytes!("test-public-key.der").to_vec();
-//!         SecioConfig {
-//!                // See the documentation of `SecioKeyPair`.
+//!         let upgrade = SecioConfig {
+//!             // See the documentation of `SecioKeyPair`.
 //!             key: SecioKeyPair::rsa_from_pkcs8(private_key, public_key).unwrap(),
-//!         }
+//!         };
+//!
+//!         upgrade::map(upgrade, |(socket, _remote_key)| socket)
 //!     });
 //!
 //! let future = transport.dial("/ip4/127.0.0.1/tcp/12345".parse::<Multiaddr>().unwrap())
@@ -179,16 +181,16 @@ enum SecioKeyPairInner {
 }
 
 #[derive(Debug, Clone)]
-pub enum SecioPublicKey<'a> {
+pub enum SecioPublicKey {
     /// DER format.
-    Rsa(&'a [u8]),
+    Rsa(Vec<u8>),
 }
 
 impl<S> libp2p_swarm::ConnectionUpgrade<S> for SecioConfig
 where
     S: AsyncRead + AsyncWrite + 'static,
 {
-    type Output = RwStreamSink<StreamMapErr<SecioMiddleware<S>, fn(SecioError) -> IoError>>;
+    type Output = (RwStreamSink<StreamMapErr<SecioMiddleware<S>, fn(SecioError) -> IoError>>, SecioPublicKey);
     type Future = Box<Future<Item = Self::Output, Error = IoError>>;
     type NamesIter = iter::Once<(Bytes, ())>;
     type UpgradeIdentifier = ();
@@ -209,9 +211,9 @@ where
         info!(target: "libp2p-secio", "starting secio upgrade with {:?}", remote_addr);
 
         let fut = SecioMiddleware::handshake(incoming, self.key);
-        let wrapped = fut.map(|stream_sink| {
+        let wrapped = fut.map(|(stream_sink, pubkey)| {
             let mapped = stream_sink.map_err(map_err as fn(_) -> _);
-            RwStreamSink::new(mapped)
+            (RwStreamSink::new(mapped), pubkey)
         }).map_err(map_err);
         Box::new(wrapped)
     }
@@ -229,7 +231,6 @@ fn map_err(err: SecioError) -> IoError {
 /// individually, so you are encouraged to group data in few frames if possible.
 pub struct SecioMiddleware<S> {
     inner: codec::FullCodec<S>,
-    remote_pubkey_der: Vec<u8>,
 }
 
 impl<S> SecioMiddleware<S>
@@ -243,24 +244,18 @@ where
     pub fn handshake<'a>(
         socket: S,
         key_pair: SecioKeyPair,
-    ) -> Box<Future<Item = SecioMiddleware<S>, Error = SecioError> + 'a>
+    ) -> Box<Future<Item = (SecioMiddleware<S>, SecioPublicKey), Error = SecioError> + 'a>
     where
         S: 'a,
     {
         let SecioKeyPairInner::Rsa { private, public } = key_pair.inner;
 
         let fut =
-            handshake::handshake(socket, public, private).map(|(inner, pubkey)| SecioMiddleware {
-                inner: inner,
-                remote_pubkey_der: pubkey,
+            handshake::handshake(socket, public, private).map(|(inner, pubkey)| {
+                let inner = SecioMiddleware { inner };
+                (inner, SecioPublicKey::Rsa(pubkey))
             });
         Box::new(fut)
-    }
-
-    /// Returns the public key of the remote in the `DER` format.
-    #[inline]
-    pub fn remote_public_key_der(&self) -> SecioPublicKey {
-        SecioPublicKey::Rsa(&self.remote_pubkey_der)
     }
 }
 

--- a/swarm/src/connection_reuse.rs
+++ b/swarm/src/connection_reuse.rs
@@ -50,6 +50,7 @@ use muxing::StreamMuxer;
 use parking_lot::Mutex;
 use std::io::Error as IoError;
 use std::sync::Arc;
+use tokio_io::{AsyncRead, AsyncWrite};
 use transport::{MuxedTransport, Transport, UpgradedNode};
 use upgrade::ConnectionUpgrade;
 
@@ -62,6 +63,7 @@ use upgrade::ConnectionUpgrade;
 pub struct ConnectionReuse<T, C>
 where
     T: Transport,
+    T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output>,
     C::Output: StreamMuxer,
 {
@@ -94,6 +96,7 @@ where
 impl<T, C> From<UpgradedNode<T, C>> for ConnectionReuse<T, C>
 where
     T: Transport,
+    T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output>,
     C::Output: StreamMuxer,
 {
@@ -116,6 +119,7 @@ where
 impl<T, C> Transport for ConnectionReuse<T, C>
 where
     T: Transport + 'static,                     // TODO: 'static :(
+    T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :(
     C: Clone,
     C::Output: StreamMuxer + Clone,
@@ -209,6 +213,7 @@ where
 impl<T, C> MuxedTransport for ConnectionReuse<T, C>
 where
     T: Transport + 'static,                     // TODO: 'static :(
+    T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :(
     C: Clone,
     C::Output: StreamMuxer + Clone,

--- a/swarm/src/connection_reuse.rs
+++ b/swarm/src/connection_reuse.rs
@@ -41,10 +41,10 @@
 
 use fnv::FnvHashMap;
 use futures::future::{self, FutureResult, IntoFuture};
-use futures::{Async, Future, Poll, Stream};
-use futures::stream::FuturesUnordered;
 use futures::stream::Fuse as StreamFuse;
+use futures::stream::FuturesUnordered;
 use futures::sync::mpsc;
+use futures::{Async, Future, Poll, Stream};
 use multiaddr::Multiaddr;
 use muxing::StreamMuxer;
 use parking_lot::Mutex;
@@ -118,7 +118,7 @@ where
 
 impl<T, C> Transport for ConnectionReuse<T, C>
 where
-    T: Transport + 'static,                     // TODO: 'static :(
+    T: Transport + 'static, // TODO: 'static :(
     T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :(
     C: Clone,
@@ -212,7 +212,7 @@ where
 
 impl<T, C> MuxedTransport for ConnectionReuse<T, C>
 where
-    T: Transport + 'static,                     // TODO: 'static :(
+    T: Transport + 'static, // TODO: 'static :(
     T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :(
     C: Clone,

--- a/swarm/src/connection_reuse.rs
+++ b/swarm/src/connection_reuse.rs
@@ -62,7 +62,7 @@ use upgrade::ConnectionUpgrade;
 pub struct ConnectionReuse<T, C>
 where
     T: Transport,
-    C: ConnectionUpgrade<T::RawConn>,
+    C: ConnectionUpgrade<T::Output>,
     C::Output: StreamMuxer,
 {
     // Underlying transport and connection upgrade for when we need to dial or listen.
@@ -94,7 +94,7 @@ where
 impl<T, C> From<UpgradedNode<T, C>> for ConnectionReuse<T, C>
 where
     T: Transport,
-    C: ConnectionUpgrade<T::RawConn>,
+    C: ConnectionUpgrade<T::Output>,
     C::Output: StreamMuxer,
 {
     #[inline]
@@ -116,15 +116,15 @@ where
 impl<T, C> Transport for ConnectionReuse<T, C>
 where
     T: Transport + 'static,                     // TODO: 'static :(
-    C: ConnectionUpgrade<T::RawConn> + 'static, // TODO: 'static :(
+    C: ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :(
     C: Clone,
     C::Output: StreamMuxer + Clone,
     C::NamesIter: Clone, // TODO: not elegant
 {
-    type RawConn = <C::Output as StreamMuxer>::Substream;
+    type Output = <C::Output as StreamMuxer>::Substream;
     type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = IoError>>;
-    type ListenerUpgrade = FutureResult<(Self::RawConn, Multiaddr), IoError>;
-    type Dial = Box<Future<Item = (Self::RawConn, Multiaddr), Error = IoError>>;
+    type ListenerUpgrade = FutureResult<(Self::Output, Multiaddr), IoError>;
+    type Dial = Box<Future<Item = (Self::Output, Multiaddr), Error = IoError>>;
 
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
         let (listener, new_addr) = match self.inner.listen_on(addr.clone()) {
@@ -209,7 +209,7 @@ where
 impl<T, C> MuxedTransport for ConnectionReuse<T, C>
 where
     T: Transport + 'static,                     // TODO: 'static :(
-    C: ConnectionUpgrade<T::RawConn> + 'static, // TODO: 'static :(
+    C: ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :(
     C: Clone,
     C::Output: StreamMuxer + Clone,
     C::NamesIter: Clone, // TODO: not elegant

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -188,7 +188,7 @@
 //! let transport = libp2p_tcp_transport::TcpConfig::new(core.handle())
 //!     .with_dummy_muxing();
 //!
-//! let (swarm_controller, swarm_future) = libp2p_swarm::swarm(transport, Ping, |(mut pinger, service), client_addr| {
+//! let (swarm_controller, swarm_future) = libp2p_swarm::swarm(transport.with_upgrade(Ping), |(mut pinger, service), client_addr| {
 //!     pinger.ping().map_err(|_| panic!())
 //!         .select(service).map_err(|_| panic!())
 //!         .map(|_| ())

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -188,11 +188,12 @@
 //! let transport = libp2p_tcp_transport::TcpConfig::new(core.handle())
 //!     .with_dummy_muxing();
 //!
-//! let (swarm_controller, swarm_future) = libp2p_swarm::swarm(transport.with_upgrade(Ping), |(mut pinger, service), client_addr| {
-//!     pinger.ping().map_err(|_| panic!())
-//!         .select(service).map_err(|_| panic!())
-//!         .map(|_| ())
-//! });
+//! let (swarm_controller, swarm_future) = libp2p_swarm::swarm(transport.with_upgrade(Ping),
+//!     |(mut pinger, service), client_addr| {
+//!         pinger.ping().map_err(|_| panic!())
+//!             .select(service).map_err(|_| panic!())
+//!             .map(|_| ())
+//!     });
 //!
 //! // The `swarm_controller` can then be used to do some operations.
 //! swarm_controller.listen_on("/ip4/0.0.0.0/tcp/0".parse().unwrap());

--- a/swarm/src/swarm.rs
+++ b/swarm/src/swarm.rs
@@ -41,7 +41,7 @@ pub fn swarm<T, C, H, F>(
 ) -> (SwarmController<T, C>, SwarmFuture<T, C, H, F::Future>)
 where
     T: MuxedTransport + Clone + 'static, // TODO: 'static :-/
-    C: ConnectionUpgrade<T::RawConn> + Clone + 'static, // TODO: 'static :-/
+    C: ConnectionUpgrade<T::Output> + Clone + 'static, // TODO: 'static :-/
     C::NamesIter: Clone,                 // TODO: not elegant
     H: FnMut(C::Output, Multiaddr) -> F,
     F: IntoFuture<Item = (), Error = IoError>,
@@ -80,7 +80,7 @@ where
 pub struct SwarmController<T, C>
 where
     T: MuxedTransport + 'static,                // TODO: 'static :-/
-    C: ConnectionUpgrade<T::RawConn> + 'static, // TODO: 'static :-/
+    C: ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
 {
     transport: T,
     upgraded: UpgradedNode<T, C>,
@@ -99,7 +99,7 @@ where
 impl<T, C> fmt::Debug for SwarmController<T, C>
 where
     T: fmt::Debug + MuxedTransport + 'static, // TODO: 'static :-/
-    C: fmt::Debug + ConnectionUpgrade<T::RawConn> + 'static, // TODO: 'static :-/
+    C: fmt::Debug + ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_tuple("SwarmController")
@@ -111,7 +111,7 @@ where
 impl<T, C> Clone for SwarmController<T, C>
 where
     T: MuxedTransport + Clone + 'static, // TODO: 'static :-/
-    C: ConnectionUpgrade<T::RawConn> + 'static + Clone, // TODO: 'static :-/
+    C: ConnectionUpgrade<T::Output> + 'static + Clone, // TODO: 'static :-/
 {
     fn clone(&self) -> SwarmController<T, C> {
         SwarmController {
@@ -127,7 +127,7 @@ where
 impl<T, C> SwarmController<T, C>
 where
     T: MuxedTransport + Clone + 'static, // TODO: 'static :-/
-    C: ConnectionUpgrade<T::RawConn> + Clone + 'static, // TODO: 'static :-/
+    C: ConnectionUpgrade<T::Output> + Clone + 'static, // TODO: 'static :-/
     C::NamesIter: Clone,                 // TODO: not elegant
 {
     /// Asks the swarm to dial the node with the given multiaddress. The connection is then
@@ -136,7 +136,7 @@ where
     // TODO: consider returning a future so that errors can be processed?
     pub fn dial_to_handler<Du>(&self, multiaddr: Multiaddr, upgrade: Du) -> Result<(), Multiaddr>
     where
-        Du: ConnectionUpgrade<T::RawConn> + Clone + 'static, // TODO: 'static :-/
+        Du: ConnectionUpgrade<T::Output> + Clone + 'static, // TODO: 'static :-/
         Du::Output: Into<C::Output>,
     {
         trace!(target: "libp2p-swarm", "Swarm dialing {}", multiaddr);
@@ -171,7 +171,7 @@ where
         and_then: Df,
     ) -> Result<(), Multiaddr>
     where
-        Du: ConnectionUpgrade<T::RawConn> + 'static, // TODO: 'static :-/
+        Du: ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
         Df: FnOnce(Du::Output, Multiaddr) -> Dfu + 'static, // TODO: 'static :-/
         Dfu: IntoFuture<Item = (), Error = IoError> + 'static, // TODO: 'static :-/
     {
@@ -209,7 +209,7 @@ where
 pub struct SwarmFuture<T, C, H, F>
 where
     T: MuxedTransport + 'static,                // TODO: 'static :-/
-    C: ConnectionUpgrade<T::RawConn> + 'static, // TODO: 'static :-/
+    C: ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
 {
     upgraded: UpgradedNode<T, C>,
     handler: H,
@@ -246,7 +246,7 @@ where
 impl<T, C, H, If, F> Future for SwarmFuture<T, C, H, F>
 where
     T: MuxedTransport + Clone + 'static, // TODO: 'static :-/,
-    C: ConnectionUpgrade<T::RawConn> + Clone + 'static, // TODO: 'static :-/
+    C: ConnectionUpgrade<T::Output> + Clone + 'static, // TODO: 'static :-/
     C::NamesIter: Clone,                 // TODO: not elegant
     H: FnMut(C::Output, Multiaddr) -> If,
     If: IntoFuture<Future = F, Item = (), Error = IoError>,

--- a/swarm/src/swarm.rs
+++ b/swarm/src/swarm.rs
@@ -23,6 +23,7 @@ use std::io::Error as IoError;
 use futures::{future, Async, Future, IntoFuture, Poll, Stream};
 use futures::stream::{FuturesUnordered, StreamFuture};
 use futures::sync::mpsc;
+use tokio_io::{AsyncRead, AsyncWrite};
 use transport::UpgradedNode;
 use {ConnectionUpgrade, Multiaddr, MuxedTransport};
 
@@ -41,6 +42,7 @@ pub fn swarm<T, C, H, F>(
 ) -> (SwarmController<T, C>, SwarmFuture<T, C, H, F::Future>)
 where
     T: MuxedTransport + Clone + 'static, // TODO: 'static :-/
+    T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output> + Clone + 'static, // TODO: 'static :-/
     C::NamesIter: Clone,                 // TODO: not elegant
     H: FnMut(C::Output, Multiaddr) -> F,
@@ -80,6 +82,7 @@ where
 pub struct SwarmController<T, C>
 where
     T: MuxedTransport + 'static,                // TODO: 'static :-/
+    T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
 {
     transport: T,
@@ -99,6 +102,7 @@ where
 impl<T, C> fmt::Debug for SwarmController<T, C>
 where
     T: fmt::Debug + MuxedTransport + 'static, // TODO: 'static :-/
+    T::Output: AsyncRead + AsyncWrite,
     C: fmt::Debug + ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
@@ -111,6 +115,7 @@ where
 impl<T, C> Clone for SwarmController<T, C>
 where
     T: MuxedTransport + Clone + 'static, // TODO: 'static :-/
+    T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output> + 'static + Clone, // TODO: 'static :-/
 {
     fn clone(&self) -> SwarmController<T, C> {
@@ -127,6 +132,7 @@ where
 impl<T, C> SwarmController<T, C>
 where
     T: MuxedTransport + Clone + 'static, // TODO: 'static :-/
+    T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output> + Clone + 'static, // TODO: 'static :-/
     C::NamesIter: Clone,                 // TODO: not elegant
 {
@@ -209,6 +215,7 @@ where
 pub struct SwarmFuture<T, C, H, F>
 where
     T: MuxedTransport + 'static,                // TODO: 'static :-/
+    T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
 {
     upgraded: UpgradedNode<T, C>,
@@ -246,6 +253,7 @@ where
 impl<T, C, H, If, F> Future for SwarmFuture<T, C, H, F>
 where
     T: MuxedTransport + Clone + 'static, // TODO: 'static :-/,
+    T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output> + Clone + 'static, // TODO: 'static :-/
     C::NamesIter: Clone,                 // TODO: not elegant
     H: FnMut(C::Output, Multiaddr) -> If,

--- a/swarm/src/swarm.rs
+++ b/swarm/src/swarm.rs
@@ -144,6 +144,7 @@ where
     where
         Du: ConnectionUpgrade<T::Output> + Clone + 'static, // TODO: 'static :-/
         Du::Output: Into<C::Output>,
+        Du::NamesIter: Clone, // TODO: not elegant
     {
         trace!(target: "libp2p-swarm", "Swarm dialing {}", multiaddr);
 
@@ -178,6 +179,7 @@ where
     ) -> Result<(), Multiaddr>
     where
         Du: ConnectionUpgrade<T::Output> + 'static, // TODO: 'static :-/
+        Du::NamesIter: Clone, // TODO: not elegant
         Df: FnOnce(Du::Output, Multiaddr) -> Dfu + 'static, // TODO: 'static :-/
         Dfu: IntoFuture<Item = (), Error = IoError> + 'static, // TODO: 'static :-/
     {

--- a/swarm/src/transport/and_then.rs
+++ b/swarm/src/transport/and_then.rs
@@ -1,0 +1,146 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use futures::prelude::*;
+use multiaddr::Multiaddr;
+use std::io::Error as IoError;
+use transport::{MuxedTransport, Transport};
+use upgrade::Endpoint;
+
+/// See the `Transport::and_then` method.
+#[inline]
+pub fn and_then<T, C>(transport: T, upgrade: C) -> AndThen<T, C> {
+    AndThen {
+        transport,
+        upgrade,
+    }
+}
+
+/// See the `Transport::and_then` method.
+#[derive(Debug, Clone)]
+pub struct AndThen<T, C> {
+    transport: T,
+    upgrade: C,
+}
+
+impl<T, C, F, O> Transport for AndThen<T, C>
+where
+    T: Transport + 'static,
+    C: FnOnce(T::Output, Endpoint, Multiaddr) -> F + Clone + 'static,
+    F: Future<Item = O, Error = IoError> + 'static,
+{
+    type Output = O;
+    type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = IoError>>;
+    type ListenerUpgrade = Box<Future<Item = (O, Multiaddr), Error = IoError>>;
+    type Dial = Box<Future<Item = (O, Multiaddr), Error = IoError>>;
+
+    #[inline]
+    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
+        let upgrade = self.upgrade;
+
+        let (listening_stream, new_addr) = match self.transport.listen_on(addr) {
+            Ok((l, new_addr)) => (l, new_addr),
+            Err((trans, addr)) => {
+                let builder = AndThen {
+                    transport: trans,
+                    upgrade: upgrade,
+                };
+
+                return Err((builder, addr));
+            }
+        };
+
+        // Try to negotiate the protocol.
+        // Note that failing to negotiate a protocol will never produce a future with an error.
+        // Instead the `stream` will produce `Ok(Err(...))`.
+        // `stream` can only produce an `Err` if `listening_stream` produces an `Err`.
+        let stream = listening_stream.map(move |connection| {
+            let upgrade = upgrade.clone();
+            let future = connection.and_then(move |(stream, client_addr)| {
+                upgrade(stream, Endpoint::Listener, client_addr.clone())
+                    .map(|o| (o, client_addr))
+            });
+
+            Box::new(future) as Box<_>
+        });
+
+        Ok((Box::new(stream), new_addr))
+    }
+
+    #[inline]
+    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
+        let upgrade = self.upgrade;
+
+        let dialed_fut = match self.transport.dial(addr.clone()) {
+            Ok(f) => f.into_future(),
+            Err((trans, addr)) => {
+                let builder = AndThen {
+                    transport: trans,
+                    upgrade: upgrade,
+                };
+
+                return Err((builder, addr));
+            }
+        };
+
+        let future = dialed_fut
+            // Try to negotiate the protocol.
+            .and_then(move |(connection, client_addr)| {
+                upgrade(connection, Endpoint::Dialer, client_addr.clone())
+                    .map(|o| (o, client_addr))
+            });
+
+        Ok(Box::new(future))
+    }
+
+    #[inline]
+    fn nat_traversal(&self, server: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
+        self.transport.nat_traversal(server, observed)
+    }
+}
+
+impl<T, C, F, O> MuxedTransport for AndThen<T, C>
+where
+    T: MuxedTransport + 'static,
+    C: FnOnce(T::Output, Endpoint, Multiaddr) -> F + Clone + 'static,
+    F: Future<Item = O, Error = IoError> + 'static,
+{
+    type Incoming = Box<Future<Item = Self::IncomingUpgrade, Error = IoError>>;
+    type IncomingUpgrade = Box<Future<Item = (O, Multiaddr), Error = IoError>>;
+
+    #[inline]
+    fn next_incoming(self) -> Self::Incoming {
+        let upgrade = self.upgrade;
+
+        let future = self.transport.next_incoming().map(|future| {
+            // Try to negotiate the protocol.
+            let future = future
+                .and_then(move |(connection, client_addr)| {
+                    let upgrade = upgrade.clone();
+                    upgrade(connection, Endpoint::Listener, client_addr.clone())
+                        .map(|o| (o, client_addr))
+                });
+
+            Box::new(future) as Box<Future<Item = _, Error = _>>
+        });
+
+        Box::new(future) as Box<_>
+    }
+}

--- a/swarm/src/transport/and_then.rs
+++ b/swarm/src/transport/and_then.rs
@@ -27,10 +27,7 @@ use upgrade::Endpoint;
 /// See the `Transport::and_then` method.
 #[inline]
 pub fn and_then<T, C>(transport: T, upgrade: C) -> AndThen<T, C> {
-    AndThen {
-        transport,
-        upgrade,
-    }
+    AndThen { transport, upgrade }
 }
 
 /// See the `Transport::and_then` method.
@@ -74,8 +71,7 @@ where
         let stream = listening_stream.map(move |connection| {
             let upgrade = upgrade.clone();
             let future = connection.and_then(move |(stream, client_addr)| {
-                upgrade(stream, Endpoint::Listener, client_addr.clone())
-                    .map(|o| (o, client_addr))
+                upgrade(stream, Endpoint::Listener, client_addr.clone()).map(|o| (o, client_addr))
             });
 
             Box::new(future) as Box<_>
@@ -131,12 +127,11 @@ where
 
         let future = self.transport.next_incoming().map(|future| {
             // Try to negotiate the protocol.
-            let future = future
-                .and_then(move |(connection, client_addr)| {
-                    let upgrade = upgrade.clone();
-                    upgrade(connection, Endpoint::Listener, client_addr.clone())
-                        .map(|o| (o, client_addr))
-                });
+            let future = future.and_then(move |(connection, client_addr)| {
+                let upgrade = upgrade.clone();
+                upgrade(connection, Endpoint::Listener, client_addr.clone())
+                    .map(|o| (o, client_addr))
+            });
 
             Box::new(future) as Box<Future<Item = _, Error = _>>
         });

--- a/swarm/src/transport/choice.rs
+++ b/swarm/src/transport/choice.rs
@@ -39,7 +39,7 @@ where
     A: Transport,
     B: Transport,
 {
-    type RawConn = EitherSocket<A::RawConn, B::RawConn>;
+    type Output = EitherSocket<A::Output, B::Output>;
     type Listener = EitherListenStream<A::Listener, B::Listener>;
     type ListenerUpgrade = EitherListenUpgrade<A::ListenerUpgrade, B::ListenerUpgrade>;
     type Dial =
@@ -88,12 +88,12 @@ where
     B::Incoming: 'static,        // TODO: meh :-/
     A::IncomingUpgrade: 'static, // TODO: meh :-/
     B::IncomingUpgrade: 'static, // TODO: meh :-/
-    A::RawConn: 'static,         // TODO: meh :-/
-    B::RawConn: 'static,         // TODO: meh :-/
+    A::Output: 'static,         // TODO: meh :-/
+    B::Output: 'static,         // TODO: meh :-/
 {
     type Incoming = Box<Future<Item = Self::IncomingUpgrade, Error = IoError>>;
     type IncomingUpgrade =
-        Box<Future<Item = (EitherSocket<A::RawConn, B::RawConn>, Multiaddr), Error = IoError>>;
+        Box<Future<Item = (EitherSocket<A::Output, B::Output>, Multiaddr), Error = IoError>>;
 
     #[inline]
     fn next_incoming(self) -> Self::Incoming {

--- a/swarm/src/transport/choice.rs
+++ b/swarm/src/transport/choice.rs
@@ -88,8 +88,8 @@ where
     B::Incoming: 'static,        // TODO: meh :-/
     A::IncomingUpgrade: 'static, // TODO: meh :-/
     B::IncomingUpgrade: 'static, // TODO: meh :-/
-    A::Output: 'static,         // TODO: meh :-/
-    B::Output: 'static,         // TODO: meh :-/
+    A::Output: 'static,          // TODO: meh :-/
+    B::Output: 'static,          // TODO: meh :-/
 {
     type Incoming = Box<Future<Item = Self::IncomingUpgrade, Error = IoError>>;
     type IncomingUpgrade =

--- a/swarm/src/transport/denied.rs
+++ b/swarm/src/transport/denied.rs
@@ -31,10 +31,10 @@ pub struct DeniedTransport;
 
 impl Transport for DeniedTransport {
     // TODO: could use `!` for associated types once stable
-    type RawConn = Cursor<Vec<u8>>;
+    type Output = Cursor<Vec<u8>>;
     type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = io::Error>>;
-    type ListenerUpgrade = Box<Future<Item = (Self::RawConn, Multiaddr), Error = io::Error>>;
-    type Dial = Box<Future<Item = (Self::RawConn, Multiaddr), Error = io::Error>>;
+    type ListenerUpgrade = Box<Future<Item = (Self::Output, Multiaddr), Error = io::Error>>;
+    type Dial = Box<Future<Item = (Self::Output, Multiaddr), Error = io::Error>>;
 
     #[inline]
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
@@ -54,7 +54,7 @@ impl Transport for DeniedTransport {
 
 impl MuxedTransport for DeniedTransport {
     type Incoming = future::Empty<Self::IncomingUpgrade, io::Error>;
-    type IncomingUpgrade = future::Empty<(Self::RawConn, Multiaddr), io::Error>;
+    type IncomingUpgrade = future::Empty<(Self::Output, Multiaddr), io::Error>;
 
     #[inline]
     fn next_incoming(self) -> Self::Incoming {

--- a/swarm/src/transport/denied.rs
+++ b/swarm/src/transport/denied.rs
@@ -22,8 +22,8 @@ use futures::future;
 use futures::prelude::*;
 use multiaddr::Multiaddr;
 use std::io::{self, Cursor};
-use transport::Transport;
 use transport::MuxedTransport;
+use transport::Transport;
 
 /// Dummy implementation of `Transport` that just denies every single attempt.
 #[derive(Debug, Copy, Clone)]

--- a/swarm/src/transport/dummy.rs
+++ b/swarm/src/transport/dummy.rs
@@ -40,7 +40,7 @@ where
     T: Transport,
 {
     type Incoming = future::Empty<Self::IncomingUpgrade, IoError>;
-    type IncomingUpgrade = future::Empty<(T::RawConn, Multiaddr), IoError>;
+    type IncomingUpgrade = future::Empty<(T::Output, Multiaddr), IoError>;
 
     fn next_incoming(self) -> Self::Incoming
     where
@@ -54,7 +54,7 @@ impl<T> Transport for DummyMuxing<T>
 where
     T: Transport,
 {
-    type RawConn = T::RawConn;
+    type Output = T::Output;
     type Listener = T::Listener;
     type ListenerUpgrade = T::ListenerUpgrade;
     type Dial = T::Dial;

--- a/swarm/src/transport/map.rs
+++ b/swarm/src/transport/map.rs
@@ -1,0 +1,104 @@
+// Copyright 2017 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use futures::prelude::*;
+use multiaddr::Multiaddr;
+use std::io::Error as IoError;
+use transport::{MuxedTransport, Transport};
+
+/// See `Transport::map`.
+#[derive(Debug, Copy, Clone)]
+pub struct Map<T, F> {
+    transport: T,
+    map: F,
+}
+
+impl<T, F> Map<T, F> {
+    /// Internal function that builds a `Map`.
+    #[inline]
+    pub(crate) fn new(transport: T, map: F) -> Map<T, F> {
+        Map { transport, map }
+    }
+}
+
+impl<T, F, D> Transport for Map<T, F>
+where T: Transport + 'static,                       // TODO: 'static :-/
+      F: Fn(T::Output) -> D + Clone + 'static,      // TODO: 'static :-/
+{
+    type Output = D;
+    type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = IoError>>;
+    type ListenerUpgrade = Box<Future<Item = (Self::Output, Multiaddr), Error = IoError>>;
+    type Dial = Box<Future<Item = (Self::Output, Multiaddr), Error = IoError>>;
+
+    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
+        let map = self.map;
+
+        match self.transport.listen_on(addr) {
+            Ok((stream, listen_addr)) => {
+                let stream = stream.map(move |future| {
+                    let map = map.clone();
+                    let future = future.into_future().map(move |(output, addr)| (map(output), addr));
+                    Box::new(future) as Box<_>
+                });
+                Ok((Box::new(stream), listen_addr))
+            },
+            Err((transport, addr)) => {
+                Err((Map { transport, map }, addr))
+            },
+        }
+    }
+
+    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
+        let map = self.map;
+
+        match self.transport.dial(addr) {
+            Ok(future) => {
+                let future = future.into_future().map(move |(output, addr)| (map(output), addr));
+                Ok(Box::new(future))
+            },
+            Err((transport, addr)) => {
+                Err((Map { transport, map }, addr))
+            }
+        }
+    }
+
+    #[inline]
+    fn nat_traversal(&self, server: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
+        self.transport.nat_traversal(server, observed)
+    }
+}
+
+impl<T, F, D> MuxedTransport for Map<T, F>
+where T: MuxedTransport + 'static,                       // TODO: 'static :-/
+      F: Fn(T::Output) -> D + Clone + 'static,      // TODO: 'static :-/
+{
+    type Incoming = Box<Future<Item = Self::IncomingUpgrade, Error = IoError>>;
+    type IncomingUpgrade = Box<Future<Item = (Self::Output, Multiaddr), Error = IoError>>;
+
+    fn next_incoming(self) -> Self::Incoming {
+        let map = self.map;
+        let future = self.transport.next_incoming()
+            .map(move |upgrade| {
+                let future = upgrade.map(move |(output, addr)| (map(output), addr));
+                Box::new(future) as Box<_>
+            });
+        Box::new(future)
+    }
+}

--- a/swarm/src/transport/mod.rs
+++ b/swarm/src/transport/mod.rs
@@ -59,7 +59,7 @@ pub use self::upgrade::UpgradedNode;
 /// >           on `Foo`.
 pub trait Transport {
     /// The raw connection to a peer.
-    type RawConn: AsyncRead + AsyncWrite;
+    type Output: AsyncRead + AsyncWrite;
 
     /// The listener produces incoming connections.
     ///
@@ -71,10 +71,10 @@ pub trait Transport {
     /// After a connection has been received, we may need to do some asynchronous pre-processing
     /// on it (eg. an intermediary protocol negotiation). While this pre-processing takes place, we
     /// want to be able to continue polling on the listener.
-    type ListenerUpgrade: Future<Item = (Self::RawConn, Multiaddr), Error = IoError>;
+    type ListenerUpgrade: Future<Item = (Self::Output, Multiaddr), Error = IoError>;
 
     /// A future which indicates that we are currently dialing to a peer.
-    type Dial: IntoFuture<Item = (Self::RawConn, Multiaddr), Error = IoError>;
+    type Dial: IntoFuture<Item = (Self::Output, Multiaddr), Error = IoError>;
 
     /// Listen on the given multiaddr. Returns a stream of incoming connections, plus a modified
     /// version of the `Multiaddr`. This new `Multiaddr` is the one that that should be advertised
@@ -129,7 +129,7 @@ pub trait Transport {
     fn with_upgrade<U>(self, upgrade: U) -> UpgradedNode<Self, U>
     where
         Self: Sized,
-        U: ConnectionUpgrade<Self::RawConn>,
+        U: ConnectionUpgrade<Self::Output>,
     {
         UpgradedNode::new(self, upgrade)
     }

--- a/swarm/src/transport/mod.rs
+++ b/swarm/src/transport/mod.rs
@@ -59,7 +59,7 @@ pub use self::upgrade::UpgradedNode;
 /// >           on `Foo`.
 pub trait Transport {
     /// The raw connection to a peer.
-    type Output: AsyncRead + AsyncWrite;
+    type Output;
 
     /// The listener produces incoming connections.
     ///
@@ -129,6 +129,7 @@ pub trait Transport {
     fn with_upgrade<U>(self, upgrade: U) -> UpgradedNode<Self, U>
     where
         Self: Sized,
+        Self::Output: AsyncRead + AsyncWrite,
         U: ConnectionUpgrade<Self::Output>,
     {
         UpgradedNode::new(self, upgrade)

--- a/swarm/src/transport/mod.rs
+++ b/swarm/src/transport/mod.rs
@@ -113,7 +113,8 @@ pub trait Transport {
     /// Applies a function on the output of the `Transport`.
     #[inline]
     fn map<F>(self, map: F) -> map::Map<Self, F>
-        where Self: Sized,
+    where
+        Self: Sized,
     {
         map::Map::new(self, map)
     }

--- a/swarm/src/transport/mod.rs
+++ b/swarm/src/transport/mod.rs
@@ -112,9 +112,10 @@ pub trait Transport {
 
     /// Applies a function on the output of the `Transport`.
     #[inline]
-    fn map<F>(self, map: F) -> map::Map<Self, F>
+    fn map<F, O>(self, map: F) -> map::Map<Self, F>
     where
         Self: Sized,
+        F: FnOnce(Self::Output, Endpoint, Multiaddr) -> O + Clone + 'static,        // TODO: 'static :-/
     {
         map::Map::new(self, map)
     }

--- a/swarm/src/transport/mod.rs
+++ b/swarm/src/transport/mod.rs
@@ -38,6 +38,7 @@ use upgrade::ConnectionUpgrade;
 pub mod choice;
 pub mod denied;
 pub mod dummy;
+pub mod map;
 pub mod muxed;
 pub mod upgrade;
 
@@ -107,6 +108,14 @@ pub trait Transport {
     /// Returns `None` if nothing can be determined. This happens if this trait implementation
     /// doesn't recognize the protocols, or if `server` and `observed` are related.
     fn nat_traversal(&self, server: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr>;
+
+    /// Applies a function on the output of the `Transport`.
+    #[inline]
+    fn map<F>(self, map: F) -> map::Map<Self, F>
+        where Self: Sized,
+    {
+        map::Map::new(self, map)
+    }
 
     /// Builds a new struct that implements `Transport` that contains both `self` and `other`.
     ///

--- a/swarm/src/transport/muxed.rs
+++ b/swarm/src/transport/muxed.rs
@@ -30,7 +30,7 @@ pub trait MuxedTransport: Transport {
     /// Future resolving to a future that will resolve to an incoming connection.
     type Incoming: Future<Item = Self::IncomingUpgrade, Error = IoError>;
     /// Future resolving to an incoming connection.
-    type IncomingUpgrade: Future<Item = (Self::RawConn, Multiaddr), Error = IoError>;
+    type IncomingUpgrade: Future<Item = (Self::Output, Multiaddr), Error = IoError>;
 
     /// Returns the next incoming substream opened by a node that we dialed ourselves.
     ///

--- a/swarm/src/transport/upgrade.rs
+++ b/swarm/src/transport/upgrade.rs
@@ -25,7 +25,7 @@ use muxing::StreamMuxer;
 use std::io::Error as IoError;
 use tokio_io::{AsyncRead, AsyncWrite};
 use transport::{MuxedTransport, Transport};
-use upgrade::{ConnectionUpgrade, Endpoint, apply};
+use upgrade::{apply, ConnectionUpgrade, Endpoint};
 
 /// Implements the `Transport` trait. Dials or listens, then upgrades any dialed or received
 /// connection.
@@ -78,7 +78,8 @@ where
         self,
         addr: Multiaddr,
     ) -> Result<Box<Future<Item = (C::Output, Multiaddr), Error = IoError> + 'a>, (Self, Multiaddr)>
-        where C::NamesIter: Clone, // TODO: not elegant
+    where
+        C::NamesIter: Clone, // TODO: not elegant
     {
         let upgrade = self.upgrade;
 
@@ -112,9 +113,9 @@ where
         self,
     ) -> Box<
         Future<
-            Item = Box<Future<Item = (C::Output, Multiaddr), Error = IoError> + 'a>,
-            Error = IoError,
-        >
+                Item = Box<Future<Item = (C::Output, Multiaddr), Error = IoError> + 'a>,
+                Error = IoError,
+            >
             + 'a,
     >
     where
@@ -126,10 +127,9 @@ where
 
         let future = self.transports.next_incoming().map(|future| {
             // Try to negotiate the protocol.
-            let future = future
-                .and_then(move |(connection, client_addr)| {
-                    apply(connection, upgrade, Endpoint::Listener, client_addr)
-                });
+            let future = future.and_then(move |(connection, client_addr)| {
+                apply(connection, upgrade, Endpoint::Listener, client_addr)
+            });
 
             Box::new(future) as Box<Future<Item = _, Error = _>>
         });
@@ -150,9 +150,9 @@ where
         (
             Box<
                 Stream<
-                    Item = Box<Future<Item = (C::Output, Multiaddr), Error = IoError> + 'a>,
-                    Error = IoError,
-                >
+                        Item = Box<Future<Item = (C::Output, Multiaddr), Error = IoError> + 'a>,
+                        Error = IoError,
+                    >
                     + 'a,
             >,
             Multiaddr,

--- a/swarm/src/transport/upgrade.rs
+++ b/swarm/src/transport/upgrade.rs
@@ -296,7 +296,6 @@ where
     T: Transport + 'static,
     T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output> + 'static,
-    C::Output: AsyncRead + AsyncWrite,
     C::NamesIter: Clone, // TODO: not elegant
     C: Clone,
 {
@@ -326,7 +325,6 @@ where
     T: MuxedTransport + 'static,
     T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output> + 'static,
-    C::Output: AsyncRead + AsyncWrite,
     C::NamesIter: Clone, // TODO: not elegant
     C: Clone,
 {

--- a/swarm/src/transport/upgrade.rs
+++ b/swarm/src/transport/upgrade.rs
@@ -18,16 +18,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use bytes::Bytes;
 use connection_reuse::ConnectionReuse;
 use futures::prelude::*;
 use multiaddr::Multiaddr;
-use multistream_select;
 use muxing::StreamMuxer;
-use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+use std::io::Error as IoError;
 use tokio_io::{AsyncRead, AsyncWrite};
 use transport::{MuxedTransport, Transport};
-use upgrade::{ConnectionUpgrade, Endpoint};
+use upgrade::{ConnectionUpgrade, Endpoint, apply};
 
 /// Implements the `Transport` trait. Dials or listens, then upgrades any dialed or received
 /// connection.
@@ -80,6 +78,7 @@ where
         self,
         addr: Multiaddr,
     ) -> Result<Box<Future<Item = (C::Output, Multiaddr), Error = IoError> + 'a>, (Self, Multiaddr)>
+        where C::NamesIter: Clone, // TODO: not elegant
     {
         let upgrade = self.upgrade;
 
@@ -98,39 +97,7 @@ where
         let future = dialed_fut
             // Try to negotiate the protocol.
             .and_then(move |(connection, client_addr)| {
-                let iter = upgrade.protocol_names()
-                    .map(|(name, id)| (name, <Bytes as PartialEq>::eq, id));
-                debug!(target: "libp2p-swarm", "Starting protocol negotiation (dialer)");
-                let negotiated = multistream_select::dialer_select_proto(connection, iter)
-                    .map_err(|err| IoError::new(IoErrorKind::Other, err));
-                negotiated.map(|(upgrade_id, conn)| (upgrade_id, conn, upgrade, client_addr))
-            })
-            .then(|negotiated| {
-                match negotiated {
-                    Ok((_, _, _, ref client_addr)) => {
-                        debug!(target: "libp2p-swarm", "Successfully negotiated protocol \
-                               upgrade with {}", client_addr)
-                    },
-                    Err(ref err) => {
-                        debug!(target: "libp2p-swarm", "Error while negotiated protocol \
-                               upgrade: {:?}", err)
-                    },
-                };
-                negotiated
-            })
-            .and_then(move |(upgrade_id, connection, upgrade, client_addr)| {
-                let f = upgrade.upgrade(connection, upgrade_id, Endpoint::Dialer, &client_addr);
-                debug!(target: "libp2p-swarm", "Trying to apply negotiated protocol with {}",
-                       client_addr);
-                f.map(|v| (v, client_addr))
-            })
-            .then(|val| {
-                match val {
-                    Ok(_) => debug!(target: "libp2p-swarm", "Successfully applied negotiated \
-                                                             protocol"),
-                    Err(_) => debug!(target: "libp2p-swarm", "Failed to apply negotiated protocol"),
-                }
-                val
+                apply(connection, upgrade, Endpoint::Dialer, client_addr)
             });
 
         Ok(Box::new(future))
@@ -160,42 +127,8 @@ where
         let future = self.transports.next_incoming().map(|future| {
             // Try to negotiate the protocol.
             let future = future
-                .and_then(move |(connection, addr)| {
-                    let iter = upgrade
-                        .protocol_names()
-                        .map::<_, fn(_) -> _>(|(name, id)| (name, <Bytes as PartialEq>::eq, id));
-                    debug!(target: "libp2p-swarm", "Starting protocol negotiation (incoming)");
-                    let negotiated = multistream_select::listener_select_proto(connection, iter)
-                        .map_err(|err| IoError::new(IoErrorKind::Other, err));
-                    negotiated.map(move |(upgrade_id, conn)| (upgrade_id, conn, upgrade, addr))
-                })
-                .then(|negotiated| {
-                    match negotiated {
-                        Ok((_, _, _, ref client_addr)) => {
-                            debug!(target: "libp2p-swarm", "Successfully negotiated protocol \
-                                upgrade with {}", client_addr)
-                        }
-                        Err(ref err) => {
-                            debug!(target: "libp2p-swarm", "Error while negotiated protocol \
-                                upgrade: {:?}", err)
-                        }
-                    };
-                    negotiated
-                })
-                .and_then(move |(upgrade_id, connection, upgrade, addr)| {
-                    let upg = upgrade.upgrade(connection, upgrade_id, Endpoint::Listener, &addr);
-                    debug!(target: "libp2p-swarm", "Trying to apply negotiated protocol with {}",
-                           addr);
-                    upg.map(|u| (u, addr))
-                })
-                .then(|val| {
-                    match val {
-                        Ok(_) => debug!(target: "libp2p-swarm", "Successfully applied negotiated \
-                                                                 protocol"),
-                        Err(_) => debug!(target: "libp2p-swarm", "Failed to apply negotiated \
-                                                                  protocol"),
-                    }
-                    val
+                .and_then(move |(connection, client_addr)| {
+                    apply(connection, upgrade, Endpoint::Listener, client_addr)
                 });
 
             Box::new(future) as Box<Future<Item = _, Error = _>>
@@ -251,38 +184,10 @@ where
         let stream = listening_stream.map(move |connection| {
             let upgrade = upgrade.clone();
             let connection = connection
-                    // Try to negotiate the protocol
-                    .and_then(move |(connection, remote_addr)| {
-                        let iter = upgrade.protocol_names()
-                            .map::<_, fn(_) -> _>(|(n, t)| (n, <Bytes as PartialEq>::eq, t));
-                        let remote_addr2 = remote_addr.clone();
-                        debug!(target: "libp2p-swarm", "Starting protocol negotiation (listener)");
-                        multistream_select::listener_select_proto(connection, iter)
-                            .map_err(|err| IoError::new(IoErrorKind::Other, err))
-                            .then(move |negotiated| {
-                                match negotiated {
-                                    Ok(_) => {
-                                        debug!(target: "libp2p-swarm", "Successfully negotiated \
-                                               protocol upgrade with {}", remote_addr2)
-                                    },
-                                    Err(ref err) => {
-                                        debug!(target: "libp2p-swarm", "Error while negotiated \
-                                               protocol upgrade: {:?}", err)
-                                    },
-                                };
-                                negotiated
-                            })
-                            .and_then(move |(upgrade_id, connection)| {
-                                let fut = upgrade.upgrade(
-                                    connection,
-                                    upgrade_id,
-                                    Endpoint::Listener,
-                                    &remote_addr,
-                                );
-                                fut.map(move |c| (c, remote_addr))
-                            })
-                            .into_future()
-                    });
+                // Try to negotiate the protocol.
+                .and_then(move |(connection, client_addr)| {
+                    apply(connection, upgrade, Endpoint::Listener, client_addr)
+                });
 
             Box::new(connection) as Box<_>
         });

--- a/swarm/src/transport/upgrade.rs
+++ b/swarm/src/transport/upgrade.rs
@@ -51,6 +51,7 @@ impl<T, C> UpgradedNode<T, C> {
 impl<'a, T, C> UpgradedNode<T, C>
 where
     T: Transport + 'a,
+    T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output> + 'a,
 {
     /// Turns this upgraded node into a `ConnectionReuse`. If the `Output` implements the
@@ -293,6 +294,7 @@ where
 impl<T, C> Transport for UpgradedNode<T, C>
 where
     T: Transport + 'static,
+    T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output> + 'static,
     C::Output: AsyncRead + AsyncWrite,
     C::NamesIter: Clone, // TODO: not elegant
@@ -322,6 +324,7 @@ where
 impl<T, C> MuxedTransport for UpgradedNode<T, C>
 where
     T: MuxedTransport + 'static,
+    T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output> + 'static,
     C::Output: AsyncRead + AsyncWrite,
     C::NamesIter: Clone, // TODO: not elegant

--- a/swarm/src/transport/upgrade.rs
+++ b/swarm/src/transport/upgrade.rs
@@ -51,7 +51,7 @@ impl<T, C> UpgradedNode<T, C> {
 impl<'a, T, C> UpgradedNode<T, C>
 where
     T: Transport + 'a,
-    C: ConnectionUpgrade<T::RawConn> + 'a,
+    C: ConnectionUpgrade<T::Output> + 'a,
 {
     /// Turns this upgraded node into a `ConnectionReuse`. If the `Output` implements the
     /// `StreamMuxer` trait, the returned object will implement `Transport` and `MuxedTransport`.
@@ -293,12 +293,12 @@ where
 impl<T, C> Transport for UpgradedNode<T, C>
 where
     T: Transport + 'static,
-    C: ConnectionUpgrade<T::RawConn> + 'static,
+    C: ConnectionUpgrade<T::Output> + 'static,
     C::Output: AsyncRead + AsyncWrite,
     C::NamesIter: Clone, // TODO: not elegant
     C: Clone,
 {
-    type RawConn = C::Output;
+    type Output = C::Output;
     type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = IoError>>;
     type ListenerUpgrade = Box<Future<Item = (C::Output, Multiaddr), Error = IoError>>;
     type Dial = Box<Future<Item = (C::Output, Multiaddr), Error = IoError>>;
@@ -322,7 +322,7 @@ where
 impl<T, C> MuxedTransport for UpgradedNode<T, C>
 where
     T: MuxedTransport + 'static,
-    C: ConnectionUpgrade<T::RawConn> + 'static,
+    C: ConnectionUpgrade<T::Output> + 'static,
     C::Output: AsyncRead + AsyncWrite,
     C::NamesIter: Clone, // TODO: not elegant
     C: Clone,

--- a/swarm/src/upgrade/apply.rs
+++ b/swarm/src/upgrade/apply.rs
@@ -1,0 +1,88 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use bytes::Bytes;
+use futures::prelude::*;
+use multiaddr::Multiaddr;
+use multistream_select;
+use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+use tokio_io::{AsyncRead, AsyncWrite};
+use upgrade::{ConnectionUpgrade, Endpoint};
+
+/// Applies a connection upgrade on a socket.
+///
+/// Returns a `Future` that returns the outcome of the connection upgrade.
+#[inline]
+pub fn apply<'a, C, U>(connection: C, upgrade: U, endpoint: Endpoint, remote_addr: Multiaddr)
+    -> Box<Future<Item = (U::Output, Multiaddr), Error = IoError> + 'a>
+where U: ConnectionUpgrade<C> + 'a,
+      U::NamesIter: Clone,  // TODO: not elegant
+      C: AsyncRead + AsyncWrite + 'a,
+{
+    let iter = upgrade.protocol_names()
+        .map::<_, fn(_) -> _>(|(n, t)| (n, <Bytes as PartialEq>::eq, t));
+    let remote_addr2 = remote_addr.clone();
+    debug!(target: "libp2p-swarm", "Starting protocol negotiation");
+
+    let negotiation = match endpoint {
+        Endpoint::Listener => {
+            multistream_select::listener_select_proto(connection, iter)
+        },
+        Endpoint::Dialer => {
+            multistream_select::dialer_select_proto(connection, iter)
+        },
+    };
+
+    let future = negotiation
+        .map_err(|err| IoError::new(IoErrorKind::Other, err))
+        .then(move |negotiated| {
+            match negotiated {
+                Ok(_) => {
+                    debug!(target: "libp2p-swarm", "Successfully negotiated \
+                            protocol upgrade with {}", remote_addr2)
+                },
+                Err(ref err) => {
+                    debug!(target: "libp2p-swarm", "Error while negotiated \
+                            protocol upgrade: {:?}", err)
+                },
+            };
+            negotiated
+        })
+        .and_then(move |(upgrade_id, connection)| {
+            let fut = upgrade.upgrade(
+                connection,
+                upgrade_id,
+                endpoint,
+                &remote_addr,
+            );
+            fut.map(move |c| (c, remote_addr))
+        })
+        .into_future()
+        .then(|val| {
+            match val {
+                Ok(_) => debug!(target: "libp2p-swarm", "Successfully applied negotiated \
+                                                            protocol"),
+                Err(_) => debug!(target: "libp2p-swarm", "Failed to apply negotiated protocol"),
+            }
+            val
+        });
+    
+    Box::new(future)
+}

--- a/swarm/src/upgrade/choice.rs
+++ b/swarm/src/upgrade/choice.rs
@@ -26,15 +26,18 @@ use std::io::Error as IoError;
 use tokio_io::{AsyncRead, AsyncWrite};
 use upgrade::{ConnectionUpgrade, Endpoint};
 
-/// See `transport::Transport::or_upgrade()`.
+/// Builds a new `ConnectionUpgrade` that chooses between `A` and `B`.
+///
+/// If both `A` and `B` are supported by the remote, then `A` will be chosen.
+// TODO: write a test for this ^
+#[inline]
+pub fn or<A, B>(me: A, other: B) -> OrUpgrade<A, B> {
+    OrUpgrade(me, other)
+}
+
+/// See `upgrade::or`.
 #[derive(Debug, Copy, Clone)]
 pub struct OrUpgrade<A, B>(A, B);
-
-impl<A, B> OrUpgrade<A, B> {
-    pub fn new(a: A, b: B) -> OrUpgrade<A, B> {
-        OrUpgrade(a, b)
-    }
-}
 
 impl<C, A, B> ConnectionUpgrade<C> for OrUpgrade<A, B>
 where

--- a/swarm/src/upgrade/denied.rs
+++ b/swarm/src/upgrade/denied.rs
@@ -19,11 +19,11 @@
 // DEALINGS IN THE SOFTWARE.
 
 use bytes::Bytes;
-use upgrade::{ConnectionUpgrade, Endpoint};
 use futures::prelude::*;
 use multiaddr::Multiaddr;
 use std::{io, iter};
 use tokio_io::{AsyncRead, AsyncWrite};
+use upgrade::{ConnectionUpgrade, Endpoint};
 
 /// Implementation of `ConnectionUpgrade` that always fails to negotiate.
 #[derive(Debug, Copy, Clone)]

--- a/swarm/src/upgrade/map.rs
+++ b/swarm/src/upgrade/map.rs
@@ -37,9 +37,10 @@ pub struct Map<U, F> {
 }
 
 impl<C, U, F, O> ConnectionUpgrade<C> for Map<U, F>
-where U: ConnectionUpgrade<C>,
-      C: AsyncRead + AsyncWrite,
-      F: FnOnce(U::Output) -> O,
+where
+    U: ConnectionUpgrade<C>,
+    C: AsyncRead + AsyncWrite,
+    F: FnOnce(U::Output) -> O,
 {
     type NamesIter = U::NamesIter;
     type UpgradeIdentifier = U::UpgradeIdentifier;
@@ -58,6 +59,8 @@ where U: ConnectionUpgrade<C>,
         ty: Endpoint,
         remote_addr: &Multiaddr,
     ) -> Self::Future {
-        self.upgrade.upgrade(socket, id, ty, remote_addr).map(self.map)
+        self.upgrade
+            .upgrade(socket, id, ty, remote_addr)
+            .map(self.map)
     }
 }

--- a/swarm/src/upgrade/mod.rs
+++ b/swarm/src/upgrade/mod.rs
@@ -18,6 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+pub mod apply;
 pub mod denied;
 pub mod traits;
 pub mod choice;
@@ -25,6 +26,7 @@ pub mod map;
 pub mod plaintext;
 pub mod simple;
 
+pub use self::apply::apply;
 pub use self::choice::{or, OrUpgrade};
 pub use self::denied::DeniedConnectionUpgrade;
 pub use self::map::map;

--- a/swarm/src/upgrade/mod.rs
+++ b/swarm/src/upgrade/mod.rs
@@ -19,12 +19,12 @@
 // DEALINGS IN THE SOFTWARE.
 
 pub mod apply;
-pub mod denied;
-pub mod traits;
 pub mod choice;
+pub mod denied;
 pub mod map;
 pub mod plaintext;
 pub mod simple;
+pub mod traits;
 
 pub use self::apply::apply;
 pub use self::choice::{or, OrUpgrade};

--- a/swarm/src/upgrade/traits.rs
+++ b/swarm/src/upgrade/traits.rs
@@ -23,7 +23,6 @@ use futures::future::Future;
 use multiaddr::Multiaddr;
 use std::io::Error as IoError;
 use tokio_io::{AsyncRead, AsyncWrite};
-use upgrade::choice::OrUpgrade;
 
 /// Type of connection for the upgrade.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -73,20 +72,4 @@ pub trait ConnectionUpgrade<C: AsyncRead + AsyncWrite> {
         ty: Endpoint,
         remote_addr: &Multiaddr,
     ) -> Self::Future;
-}
-
-/// Extension trait for `ConnectionUpgrade`. Automatically implemented on everything.
-pub trait UpgradeExt {
-    /// Builds a struct that will choose an upgrade between `self` and `other`, depending on what
-    /// the remote supports.
-    fn or_upgrade<T>(self, other: T) -> OrUpgrade<Self, T>
-    where
-        Self: Sized;
-}
-
-impl<T> UpgradeExt for T {
-    #[inline]
-    fn or_upgrade<U>(self, other: U) -> OrUpgrade<Self, U> {
-        OrUpgrade::new(self, other)
-    }
 }

--- a/swarm/tests/multiplex.rs
+++ b/swarm/tests/multiplex.rs
@@ -53,7 +53,7 @@ impl<T: Clone> Clone for OnlyOnce<T> {
     }
 }
 impl<T: Transport> Transport for OnlyOnce<T> {
-    type RawConn = T::RawConn;
+    type Output = T::Output;
     type Listener = T::Listener;
     type ListenerUpgrade = T::ListenerUpgrade;
     type Dial = T::Dial;

--- a/swarm/tests/multiplex.rs
+++ b/swarm/tests/multiplex.rs
@@ -31,10 +31,10 @@ use futures::future::Future;
 use futures::{Sink, Stream};
 use libp2p_swarm::{Multiaddr, MuxedTransport, StreamMuxer, Transport};
 use libp2p_tcp_transport::TcpConfig;
-use tokio_core::reactor::Core;
-use tokio_io::codec::length_delimited::Framed;
 use std::sync::{atomic, mpsc};
 use std::thread;
+use tokio_core::reactor::Core;
+use tokio_io::codec::length_delimited::Framed;
 
 // Ensures that a transport is only ever used once for dialing.
 #[derive(Debug)]

--- a/tcp-transport/src/lib.rs
+++ b/tcp-transport/src/lib.rs
@@ -87,9 +87,9 @@ impl TcpConfig {
 }
 
 impl Transport for TcpConfig {
-    type RawConn = TcpStream;
+    type Output = TcpStream;
     type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = IoError>>;
-    type ListenerUpgrade = FutureResult<(Self::RawConn, Multiaddr), IoError>;
+    type ListenerUpgrade = FutureResult<(Self::Output, Multiaddr), IoError>;
     type Dial = Box<Future<Item = (TcpStream, Multiaddr), Error = IoError>>;
 
     /// Listen on the given multi-addr.

--- a/tcp-transport/src/lib.rs
+++ b/tcp-transport/src/lib.rs
@@ -57,15 +57,15 @@ extern crate multiaddr;
 extern crate tokio_core;
 extern crate tokio_io;
 
-use std::io::Error as IoError;
-use std::iter;
-use std::net::SocketAddr;
-use tokio_core::reactor::Handle;
-use tokio_core::net::{TcpListener, TcpStream};
 use futures::future::{self, Future, FutureResult, IntoFuture};
 use futures::stream::Stream;
 use multiaddr::{AddrComponent, Multiaddr, ToMultiaddr};
+use std::io::Error as IoError;
+use std::iter;
+use std::net::SocketAddr;
 use swarm::Transport;
+use tokio_core::net::{TcpListener, TcpStream};
+use tokio_core::reactor::Handle;
 
 /// Represents the configuration for a TCP/IP transport capability for libp2p.
 ///
@@ -195,14 +195,14 @@ fn multiaddr_to_socketaddr(addr: &Multiaddr) -> Result<SocketAddr, ()> {
 #[cfg(test)]
 mod tests {
     use super::{multiaddr_to_socketaddr, TcpConfig};
-    use std;
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-    use tokio_core::reactor::Core;
-    use tokio_io;
     use futures::Future;
     use futures::stream::Stream;
     use multiaddr::Multiaddr;
+    use std;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use swarm::Transport;
+    use tokio_core::reactor::Core;
+    use tokio_io;
 
     #[test]
     fn multiaddr_to_tcp_conversion() {

--- a/websocket/src/browser.rs
+++ b/websocket/src/browser.rs
@@ -52,10 +52,10 @@ impl BrowserWsConfig {
 }
 
 impl Transport for BrowserWsConfig {
-    type RawConn = BrowserWsConn;
+    type Output = BrowserWsConn;
     type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = IoError>>; // TODO: use `!`
-    type ListenerUpgrade = Box<Future<Item = (Self::RawConn, Multiaddr), Error = IoError>>; // TODO: use `!`
-    type Dial = Box<Future<Item = (Self::RawConn, Multiaddr), Error = IoError>>;
+    type ListenerUpgrade = Box<Future<Item = (Self::Output, Multiaddr), Error = IoError>>; // TODO: use `!`
+    type Dial = Box<Future<Item = (Self::Output, Multiaddr), Error = IoError>>;
 
     #[inline]
     fn listen_on(self, a: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {

--- a/websocket/src/browser.rs
+++ b/websocket/src/browser.rs
@@ -18,17 +18,17 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures::{Async, Future, Poll, Stream};
 use futures::stream::Then as StreamThen;
 use futures::sync::{mpsc, oneshot};
+use futures::{Async, Future, Poll, Stream};
 use multiaddr::{AddrComponent, Multiaddr};
 use rw_stream_sink::RwStreamSink;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::io::{Read, Write};
 use std::iter;
 use std::sync::{Arc, Mutex};
-use stdweb::{self, Reference};
 use stdweb::web::TypedArray;
+use stdweb::{self, Reference};
 use swarm::Transport;
 use tokio_io::{AsyncRead, AsyncWrite};
 

--- a/websocket/src/desktop.rs
+++ b/websocket/src/desktop.rs
@@ -59,13 +59,13 @@ where
     // TODO: this 'static is pretty arbitrary and is necessary because of the websocket library
     T: Transport + 'static,
     // TODO: this Send is pretty arbitrary and is necessary because of the websocket library
-    T::RawConn: Send,
+    T::Output: Send,
 {
-    type RawConn = Box<AsyncStream>;
+    type Output = Box<AsyncStream>;
     type Listener =
         stream::Map<T::Listener, fn(<T as Transport>::ListenerUpgrade) -> Self::ListenerUpgrade>;
-    type ListenerUpgrade = Box<Future<Item = (Self::RawConn, Multiaddr), Error = IoError>>;
-    type Dial = Box<Future<Item = (Self::RawConn, Multiaddr), Error = IoError>>;
+    type ListenerUpgrade = Box<Future<Item = (Self::Output, Multiaddr), Error = IoError>>;
+    type Dial = Box<Future<Item = (Self::Output, Multiaddr), Error = IoError>>;
 
     fn listen_on(
         self,

--- a/websocket/src/desktop.rs
+++ b/websocket/src/desktop.rs
@@ -23,6 +23,7 @@ use multiaddr::{AddrComponent, Multiaddr};
 use rw_stream_sink::RwStreamSink;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use swarm::Transport;
+use tokio_io::{AsyncRead, AsyncWrite};
 use websocket::client::builder::ClientBuilder;
 use websocket::message::OwnedMessage;
 use websocket::server::upgrade::async::IntoWs;
@@ -59,7 +60,7 @@ where
     // TODO: this 'static is pretty arbitrary and is necessary because of the websocket library
     T: Transport + 'static,
     // TODO: this Send is pretty arbitrary and is necessary because of the websocket library
-    T::Output: Send,
+    T::Output: AsyncRead + AsyncWrite + Send,
 {
     type Output = Box<AsyncStream>;
     type Listener =

--- a/websocket/src/lib.rs
+++ b/websocket/src/lib.rs
@@ -88,10 +88,10 @@ extern crate stdweb;
 #[cfg(not(target_os = "emscripten"))]
 extern crate websocket;
 
-#[cfg(not(target_os = "emscripten"))]
-mod desktop;
 #[cfg(target_os = "emscripten")]
 mod browser;
+#[cfg(not(target_os = "emscripten"))]
+mod desktop;
 
 #[cfg(target_os = "emscripten")]
 pub use self::browser::{BrowserWsConfig, BrowserWsConn};


### PR DESCRIPTION
cc #100 
cc #101 

This changes the API in the following ways:

- The output of a `Transport` is no longer necessarily a socket (`AsyncRead + AsyncWrite`).

- `secio`'s output now returns the public key of the remote in addition to the socket.

- Adds `map`, `apply` and `or` to the `upgrade` module, and removes `UpgradeExt`.
- Adds `Transport::map` and `Transport::and_then`.

- The `swarm` now requires passing an already-upgraded transport with the final protocol. The `dial_*` methods require passing a full transport instead of just an upgrade.

- `kad` has been adjusted to reflect that. You now need to pass an upgraded transport to `start()`.

This will make it possible to propagate the public key to the swarm handler, and to handle the `p2p-circuit` returning an enum.

In the future we should add modifiers that allow building more elaborate transports, such as loops or being able to upgrade multiplexing and secio in any order.
