### PR TITLE
Add some Send implementations to Futures

### DIFF
--- a/core/src/transport/denied.rs
+++ b/core/src/transport/denied.rs
@@ -32,10 +32,10 @@ pub struct DeniedTransport;
 impl Transport for DeniedTransport {
     // TODO: could use `!` for associated types once stable
     type Output = Cursor<Vec<u8>>;
-    type MultiaddrFuture = Box<Future<Item = Multiaddr, Error = io::Error>>;
-    type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = io::Error>>;
-    type ListenerUpgrade = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = io::Error>>;
-    type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = io::Error>>;
+    type MultiaddrFuture = Box<Future<Item = Multiaddr, Error = io::Error> + Send + Sync>;
+    type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = io::Error> + Send + Sync>;
+    type ListenerUpgrade = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = io::Error> + Send + Sync>;
+    type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = io::Error> + Send + Sync>;
 
     #[inline]
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {

--- a/core/src/upgrade/denied.rs
+++ b/core/src/upgrade/denied.rs
@@ -36,8 +36,8 @@ where
     type NamesIter = iter::Empty<(Bytes, ())>;
     type UpgradeIdentifier = (); // TODO: could use `!`
     type Output = (); // TODO: could use `!`
-    type MultiaddrFuture = Box<Future<Item = Multiaddr, Error = io::Error>>; // TODO: could use `!`
-    type Future = Box<Future<Item = ((), Self::MultiaddrFuture), Error = io::Error>>; // TODO: could use `!`
+    type MultiaddrFuture = Box<Future<Item = Multiaddr, Error = io::Error> + Send + Sync>; // TODO: could use `!`
+    type Future = Box<Future<Item = ((), Self::MultiaddrFuture), Error = io::Error> + Send + Sync>; // TODO: could use `!`
 
     #[inline]
     fn protocol_names(&self) -> Self::NamesIter {

--- a/multistream-select/src/protocol/dialer.rs
+++ b/multistream-select/src/protocol/dialer.rs
@@ -46,23 +46,19 @@ where
 {
     /// Takes ownership of a socket and starts the handshake. If the handshake succeeds, the
     /// future returns a `Dialer`.
-    pub fn new<'a>(inner: R) -> Box<Future<Item = Dialer<R>, Error = MultistreamSelectError> + 'a>
-    where
-        R: 'a,
-    {
+    pub fn new(inner: R) -> impl Future<Item = Dialer<R>, Error = MultistreamSelectError> {
         let write = LengthDelimitedBuilder::new()
             .length_field_length(1)
             .new_write(inner);
         let inner = LengthDelimitedFramedRead::new(write);
 
-        let future = inner
+        inner
             .send(BytesMut::from(MULTISTREAM_PROTOCOL_WITH_LF))
             .from_err()
             .map(|inner| Dialer {
                 inner,
                 handshake_finished: false,
-            });
-        Box::new(future)
+            })
     }
 
     /// Grants back the socket. Typically used after a `ProtocolAck` has been received.

--- a/multistream-select/src/protocol/listener.rs
+++ b/multistream-select/src/protocol/listener.rs
@@ -44,16 +44,13 @@ where
 {
     /// Takes ownership of a socket and starts the handshake. If the handshake succeeds, the
     /// future returns a `Listener`.
-    pub fn new<'a>(inner: R) -> Box<Future<Item = Listener<R>, Error = MultistreamSelectError> + 'a>
-    where
-        R: 'a,
-    {
+    pub fn new(inner: R) -> impl Future<Item = Listener<R>, Error = MultistreamSelectError> {
         let write = LengthDelimitedBuilder::new()
             .length_field_length(1)
             .new_write(inner);
         let inner = LengthDelimitedFramedRead::<Bytes, _>::new(write);
 
-        let future = inner
+        inner
             .into_future()
             .map_err(|(e, _)| e.into())
             .and_then(|(msg, rest)| {
@@ -69,9 +66,7 @@ where
                     .send(BytesMut::from(MULTISTREAM_PROTOCOL_WITH_LF))
                     .from_err()
             })
-            .map(|inner| Listener { inner });
-
-        Box::new(future)
+            .map(|inner| Listener { inner })
     }
 
     /// Grants back the socket. Typically used after a `ProtocolRequest` has been received and a

--- a/uds/src/lib.rs
+++ b/uds/src/lib.rs
@@ -86,10 +86,10 @@ impl UdsConfig {
 
 impl Transport for UdsConfig {
     type Output = UnixStream;
-    type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = IoError>>;
+    type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = IoError> + Send + Sync>;
     type ListenerUpgrade = FutureResult<(Self::Output, Self::MultiaddrFuture), IoError>;
     type MultiaddrFuture = FutureResult<Multiaddr, IoError>;
-    type Dial = Box<Future<Item = (UnixStream, Self::MultiaddrFuture), Error = IoError>>;
+    type Dial = Box<Future<Item = (UnixStream, Self::MultiaddrFuture), Error = IoError> + Send + Sync>;
 
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
         if let Ok(path) = multiaddr_to_path(&addr) {


### PR DESCRIPTION
cc #369 

We need to make things `Send` when possible so that we can spawn sub-tasks with tokio.

This PR makes some `Future` types `Send`.
I didn't do all at once, otherwise the changes would be quite huge and difficult to review.
I went for the most straight-forward ones, and the remaining ones should be done with individual PRs.
