### PR TITLE
Put secio behind a feature flag in the facade

### DIFF
--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -21,7 +21,7 @@ tokio-io = "0.1"
 
 [target.'cfg(not(target_os = "emscripten"))'.dependencies]
 libp2p-dns = { path = "../dns" }
-libp2p-secio = { path = "../secio" }
+libp2p-secio = { path = "../secio", optional = true }
 libp2p-tcp-transport = { path = "../tcp-transport" }
 tokio-core = "0.1"
 

--- a/libp2p/src/lib.rs
+++ b/libp2p/src/lib.rs
@@ -36,7 +36,7 @@ pub extern crate libp2p_peerstore as peerstore;
 pub extern crate libp2p_ping as ping;
 pub extern crate libp2p_ratelimit as ratelimit;
 pub extern crate libp2p_relay as relay;
-#[cfg(not(target_os = "emscripten"))]
+#[cfg(all(not(target_os = "emscripten"), feature = "libp2p-secio"))]
 pub extern crate libp2p_secio as secio;
 #[cfg(not(target_os = "emscripten"))]
 pub extern crate libp2p_tcp_transport as tcp;


### PR DESCRIPTION
Since `secio` has this whole `ring` dependency that causes troubles, I think it's not a bad idea to put it behind a feature flag.