### PR TITLE
Remove Peerstore from identify and kademlia

### DIFF
--- a/identify/Cargo.toml
+++ b/identify/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Parity Technologies <admin@parity.io>"]
 [dependencies]
 bytes = "0.4"
 futures = "0.1"
-libp2p-peerstore = { path = "../peerstore" }
 libp2p-core = { path = "../core" }
 log = "0.4.1"
 multiaddr = { path = "../multiaddr" }
@@ -15,5 +14,6 @@ tokio-io = "0.1.0"
 varint = { path = "../varint-rs" }
 
 [dev-dependencies]
+libp2p-peerstore = { path = "../peerstore" }
 libp2p-tcp-transport = { path = "../tcp-transport" }
 tokio-core = "0.1.0"

--- a/identify/src/lib.rs
+++ b/identify/src/lib.rs
@@ -67,7 +67,6 @@
 
 extern crate bytes;
 extern crate futures;
-extern crate libp2p_peerstore;
 extern crate libp2p_core;
 #[macro_use]
 extern crate log;
@@ -77,7 +76,7 @@ extern crate tokio_io;
 extern crate varint;
 
 pub use self::protocol::{IdentifyInfo, IdentifyOutput, IdentifyProtocolConfig, IdentifySender};
-pub use self::transport::IdentifyTransport;
+pub use self::transport::{IdentifyTransport, IdentifyPeerInterface};
 
 mod protocol;
 mod structs_proto;

--- a/kad/Cargo.toml
+++ b/kad/Cargo.toml
@@ -12,7 +12,6 @@ datastore = { path = "../datastore" }
 fnv = "1.0"
 futures = "0.1"
 libp2p-identify = { path = "../identify" }
-libp2p-peerstore = { path = "../peerstore" }
 libp2p-ping = { path = "../ping" }
 libp2p-core = { path = "../core" }
 log = "0.4"

--- a/kad/src/kad_server.rs
+++ b/kad/src/kad_server.rs
@@ -38,9 +38,7 @@
 use bytes::Bytes;
 use futures::sync::{mpsc, oneshot};
 use futures::{future, Future, Sink, Stream};
-use libp2p_peerstore::PeerId;
-use libp2p_core::ConnectionUpgrade;
-use libp2p_core::Endpoint;
+use libp2p_core::{ConnectionUpgrade, Endpoint, PeerId};
 use multiaddr::{AddrComponent, Multiaddr};
 use protocol::{self, KadMsg, KademliaProtocolConfig, Peer};
 use std::collections::VecDeque;

--- a/kad/src/kbucket.rs
+++ b/kad/src/kbucket.rs
@@ -29,7 +29,7 @@
 
 use arrayvec::ArrayVec;
 use bigint::U512;
-use libp2p_peerstore::PeerId;
+use libp2p_core::PeerId;
 use parking_lot::{Mutex, MutexGuard};
 use std::mem;
 use std::slice::Iter as SliceIter;
@@ -335,7 +335,7 @@ mod tests {
     extern crate rand;
     use self::rand::random;
     use kbucket::{KBucketsTable, UpdateOutcome, MAX_NODES_PER_BUCKET};
-    use libp2p_peerstore::PeerId;
+    use libp2p_core::PeerId;
     use std::thread;
     use std::time::Duration;
 

--- a/kad/src/lib.rs
+++ b/kad/src/lib.rs
@@ -69,7 +69,6 @@ extern crate datastore;
 extern crate fnv;
 extern crate futures;
 extern crate libp2p_identify;
-extern crate libp2p_peerstore;
 extern crate libp2p_ping;
 extern crate libp2p_core;
 #[macro_use]
@@ -84,7 +83,7 @@ extern crate tokio_timer;
 extern crate varint;
 
 pub use self::high_level::{KademliaConfig, KademliaController, KademliaControllerPrototype};
-pub use self::high_level::{KademliaProcessingFuture, KademliaUpgrade};
+pub use self::high_level::{KademliaProcessingFuture, KademliaUpgrade, KademliaPeerInterface};
 
 mod high_level;
 mod kad_server;

--- a/kad/src/protocol.rs
+++ b/kad/src/protocol.rs
@@ -28,8 +28,7 @@
 use bytes::Bytes;
 use futures::future;
 use futures::{Sink, Stream};
-use libp2p_peerstore::PeerId;
-use libp2p_core::{ConnectionUpgrade, Endpoint, Multiaddr};
+use libp2p_core::{ConnectionUpgrade, Endpoint, Multiaddr, PeerId};
 use protobuf::{self, Message};
 use protobuf_structs;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
@@ -307,8 +306,7 @@ mod tests {
     use self::libp2p_tcp_transport::TcpConfig;
     use self::tokio_core::reactor::Core;
     use futures::{Future, Sink, Stream};
-    use libp2p_peerstore::PeerId;
-    use libp2p_core::Transport;
+    use libp2p_core::{Transport, PeerId};
     use protocol::{ConnectionType, KadMsg, KademliaProtocolConfig, Peer};
     use std::sync::mpsc;
     use std::thread;

--- a/kad/src/query.rs
+++ b/kad/src/query.rs
@@ -24,7 +24,7 @@ use fnv::FnvHashSet;
 use futures::{future, Future};
 use kad_server::KademliaServerController;
 use kbucket::KBucketsPeerId;
-use libp2p_peerstore::PeerId;
+use libp2p_core::PeerId;
 use multiaddr::{AddrComponent, Multiaddr};
 use protocol;
 use rand;
@@ -32,7 +32,6 @@ use smallvec::SmallVec;
 use std::cmp::Ordering;
 use std::io::Error as IoError;
 use std::mem;
-use std::time::Duration;
 
 /// Interface that the query uses to communicate with the rest of the system.
 pub trait QueryInterface: Clone {
@@ -43,7 +42,7 @@ pub trait QueryInterface: Clone {
     fn kbuckets_find_closest(&self, addr: &PeerId) -> Vec<PeerId>;
 
     /// Adds new known multiaddrs for the given peer.
-    fn peer_add_addrs<I>(&self, peer: &PeerId, multiaddrs: I, ttl: Duration)
+    fn peer_add_addrs<I>(&self, peer: &PeerId, multiaddrs: I)
     where
         I: Iterator<Item = Multiaddr>;
 
@@ -297,8 +296,7 @@ where
                     query_interface2.peer_add_addrs(
                         &peer.node_id,
                         valid_multiaddrs,
-                        Duration::from_secs(3600),
-                    ); // TODO: which TTL?
+                    );
                 }
 
                 if peer.node_id.distance_with(&searched_key)

--- a/libp2p/src/lib.rs
+++ b/libp2p/src/lib.rs
@@ -42,10 +42,12 @@ pub extern crate libp2p_secio as secio;
 pub extern crate libp2p_tcp_transport as tcp;
 pub extern crate libp2p_websocket as websocket;
 
+mod peerstore_ext;
 pub mod simple;
 
 pub use self::core::{Transport, ConnectionUpgrade, PeerId, swarm};
 pub use self::multiaddr::Multiaddr;
+pub use self::peerstore_ext::PeerstoreWrapper;
 pub use self::simple::SimpleProtocol;
 
 /// Implementation of `Transport` that supports the most common protocols.

--- a/libp2p/src/peerstore_ext.rs
+++ b/libp2p/src/peerstore_ext.rs
@@ -1,0 +1,94 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! This module contains a wrapper around `Peerstore` that implements the identify and kademlia
+//! interfaces.
+
+use std::ops::Deref;
+use std::time::Duration;
+use std::vec::IntoIter as VecIntoIter;
+use core::{Multiaddr, PeerId};
+use identify::{IdentifyInfo, IdentifyPeerInterface};
+use kad::KademliaPeerInterface;
+use peerstore::{Peerstore, PeerAccess};
+
+#[derive(Clone)]
+pub struct PeerstoreWrapper<PRef>(pub PRef);
+
+impl<PRef, PStore> KademliaPeerInterface for PeerstoreWrapper<PRef>
+where PRef: Deref<Target = PStore>,
+      for<'r> &'r PStore: Peerstore,
+{
+    type AddrsIter = VecIntoIter<Multiaddr>;
+    type PeersIter = VecIntoIter<PeerId>;
+
+    fn add_addrs<I>(&self, peer: &PeerId, multiaddrs: I)
+        where I: Iterator<Item = Multiaddr>
+    {
+        self.0.peer_or_create(peer)
+            .add_addrs(multiaddrs, Duration::from_secs(3600));
+    }
+
+    fn peer_addrs(&self, peer_id: &PeerId) -> Self::AddrsIter {
+        match self.0.peer(peer_id) {
+            Some(peer) => peer.addrs().collect::<Vec<_>>().into_iter(),
+            None => Vec::new().into_iter(),
+        }
+    }
+
+    fn peers(&self) -> Self::PeersIter {
+        self.0.peers().collect::<Vec<_>>().into_iter()
+    }
+}
+
+impl<PRef, PStore> IdentifyPeerInterface for PeerstoreWrapper<PRef>
+where PRef: Deref<Target = PStore>,
+      for<'r> &'r PStore: Peerstore,
+{
+    type Iter = VecIntoIter<Multiaddr>;
+
+    fn store_info(&self, info: &IdentifyInfo, multiaddr: Multiaddr) {
+        let peer_id = PeerId::from_public_key(&info.public_key);
+        self.0.peer_or_create(&peer_id)
+            .add_addr(multiaddr, Duration::from_secs(3600));
+    }
+
+    fn peer_id_by_multiaddress(&self, multiaddr: &Multiaddr) -> Option<PeerId> {
+        for peer_id in self.0.peers() {
+            let peer = match self.0.peer(&peer_id) {
+                Some(p) => p,
+                None => continue,
+            };
+
+            if peer.addrs().any(|addr| &addr == multiaddr) {
+                return Some(peer_id);
+            }
+        }
+
+        None
+    }
+
+    fn multiaddresses_by_peer_id(&self, peer_id: PeerId) -> Self::Iter {
+        match self.0.peer(&peer_id) {
+            Some(peer) => peer.addrs().collect::<Vec<_>>().into_iter(),
+            None => Vec::new().into_iter(),
+        }
+    }
+}


### PR DESCRIPTION
Removes the dependency of `libp2p-peerstore` from `libp2p-identify` and `libp2p-kad`.

This makes the user code a bit more messy. Let me know what you think.
I think that ultimately we should provide helpers in the `libp2p` facade for the peerstore trait implementations.