### PR TITLE
Fix wrong endpoint in and_then

### DIFF
--- a/core/src/transport/and_then.rs
+++ b/core/src/transport/and_then.rs
@@ -101,7 +101,7 @@ where
         let future = dialed_fut
             // Try to negotiate the protocol.
             .and_then(move |(connection, client_addr)| {
-                upgrade(connection, Endpoint::Listener, client_addr)
+                upgrade(connection, Endpoint::Dialer, client_addr)
             });
 
         Ok(Box::new(future))


### PR DESCRIPTION
The major consequence is that if you used `upgrade::apply`, it would wait for a protocol selection from the remote instead of doing the protocol selection itself.