### PR TITLE
The Multiaddr of the remote is now a Future

### DIFF
--- a/core/src/transport/denied.rs
+++ b/core/src/transport/denied.rs
@@ -32,9 +32,10 @@ pub struct DeniedTransport;
 impl Transport for DeniedTransport {
     // TODO: could use `!` for associated types once stable
     type Output = Cursor<Vec<u8>>;
+    type MultiaddrFuture = Box<Future<Item = Multiaddr, Error = io::Error>>;
     type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = io::Error>>;
-    type ListenerUpgrade = Box<Future<Item = (Self::Output, Multiaddr), Error = io::Error>>;
-    type Dial = Box<Future<Item = (Self::Output, Multiaddr), Error = io::Error>>;
+    type ListenerUpgrade = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = io::Error>>;
+    type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = io::Error>>;
 
     #[inline]
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
@@ -54,7 +55,7 @@ impl Transport for DeniedTransport {
 
 impl MuxedTransport for DeniedTransport {
     type Incoming = future::Empty<Self::IncomingUpgrade, io::Error>;
-    type IncomingUpgrade = future::Empty<(Self::Output, Multiaddr), io::Error>;
+    type IncomingUpgrade = future::Empty<(Self::Output, Self::MultiaddrFuture), io::Error>;
 
     #[inline]
     fn next_incoming(self) -> Self::Incoming {

--- a/core/src/transport/dummy.rs
+++ b/core/src/transport/dummy.rs
@@ -40,7 +40,7 @@ where
     T: Transport,
 {
     type Incoming = future::Empty<Self::IncomingUpgrade, IoError>;
-    type IncomingUpgrade = future::Empty<(T::Output, Multiaddr), IoError>;
+    type IncomingUpgrade = future::Empty<(T::Output, Self::MultiaddrFuture), IoError>;
 
     fn next_incoming(self) -> Self::Incoming
     where
@@ -55,6 +55,7 @@ where
     T: Transport,
 {
     type Output = T::Output;
+    type MultiaddrFuture = T::MultiaddrFuture;
     type Listener = T::Listener;
     type ListenerUpgrade = T::ListenerUpgrade;
     type Dial = T::Dial;

--- a/core/src/transport/muxed.rs
+++ b/core/src/transport/muxed.rs
@@ -20,7 +20,6 @@
 
 use futures::prelude::*;
 use futures::stream;
-use multiaddr::Multiaddr;
 use std::io::Error as IoError;
 use transport::Transport;
 
@@ -30,7 +29,7 @@ pub trait MuxedTransport: Transport {
     /// Future resolving to a future that will resolve to an incoming connection.
     type Incoming: Future<Item = Self::IncomingUpgrade, Error = IoError>;
     /// Future resolving to an incoming connection.
-    type IncomingUpgrade: Future<Item = (Self::Output, Multiaddr), Error = IoError>;
+    type IncomingUpgrade: Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>;
 
     /// Returns the next incoming substream opened by a node that we dialed ourselves.
     ///

--- a/core/src/upgrade/choice.rs
+++ b/core/src/upgrade/choice.rs
@@ -19,8 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use bytes::Bytes;
-use futures::prelude::*;
-use multiaddr::Multiaddr;
+use futures::{future, prelude::*};
 use std::io::Error as IoError;
 use tokio_io::{AsyncRead, AsyncWrite};
 use upgrade::{ConnectionUpgrade, Endpoint};
@@ -38,11 +37,11 @@ pub fn or<A, B>(me: A, other: B) -> OrUpgrade<A, B> {
 #[derive(Debug, Copy, Clone)]
 pub struct OrUpgrade<A, B>(A, B);
 
-impl<C, A, B, O> ConnectionUpgrade<C> for OrUpgrade<A, B>
+impl<C, A, B, O, Maf> ConnectionUpgrade<C, Maf> for OrUpgrade<A, B>
 where
     C: AsyncRead + AsyncWrite,
-    A: ConnectionUpgrade<C, Output = O>,
-    B: ConnectionUpgrade<C, Output = O>,
+    A: ConnectionUpgrade<C, Maf, Output = O>,
+    B: ConnectionUpgrade<C, Maf, Output = O>,
 {
     type NamesIter = NamesIterChain<A::NamesIter, B::NamesIter>;
     type UpgradeIdentifier = EitherUpgradeIdentifier<A::UpgradeIdentifier, B::UpgradeIdentifier>;
@@ -56,6 +55,7 @@ where
     }
 
     type Output = O;
+    type MultiaddrFuture = future::Either<A::MultiaddrFuture, B::MultiaddrFuture>;
     type Future = EitherConnUpgrFuture<A::Future, B::Future>;
 
     #[inline]
@@ -64,7 +64,7 @@ where
         socket: C,
         id: Self::UpgradeIdentifier,
         ty: Endpoint,
-        remote_addr: &Multiaddr,
+        remote_addr: Maf,
     ) -> Self::Future {
         match id {
             EitherUpgradeIdentifier::First(id) => {
@@ -97,24 +97,24 @@ pub enum EitherConnUpgrFuture<A, B> {
     Second(B),
 }
 
-impl<A, B, O> Future for EitherConnUpgrFuture<A, B>
+impl<A, B, O, Ma, Mb> Future for EitherConnUpgrFuture<A, B>
 where
-    A: Future<Error = IoError, Item = O>,
-    B: Future<Error = IoError, Item = O>,
+    A: Future<Error = IoError, Item = (O, Ma)>,
+    B: Future<Error = IoError, Item = (O, Mb)>,
 {
-    type Item = O;
+    type Item = (O, future::Either<Ma, Mb>);
     type Error = IoError;
 
     #[inline]
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         match self {
             &mut EitherConnUpgrFuture::First(ref mut a) => {
-                let item = try_ready!(a.poll());
-                Ok(Async::Ready(item))
+                let (item, fut) = try_ready!(a.poll());
+                Ok(Async::Ready((item, future::Either::A(fut))))
             }
             &mut EitherConnUpgrFuture::Second(ref mut b) => {
-                let item = try_ready!(b.poll());
-                Ok(Async::Ready(item))
+                let (item, fut) = try_ready!(b.poll());
+                Ok(Async::Ready((item, future::Either::B(fut))))
             }
         }
     }

--- a/core/src/upgrade/denied.rs
+++ b/core/src/upgrade/denied.rs
@@ -29,14 +29,15 @@ use upgrade::{ConnectionUpgrade, Endpoint};
 #[derive(Debug, Copy, Clone)]
 pub struct DeniedConnectionUpgrade;
 
-impl<C> ConnectionUpgrade<C> for DeniedConnectionUpgrade
+impl<C, Maf> ConnectionUpgrade<C, Maf> for DeniedConnectionUpgrade
 where
     C: AsyncRead + AsyncWrite,
 {
     type NamesIter = iter::Empty<(Bytes, ())>;
     type UpgradeIdentifier = (); // TODO: could use `!`
     type Output = (); // TODO: could use `!`
-    type Future = Box<Future<Item = (), Error = io::Error>>; // TODO: could use `!`
+    type MultiaddrFuture = Box<Future<Item = Multiaddr, Error = io::Error>>; // TODO: could use `!`
+    type Future = Box<Future<Item = ((), Self::MultiaddrFuture), Error = io::Error>>; // TODO: could use `!`
 
     #[inline]
     fn protocol_names(&self) -> Self::NamesIter {
@@ -44,7 +45,7 @@ where
     }
 
     #[inline]
-    fn upgrade(self, _: C, _: Self::UpgradeIdentifier, _: Endpoint, _: &Multiaddr) -> Self::Future {
+    fn upgrade(self, _: C, _: Self::UpgradeIdentifier, _: Endpoint, _: Maf) -> Self::Future {
         unreachable!("the denied connection upgrade always fails to negotiate")
     }
 }

--- a/core/src/upgrade/plaintext.rs
+++ b/core/src/upgrade/plaintext.rs
@@ -20,7 +20,6 @@
 
 use bytes::Bytes;
 use futures::future::{self, FutureResult};
-use multiaddr::Multiaddr;
 use std::{iter, io::Error as IoError};
 use tokio_io::{AsyncRead, AsyncWrite};
 use upgrade::{ConnectionUpgrade, Endpoint};
@@ -33,18 +32,19 @@ use upgrade::{ConnectionUpgrade, Endpoint};
 #[derive(Debug, Copy, Clone)]
 pub struct PlainTextConfig;
 
-impl<C> ConnectionUpgrade<C> for PlainTextConfig
+impl<C, F> ConnectionUpgrade<C, F> for PlainTextConfig
 where
     C: AsyncRead + AsyncWrite,
 {
     type Output = C;
-    type Future = FutureResult<C, IoError>;
+    type Future = FutureResult<(C, F), IoError>;
     type UpgradeIdentifier = ();
+    type MultiaddrFuture = F;
     type NamesIter = iter::Once<(Bytes, ())>;
 
     #[inline]
-    fn upgrade(self, i: C, _: (), _: Endpoint, _: &Multiaddr) -> Self::Future {
-        future::ok(i)
+    fn upgrade(self, i: C, _: (), _: Endpoint, remote_addr: F) -> Self::Future {
+        future::ok((i, remote_addr))
     }
 
     #[inline]

--- a/core/tests/multiplex.rs
+++ b/core/tests/multiplex.rs
@@ -54,6 +54,7 @@ impl<T: Clone> Clone for OnlyOnce<T> {
 }
 impl<T: Transport> Transport for OnlyOnce<T> {
     type Output = T::Output;
+    type MultiaddrFuture = T::MultiaddrFuture;
     type Listener = T::Listener;
     type ListenerUpgrade = T::ListenerUpgrade;
     type Dial = T::Dial;

--- a/dns/src/lib.rs
+++ b/dns/src/lib.rs
@@ -100,9 +100,10 @@ where
     T: Transport + 'static, // TODO: 'static :-/
 {
     type Output = T::Output;
+    type MultiaddrFuture = T::MultiaddrFuture;
     type Listener = T::Listener;
     type ListenerUpgrade = T::ListenerUpgrade;
-    type Dial = Box<Future<Item = (Self::Output, Multiaddr), Error = IoError>>;
+    type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
 
     #[inline]
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
@@ -237,9 +238,10 @@ mod tests {
         struct CustomTransport;
         impl Transport for CustomTransport {
             type Output = <TcpConfig as Transport>::Output;
+            type MultiaddrFuture = <TcpConfig as Transport>::MultiaddrFuture;
             type Listener = <TcpConfig as Transport>::Listener;
             type ListenerUpgrade = <TcpConfig as Transport>::ListenerUpgrade;
-            type Dial = future::Empty<(Self::Output, Multiaddr), IoError>;
+            type Dial = future::Empty<(Self::Output, Self::MultiaddrFuture), IoError>;
 
             #[inline]
             fn listen_on(

--- a/kad/src/high_level.rs
+++ b/kad/src/high_level.rs
@@ -125,7 +125,6 @@ impl KademliaControllerPrototype {
         T: Clone + MuxedTransport + 'static, // TODO: 'static :-/
         K: Transport<Output = KademliaPeerReqStream> + Clone + 'static, // TODO: 'static :-/
         M: FnOnce(KademliaPeerReqStream) -> T::Output + Clone + 'static,
-        T::MultiaddrFuture: From<K::MultiaddrFuture>,
     {
         // TODO: initialization
 
@@ -212,7 +211,6 @@ where
     where
         K: Transport<Output = KademliaPeerReqStream> + Clone + 'static,
         M: FnOnce(KademliaPeerReqStream) -> T::Output + Clone + 'static,     // TODO: 'static :-/
-        T::MultiaddrFuture: From<K::MultiaddrFuture>,
     {
         let me = self.clone();
         query::find_node(gen_query_params!(me.clone()), searched_key)
@@ -466,7 +464,6 @@ where
     T: Clone + MuxedTransport + 'static, // TODO: 'static :-/
     K: Transport<Output = KademliaPeerReqStream> + Clone + 'static,      // TODO: 'static
     M: FnOnce(KademliaPeerReqStream) -> T::Output + Clone + 'static,     // TODO: 'static :-/
-    T::MultiaddrFuture: From<K::MultiaddrFuture>,
 {
     #[inline]
     fn send<F, FRet>(

--- a/kad/src/high_level.rs
+++ b/kad/src/high_level.rs
@@ -125,6 +125,7 @@ impl KademliaControllerPrototype {
         T: Clone + MuxedTransport + 'static, // TODO: 'static :-/
         K: Transport<Output = KademliaPeerReqStream> + Clone + 'static, // TODO: 'static :-/
         M: FnOnce(KademliaPeerReqStream) -> T::Output + Clone + 'static,
+        T::MultiaddrFuture: From<K::MultiaddrFuture>,
     {
         // TODO: initialization
 
@@ -211,6 +212,7 @@ where
     where
         K: Transport<Output = KademliaPeerReqStream> + Clone + 'static,
         M: FnOnce(KademliaPeerReqStream) -> T::Output + Clone + 'static,     // TODO: 'static :-/
+        T::MultiaddrFuture: From<K::MultiaddrFuture>,
     {
         let me = self.clone();
         query::find_node(gen_query_params!(me.clone()), searched_key)
@@ -247,118 +249,124 @@ impl KademliaUpgrade {
     }
 }
 
-impl<C> ConnectionUpgrade<C> for KademliaUpgrade
+impl<C, Maf> ConnectionUpgrade<C, Maf> for KademliaUpgrade
 where
     C: AsyncRead + AsyncWrite + 'static,     // TODO: 'static :-/
+    Maf: Future<Item = Multiaddr, Error = IoError> + 'static,       // TODO: 'static :(
 {
     type Output = KademliaPeerReqStream;
-    type Future = Box<Future<Item = Self::Output, Error = IoError>>;
+    type MultiaddrFuture = future::FutureResult<Multiaddr, IoError>;
+    type Future = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
     type NamesIter = iter::Once<(Bytes, ())>;
     type UpgradeIdentifier = ();
 
     #[inline]
     fn protocol_names(&self) -> Self::NamesIter {
-        ConnectionUpgrade::<C>::protocol_names(&self.upgrade)
+        ConnectionUpgrade::<C, Maf>::protocol_names(&self.upgrade)
     }
 
     #[inline]
-    fn upgrade(self, incoming: C, id: (), endpoint: Endpoint, addr: &Multiaddr) -> Self::Future {
-        let inner = self.inner;
-        let client_addr = addr.clone();
+    fn upgrade(self, incoming: C, id: (), endpoint: Endpoint, addr: Maf) -> Self::Future {
+        let future = addr.and_then(move |addr| {
+            let inner = self.inner;
+            let client_addr = addr.clone();
 
-        let peer_id = {
-            let mut iter = addr.iter();
-            let protocol = iter.next();
-            let after_proto = iter.next();
-            match (protocol, after_proto) {
-                (Some(AddrComponent::P2P(key)), None) | (Some(AddrComponent::IPFS(key)), None) => {
-                    match PeerId::from_bytes(key) {
-                        Ok(id) => id,
-                        Err(_) => {
-                            let err = IoError::new(
-                                IoErrorKind::InvalidData,
-                                "invalid peer ID sent by remote identification",
-                            );
-                            return Box::new(future::err(err));
+            let peer_id = {
+                let mut iter = addr.iter();
+                let protocol = iter.next();
+                let after_proto = iter.next();
+                match (protocol, after_proto) {
+                    (Some(AddrComponent::P2P(key)), None) | (Some(AddrComponent::IPFS(key)), None) => {
+                        match PeerId::from_bytes(key) {
+                            Ok(id) => id,
+                            Err(_) => {
+                                let err = IoError::new(
+                                    IoErrorKind::InvalidData,
+                                    "invalid peer ID sent by remote identification",
+                                );
+                                return Box::new(future::err(err)) as Box<Future<Item = _, Error = _>>;
+                            }
                         }
                     }
+                    _ => {
+                        let err =
+                            IoError::new(IoErrorKind::InvalidData, "couldn't identify connected node");
+                        return Box::new(future::err(err));
+                    }
                 }
-                _ => {
-                    let err =
-                        IoError::new(IoErrorKind::InvalidData, "couldn't identify connected node");
-                    return Box::new(future::err(err));
-                }
-            }
-        };
+            };
 
-        let future = self.upgrade.upgrade(incoming, id, endpoint, addr).map(
-            move |(controller, stream)| {
-                match inner.connections.lock().entry(client_addr) {
-                    Entry::Occupied(mut entry) => {
-                        match entry.insert(Connection::Active(controller)) {
-                            // If there was already an active connection to this remote, it gets
-                            // replaced by the new more recent one.
-                            Connection::Active(_old_connection) => {}
-                            Connection::Pending(closures) => {
-                                let new_ctl = match entry.get_mut() {
-                                    &mut Connection::Active(ref mut ctl) => ctl,
-                                    _ => unreachable!(
-                                        "logic error: an Active enum variant was \
-                                         inserted, but reading back didn't give \
-                                         an Active"
-                                    ),
-                                };
+            let future = self.upgrade.upgrade(incoming, id, endpoint, future::ok::<_, IoError>(addr)).map(
+                move |((controller, stream), _)| {
+                    match inner.connections.lock().entry(client_addr.clone()) {
+                        Entry::Occupied(mut entry) => {
+                            match entry.insert(Connection::Active(controller)) {
+                                // If there was already an active connection to this remote, it gets
+                                // replaced by the new more recent one.
+                                Connection::Active(_old_connection) => {}
+                                Connection::Pending(closures) => {
+                                    let new_ctl = match entry.get_mut() {
+                                        &mut Connection::Active(ref mut ctl) => ctl,
+                                        _ => unreachable!(
+                                            "logic error: an Active enum variant was \
+                                            inserted, but reading back didn't give \
+                                            an Active"
+                                        ),
+                                    };
 
-                                for mut closure in closures {
-                                    closure(new_ctl);
+                                    for mut closure in closures {
+                                        closure(new_ctl);
+                                    }
                                 }
-                            }
-                        };
-                    }
-                    Entry::Vacant(entry) => {
-                        entry.insert(Connection::Active(controller));
-                    }
-                };
-
-                let stream = stream.map(move |query| {
-                    match inner.kbuckets.update(peer_id.clone(), ()) {
-                        UpdateOutcome::NeedPing(node_to_ping) => {
-                            // TODO: do something with this info
-                            println!("need to ping {:?}", node_to_ping);
+                            };
                         }
-                        _ => (),
-                    }
+                        Entry::Vacant(entry) => {
+                            entry.insert(Connection::Active(controller));
+                        }
+                    };
 
-                    match query {
-                        KademliaIncomingRequest::FindNode { searched, responder } => {
-                            let mut intermediate: Vec<_> = inner.kbuckets.find_closest(&searched).collect();
-                            let my_id = inner.kbuckets.my_id().clone();
-                            if let Some(pos) = intermediate
-                                .iter()
-                                .position(|e| e.distance_with(&searched) >= my_id.distance_with(&searched))
-                            {
-                                if intermediate[pos] != my_id {
-                                    intermediate.insert(pos, my_id);
-                                }
-                            } else {
-                                intermediate.push(my_id);
+                    let stream = stream.map(move |query| {
+                        match inner.kbuckets.update(peer_id.clone(), ()) {
+                            UpdateOutcome::NeedPing(node_to_ping) => {
+                                // TODO: do something with this info
+                                println!("need to ping {:?}", node_to_ping);
                             }
+                            _ => (),
+                        }
 
-                            Some(KademliaPeerReq {
-                                requested_peers: intermediate,
-                                inner: responder,
-                            })
-                        },
-                        KademliaIncomingRequest::PingPong => {
-                            // We updated the k-bucket above.
-                            None
-                        },
-                    }
-                }).filter_map(|val| val);
+                        match query {
+                            KademliaIncomingRequest::FindNode { searched, responder } => {
+                                let mut intermediate: Vec<_> = inner.kbuckets.find_closest(&searched).collect();
+                                let my_id = inner.kbuckets.my_id().clone();
+                                if let Some(pos) = intermediate
+                                    .iter()
+                                    .position(|e| e.distance_with(&searched) >= my_id.distance_with(&searched))
+                                {
+                                    if intermediate[pos] != my_id {
+                                        intermediate.insert(pos, my_id);
+                                    }
+                                } else {
+                                    intermediate.push(my_id);
+                                }
 
-                KademliaPeerReqStream { inner: Box::new(stream) }
-            },
-        );
+                                Some(KademliaPeerReq {
+                                    requested_peers: intermediate,
+                                    inner: responder,
+                                })
+                            },
+                            KademliaIncomingRequest::PingPong => {
+                                // We updated the k-bucket above.
+                                None
+                            },
+                        }
+                    }).filter_map(|val| val);
+
+                    (KademliaPeerReqStream { inner: Box::new(stream) }, future::ok(client_addr))
+                },
+            );
+
+            Box::new(future) as Box<_>
+        });
 
         Box::new(future) as Box<_>
     }
@@ -458,6 +466,7 @@ where
     T: Clone + MuxedTransport + 'static, // TODO: 'static :-/
     K: Transport<Output = KademliaPeerReqStream> + Clone + 'static,      // TODO: 'static
     M: FnOnce(KademliaPeerReqStream) -> T::Output + Clone + 'static,     // TODO: 'static :-/
+    T::MultiaddrFuture: From<K::MultiaddrFuture>,
 {
     #[inline]
     fn send<F, FRet>(
@@ -486,7 +495,7 @@ where
                 // Need to open a connection.
                 let map = self.map.clone();
                 match self.swarm_controller
-                    .dial(addr, self.kademlia_transport.clone().map(move |out, _, _| map(out)))
+                    .dial(addr, self.kademlia_transport.clone().map(move |out, _| map(out)))
                 {
                     Ok(()) => (),
                     Err(_addr) => {

--- a/kad/src/protocol.rs
+++ b/kad/src/protocol.rs
@@ -116,12 +116,13 @@ impl Into<protobuf_structs::dht::Message_Peer> for Peer {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct KademliaProtocolConfig;
 
-impl<C> ConnectionUpgrade<C> for KademliaProtocolConfig
+impl<C, Maf> ConnectionUpgrade<C, Maf> for KademliaProtocolConfig
 where
     C: AsyncRead + AsyncWrite + 'static, // TODO: 'static :-/
 {
     type Output = KadStreamSink<C>;
-    type Future = future::FutureResult<Self::Output, IoError>;
+    type MultiaddrFuture = Maf;
+    type Future = future::FutureResult<(Self::Output, Self::MultiaddrFuture), IoError>;
     type NamesIter = iter::Once<(Bytes, ())>;
     type UpgradeIdentifier = ();
 
@@ -131,8 +132,8 @@ where
     }
 
     #[inline]
-    fn upgrade(self, incoming: C, _: (), _: Endpoint, _: &Multiaddr) -> Self::Future {
-        future::ok(kademlia_protocol(incoming))
+    fn upgrade(self, incoming: C, _: (), _: Endpoint, addr: Maf) -> Self::Future {
+        future::ok((kademlia_protocol(incoming), addr))
     }
 }
 

--- a/libp2p/examples/echo-server.rs
+++ b/libp2p/examples/echo-server.rs
@@ -101,14 +101,13 @@ fn main() {
     // outgoing connections for us.
     let (swarm_controller, swarm_future) = libp2p::core::swarm(
         transport.clone().with_upgrade(proto),
-        |socket, client_addr| {
-            println!("Successfully negotiated protocol with {}", client_addr);
+        |socket, _client_addr| {
+            println!("Successfully negotiated protocol");
 
             // The type of `socket` is exactly what the closure of `SimpleProtocol` returns.
 
             // We loop forever in order to handle all the messages sent by the client.
             loop_fn(socket, move |socket| {
-                let client_addr = client_addr.clone();
                 socket
                     .into_future()
                     .map_err(|(e, _)| e)
@@ -116,15 +115,14 @@ fn main() {
                         if let Some(msg) = msg {
                             // One message has been received. We send it back to the client.
                             println!(
-                                "Received a message from {}: {:?}\n => Sending back \
-                                 identical message to remote",
-                                client_addr, msg
+                                "Received a message: {:?}\n => Sending back \
+                                 identical message to remote", msg
                             );
                             Box::new(rest.send(msg.freeze()).map(|m| Loop::Continue(m)))
                                 as Box<Future<Item = _, Error = _>>
                         } else {
                             // End of stream. Connection closed. Breaking the loop.
-                            println!("Received EOF from {}\n => Dropping connection", client_addr);
+                            println!("Received EOF\n => Dropping connection");
                             Box::new(Ok(Loop::Break(())).into_future())
                                 as Box<Future<Item = _, Error = _>>
                         }

--- a/libp2p/examples/floodsub.rs
+++ b/libp2p/examples/floodsub.rs
@@ -100,8 +100,8 @@ fn main() {
     // outgoing connections for us.
     let (swarm_controller, swarm_future) = libp2p::core::swarm(
         transport.clone().with_upgrade(floodsub_upgrade.clone()),
-        |socket, client_addr| {
-            println!("Successfully negotiated protocol with {}", client_addr);
+        |socket, _| {
+            println!("Successfully negotiated protocol");
             socket
         },
     );

--- a/libp2p/examples/kademlia.rs
+++ b/libp2p/examples/kademlia.rs
@@ -89,7 +89,7 @@ fn main() {
         .into_connection_reuse();
 
     let transport = libp2p::identify::IdentifyTransport::new(transport, peer_store.clone())
-        .map(|id_out, _, _| {
+        .map(|id_out, _| {
             id_out.socket
         });
 

--- a/libp2p/src/lib.rs
+++ b/libp2p/src/lib.rs
@@ -97,6 +97,7 @@ impl CommonTransport {
 
 impl Transport for CommonTransport {
     type Output = <InnerImplementation as Transport>::Output;
+    type MultiaddrFuture = <InnerImplementation as Transport>::MultiaddrFuture;
     type Listener = <InnerImplementation as Transport>::Listener;
     type ListenerUpgrade = <InnerImplementation as Transport>::ListenerUpgrade;
     type Dial = <InnerImplementation as Transport>::Dial;

--- a/ratelimit/src/lib.rs
+++ b/ratelimit/src/lib.rs
@@ -142,7 +142,7 @@ where
     T: Transport + 'static,
     T::Output: AsyncRead + AsyncWrite,
 {
-    type Item = (Connection<T::Output>, Multiaddr);
+    type Item = (Connection<T::Output>, T::MultiaddrFuture);
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
@@ -159,9 +159,10 @@ where
     T::Output: AsyncRead + AsyncWrite,
 {
     type Output = Connection<T::Output>;
+    type MultiaddrFuture = T::MultiaddrFuture;
     type Listener = Listener<T>;
     type ListenerUpgrade = ListenerUpgrade<T>;
-    type Dial = Box<Future<Item = (Connection<T::Output>, Multiaddr), Error = io::Error>>;
+    type Dial = Box<Future<Item = (Connection<T::Output>, Self::MultiaddrFuture), Error = io::Error>>;
 
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)>
     where

--- a/relay/src/protocol.rs
+++ b/relay/src/protocol.rs
@@ -22,7 +22,6 @@ use bytes::Bytes;
 use core::{ConnectionUpgrade, Endpoint, Transport};
 use futures::{stream, future::{self, Either::{A, B}, FutureResult}, prelude::*};
 use message::{CircuitRelay, CircuitRelay_Peer, CircuitRelay_Status, CircuitRelay_Type};
-use multiaddr::Multiaddr;
 use peerstore::{PeerAccess, PeerId, Peerstore};
 use std::{io, iter, ops::Deref};
 use tokio_io::{io as aio, AsyncRead, AsyncWrite};
@@ -49,13 +48,14 @@ pub enum Output<C> {
     Sealed(Box<Future<Item=(), Error=io::Error>>)
 }
 
-impl<C, T, P, S> ConnectionUpgrade<C> for RelayConfig<T, P>
+impl<C, T, P, S, Maf> ConnectionUpgrade<C, Maf> for RelayConfig<T, P>
 where
     C: AsyncRead + AsyncWrite + 'static,
     T: Transport + Clone + 'static,
     T::Output: AsyncRead + AsyncWrite,
     P: Deref<Target=S> + Clone + 'static,
     S: 'static,
+    Maf: 'static,
     for<'a> &'a S: Peerstore
 {
     type NamesIter = iter::Once<(Bytes, Self::UpgradeIdentifier)>;
@@ -66,9 +66,10 @@ where
     }
 
     type Output = Output<C>;
-    type Future = Box<Future<Item=Self::Output, Error=io::Error>>;
+    type MultiaddrFuture = Maf;
+    type Future = Box<Future<Item=(Self::Output, Maf), Error=io::Error>>;
 
-    fn upgrade(self, conn: C, _: (), _: Endpoint, _: &Multiaddr) -> Self::Future {
+    fn upgrade(self, conn: C, _: (), _: Endpoint, remote_addr: Maf) -> Self::Future {
         let future = Io::new(conn).recv().and_then(move |(message, io)| {
             let msg = if let Some(m) = message {
                 m
@@ -89,7 +90,7 @@ where
                 }
             }
         });
-        Box::new(future)
+        Box::new(future.map(move |out| (out, remote_addr)))
     }
 }
 
@@ -241,7 +242,7 @@ fn stop_message(from: &Peer, dest: &Peer) -> CircuitRelay {
 #[derive(Debug, Clone)]
 struct TrivialUpgrade;
 
-impl<C> ConnectionUpgrade<C> for TrivialUpgrade
+impl<C, Maf> ConnectionUpgrade<C, Maf> for TrivialUpgrade
 where
     C: AsyncRead + AsyncWrite + 'static
 {
@@ -253,19 +254,21 @@ where
     }
 
     type Output = C;
-    type Future = FutureResult<Self::Output, io::Error>;
+    type MultiaddrFuture = Maf;
+    type Future = FutureResult<(Self::Output, Maf), io::Error>;
 
-    fn upgrade(self, conn: C, _: (), _: Endpoint, _: &Multiaddr) -> Self::Future {
-        future::ok(conn)
+    fn upgrade(self, conn: C, _: (), _: Endpoint, remote_addr: Maf) -> Self::Future {
+        future::ok((conn, remote_addr))
     }
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct Source(pub(crate) CircuitRelay);
 
-impl<C> ConnectionUpgrade<C> for Source
+impl<C, Maf> ConnectionUpgrade<C, Maf> for Source
 where
     C: AsyncRead + AsyncWrite + 'static,
+    Maf: 'static,
 {
     type NamesIter = iter::Once<(Bytes, Self::UpgradeIdentifier)>;
     type UpgradeIdentifier = ();
@@ -275,9 +278,10 @@ where
     }
 
     type Output = C;
-    type Future = Box<Future<Item=Self::Output, Error=io::Error>>;
+    type MultiaddrFuture = Maf;
+    type Future = Box<Future<Item=(Self::Output, Maf), Error=io::Error>>;
 
-    fn upgrade(self, conn: C, _: (), _: Endpoint, _: &Multiaddr) -> Self::Future {
+    fn upgrade(self, conn: C, _: (), _: Endpoint, remote_addr: Maf) -> Self::Future {
         let future = Io::new(conn)
             .send(self.0)
             .and_then(Io::recv)
@@ -292,7 +296,7 @@ where
                     Err(io_err("no success response from relay"))
                 }
             });
-        Box::new(future)
+        Box::new(future.map(move |out| (out, remote_addr)))
     }
 }
 

--- a/websocket/src/browser.rs
+++ b/websocket/src/browser.rs
@@ -20,7 +20,7 @@
 
 use futures::stream::Then as StreamThen;
 use futures::sync::{mpsc, oneshot};
-use futures::{Async, Future, Poll, Stream};
+use futures::{Async, future, Future, Poll, Stream, future::FutureResult};
 use multiaddr::{AddrComponent, Multiaddr};
 use rw_stream_sink::RwStreamSink;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
@@ -53,9 +53,10 @@ impl BrowserWsConfig {
 
 impl Transport for BrowserWsConfig {
     type Output = BrowserWsConn;
+    type MultiaddrFuture = FutureResult<Multiaddr, IoError>;
     type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = IoError>>; // TODO: use `!`
-    type ListenerUpgrade = Box<Future<Item = (Self::Output, Multiaddr), Error = IoError>>; // TODO: use `!`
-    type Dial = Box<Future<Item = (Self::Output, Multiaddr), Error = IoError>>;
+    type ListenerUpgrade = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>; // TODO: use `!`
+    type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
 
     #[inline]
     fn listen_on(self, a: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
@@ -194,7 +195,7 @@ impl Transport for BrowserWsConfig {
 
         Ok(Box::new(open_rx.then(|result| {
             match result {
-                Ok(Ok(r)) => Ok((r, original_addr)),
+                Ok(Ok(r)) => Ok((r, future::ok(original_addr))),
                 Ok(Err(e)) => Err(e),
                 // `Err` would happen here if `open_tx` is destroyed. `open_tx` is captured by
                 // the `WebSocket`, and the `WebSocket` is captured by `open_cb`, which is itself


### PR DESCRIPTION
The `Transport` trait now produces a `Future` to the `Multiaddr` of the remote, instead of producing the `Multiaddr` directly. Therefore a new associated type has been added to the trait.

Similarly the `ConnectionUpgrade::upgrade` method now takes a `Future` to the `Multiaddr`, instead of the `Multiaddr` directly. The consequence is that a new generic and a new associated type have been added to the trait.

The closure passed to `Transport::map` no longer accepts a `Multiaddr`. The closure passed to `Transport::and_then` now accepts the `Future` to the `Multiaddr` and must return a new `Future` (possibly the same).

The intent of this change is to make it possible to identify clients (ie. determine their peer ID) *after* we start processing their requests. This is mostly to avoid possible deadlock, but also to make things more asynchronous.