### PR TITLE
Use eth-secp256k1 instead of secp256k1

### DIFF
--- a/secio/Cargo.toml
+++ b/secio/Cargo.toml
@@ -14,12 +14,13 @@ rand = "0.3.17"
 ring = { version = "0.12.1", features = ["rsa_signing"] }
 rust-crypto = "^0.2"
 rw-stream-sink = { path = "../rw-stream-sink" }
-secp256k1 = { version = "0.9", optional = true }
+eth-secp256k1 = { git = "https://github.com/paritytech/rust-secp256k1", optional = true }
 tokio-io = "0.1.0"
 untrusted = "0.5.1"
 
 [features]
 default = ["secp256k1"]
+secp256k1 = ["eth-secp256k1"]
 
 [dev-dependencies]
 libp2p-tcp-transport = { path = "../tcp-transport" }

--- a/secio/src/lib.rs
+++ b/secio/src/lib.rs
@@ -242,7 +242,7 @@ impl SecioKeyPair {
                 let secp = secp256k1::Secp256k1::with_caps(secp256k1::ContextFlag::SignOnly);
                 let pubkey = secp256k1::key::PublicKey::from_secret_key(&secp, private)
                     .expect("wrong secp256k1 private key ; type safety violated");
-                PublicKey::Secp256k1(pubkey.serialize().to_vec())
+                PublicKey::Secp256k1(pubkey.serialize_vec(&secp, true).to_vec())
             },
         }
     }


### PR DESCRIPTION
This is something a Parity-egoistical pull request, but Polkadot uses the `eth-secp256k1` library, which cannot be linked at the same time as `secp256k1` because it uses the same symbols.

This PR makes secp256k1 usable in Polkadot.