### PR TITLE
Fix compiling error on windows

### DIFF
--- a/datastore/Cargo.toml
+++ b/datastore/Cargo.toml
@@ -10,4 +10,4 @@ chashmap = { git = "https://github.com/redox-os/tfs" }
 futures = "0.1"
 serde = "1.0"
 serde_json = "1.0"
-tempfile = "2.2"
+tempfile = "3"

--- a/datastore/src/json_file.rs
+++ b/datastore/src/json_file.rs
@@ -272,34 +272,42 @@ mod tests {
     use futures::{Future, Stream};
     use tempfile::NamedTempFile;
     use {Filter, FilterOp, FilterTy, Order, Query};
+    use std::path::PathBuf;
+
+    fn gen_random_path() -> PathBuf {
+        let temp_file = NamedTempFile::new().unwrap();
+        temp_file.path().to_path_buf()
+    }
 
     #[test]
     fn open_and_flush() {
-        let temp_file = NamedTempFile::new().unwrap();
-        let datastore = JsonFileDatastore::<Vec<u8>>::new(temp_file.path()).unwrap();
+        let path = gen_random_path();
+
+        let datastore = JsonFileDatastore::<Vec<u8>>::new(&path).unwrap();
         datastore.flush().unwrap();
     }
 
     #[test]
     fn values_store_and_reload() {
-        let temp_file = NamedTempFile::new().unwrap();
+        let path = gen_random_path();
 
-        let datastore = JsonFileDatastore::<Vec<u8>>::new(temp_file.path()).unwrap();
+        let datastore = JsonFileDatastore::<Vec<u8>>::new(&path).unwrap();
         datastore.put("foo".into(), vec![1, 2, 3]);
         datastore.put("bar".into(), vec![0, 255, 127]);
         datastore.flush().unwrap();
         drop(datastore);
 
-        let reload = JsonFileDatastore::<Vec<u8>>::new(temp_file.path()).unwrap();
+
+        let reload = JsonFileDatastore::<Vec<u8>>::new(&path).unwrap();
         assert_eq!(reload.get("bar").unwrap(), &[0, 255, 127]);
         assert_eq!(reload.get("foo").unwrap(), &[1, 2, 3]);
     }
 
     #[test]
     fn query_basic() {
-        let temp_file = NamedTempFile::new().unwrap();
+        let path = gen_random_path();
 
-        let datastore = JsonFileDatastore::<Vec<u8>>::new(temp_file.path()).unwrap();
+        let datastore = JsonFileDatastore::<Vec<u8>>::new(&path).unwrap();
         datastore.put("foo1".into(), vec![6, 7, 8]);
         datastore.put("foo2".into(), vec![6, 7, 8]);
         datastore.put("foo3".into(), vec![7, 8, 9]);

--- a/datastore/src/json_file.rs
+++ b/datastore/src/json_file.rs
@@ -140,7 +140,7 @@ where
                 .map(|(k, v)| (k, to_value(v).unwrap()))
                 .collect::<Map<_, _>>(),
         )?;
-        temporary_file.sync_data()?;
+        temporary_file.as_file().sync_data()?;
 
         // Note that `persist` will fail if we try to persist across filesystems. However that
         // shouldn't happen since we created the temporary file in the same directory as the final
@@ -275,9 +275,7 @@ mod tests {
 
     #[test]
     fn open_and_flush() {
-        let temp_file = NamedTempFile::new().unwrap();
-        let path = temp_file.path().to_path_buf();
-        temp_file.close().unwrap();
+        let path = NamedTempFile::new().unwrap().into_temp_path();
 
         let datastore = JsonFileDatastore::<Vec<u8>>::new(&path).unwrap();
         datastore.flush().unwrap();
@@ -285,9 +283,7 @@ mod tests {
 
     #[test]
     fn values_store_and_reload() {
-        let temp_file = NamedTempFile::new().unwrap();
-        let path = temp_file.path().to_path_buf();
-        temp_file.close().unwrap();
+        let path = NamedTempFile::new().unwrap().into_temp_path();
 
         let datastore = JsonFileDatastore::<Vec<u8>>::new(&path).unwrap();
         datastore.put("foo".into(), vec![1, 2, 3]);
@@ -303,9 +299,7 @@ mod tests {
 
     #[test]
     fn query_basic() {
-        let temp_file = NamedTempFile::new().unwrap();
-        let path = temp_file.path().to_path_buf();
-        temp_file.close().unwrap();
+        let path = NamedTempFile::new().unwrap().into_temp_path();
 
         let datastore = JsonFileDatastore::<Vec<u8>>::new(&path).unwrap();
         datastore.put("foo1".into(), vec![6, 7, 8]);

--- a/datastore/src/json_file.rs
+++ b/datastore/src/json_file.rs
@@ -272,16 +272,12 @@ mod tests {
     use futures::{Future, Stream};
     use tempfile::NamedTempFile;
     use {Filter, FilterOp, FilterTy, Order, Query};
-    use std::path::PathBuf;
-
-    fn gen_random_path() -> PathBuf {
-        let temp_file = NamedTempFile::new().unwrap();
-        temp_file.path().to_path_buf()
-    }
 
     #[test]
     fn open_and_flush() {
-        let path = gen_random_path();
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path().to_path_buf();
+        temp_file.close().unwrap();
 
         let datastore = JsonFileDatastore::<Vec<u8>>::new(&path).unwrap();
         datastore.flush().unwrap();
@@ -289,7 +285,9 @@ mod tests {
 
     #[test]
     fn values_store_and_reload() {
-        let path = gen_random_path();
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path().to_path_buf();
+        temp_file.close().unwrap();
 
         let datastore = JsonFileDatastore::<Vec<u8>>::new(&path).unwrap();
         datastore.put("foo".into(), vec![1, 2, 3]);
@@ -305,7 +303,9 @@ mod tests {
 
     #[test]
     fn query_basic() {
-        let path = gen_random_path();
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = temp_file.path().to_path_buf();
+        temp_file.close().unwrap();
 
         let datastore = JsonFileDatastore::<Vec<u8>>::new(&path).unwrap();
         datastore.put("foo1".into(), vec![6, 7, 8]);

--- a/secio/Cargo.toml
+++ b/secio/Cargo.toml
@@ -12,7 +12,7 @@ libp2p-core = { path = "../core" }
 log = "0.4.1"
 protobuf = "2.0.2"
 rand = "0.3.17"
-ring = { version = "0.12.1", features = ["rsa_signing"] }
+ring = { version = "0.13.2", features = ["rsa_signing"] }
 aes-ctr = "0.1.0"
 aesni = { version = "0.4.1", features = ["nocheck"], optional = true }
 ctr = { version = "0.1", optional = true }
@@ -20,7 +20,7 @@ lazy_static = { version = "0.2.11", optional = true }
 rw-stream-sink = { path = "../rw-stream-sink" }
 eth-secp256k1 = { git = "https://github.com/paritytech/rust-secp256k1", optional = true }
 tokio-io = "0.1.0"
-untrusted = "0.5.1"
+untrusted = "0.6.2"
 
 [features]
 default = ["secp256k1"]


### PR DESCRIPTION
I'm trying compile libp2p on my Windows 10 1803 PC, but got error

```
error: failed to run custom build command for `ring v0.12.1`
process didn't exit successfully: `C:\Users\jasl9\Workspaces\Rust\rust-libp2p\ta                                                   rget\debug\build\ring-4c88590251fb12fa\build-script-build` (exit code: 101)
--- stderr
thread '<unnamed>' panicked at 'execution failed', C:\Users\jasl9\.cargo\registr                                                   y\src\github.com-1ecc6299db9ec823\ring-0.12.1\build.rs:636:9
note: Run with `RUST_BACKTRACE=1` for a backtrace.
thread '<unnamed>' panicked at 'execution failed', C:\Users\jasl9\.cargo\registr                                                   y\src\github.com-1ecc6299db9ec823\ring-0.12.1\build.rs:636:9
thread '<unnamed>' panicked at 'execution failed', C:\Users\jasl9\.cargo\registr                                                   y\src\github.com-1ecc6299db9ec823\ring-0.12.1\build.rs:636:9
thread '<unnamed>' panicked at 'execution failed', C:\Users\jasl9\.cargo\registr                                                   y\src\github.com-1ecc6299db9ec823\ring-0.12.1\build.rs:636:9
thread '<unnamed>' panicked at 'execution failed', C:\Users\jasl9\.cargo\registr                                                   y\src\github.com-1ecc6299db9ec823\ring-0.12.1\build.rs:636:9
thread '<unnamed>' panicked at 'execution failed', C:\Users\jasl9\.cargo\registr                                                   y\src\github.com-1ecc6299db9ec823\ring-0.12.1\build.rs:636:9
```

So I update `ring` to the latest version that resolved the compiling problem.

In addition, there are issues when running  `json_file` tests, they failed because `Code 5, Permission denied`, I think that are Windows platform behavior that a NamedTempfile object holding the file so others can not write it, and I guess we only need a random filename in temp dir, so I refactor these failing tests. I have tested it in my Linux PC, no breaking.

BTW, there's an another failing test

```
---- lots_of_swarms stdout ----
thread 'lots_of_swarms' panicked at 'assertion failed: `(left == right)`
  left: `324`,
 right: `358`', core\tests\lots_of_connec.rs:76:5
```

I'm not sure it relates to <https://doc.rust-lang.org/beta/src/alloc/sync.rs.html#156-159>, don't know how to fix it or it can be ignored.