### PR TITLE
Use the new version of tokio

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,4 +23,4 @@ libp2p-ping = { path = "../ping" }
 libp2p-tcp-transport = { path = "../tcp-transport" }
 libp2p-mplex = { path = "../mplex" }
 rand = "0.5"
-tokio-core = "0.1"
+tokio-current-thread = "0.1"

--- a/core/README.md
+++ b/core/README.md
@@ -66,7 +66,7 @@ connection upgrade.
 ```rust
 extern crate libp2p_core;
 extern crate libp2p_tcp_transport;
-extern crate tokio_core;
+extern crate tokio_current_thread;
 
 use libp2p_core::Transport;
 
@@ -111,7 +111,7 @@ extern crate futures;
 extern crate libp2p_ping;
 extern crate libp2p_core;
 extern crate libp2p_tcp_transport;
-extern crate tokio_core;
+extern crate tokio_current_thread;
 
 use futures::Future;
 use libp2p_ping::Ping;
@@ -119,7 +119,7 @@ use libp2p_core::Transport;
 
 let mut core = tokio_core::reactor::Core::new().unwrap();
 
-let ping_finished_future = libp2p_tcp_transport::TcpConfig::new(core.handle())
+let ping_finished_future = libp2p_tcp_transport::TcpConfig::new()
     // We have a `TcpConfig` struct that implements `Transport`, and apply a `Ping` upgrade on it.
     .with_upgrade(Ping)
     // TODO: right now the only available protocol is ping, but we want to replace it with
@@ -130,7 +130,7 @@ let ping_finished_future = libp2p_tcp_transport::TcpConfig::new(core.handle())
     });
 
 // Runs until the ping arrives.
-core.run(ping_finished_future).unwrap();
+tokio_current_thread::block_on_all(ping_finished_future).unwrap();
 ```
 
 ## Grouping protocols
@@ -151,7 +151,7 @@ extern crate futures;
 extern crate libp2p_ping;
 extern crate libp2p_core;
 extern crate libp2p_tcp_transport;
-extern crate tokio_core;
+extern crate tokio_current_thread;
 
 use futures::Future;
 use libp2p_ping::Ping;
@@ -159,7 +159,7 @@ use libp2p_core::Transport;
 
 let mut core = tokio_core::reactor::Core::new().unwrap();
 
-let transport = libp2p_tcp_transport::TcpConfig::new(core.handle())
+let transport = libp2p_tcp_transport::TcpConfig::new()
     .with_dummy_muxing();
 
 let (swarm_controller, swarm_future) = libp2p_core::swarm(transport, Ping, |(mut pinger, service), client_addr| {
@@ -172,5 +172,5 @@ let (swarm_controller, swarm_future) = libp2p_core::swarm(transport, Ping, |(mut
 swarm_controller.listen_on("/ip4/0.0.0.0/tcp/0".parse().unwrap());
 
 // Runs until everything is finished.
-core.run(swarm_future).unwrap();
+tokio_current_thread::block_on_all(swarm_future).unwrap();
 ```

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -87,13 +87,11 @@
 //! ```
 //! extern crate libp2p_core;
 //! extern crate libp2p_tcp_transport;
-//! extern crate tokio_core;
 //!
 //! use libp2p_core::Transport;
 //!
 //! # fn main() {
-//! let tokio_core = tokio_core::reactor::Core::new().unwrap();
-//! let tcp_transport = libp2p_tcp_transport::TcpConfig::new(tokio_core.handle());
+//! let tcp_transport = libp2p_tcp_transport::TcpConfig::new();
 //! let upgraded = tcp_transport.with_upgrade(libp2p_core::upgrade::PlainTextConfig);
 //!
 //! // upgraded.dial(...)   // automatically applies the plain text protocol on the socket
@@ -134,16 +132,14 @@
 //! extern crate libp2p_ping;
 //! extern crate libp2p_core;
 //! extern crate libp2p_tcp_transport;
-//! extern crate tokio_core;
+//! extern crate tokio_current_thread;
 //!
 //! use futures::Future;
 //! use libp2p_ping::Ping;
 //! use libp2p_core::Transport;
 //!
 //! # fn main() {
-//! let mut core = tokio_core::reactor::Core::new().unwrap();
-//!
-//! let ping_finished_future = libp2p_tcp_transport::TcpConfig::new(core.handle())
+//! let ping_finished_future = libp2p_tcp_transport::TcpConfig::new()
 //!     // We have a `TcpConfig` struct that implements `Transport`, and apply a `Ping` upgrade on it.
 //!     .with_upgrade(Ping)
 //!     // TODO: right now the only available protocol is ping, but we want to replace it with
@@ -154,7 +150,7 @@
 //!     });
 //!
 //! // Runs until the ping arrives.
-//! core.run(ping_finished_future).unwrap();
+//! tokio_current_thread::block_on_all(ping_finished_future).unwrap();
 //! # }
 //! ```
 //!
@@ -176,16 +172,14 @@
 //! extern crate libp2p_ping;
 //! extern crate libp2p_core;
 //! extern crate libp2p_tcp_transport;
-//! extern crate tokio_core;
+//! extern crate tokio_current_thread;
 //!
 //! use futures::Future;
 //! use libp2p_ping::Ping;
 //! use libp2p_core::Transport;
 //!
 //! # fn main() {
-//! let mut core = tokio_core::reactor::Core::new().unwrap();
-//!
-//! let transport = libp2p_tcp_transport::TcpConfig::new(core.handle())
+//! let transport = libp2p_tcp_transport::TcpConfig::new()
 //!     .with_dummy_muxing();
 //!
 //! let (swarm_controller, swarm_future) = libp2p_core::swarm(transport.with_upgrade(Ping),
@@ -199,7 +193,7 @@
 //! swarm_controller.listen_on("/ip4/0.0.0.0/tcp/0".parse().unwrap());
 //!
 //! // Runs until everything is finished.
-//! core.run(swarm_future).unwrap();
+//! tokio_current_thread::block_on_all(swarm_future).unwrap();
 //! # }
 //! ```
 

--- a/dns/Cargo.toml
+++ b/dns/Cargo.toml
@@ -8,7 +8,7 @@ libp2p-core = { path = "../core" }
 log = "0.4.1"
 futures = "0.1"
 multiaddr = { path = "../multiaddr" }
-tokio-dns-unofficial = "0.1"
+tokio-dns-unofficial = "0.3"
 tokio-io = "0.1"
 
 [dev-dependencies]

--- a/identify/Cargo.toml
+++ b/identify/Cargo.toml
@@ -19,4 +19,4 @@ varint = { path = "../varint-rs" }
 
 [dev-dependencies]
 libp2p-tcp-transport = { path = "../tcp-transport" }
-tokio-core = "0.1.0"
+tokio-current-thread = "0.1"

--- a/identify/src/peer_id_transport.rs
+++ b/identify/src/peer_id_transport.rs
@@ -292,10 +292,9 @@ fn multiaddr_to_peerid(addr: Multiaddr) -> Result<PeerId, Multiaddr> {
 #[cfg(test)]
 mod tests {
     extern crate libp2p_tcp_transport;
-    extern crate tokio_core;
+    extern crate tokio_current_thread;
 
     use self::libp2p_tcp_transport::TcpConfig;
-    use self::tokio_core::reactor::Core;
     use PeerIdTransport;
     use futures::{Future, Stream};
     use libp2p_core::{Transport, PeerId, PublicKey};
@@ -341,9 +340,8 @@ mod tests {
 
         let peer_id = PeerId::from_public_key(PublicKey::Ed25519(vec![1, 2, 3, 4]));
 
-        let mut core = Core::new().unwrap();
         let underlying = UnderlyingTrans {
-            inner: TcpConfig::new(core.handle()),
+            inner: TcpConfig::new(),
         };
         let transport = PeerIdTransport::new(underlying, {
             let peer_id = peer_id.clone();
@@ -358,6 +356,6 @@ mod tests {
             .unwrap_or_else(|_| panic!())
             .then::<_, Result<(), ()>>(|_| Ok(()));
 
-        let _ = core.run(future).unwrap();
+        let _ = tokio_current_thread::block_on_all(future).unwrap();
     }
 }

--- a/kad/Cargo.toml
+++ b/kad/Cargo.toml
@@ -28,4 +28,4 @@ varint = { path = "../varint-rs" }
 [dev-dependencies]
 libp2p-tcp-transport = { path = "../tcp-transport" }
 rand = "0.4.2"
-tokio-core = "0.1"
+tokio-current-thread = "0.1"

--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -30,7 +30,7 @@ tokio-io = "0.1"
 libp2p-dns = { path = "../dns" }
 libp2p-secio = { path = "../secio", optional = true, default-features = false }
 libp2p-tcp-transport = { path = "../tcp-transport" }
-tokio-core = "0.1"
+tokio-current-thread = "0.1"
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
 stdweb = { version = "0.1.3", default-features = false }
@@ -40,7 +40,7 @@ bigint = "4.2"
 env_logger = "0.5.4"
 rand = "0.4"
 structopt =  "0.2"
-tokio-core = "0.1"
+tokio-current-thread = "0.1"
 tokio-io = "0.1"
 tokio-stdin = "0.1"
 

--- a/libp2p/examples/ping-client.rs
+++ b/libp2p/examples/ping-client.rs
@@ -22,7 +22,7 @@ extern crate bytes;
 extern crate env_logger;
 extern crate futures;
 extern crate libp2p;
-extern crate tokio_core;
+extern crate tokio_current_thread;
 extern crate tokio_io;
 
 use futures::Future;
@@ -31,7 +31,6 @@ use std::env;
 use libp2p::core::Transport;
 use libp2p::core::{upgrade, either::EitherOutput};
 use libp2p::tcp::TcpConfig;
-use tokio_core::reactor::Core;
 
 fn main() {
     env_logger::init();
@@ -41,12 +40,8 @@ fn main() {
         .nth(1)
         .unwrap_or("/ip4/127.0.0.1/tcp/4001".to_owned());
 
-    // We start by building the tokio engine that will run all the sockets.
-    let mut core = Core::new().unwrap();
-
-    // Now let's build the transport stack.
     // We start by creating a `TcpConfig` that indicates that we want TCP/IP.
-    let transport = TcpConfig::new(core.handle())
+    let transport = TcpConfig::new()
 
         // On top of TCP/IP, we will use either the plaintext protocol or the secio protocol,
         // depending on which one the remote supports.
@@ -110,7 +105,7 @@ fn main() {
     // `swarm_future` is a future that contains all the behaviour that we want, but nothing has
     // actually started yet. Because we created the `TcpConfig` with tokio, we need to run the
     // future through the tokio core.
-    core.run(
+    tokio_current_thread::block_on_all(
         rx.select(swarm_future.map_err(|_| unreachable!()))
             .map_err(|(e, _)| e)
             .map(|_| ()),

--- a/libp2p/src/lib.rs
+++ b/libp2p/src/lib.rs
@@ -21,7 +21,7 @@
 pub extern crate bytes;
 pub extern crate futures;
 #[cfg(not(target_os = "emscripten"))]
-pub extern crate tokio_core;
+pub extern crate tokio_current_thread;
 pub extern crate multiaddr;
 pub extern crate tokio_io;
 pub extern crate tokio_codec;
@@ -55,7 +55,6 @@ pub use self::transport_timeout::TransportTimeout;
 ///
 /// The list currently is TCP/IP, DNS, and WebSockets. However this list could change in the
 /// future to get new transports.
-// TODO: handle the emscripten situation, because we shouldn't depend on tokio-core with emscripten
 #[derive(Debug, Clone)]
 pub struct CommonTransport {
     // The actual implementation of everything.
@@ -76,8 +75,8 @@ impl CommonTransport {
     /// Initializes the `CommonTransport`.
     #[inline]
     #[cfg(not(target_os = "emscripten"))]
-    pub fn new(tokio_handle: tokio_core::reactor::Handle) -> CommonTransport {
-        let tcp = tcp::TcpConfig::new(tokio_handle);
+    pub fn new() -> CommonTransport {
+        let tcp = tcp::TcpConfig::new();
         let with_dns = dns::DnsConfig::new(tcp);
         let with_ws = websocket::WsConfig::new(with_dns.clone());
         let inner = with_dns.or_transport(with_ws);

--- a/mplex/Cargo.toml
+++ b/mplex/Cargo.toml
@@ -21,4 +21,4 @@ varint = { path = "../varint-rs" }
 
 [dev-dependencies]
 libp2p-tcp-transport = { path = "../tcp-transport" }
-tokio-core = "0.1"
+tokio-current-thread = "0.1"

--- a/multistream-select/Cargo.toml
+++ b/multistream-select/Cargo.toml
@@ -12,4 +12,5 @@ tokio-io = "0.1"
 varint = { path = "../varint-rs" }
 
 [dev-dependencies]
-tokio-core = "0.1"
+tokio-current-thread = "0.1"
+tokio-tcp = "0.1"

--- a/multistream-select/README.md
+++ b/multistream-select/README.md
@@ -25,7 +25,7 @@ For a dialer:
 extern crate bytes;
 extern crate futures;
 extern crate multistream_select;
-extern crate tokio_core;
+extern crate tokio_current_thread;
 
 use bytes::Bytes;
 use multistream_select::dialer_select_proto;
@@ -49,7 +49,7 @@ let client = TcpStream::connect(&"127.0.0.1:10333".parse().unwrap(), &core.handl
         dialer_select_proto(connec, protos).map(|r| r.0)
     });
 
-let negotiated_protocol: MyProto = core.run(client).expect("failed to find a protocol");
+let negotiated_protocol: MyProto = tokio_current_thread::block_on_all(client).expect("failed to find a protocol");
 println!("negotiated: {:?}", negotiated_protocol);
 ```
 
@@ -59,7 +59,7 @@ For a listener:
 extern crate bytes;
 extern crate futures;
 extern crate multistream_select;
-extern crate tokio_core;
+extern crate tokio_current_thread;
 
 use bytes::Bytes;
 use multistream_select::listener_select_proto;
@@ -88,5 +88,5 @@ let server = TcpListener::bind(&"127.0.0.1:0".parse().unwrap(), &core.handle()).
         Ok(())
     });
 
-core.run(server).expect("failed to run server");
+tokio_current_thread::block_on_all(server).expect("failed to run server");
 ```

--- a/multistream-select/src/lib.rs
+++ b/multistream-select/src/lib.rs
@@ -48,21 +48,19 @@
 //! extern crate bytes;
 //! extern crate futures;
 //! extern crate multistream_select;
-//! extern crate tokio_core;
+//! extern crate tokio_current_thread;
+//! extern crate tokio_tcp;
 //!
 //! # fn main() {
 //! use bytes::Bytes;
 //! use multistream_select::dialer_select_proto;
 //! use futures::{Future, Sink, Stream};
-//! use tokio_core::net::TcpStream;
-//! use tokio_core::reactor::Core;
-//!
-//! let mut core = Core::new().unwrap();
+//! use tokio_tcp::TcpStream;
 //!
 //! #[derive(Debug, Copy, Clone)]
 //! enum MyProto { Echo, Hello }
 //!
-//! let client = TcpStream::connect(&"127.0.0.1:10333".parse().unwrap(), &core.handle())
+//! let client = TcpStream::connect(&"127.0.0.1:10333".parse().unwrap())
 //!     .from_err()
 //!     .and_then(move |connec| {
 //!         let protos = vec![
@@ -73,7 +71,8 @@
 //!         dialer_select_proto(connec, protos).map(|r| r.0)
 //!     });
 //!
-//! let negotiated_protocol: MyProto = core.run(client).expect("failed to find a protocol");
+//! let negotiated_protocol: MyProto = tokio_current_thread::block_on_all(client)
+//!     .expect("failed to find a protocol");
 //! println!("negotiated: {:?}", negotiated_protocol);
 //! # }
 //! ```
@@ -84,24 +83,22 @@
 //! extern crate bytes;
 //! extern crate futures;
 //! extern crate multistream_select;
-//! extern crate tokio_core;
+//! extern crate tokio_current_thread;
+//! extern crate tokio_tcp;
 //!
 //! # fn main() {
 //! use bytes::Bytes;
 //! use multistream_select::listener_select_proto;
 //! use futures::{Future, Sink, Stream};
-//! use tokio_core::net::TcpListener;
-//! use tokio_core::reactor::Core;
-//!
-//! let mut core = Core::new().unwrap();
+//! use tokio_tcp::TcpListener;
 //!
 //! #[derive(Debug, Copy, Clone)]
 //! enum MyProto { Echo, Hello }
 //!
-//! let server = TcpListener::bind(&"127.0.0.1:0".parse().unwrap(), &core.handle()).unwrap()
+//! let server = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap()
 //!     .incoming()
 //!     .from_err()
-//!     .and_then(move |(connec, _)| {
+//!     .and_then(move |connec| {
 //!         let protos = vec![
 //!             (Bytes::from("/echo/1.0.0"), <Bytes as PartialEq>::eq, MyProto::Echo),
 //!             (Bytes::from("/hello/2.5.0"), <Bytes as PartialEq>::eq, MyProto::Hello),
@@ -114,7 +111,7 @@
 //!         Ok(())
 //!     });
 //!
-//! core.run(server).expect("failed to run server");
+//! tokio_current_thread::block_on_all(server).expect("failed to run server");
 //! # }
 //! ```
 

--- a/multistream-select/src/protocol/dialer.rs
+++ b/multistream-select/src/protocol/dialer.rs
@@ -190,9 +190,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    extern crate tokio_core;
-    use self::tokio_core::net::{TcpListener, TcpStream};
-    use self::tokio_core::reactor::Core;
+    extern crate tokio_current_thread;
+    extern crate tokio_tcp;
+    use self::tokio_tcp::{TcpListener, TcpStream};
     use bytes::Bytes;
     use futures::Future;
     use futures::{Sink, Stream};
@@ -200,9 +200,7 @@ mod tests {
 
     #[test]
     fn wrong_proto_name() {
-        let mut core = Core::new().unwrap();
-
-        let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap(), &core.handle()).unwrap();
+        let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
         let listener_addr = listener.local_addr().unwrap();
 
         let server = listener
@@ -211,7 +209,7 @@ mod tests {
             .map(|_| ())
             .map_err(|(e, _)| e.into());
 
-        let client = TcpStream::connect(&listener_addr, &core.handle())
+        let client = TcpStream::connect(&listener_addr)
             .from_err()
             .and_then(move |stream| Dialer::new(stream))
             .and_then(move |dialer| {
@@ -219,7 +217,7 @@ mod tests {
                 dialer.send(DialerToListenerMessage::ProtocolRequest { name: p })
             });
 
-        match core.run(server.join(client)) {
+        match tokio_current_thread::block_on_all(server.join(client)) {
             Err(MultistreamSelectError::WrongProtocolName) => (),
             _ => panic!(),
         }

--- a/ping/Cargo.toml
+++ b/ping/Cargo.toml
@@ -17,4 +17,5 @@ tokio-io = "0.1"
 
 [dev-dependencies]
 libp2p-tcp-transport = { path = "../tcp-transport" }
-tokio-core = "0.1"
+tokio-current-thread = "0.1"
+tokio-tcp = "0.1"

--- a/ping/README.md
+++ b/ping/README.md
@@ -33,15 +33,13 @@ extern crate futures;
 extern crate libp2p_ping;
 extern crate libp2p_core;
 extern crate libp2p_tcp_transport;
-extern crate tokio_core;
+extern crate tokio_current_thread;
 
 use futures::Future;
 use libp2p_ping::Ping;
 use libp2p_core::Transport;
 
-let mut core = tokio_core::reactor::Core::new().unwrap();
-
-let ping_finished_future = libp2p_tcp_transport::TcpConfig::new(core.handle())
+let ping_finished_future = libp2p_tcp_transport::TcpConfig::new()
     .with_upgrade(Ping)
     .dial("127.0.0.1:12345".parse::<libp2p_core::Multiaddr>().unwrap()).unwrap_or_else(|_| panic!())
     .and_then(|((mut pinger, service), _)| {
@@ -49,6 +47,6 @@ let ping_finished_future = libp2p_tcp_transport::TcpConfig::new(core.handle())
     });
 
 // Runs until the ping arrives.
-core.run(ping_finished_future).unwrap();
+tokio_current_thread::block_on_all(ping_finished_future).unwrap();
 ```
 

--- a/secio/Cargo.toml
+++ b/secio/Cargo.toml
@@ -24,4 +24,5 @@ secp256k1 = ["eth-secp256k1"]
 
 [dev-dependencies]
 libp2p-tcp-transport = { path = "../tcp-transport" }
-tokio-core = "0.1.6"
+tokio-current-thread = "0.1"
+tokio-tcp = "0.1"

--- a/secio/README.md
+++ b/secio/README.md
@@ -10,7 +10,7 @@ through it.
 
 ```rust
 extern crate futures;
-extern crate tokio_core;
+extern crate tokio_current_thread;
 extern crate tokio_io;
 extern crate libp2p_core;
 extern crate libp2p_secio;
@@ -25,7 +25,7 @@ use tokio_io::io::write_all;
 
 let mut core = Core::new().unwrap();
 
-let transport = TcpConfig::new(core.handle())
+let transport = TcpConfig::new()
     .with_upgrade({
         # let private_key = b"";
         //let private_key = include_bytes!("test-rsa-private-key.pk8");
@@ -44,7 +44,7 @@ let future = transport.dial("/ip4/127.0.0.1/tcp/12345".parse::<Multiaddr>().unwr
         write_all(connection, "hello world")
     });
 
-core.run(future).unwrap();
+tokio_current_thread::block_on_all(future).unwrap();
 ```
 
 # Manual usage

--- a/secio/src/lib.rs
+++ b/secio/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! ```no_run
 //! extern crate futures;
-//! extern crate tokio_core;
+//! extern crate tokio_current_thread;
 //! extern crate tokio_io;
 //! extern crate libp2p_core;
 //! extern crate libp2p_secio;
@@ -41,12 +41,9 @@
 //! use libp2p_secio::{SecioConfig, SecioKeyPair, SecioOutput};
 //! use libp2p_core::{Multiaddr, Transport, upgrade};
 //! use libp2p_tcp_transport::TcpConfig;
-//! use tokio_core::reactor::Core;
 //! use tokio_io::io::write_all;
 //!
-//! let mut core = Core::new().unwrap();
-//!
-//! let transport = TcpConfig::new(core.handle())
+//! let transport = TcpConfig::new()
 //!     .with_upgrade({
 //!         # let private_key = b"";
 //!         //let private_key = include_bytes!("test-rsa-private-key.pk8");
@@ -67,7 +64,7 @@
 //!         write_all(connection, "hello world")
 //!     });
 //!
-//! core.run(future).unwrap();
+//! tokio_current_thread::block_on_all(future).unwrap();
 //! # }
 //! ```
 //!

--- a/tcp-transport/Cargo.toml
+++ b/tcp-transport/Cargo.toml
@@ -8,5 +8,8 @@ libp2p-core = { path = "../core" }
 log = "0.4.1"
 futures = "0.1"
 multiaddr = { path = "../multiaddr" }
-tokio-core = "0.1"
+tokio-tcp = "0.1"
+
+[dev-dependencies]
+tokio-current-thread = "0.1"
 tokio-io = "0.1"

--- a/tcp-transport/README.md
+++ b/tcp-transport/README.md
@@ -6,21 +6,17 @@ Uses [the *tokio* library](https://tokio.rs).
 
 ## Usage
 
-Create [a tokio `Core`](https://docs.rs/tokio-core/0.1/tokio_core/reactor/struct.Core.html),
-then grab a handle by calling the `handle()` method on it, then create a `TcpConfig` and pass
-the handle.
-
 Example:
 
 ```rust
 extern crate libp2p_tcp_transport;
-extern crate tokio_core;
+extern crate tokio_current_thread;
 
 use libp2p_tcp_transport::TcpConfig;
 use tokio_core::reactor::Core;
 
 let mut core = Core::new().unwrap();
-let tcp = TcpConfig::new(core.handle());
+let tcp = TcpConfig::new();
 ```
 
 The `TcpConfig` structs implements the `Transport` trait of the `swarm` library. See the

--- a/websocket/Cargo.toml
+++ b/websocket/Cargo.toml
@@ -19,4 +19,4 @@ stdweb = { version = "0.1.3", default-features = false }
 
 [target.'cfg(not(target_os = "emscripten"))'.dev-dependencies]
 libp2p-tcp-transport = { path = "../tcp-transport" }
-tokio-core = "0.1"
+tokio-current-thread = "0.1"

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -33,7 +33,7 @@ This underlying transport must be put inside a `WsConfig` object through the
 extern crate libp2p_core;
 extern crate libp2p_tcp_transport;
 extern crate libp2p_websocket;
-extern crate tokio_core;
+extern crate tokio_current_thread;
 
 use libp2p_core::{Multiaddr, Transport};
 use libp2p_tcp_transport::TcpConfig;
@@ -41,6 +41,6 @@ use libp2p_websocket::WsConfig;
 use tokio_core::reactor::Core;
 
 let core = Core::new().unwrap();
-let ws_config = WsConfig::new(TcpConfig::new(core.handle()));
+let ws_config = WsConfig::new(TcpConfig::new());
 let _ = ws_config.dial("/ip4/40.41.42.43/tcp/12345/ws".parse().unwrap());
 ```

--- a/websocket/src/desktop.rs
+++ b/websocket/src/desktop.rs
@@ -289,8 +289,7 @@ fn client_addr_to_ws(client_addr: &Multiaddr, is_wss: bool) -> String {
 #[cfg(test)]
 mod tests {
     extern crate libp2p_tcp_transport as tcp;
-    extern crate tokio_core;
-    use self::tokio_core::reactor::Core;
+    extern crate tokio_current_thread;
     use futures::{Future, Stream};
     use multiaddr::Multiaddr;
     use swarm::Transport;
@@ -298,8 +297,7 @@ mod tests {
 
     #[test]
     fn dialer_connects_to_listener_ipv4() {
-        let mut core = Core::new().unwrap();
-        let ws_config = WsConfig::new(tcp::TcpConfig::new(core.handle()));
+        let ws_config = WsConfig::new(tcp::TcpConfig::new());
 
         let (listener, addr) = ws_config
             .clone()
@@ -317,13 +315,12 @@ mod tests {
             .select(dialer)
             .map_err(|(e, _)| e)
             .and_then(|(_, n)| n);
-        core.run(future).unwrap();
+        tokio_current_thread::block_on_all(future).unwrap();
     }
 
     #[test]
     fn dialer_connects_to_listener_ipv6() {
-        let mut core = Core::new().unwrap();
-        let ws_config = WsConfig::new(tcp::TcpConfig::new(core.handle()));
+        let ws_config = WsConfig::new(tcp::TcpConfig::new());
 
         let (listener, addr) = ws_config
             .clone()
@@ -341,13 +338,12 @@ mod tests {
             .select(dialer)
             .map_err(|(e, _)| e)
             .and_then(|(_, n)| n);
-        core.run(future).unwrap();
+        tokio_current_thread::block_on_all(future).unwrap();
     }
 
     #[test]
     fn nat_traversal() {
-        let core = Core::new().unwrap();
-        let ws_config = WsConfig::new(tcp::TcpConfig::new(core.handle()));
+        let ws_config = WsConfig::new(tcp::TcpConfig::new());
 
         {
             let server = "/ip4/127.0.0.1/tcp/10000/ws".parse::<Multiaddr>().unwrap();

--- a/websocket/src/lib.rs
+++ b/websocket/src/lib.rs
@@ -58,16 +58,13 @@
 //! extern crate libp2p_core;
 //! extern crate libp2p_tcp_transport;
 //! extern crate libp2p_websocket;
-//! extern crate tokio_core;
 //!
 //! use libp2p_core::{Multiaddr, Transport};
 //! use libp2p_tcp_transport::TcpConfig;
 //! use libp2p_websocket::WsConfig;
-//! use tokio_core::reactor::Core;
 //!
 //! # fn main() {
-//! let core = Core::new().unwrap();
-//! let ws_config = WsConfig::new(TcpConfig::new(core.handle()));
+//! let ws_config = WsConfig::new(TcpConfig::new());
 //! # return;
 //! let _ = ws_config.dial("/ip4/40.41.42.43/tcp/12345/ws".parse().unwrap());
 //! # }


### PR DESCRIPTION
Close #299 

After this change, only `websockets` is still using the old version.