### PR TITLE
Pin protobuf to 1.4

### DIFF
--- a/floodsub/Cargo.toml
+++ b/floodsub/Cargo.toml
@@ -14,7 +14,7 @@ libp2p-swarm = { path = "../swarm" }
 log = "0.4.1"
 multiaddr = "0.3"
 parking_lot = "0.5.3"
-protobuf = "1.4.2"
+protobuf = "=1.4.2"
 smallvec = "0.6.0"
 tokio-io = "0.1"
 varint = { path = "../varint-rs" }

--- a/identify/Cargo.toml
+++ b/identify/Cargo.toml
@@ -10,7 +10,7 @@ libp2p-peerstore = { path = "../peerstore" }
 libp2p-swarm = { path = "../swarm" }
 log = "0.4.1"
 multiaddr = "0.3.0"
-protobuf = "1.4.2"
+protobuf = "=1.4.2"
 tokio-io = "0.1.0"
 varint = { path = "../varint-rs" }
 

--- a/kad/Cargo.toml
+++ b/kad/Cargo.toml
@@ -18,7 +18,7 @@ libp2p-swarm = { path = "../swarm" }
 log = "0.4"
 multiaddr = "0.3"
 parking_lot = "0.5.1"
-protobuf = "1.4.2"
+protobuf = "=1.4.2"
 rand = "0.4.2"
 smallvec = "0.5"
 tokio-io = "0.1"

--- a/secio/Cargo.toml
+++ b/secio/Cargo.toml
@@ -8,7 +8,7 @@ bytes = "0.4"
 futures = "0.1"
 libp2p-swarm = { path = "../swarm" }
 log = "0.4.1"
-protobuf = "1.4.2"
+protobuf = "=1.4.2"
 rand = "0.3.17"
 ring = { version = "0.12.1", features = ["rsa_signing"] }
 rust-crypto = "^0.2"


### PR DESCRIPTION
CI is failing because protobuf v1.6 broke backward compatibility, so let's pin to 1.4.
Eventually the correct solution is #183 