### PR TITLE
Remove exposed unimplemented!() in the Kad server

### DIFF
--- a/kad/src/kad_server.rs
+++ b/kad/src/kad_server.rs
@@ -383,10 +383,16 @@ where
                             Box::new(future)
                         }
                         Some(EventSource::Remote(KadMsg::GetValueReq { .. })) => {
-                            unimplemented!()        // FIXME:
+                            warn!("GET_VALUE requests are not implemented yet");
+                            let future = future::err(IoError::new(IoErrorKind::Other,
+                                "GET_VALUE requests are not implemented yet"));
+                            return Box::new(future);
                         }
                         Some(EventSource::Remote(KadMsg::PutValue { .. })) => {
-                            unimplemented!()        // FIXME:
+                            warn!("PUT_VALUE requests are not implemented yet");
+                            let state = (events, kad_sink, responders_tx, send_back_queue, expected_pongs, finished);
+                            let future = future::ok((None, state));
+                            return Box::new(future);
                         }
                     }
                 }))

--- a/kad/src/protocol.rs
+++ b/kad/src/protocol.rs
@@ -227,7 +227,7 @@ fn msg_to_proto(kad_msg: KadMsg) -> protobuf_structs::dht::Message {
             msg.set_clusterLevelRaw(10);
             msg
         }
-        KadMsg::GetValueRes { .. } => unimplemented!(),
+        KadMsg::GetValueRes { .. } => unimplemented!(),     // TODO:
         KadMsg::FindNodeReq { key } => {
             let mut msg = protobuf_structs::dht::Message::new();
             msg.set_field_type(protobuf_structs::dht::Message_MessageType::FIND_NODE);


### PR DESCRIPTION
cc #295 

Avoids crashing the server with `unimplemented!()` if we receive a `PUT_VALUE` or `GET_VALUE` message from a Kademlia remote.
