### PR TITLE
[tracking] Make it Send + Sync

### DIFF
--- a/multiaddr/src/lib.rs
+++ b/multiaddr/src/lib.rs
@@ -53,6 +53,10 @@ impl fmt::Display for Multiaddr {
     }
 }
 
+unsafe impl Send for Multiaddr {}
+unsafe impl Sync for Multiaddr {}
+
+
 impl Multiaddr {
     /// Returns the raw bytes representation of the multiaddr.
     #[inline]


### PR DESCRIPTION
Working through removing as many `Box`es as possible and make our types Send + Sync, one component at a time.

- [ ] circular-buffer
- [ ] datastore
- [ ] dns
- [ ] floodsub
- [ ] identify
- [ ] kad
- [ ] libp2p-core
- [x] multiaddr
- [ ] multihash
- [ ] mplex
- [ ] multistream-select
- [ ] peerstore
- [ ] ping
- [ ] ratelimit
- [ ] relay
- [ ] rw-stream-sink
- [ ] secio
- [ ] tcp-transport
- [ ] transport-timeout
- [ ] uds
- [ ] websocket
- [ ] yamux


Make Multiaddr Send + Sync