### PR TITLE
Make the libp2p facade compilable for emscripten

### DIFF
--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -7,20 +7,25 @@ authors = ["Parity Technologies <admin@parity.io>"]
 bytes = "0.4"
 futures = "0.1"
 multiaddr = "0.3"
-libp2p-dns = { path = "../dns" }
 libp2p-mplex = { path = "../mplex" }
 libp2p-identify = { path = "../identify" }
 libp2p-kad = { path = "../kad" }
 libp2p-floodsub = { path = "../floodsub" }
 libp2p-peerstore = { path = "../peerstore" }
 libp2p-ping = { path = "../ping" }
-libp2p-ratelimit = { path = "../ratelimit" }
 libp2p-relay = { path = "../relay" }
-libp2p-secio = { path = "../secio" }
 libp2p-core = { path = "../core" }
-libp2p-tcp-transport = { path = "../tcp-transport" }
 libp2p-websocket = { path = "../websocket" }
+
+[target.'cfg(not(target_os = "emscripten"))'.dependencies]
+libp2p-dns = { path = "../dns" }
+libp2p-ratelimit = { path = "../ratelimit" }       # TODO: https://github.com/libp2p/rust-libp2p/issues/204
+libp2p-secio = { path = "../secio" }
+libp2p-tcp-transport = { path = "../tcp-transport" }
 tokio-core = "0.1"
+
+[target.'cfg(target_os = "emscripten")'.dependencies]
+stdweb = { version = "0.1.3", default-features = false }
 
 [dev-dependencies]
 bigint = "4.2"


### PR DESCRIPTION
`CommonTransport` now works and returns two different things for emscripten and non-emscripten.

Moves `ratelimit` to emscripten-only for now, because of #204.