### PR TITLE
Tcp refinements

### DIFF
--- a/tcp-transport/Cargo.toml
+++ b/tcp-transport/Cargo.toml
@@ -9,6 +9,7 @@ libp2p-core = { path = "../core" }
 log = "0.4.1"
 futures = "0.1"
 multiaddr = { path = "../multiaddr" }
+tk-listen = "0.2.0"
 tokio-io = "0.1"
 tokio-tcp = "0.1"
 

--- a/tcp-transport/src/lib.rs
+++ b/tcp-transport/src/lib.rs
@@ -150,28 +150,16 @@ impl Transport for TcpConfig {
     fn nat_traversal(&self, server: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
         // Check that `server` only has two components and retreive them.
         let mut server_protocols_iter = server.iter();
-        let server_proto1 = match server_protocols_iter.next() {
-            Some(v) => v,
-            None => return None
-        };
-        let server_proto2 = match server_protocols_iter.next() {
-            Some(v) => v,
-            None => return None
-        };
+        let server_proto1 = server_protocols_iter.next()?;
+        let server_proto2 = server_protocols_iter.next()?;
         if server_protocols_iter.next().is_some() {
             return None;
         }
 
         // Check that `observed` only has two components and retreive them.
         let mut observed_protocols_iter = observed.iter();
-        let observed_proto1 = match observed_protocols_iter.next() {
-            Some(v) => v,
-            None => return None
-        };
-        let observed_proto2 = match observed_protocols_iter.next() {
-            Some(v) => v,
-            None => return None
-        };
+        let observed_proto1 = observed_protocols_iter.next()?;
+        let observed_proto2 = observed_protocols_iter.next()?;
         if observed_protocols_iter.next().is_some() {
             return None;
         }

--- a/tcp-transport/src/lib.rs
+++ b/tcp-transport/src/lib.rs
@@ -199,18 +199,28 @@ impl Transport for TcpConfig {
 
 // This type of logic should probably be moved into the multiaddr package
 fn multiaddr_to_socketaddr(addr: &Multiaddr) -> Result<SocketAddr, ()> {
-    let protocols: Vec<_> = addr.iter().collect();
+    let mut iter = addr.iter();
 
-    if protocols.len() != 2 {
+    let proto1 = match iter.next() {
+        Some(v) => v,
+        None => return Err(())
+    };
+
+    let proto2 = match iter.next() {
+        Some(v) => v,
+        None => return Err(())
+    };
+
+    if iter.next().is_some() {
         return Err(());
     }
 
-    match (&protocols[0], &protocols[1]) {
-        (&AddrComponent::IP4(ref ip), &AddrComponent::TCP(port)) => {
-            Ok(SocketAddr::new(ip.clone().into(), port))
+    match (proto1, proto2) {
+        (AddrComponent::IP4(ip), AddrComponent::TCP(port)) => {
+            Ok(SocketAddr::new(ip.into(), port))
         }
-        (&AddrComponent::IP6(ref ip), &AddrComponent::TCP(port)) => {
-            Ok(SocketAddr::new(ip.clone().into(), port))
+        (AddrComponent::IP6(ip), AddrComponent::TCP(port)) => {
+            Ok(SocketAddr::new(ip.into(), port))
         }
         _ => Err(()),
     }


### PR DESCRIPTION
Beginning of an effort to remove boxes from the crate. cc #369 

You can review commit by commit, especially as there's a `cargo fmt` in the middle of the stack.