### PR TITLE
Use tk_listen to absorb errors on the TcpListener

### DIFF
--- a/tcp-transport/Cargo.toml
+++ b/tcp-transport/Cargo.toml
@@ -9,6 +9,7 @@ libp2p-core = { path = "../core" }
 log = "0.4.1"
 futures = "0.1"
 multiaddr = { path = "../multiaddr" }
+tk-listen = "0.2.0"
 tokio-io = "0.1"
 tokio-tcp = "0.1"
 


### PR DESCRIPTION
[The documentation of TcpListener](https://docs.rs/tokio-tcp/0.1.1/tokio_tcp/struct.TcpListener.html#errors) suggests doing what this PR does.
The `TcpListener` can sometimes produce an error which would just close the listener.

I think handling this directly in the TCP transport is the right location. There might be valid reasons why a listener produces an error, therefore the upper layers should continue to drop the listener if an error happens.