### PR TITLE
Turn warn! into debug!

### DIFF
--- a/core/src/swarm.rs
+++ b/core/src/swarm.rs
@@ -245,7 +245,7 @@ where
                     self.listeners.push(remaining.into_future());
                 }
                 Err((err, _)) => {
-                    warn!("Error in listener: {:?}", err);
+                    debug!("Error in listener: {:?}", err);
                     break
                 }
                 _ => break
@@ -263,7 +263,7 @@ where
                 ));
             }
             Err(err) => {
-                warn!("Error in listener upgrade: {:?}", err);
+                debug!("Error in listener upgrade: {:?}", err);
             }
             _ => {}
         }
@@ -275,7 +275,7 @@ where
                     .push(future::Either::A(handler(output, addr).into_future()));
             }
             Err(err) => {
-                warn!("Error in dialer upgrade: {:?}", err);
+                debug!("Error in dialer upgrade: {:?}", err);
             }
             _ => {}
         }
@@ -285,7 +285,7 @@ where
                 trace!("Future returned by swarm handler driven to completion");
             }
             Err(err) => {
-                warn!("Error in processing: {:?}", err);
+                debug!("Error in processing: {:?}", err);
             }
             _ => {}
         }

--- a/identify/src/transport.rs
+++ b/identify/src/transport.rs
@@ -145,7 +145,7 @@ where
                         Ok((out, real_addr))
                     })
                     .map_err(move |err| {
-                        warn!("Failed to identify incoming {}", client_addr);
+                        debug!("Failed to identify incoming {}", client_addr);
                         err
                     });
                 future::Either::B(future)
@@ -180,7 +180,7 @@ where
                         match transport.clone().dial(addr) {
                             Ok(dial) => Some(dial),
                             Err((_, addr)) => {
-                                warn!("Address {} not supported by underlying transport", addr);
+                                debug!("Address {} not supported by underlying transport", addr);
                                 None
                             },
                         }

--- a/websocket/src/desktop.rs
+++ b/websocket/src/desktop.rs
@@ -168,7 +168,7 @@ where
         let inner_dial = match self.transport.dial(inner_addr) {
             Ok(d) => d,
             Err((transport, old_addr)) => {
-                warn!("Failed to dial {} because {} is not supported by the underlying transport",
+                debug!("Failed to dial {} because {} is not supported by the underlying transport",
                       original_addr,
                       old_addr);
                 return Err((


### PR DESCRIPTION
This is a very pragmatic problem, but Parity and Polkadot automatically write on stdout any `warn!` or `error!`.
However every time we try to dial an obsolete multiaddr (which happens often), we print a `warn!`. This generates a lot of noise.