### PR TITLE
upgrade::or() now requires the upgrades to have the same Output

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -222,9 +222,9 @@ extern crate tokio_io;
 pub extern crate multiaddr;
 
 mod connection_reuse;
-mod either;
 mod peer_id;
 
+pub mod either;
 pub mod muxing;
 pub mod swarm;
 pub mod transport;

--- a/libp2p/examples/echo-dialer.rs
+++ b/libp2p/examples/echo-dialer.rs
@@ -30,7 +30,7 @@ use futures::{Future, Sink, Stream};
 use std::env;
 use libp2p::SimpleProtocol;
 use libp2p::core::Transport;
-use libp2p::core::upgrade;
+use libp2p::core::{upgrade, either::EitherOutput};
 use libp2p::tcp::TcpConfig;
 use tokio_core::reactor::Core;
 use tokio_io::AsyncRead;
@@ -70,7 +70,10 @@ fn main() {
                 }
             };
 
-            upgrade::or(plain_text, upgrade::map(secio, |(socket, _)| socket))
+            upgrade::or(
+                upgrade::map(plain_text, |pt| EitherOutput::First(pt)),
+                upgrade::map(secio, |(socket, _)| EitherOutput::Second(socket))
+            )
         })
 
         // On top of plaintext or secio, we will use the multiplex protocol.

--- a/libp2p/examples/echo-server.rs
+++ b/libp2p/examples/echo-server.rs
@@ -30,7 +30,7 @@ use futures::{Sink, Stream};
 use std::env;
 use libp2p::SimpleProtocol;
 use libp2p::core::Transport;
-use libp2p::core::upgrade;
+use libp2p::core::{upgrade, either::EitherOutput};
 use libp2p::tcp::TcpConfig;
 use tokio_core::reactor::Core;
 use tokio_io::AsyncRead;
@@ -69,7 +69,10 @@ fn main() {
                 }
             };
 
-            upgrade::or(plain_text, upgrade::map(secio, |(socket, _)| socket))
+            upgrade::or(
+                upgrade::map(plain_text, |pt| EitherOutput::First(pt)),
+                upgrade::map(secio, |(socket, _)| EitherOutput::Second(socket))
+            )
         })
 
         // On top of plaintext or secio, we will use the multiplex protocol.

--- a/libp2p/examples/floodsub.rs
+++ b/libp2p/examples/floodsub.rs
@@ -30,7 +30,7 @@ extern crate tokio_stdin;
 use futures::Stream;
 use futures::future::Future;
 use std::{env, mem};
-use libp2p::core::upgrade;
+use libp2p::core::{either::EitherOutput, upgrade};
 use libp2p::core::{Multiaddr, Transport};
 use libp2p::peerstore::PeerId;
 use libp2p::tcp::TcpConfig;
@@ -69,7 +69,10 @@ fn main() {
                 }
             };
 
-            upgrade::or(plain_text, upgrade::map(secio, |(socket, _)| socket))
+            upgrade::or(
+                upgrade::map(plain_text, |pt| EitherOutput::First(pt)),
+                upgrade::map(secio, |(socket, _)| EitherOutput::Second(socket))
+            )
         })
 
         // On top of plaintext or secio, we will use the multiplex protocol.

--- a/libp2p/examples/kademlia.rs
+++ b/libp2p/examples/kademlia.rs
@@ -34,7 +34,7 @@ use std::env;
 use std::sync::Arc;
 use std::time::Duration;
 use libp2p::core::Transport;
-use libp2p::core::upgrade;
+use libp2p::core::{upgrade, either::EitherOutput};
 use libp2p::tcp::TcpConfig;
 use tokio_core::reactor::Core;
 
@@ -73,7 +73,10 @@ fn main() {
                 }
             };
 
-            upgrade::or(plain_text, upgrade::map(secio, |(socket, _)| socket))
+            upgrade::or(
+                upgrade::map(plain_text, |pt| EitherOutput::First(pt)),
+                upgrade::map(secio, |(socket, _)| EitherOutput::Second(socket))
+            )
         })
 
         // On top of plaintext or secio, we will use the multiplex protocol.

--- a/libp2p/examples/ping-client.rs
+++ b/libp2p/examples/ping-client.rs
@@ -29,7 +29,7 @@ use futures::Future;
 use futures::sync::oneshot;
 use std::env;
 use libp2p::core::Transport;
-use libp2p::core::upgrade;
+use libp2p::core::{upgrade, either::EitherOutput};
 use libp2p::tcp::TcpConfig;
 use tokio_core::reactor::Core;
 
@@ -61,7 +61,10 @@ fn main() {
                 }
             };
 
-            upgrade::or(plain_text, upgrade::map(secio, |(socket, _)| socket))
+            upgrade::or(
+                upgrade::map(plain_text, |pt| EitherOutput::First(pt)),
+                upgrade::map(secio, |(socket, _)| EitherOutput::Second(socket))
+            )
         })
 
         // On top of plaintext or secio, we will use the multiplex protocol.


### PR DESCRIPTION
The user has to use `EitherOutput` manually, which looks less confusing in my opinion.