### PR TITLE
Fix repeatedly spelling, more and more, add a clarification

### DIFF
--- a/ping/README.md
+++ b/ping/README.md
@@ -18,13 +18,13 @@ future that is signalled only when the remote answers. If the remote is not resp
 future will never be signalled.
 
 For implementation reasons, resources allocated for a ping are only ever fully reclaimed after
-a pong has been received by the remote. Therefore if you repeatidely ping a non-responsive
-remote you will end up using more and memory memory (albeit the amount is very very small every
+a pong has been received by the remote. Therefore if you repeatedly ping a non-responsive
+remote you will end up using more and more memory (albeit the amount is very very small every
 time), even if you destroy the future returned by `ping`.
 
 This is probably not a problem in practice, because the nature of the ping protocol is to
 determine whether a remote is still alive, and any reasonable user of this crate will close
-connections to non-responsive remotes.
+connections to non-responsive remotes (which would then de-allocate memory for the ping).
 
 # Example
 


### PR DESCRIPTION
Correct me if saying "close connections to non-responsive remotes (which would then de-allocate memory for the ping)" is wrong.