### PR TITLE
Import Transport Failure story with new `TransportError` and type aliases

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,6 +19,8 @@ quick-error = "1.2"
 rw-stream-sink = { path = "../misc/rw-stream-sink" }
 smallvec = "0.5"
 tokio-io = "0.1"
+failure = "0.1.2"
+failure_derive = "0.1.2"
 
 [dev-dependencies]
 libp2p-ping = { path = "../protocols/ping" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,8 +19,6 @@ quick-error = "1.2"
 rw-stream-sink = { path = "../misc/rw-stream-sink" }
 smallvec = "0.5"
 tokio-io = "0.1"
-failure = "0.1.2"
-failure_derive = "0.1.2"
 
 [dev-dependencies]
 libp2p-ping = { path = "../protocols/ping" }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -206,6 +206,9 @@
 
 extern crate bs58;
 extern crate bytes;
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
 extern crate fnv;
 #[macro_use]
 extern crate futures;
@@ -253,6 +256,6 @@ pub use self::muxing::StreamMuxer;
 pub use self::peer_id::PeerId;
 pub use self::public_key::PublicKey;
 pub use self::swarm::{swarm, SwarmController, SwarmFuture};
-pub use self::transport::{MuxedTransport, Transport};
+pub use self::transport::{MuxedTransport, Transport, TransportError, DialResult, ListenerResult};
 pub use self::unique::{UniqueConnec, UniqueConnecFuture, UniqueConnecState};
 pub use self::upgrade::{ConnectionUpgrade, Endpoint};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -256,6 +256,6 @@ pub use self::muxing::StreamMuxer;
 pub use self::peer_id::PeerId;
 pub use self::public_key::PublicKey;
 pub use self::swarm::{swarm, SwarmController, SwarmFuture};
-pub use self::transport::{MuxedTransport, Transport, TransportError, DialResult, ListenerResult};
+pub use self::transport::{MuxedTransport, Transport, TransportError, TransportResult};
 pub use self::unique::{UniqueConnec, UniqueConnecFuture, UniqueConnecState};
 pub use self::upgrade::{ConnectionUpgrade, Endpoint};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -206,9 +206,6 @@
 
 extern crate bs58;
 extern crate bytes;
-extern crate failure;
-#[macro_use]
-extern crate failure_derive;
 extern crate fnv;
 #[macro_use]
 extern crate futures;

--- a/core/src/transport/and_then.rs
+++ b/core/src/transport/and_then.rs
@@ -21,7 +21,7 @@
 use futures::prelude::*;
 use multiaddr::Multiaddr;
 use std::io::Error as IoError;
-use transport::{MuxedTransport, Transport, ListenerResult, DialResult};
+use transport::{MuxedTransport, Transport, TransportResult};
 use upgrade::Endpoint;
 
 /// See the `Transport::and_then` method.
@@ -51,7 +51,7 @@ where
     type Dial = Box<Future<Item = (O, Self::MultiaddrFuture), Error = IoError>>;
 
     #[inline]
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         let upgrade = self.upgrade.clone();
 
         let (listening_stream, new_addr) = self.transport.listen_on(addr)?;
@@ -73,7 +73,7 @@ where
     }
 
     #[inline]
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
         let upgrade = self.upgrade.clone();
 
         let future = self.transport.dial(addr.clone())?

--- a/core/src/transport/choice.rs
+++ b/core/src/transport/choice.rs
@@ -22,7 +22,7 @@ use either::{EitherListenStream, EitherListenUpgrade, EitherOutput};
 use futures::{prelude::*, future};
 use multiaddr::Multiaddr;
 use std::io::Error as IoError;
-use transport::{MuxedTransport, Transport, ListenerResult, DialResult};
+use transport::{MuxedTransport, Transport, TransportResult};
 
 /// Struct returned by `or_transport()`.
 #[derive(Debug, Copy, Clone)]
@@ -46,7 +46,7 @@ where
     type Dial =
         EitherListenUpgrade<<A::Dial as IntoFuture>::Future, <B::Dial as IntoFuture>::Future>;
 
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         if let Ok((connec, addr)) = self.0.listen_on(addr.clone()) {
             return Ok((EitherListenStream::First(connec), addr))
         }
@@ -55,7 +55,7 @@ where
             .map(|(connec, addr)| (EitherListenStream::Second(connec), addr))
     }
 
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
         if let Ok(connec) = self.0.dial(addr.clone()) {
             return Ok(EitherListenUpgrade::First(connec))
         }

--- a/core/src/transport/denied.rs
+++ b/core/src/transport/denied.rs
@@ -22,7 +22,7 @@ use futures::future;
 use futures::prelude::*;
 use multiaddr::Multiaddr;
 use std::io::{self, Cursor};
-use transport::{MuxedTransport, Transport, TransportError, ListenerResult, DialResult};
+use transport::{MuxedTransport, Transport, TransportError, TransportResult};
 
 /// Dummy implementation of `Transport` that just denies every single attempt.
 #[derive(Debug, Copy, Clone)]
@@ -37,12 +37,12 @@ impl Transport for DeniedTransport {
     type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = io::Error> + Send + Sync>;
 
     #[inline]
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         Err(TransportError::ListenNotSupported(addr))
     }
 
     #[inline]
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
         Err(TransportError::DialNotSupported(addr))
     }
 

--- a/core/src/transport/denied.rs
+++ b/core/src/transport/denied.rs
@@ -37,13 +37,13 @@ impl Transport for DeniedTransport {
     type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = io::Error> + Send + Sync>;
 
     #[inline]
-    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self> {
-        Err((DeniedTransport, TransportError::ListenNotSupported(addr)))
+    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+        Err(TransportError::ListenNotSupported(addr))
     }
 
     #[inline]
-    fn dial(self, addr: Multiaddr) -> DialResult<Self> {
-        Err((DeniedTransport, TransportError::DialNotSupported(addr)))
+    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+        Err(TransportError::DialNotSupported(addr))
     }
 
     #[inline]

--- a/core/src/transport/denied.rs
+++ b/core/src/transport/denied.rs
@@ -22,8 +22,7 @@ use futures::future;
 use futures::prelude::*;
 use multiaddr::Multiaddr;
 use std::io::{self, Cursor};
-use transport::MuxedTransport;
-use transport::Transport;
+use transport::{MuxedTransport, Transport, TransportError, ListenerResult, DialResult};
 
 /// Dummy implementation of `Transport` that just denies every single attempt.
 #[derive(Debug, Copy, Clone)]
@@ -38,13 +37,13 @@ impl Transport for DeniedTransport {
     type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = io::Error> + Send + Sync>;
 
     #[inline]
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
-        Err((DeniedTransport, addr))
+    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self> {
+        Err((DeniedTransport, TransportError::ListenNotSupported(addr)))
     }
 
     #[inline]
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
-        Err((DeniedTransport, addr))
+    fn dial(self, addr: Multiaddr) -> DialResult<Self> {
+        Err((DeniedTransport, TransportError::DialNotSupported(addr)))
     }
 
     #[inline]

--- a/core/src/transport/dummy.rs
+++ b/core/src/transport/dummy.rs
@@ -61,23 +61,21 @@ where
     type Dial = T::Dial;
 
     #[inline]
-    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self>
+    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener>
     where
         Self: Sized,
     {
         self.inner
             .listen_on(addr)
-            .map_err(|(inner, addr)| (DummyMuxing { inner }, addr))
     }
 
     #[inline]
-    fn dial(self, addr: Multiaddr) -> DialResult<Self>
+    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial>
     where
         Self: Sized,
     {
         self.inner
             .dial(addr)
-            .map_err(|(inner, addr)| (DummyMuxing { inner }, addr))
     }
 
     #[inline]

--- a/core/src/transport/dummy.rs
+++ b/core/src/transport/dummy.rs
@@ -21,7 +21,7 @@
 use futures::future;
 use multiaddr::Multiaddr;
 use std::io::Error as IoError;
-use transport::{MuxedTransport, Transport, ListenerResult, DialResult};
+use transport::{MuxedTransport, Transport, TransportResult};
 
 /// Dummy implementation of `MuxedTransport` that uses an inner `Transport`.
 #[derive(Debug, Copy, Clone)]
@@ -61,7 +61,7 @@ where
     type Dial = T::Dial;
 
     #[inline]
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener>
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)>
     where
         Self: Sized,
     {
@@ -70,7 +70,7 @@ where
     }
 
     #[inline]
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial>
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial>
     where
         Self: Sized,
     {

--- a/core/src/transport/dummy.rs
+++ b/core/src/transport/dummy.rs
@@ -21,7 +21,7 @@
 use futures::future;
 use multiaddr::Multiaddr;
 use std::io::Error as IoError;
-use transport::{MuxedTransport, Transport};
+use transport::{MuxedTransport, Transport, ListenerResult, DialResult};
 
 /// Dummy implementation of `MuxedTransport` that uses an inner `Transport`.
 #[derive(Debug, Copy, Clone)]
@@ -61,7 +61,7 @@ where
     type Dial = T::Dial;
 
     #[inline]
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)>
+    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self>
     where
         Self: Sized,
     {
@@ -71,7 +71,7 @@ where
     }
 
     #[inline]
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)>
+    fn dial(self, addr: Multiaddr) -> DialResult<Self>
     where
         Self: Sized,
     {

--- a/core/src/transport/interruptible.rs
+++ b/core/src/transport/interruptible.rs
@@ -52,24 +52,16 @@ where
     type Dial = InterruptibleDial<T::Dial>;
 
     #[inline]
-    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self> {
-        match self.transport.listen_on(addr) {
-            Ok(val) => Ok(val),
-            Err((transport, addr)) => Err((Interruptible { transport, rx: self.rx }, addr)),
-        }
+    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+        self.transport.listen_on(addr)
     }
 
     #[inline]
-    fn dial(self, addr: Multiaddr) -> DialResult<Self> {
-        match self.transport.dial(addr) {
-            Ok(future) => {
-                Ok(InterruptibleDial {
-                    inner: future,
-                    rx: self.rx,
-                })
-            }
-            Err((transport, addr)) => Err((Interruptible { transport, rx: self.rx }, addr)),
-        }
+    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+        Ok(InterruptibleDial {
+            inner: self.transport.dial(addr)?,
+            rx: self.rx.clone(),
+        })
     }
 
     #[inline]

--- a/core/src/transport/interruptible.rs
+++ b/core/src/transport/interruptible.rs
@@ -20,7 +20,7 @@
 
 use futures::{future, prelude::*, sync::oneshot};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
-use transport::{MuxedTransport, Transport};
+use transport::{MuxedTransport, Transport, ListenerResult, DialResult};
 use Multiaddr;
 
 /// See `Transport::interruptible`.
@@ -52,7 +52,7 @@ where
     type Dial = InterruptibleDial<T::Dial>;
 
     #[inline]
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
+    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self> {
         match self.transport.listen_on(addr) {
             Ok(val) => Ok(val),
             Err((transport, addr)) => Err((Interruptible { transport, rx: self.rx }, addr)),
@@ -60,7 +60,7 @@ where
     }
 
     #[inline]
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
+    fn dial(self, addr: Multiaddr) -> DialResult<Self> {
         match self.transport.dial(addr) {
             Ok(future) => {
                 Ok(InterruptibleDial {

--- a/core/src/transport/interruptible.rs
+++ b/core/src/transport/interruptible.rs
@@ -20,7 +20,7 @@
 
 use futures::{future, prelude::*, sync::oneshot};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
-use transport::{MuxedTransport, Transport, ListenerResult, DialResult};
+use transport::{MuxedTransport, Transport, TransportResult};
 use Multiaddr;
 
 /// See `Transport::interruptible`.
@@ -52,12 +52,12 @@ where
     type Dial = InterruptibleDial<T::Dial>;
 
     #[inline]
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         self.transport.listen_on(addr)
     }
 
     #[inline]
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
         Ok(InterruptibleDial {
             inner: self.transport.dial(addr)?,
             rx: self.rx.clone(),

--- a/core/src/transport/map.rs
+++ b/core/src/transport/map.rs
@@ -21,7 +21,7 @@
 use futures::prelude::*;
 use multiaddr::Multiaddr;
 use std::io::Error as IoError;
-use transport::{MuxedTransport, Transport, DialResult, ListenerResult};
+use transport::{MuxedTransport, Transport, TransportResult};
 use Endpoint;
 
 /// See `Transport::map`.
@@ -50,7 +50,7 @@ where
     type ListenerUpgrade = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
     type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
 
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         let map = self.map.clone();
 
         let (stream, listen_addr) = self.transport.listen_on(addr)?;
@@ -64,7 +64,7 @@ where
         Ok((Box::new(stream), listen_addr))
     }
 
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
         let map = self.map.clone();
 
         let future = self.transport.dial(addr)?

--- a/core/src/transport/map.rs
+++ b/core/src/transport/map.rs
@@ -21,7 +21,7 @@
 use futures::prelude::*;
 use multiaddr::Multiaddr;
 use std::io::Error as IoError;
-use transport::{MuxedTransport, Transport};
+use transport::{MuxedTransport, Transport, DialResult, ListenerResult};
 use Endpoint;
 
 /// See `Transport::map`.
@@ -50,7 +50,7 @@ where
     type ListenerUpgrade = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
     type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
 
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
+    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self> {
         let map = self.map;
 
         match self.transport.listen_on(addr) {
@@ -68,7 +68,7 @@ where
         }
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
+    fn dial(self, addr: Multiaddr) -> DialResult<Self> {
         let map = self.map;
 
         match self.transport.dial(addr) {

--- a/core/src/transport/map_err.rs
+++ b/core/src/transport/map_err.rs
@@ -21,7 +21,7 @@
 use futures::prelude::*;
 use multiaddr::Multiaddr;
 use std::io::Error as IoError;
-use transport::{MuxedTransport, Transport, ListenerResult, DialResult};
+use transport::{MuxedTransport, Transport, TransportResult};
 
 /// See `Transport::map_err`.
 #[derive(Debug, Copy, Clone)]
@@ -50,7 +50,7 @@ where
         Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
     type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
 
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         let map = self.map.clone();
 
         let (stream, listen_addr) = self.transport.listen_on(addr)?;
@@ -68,7 +68,7 @@ where
         Ok((Box::new(stream), listen_addr))
     }
 
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
         let map = self.map.clone();
 
         Ok(Box::new(self.transport.dial(addr)?

--- a/core/src/transport/map_err.rs
+++ b/core/src/transport/map_err.rs
@@ -21,7 +21,7 @@
 use futures::prelude::*;
 use multiaddr::Multiaddr;
 use std::io::Error as IoError;
-use transport::{MuxedTransport, Transport};
+use transport::{MuxedTransport, Transport, ListenerResult, DialResult};
 
 /// See `Transport::map_err`.
 #[derive(Debug, Copy, Clone)]
@@ -50,7 +50,7 @@ where
         Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
     type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
 
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
+    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self> {
         let map = self.map;
 
         match self.transport.listen_on(addr) {
@@ -72,7 +72,7 @@ where
         }
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
+    fn dial(self, addr: Multiaddr) -> DialResult<Self> {
         let map = self.map;
 
         match self.transport.dial(addr) {

--- a/core/src/transport/map_err_dial.rs
+++ b/core/src/transport/map_err_dial.rs
@@ -21,7 +21,7 @@
 use futures::prelude::*;
 use multiaddr::Multiaddr;
 use std::io::Error as IoError;
-use transport::{MuxedTransport, Transport};
+use transport::{MuxedTransport, Transport, ListenerResult, DialResult};
 
 /// See `Transport::map_err_dial`.
 #[derive(Debug, Copy, Clone)]
@@ -49,14 +49,14 @@ where
     type ListenerUpgrade = T::ListenerUpgrade;
     type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
 
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
+    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self> {
         match self.transport.listen_on(addr) {
             Ok(l) => Ok(l),
             Err((transport, addr)) => Err((MapErrDial { transport, map: self.map }, addr)),
         }
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
+    fn dial(self, addr: Multiaddr) -> DialResult<Self> {
         let map = self.map;
 
         match self.transport.dial(addr.clone()) {

--- a/core/src/transport/map_err_dial.rs
+++ b/core/src/transport/map_err_dial.rs
@@ -21,7 +21,7 @@
 use futures::prelude::*;
 use multiaddr::Multiaddr;
 use std::io::Error as IoError;
-use transport::{MuxedTransport, Transport, ListenerResult, DialResult};
+use transport::{MuxedTransport, Transport, TransportResult};
 
 /// See `Transport::map_err_dial`.
 #[derive(Debug, Copy, Clone)]
@@ -49,11 +49,11 @@ where
     type ListenerUpgrade = T::ListenerUpgrade;
     type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
 
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         self.transport.listen_on(addr)
     }
 
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
         let map = self.map.clone();
         Ok(Box::new(self.transport.dial(addr.clone())?
             .into_future()

--- a/core/src/transport/memory.rs
+++ b/core/src/transport/memory.rs
@@ -24,7 +24,7 @@ use multiaddr::{AddrComponent, Multiaddr};
 use parking_lot::Mutex;
 use rw_stream_sink::RwStreamSink;
 use std::{io, sync::Arc};
-use transport::{Transport, TransportError,  ListenerResult, DialResult};
+use transport::{Transport, TransportError,  TransportResult};
 
 /// Builds a new pair of `Transport`s. The dialer can reach the listener by dialing `/memory`.
 #[inline]
@@ -57,11 +57,11 @@ impl<T: IntoBuf + 'static> Transport for Dialer<T> {
     type MultiaddrFuture = FutureResult<Multiaddr, io::Error>;
     type Dial = Box<Future<Item=(Self::Output, Self::MultiaddrFuture), Error=io::Error>>;
 
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         Err(TransportError::ListenNotSupported(addr))
     }
 
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
         if !is_memory_addr(&addr) {
             return Err(TransportError::DialNotSupported(addr))
         }
@@ -100,7 +100,7 @@ impl<T: IntoBuf + 'static> Transport for Listener<T> {
     type MultiaddrFuture = FutureResult<Multiaddr, io::Error>;
     type Dial = Box<Future<Item=(Self::Output, Self::MultiaddrFuture), Error=io::Error>>;
 
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         if !is_memory_addr(&addr) {
             return Err(TransportError::ListenNotSupported(addr))
         }
@@ -115,7 +115,7 @@ impl<T: IntoBuf + 'static> Transport for Listener<T> {
     }
 
     #[inline]
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
         Err(TransportError::DialNotSupported(addr))
     }
 

--- a/core/src/transport/mod.rs
+++ b/core/src/transport/mod.rs
@@ -57,11 +57,6 @@ pub use self::upgrade::UpgradedNode;
 
 #[derive(Debug, Fail)]
 pub enum TransportError {
-    #[fail(display= "Error parsing Address {}: {}", addr, err)]
-    MultiAddrParseError {
-        addr: Multiaddr,
-        #[cause] err: MultiaddrError
-    },
     #[fail(display = "Listening is not support for Multiaddress {}", _0)]
     ListenNotSupported(Multiaddr),
 

--- a/core/src/transport/mod.rs
+++ b/core/src/transport/mod.rs
@@ -55,11 +55,6 @@ pub use self::muxed::MuxedTransport;
 pub use self::upgrade::UpgradedNode;
 
 
-// This is a new error type that you've created. It represents the ways a
-// toolchain could be invalid.
-//
-// The custom derive for Fail derives an impl of both Fail and Display.
-// We don't do any other magic like creating new types.
 #[derive(Debug, Fail)]
 pub enum TransportError {
     #[fail(display= "Error parsing Address {}: {}", addr, err)]

--- a/core/src/transport/mod.rs
+++ b/core/src/transport/mod.rs
@@ -30,7 +30,7 @@
 //! together in a complex chain of protocols negotiation.
 
 use futures::prelude::*;
-use multiaddr::{Multiaddr, Error as MultiaddrError};
+use multiaddr::Multiaddr;
 use std::io::Error as IoError;
 use tokio_io::{AsyncRead, AsyncWrite};
 use upgrade::{ConnectionUpgrade, Endpoint};
@@ -70,9 +70,7 @@ pub enum TransportError {
     DialingFailed(Multiaddr, #[cause] IoError),
 }
 
-pub type ListenerResult<L> = Result<(L, Multiaddr), TransportError>;
-pub type DialResult<D> = Result<D, TransportError>;
-
+pub type TransportResult<L> = Result<L, TransportError>;
 
 /// A transport is an object that can be used to produce connections by listening or dialing a
 /// peer.
@@ -116,14 +114,14 @@ pub trait Transport {
     /// > **Note**: The reason why w eneed to change the `Multiaddr` on success is to handle
     /// >             situations such as turning `/ip4/127.0.0.1/tcp/0` into
     /// >             `/ip4/127.0.0.1/tcp/<actual port>`.
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener>
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)>
     where
         Self: Sized;
 
     /// Dial to the given multi-addr.
     ///
     /// Returns either a future which may resolve to a connection, or gives back the multiaddress.
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial>
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial>
     where
         Self: Sized;
 

--- a/core/src/transport/mod.rs
+++ b/core/src/transport/mod.rs
@@ -75,8 +75,8 @@ pub enum TransportError {
     DialingFailed(Multiaddr, #[cause] IoError),
 }
 
-pub type ListenerResult<T> = Result<(<T as Transport>::Listener, Multiaddr), (T, TransportError)>;
-pub type DialResult<T> = Result<<T as Transport>::Dial, (T, TransportError)>;
+pub type ListenerResult<L> = Result<(L, Multiaddr), TransportError>;
+pub type DialResult<D> = Result<D, TransportError>;
 
 
 /// A transport is an object that can be used to produce connections by listening or dialing a
@@ -121,14 +121,14 @@ pub trait Transport {
     /// > **Note**: The reason why w eneed to change the `Multiaddr` on success is to handle
     /// >             situations such as turning `/ip4/127.0.0.1/tcp/0` into
     /// >             `/ip4/127.0.0.1/tcp/<actual port>`.
-    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self>
+    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener>
     where
         Self: Sized;
 
     /// Dial to the given multi-addr.
     ///
     /// Returns either a future which may resolve to a connection, or gives back the multiaddress.
-    fn dial(self, addr: Multiaddr) -> DialResult<Self>
+    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial>
     where
         Self: Sized;
 

--- a/core/src/transport/mod.rs
+++ b/core/src/transport/mod.rs
@@ -134,7 +134,7 @@ pub trait Transport {
     ///
     /// Returns the address back if it isn't supported.
     ///
-    /// > **Note**: The reason why w eneed to change the `Multiaddr` on success is to handle
+    /// > **Note**: The reason why we need to change the `Multiaddr` on success is to handle
     /// >             situations such as turning `/ip4/127.0.0.1/tcp/0` into
     /// >             `/ip4/127.0.0.1/tcp/<actual port>`.
     fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)>

--- a/core/src/transport/mod.rs
+++ b/core/src/transport/mod.rs
@@ -82,13 +82,11 @@ impl fmt::Display for TransportError {
 
 
 impl StdError for TransportError {
-    fn description(&self) -> &str {
+    fn cause(&self) -> Option<&StdError> {
         match *self {
-            TransportError::ListenNotSupported(_) =>  "Listening is not support",
-            TransportError::ListenFailed(_, _) => "Listening failed",
-            TransportError::DialNotSupported(_) => "Dialing is not support",
-            TransportError::DialingFailed(_, _) => "Dialing failed",
-
+            TransportError::ListenFailed(_, ref cause)
+            | TransportError::DialingFailed(_, ref cause) => Some(cause),
+            _ => None
         }
     }
 }

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -24,7 +24,7 @@ use multiaddr::Multiaddr;
 use muxing::StreamMuxer;
 use std::io::Error as IoError;
 use tokio_io::{AsyncRead, AsyncWrite};
-use transport::{MuxedTransport, Transport, TransportError, ListenerResult, DialResult};
+use transport::{MuxedTransport, Transport, TransportError, TransportResult};
 use upgrade::{apply, ConnectionUpgrade, Endpoint};
 
 /// Implements the `Transport` trait. Dials or listens, then upgrades any dialed or received
@@ -190,12 +190,12 @@ where
     type Dial = Box<Future<Item = (C::Output, Self::MultiaddrFuture), Error = IoError>>;
 
     #[inline]
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         self.listen_on(addr)
     }
 
     #[inline]
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
         self.dial(addr)
     }
 

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -24,7 +24,7 @@ use multiaddr::Multiaddr;
 use muxing::StreamMuxer;
 use std::io::Error as IoError;
 use tokio_io::{AsyncRead, AsyncWrite};
-use transport::{MuxedTransport, Transport};
+use transport::{MuxedTransport, Transport, TransportError, ListenerResult, DialResult};
 use upgrade::{apply, ConnectionUpgrade, Endpoint};
 
 /// Implements the `Transport` trait. Dials or listens, then upgrades any dialed or received
@@ -77,7 +77,7 @@ where
     pub fn dial(
         self,
         addr: Multiaddr,
-    ) -> Result<Box<Future<Item = (C::Output, C::MultiaddrFuture), Error = IoError> + 'a>, (Self, Multiaddr)>
+    ) -> Result<Box<Future<Item = (C::Output, C::MultiaddrFuture), Error = IoError> + 'a>, (Self, TransportError)>
     where
         C::NamesIter: Clone, // TODO: not elegant
     {
@@ -157,7 +157,7 @@ where
             >,
             Multiaddr,
         ),
-        (Self, Multiaddr),
+        (Self, TransportError),
     >
     where
         C::NamesIter: Clone, // TODO: not elegant
@@ -212,12 +212,12 @@ where
     type Dial = Box<Future<Item = (C::Output, Self::MultiaddrFuture), Error = IoError>>;
 
     #[inline]
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
+    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self> {
         self.listen_on(addr)
     }
 
     #[inline]
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
+    fn dial(self, addr: Multiaddr) -> DialResult<Self> {
         self.dial(addr)
     }
 

--- a/core/tests/multiplex.rs
+++ b/core/tests/multiplex.rs
@@ -29,7 +29,7 @@ extern crate tokio_io;
 use bytes::BytesMut;
 use futures::future::Future;
 use futures::{Sink, Stream};
-use libp2p_core::{Multiaddr, MuxedTransport, StreamMuxer, Transport, transport, ListenerResult, DialResult};
+use libp2p_core::{Multiaddr, MuxedTransport, StreamMuxer, Transport, transport, TransportResult};
 use std::sync::atomic;
 use std::thread;
 use tokio_io::codec::length_delimited::Framed;
@@ -56,10 +56,10 @@ impl<T: Transport> Transport for OnlyOnce<T> {
     type Listener = T::Listener;
     type ListenerUpgrade = T::ListenerUpgrade;
     type Dial = T::Dial;
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         Ok(self.0.listen_on(addr).unwrap_or_else(|_| panic!()))
     }
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
         assert!(!self.1.swap(true, atomic::Ordering::SeqCst));
         Ok(self.0.dial(addr).unwrap_or_else(|_| panic!()))
     }

--- a/core/tests/multiplex.rs
+++ b/core/tests/multiplex.rs
@@ -29,7 +29,7 @@ extern crate tokio_io;
 use bytes::BytesMut;
 use futures::future::Future;
 use futures::{Sink, Stream};
-use libp2p_core::{Multiaddr, MuxedTransport, StreamMuxer, Transport, transport};
+use libp2p_core::{Multiaddr, MuxedTransport, StreamMuxer, Transport, transport, ListenerResult, DialResult};
 use std::sync::atomic;
 use std::thread;
 use tokio_io::codec::length_delimited::Framed;
@@ -56,10 +56,10 @@ impl<T: Transport> Transport for OnlyOnce<T> {
     type Listener = T::Listener;
     type ListenerUpgrade = T::ListenerUpgrade;
     type Dial = T::Dial;
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
+    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self> {
         Ok(self.0.listen_on(addr).unwrap_or_else(|_| panic!()))
     }
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
+    fn dial(self, addr: Multiaddr) -> DialResult<Self> {
         assert!(!self.1.swap(true, atomic::Ordering::SeqCst));
         Ok(self.0.dial(addr).unwrap_or_else(|_| panic!()))
     }

--- a/core/tests/multiplex.rs
+++ b/core/tests/multiplex.rs
@@ -56,10 +56,10 @@ impl<T: Transport> Transport for OnlyOnce<T> {
     type Listener = T::Listener;
     type ListenerUpgrade = T::ListenerUpgrade;
     type Dial = T::Dial;
-    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self> {
+    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
         Ok(self.0.listen_on(addr).unwrap_or_else(|_| panic!()))
     }
-    fn dial(self, addr: Multiaddr) -> DialResult<Self> {
+    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
         assert!(!self.1.swap(true, atomic::Ordering::SeqCst));
         Ok(self.0.dial(addr).unwrap_or_else(|_| panic!()))
     }

--- a/protocols/identify/src/identify_transport.rs
+++ b/protocols/identify/src/identify_transport.rs
@@ -20,7 +20,7 @@
 
 use fnv::FnvHashMap;
 use futures::{future, Future, Stream};
-use libp2p_core::{Multiaddr, MuxedTransport, Transport};
+use libp2p_core::{Multiaddr, MuxedTransport, Transport, ListenerResult, DialResult};
 use parking_lot::Mutex;
 use protocol::{IdentifyInfo, IdentifyOutput, IdentifyProtocolConfig};
 use std::collections::hash_map::Entry;
@@ -73,7 +73,7 @@ where
     type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
 
     #[inline]
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
+    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self> {
         let (listener, new_addr) = match self.transport.clone().listen_on(addr.clone()) {
             Ok((l, a)) => (l, a),
             Err((inner, addr)) => {
@@ -146,7 +146,7 @@ where
     }
 
     #[inline]
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
+    fn dial(self, addr: Multiaddr) -> DialResult<Self> {
         // We dial a first time the node.
         let dial = match self.transport.clone().dial(addr) {
             Ok(d) => d,

--- a/protocols/identify/src/identify_transport.rs
+++ b/protocols/identify/src/identify_transport.rs
@@ -20,7 +20,7 @@
 
 use fnv::FnvHashMap;
 use futures::{future, Future, Stream};
-use libp2p_core::{Multiaddr, MuxedTransport, Transport, ListenerResult, DialResult};
+use libp2p_core::{Multiaddr, MuxedTransport, Transport, TransportResult};
 use parking_lot::Mutex;
 use protocol::{IdentifyInfo, IdentifyOutput, IdentifyProtocolConfig};
 use std::collections::hash_map::Entry;
@@ -73,7 +73,7 @@ where
     type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
 
     #[inline]
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         let (listener, new_addr) = self.transport.clone().listen_on(addr.clone())?;
 
         let identify_upgrade = self.transport.clone().with_upgrade(IdentifyProtocolConfig);
@@ -137,7 +137,7 @@ where
     }
 
     #[inline]
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
         // We dial a first time the node.
         let dial = self.transport.clone().dial(addr)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ pub extern crate libp2p_yamux as yamux;
 
 pub mod simple;
 
-pub use self::core::{Transport, ConnectionUpgrade, PeerId, swarm, ListenerResult, DialResult};
+pub use self::core::{Transport, ConnectionUpgrade, PeerId, swarm, TransportResult};
 pub use self::multiaddr::Multiaddr;
 pub use self::simple::SimpleProtocol;
 pub use self::transport_timeout::TransportTimeout;
@@ -221,12 +221,12 @@ impl Transport for CommonTransport {
     type Dial = <InnerImplementation as Transport>::Dial;
 
     #[inline]
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         self.inner.inner.listen_on(addr)
     }
 
     #[inline]
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
         self.inner.inner.dial(addr)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ pub extern crate libp2p_yamux as yamux;
 
 pub mod simple;
 
-pub use self::core::{Transport, ConnectionUpgrade, PeerId, swarm};
+pub use self::core::{Transport, ConnectionUpgrade, PeerId, swarm, ListenerResult, DialResult};
 pub use self::multiaddr::Multiaddr;
 pub use self::simple::SimpleProtocol;
 pub use self::transport_timeout::TransportTimeout;
@@ -221,7 +221,7 @@ impl Transport for CommonTransport {
     type Dial = <InnerImplementation as Transport>::Dial;
 
     #[inline]
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
+    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self> {
         match self.inner.inner.listen_on(addr) {
             Ok(res) => Ok(res),
             Err((inner, addr)) => {
@@ -232,7 +232,7 @@ impl Transport for CommonTransport {
     }
 
     #[inline]
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
+    fn dial(self, addr: Multiaddr) -> DialResult<Self> {
         match self.inner.inner.dial(addr) {
             Ok(res) => Ok(res),
             Err((inner, addr)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,25 +221,13 @@ impl Transport for CommonTransport {
     type Dial = <InnerImplementation as Transport>::Dial;
 
     #[inline]
-    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self> {
-        match self.inner.inner.listen_on(addr) {
-            Ok(res) => Ok(res),
-            Err((inner, addr)) => {
-                let trans = CommonTransport { inner: CommonTransportInner { inner: inner } };
-                Err((trans, addr))
-            }
-        }
+    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+        self.inner.inner.listen_on(addr)
     }
 
     #[inline]
-    fn dial(self, addr: Multiaddr) -> DialResult<Self> {
-        match self.inner.inner.dial(addr) {
-            Ok(res) => Ok(res),
-            Err((inner, addr)) => {
-                let trans = CommonTransport { inner: CommonTransportInner { inner: inner } };
-                Err((trans, addr))
-            }
-        }
+    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+        self.inner.inner.dial(addr)
     }
 
     #[inline]

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -47,7 +47,7 @@ use multiaddr::{AddrComponent, Multiaddr};
 use std::fmt;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::net::IpAddr;
-use swarm::{Transport, ListenerResult, DialResult};
+use swarm::{Transport, TransportResult};
 use tokio_dns::{CpuPoolResolver, Resolver};
 
 /// Represents the configuration for a DNS transport capability of libp2p.
@@ -103,11 +103,11 @@ where
     type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
 
     #[inline]
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         self.inner.listen_on(addr)
     }
 
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
         let contains_dns = addr.iter().any(|cmp| match cmp {
             AddrComponent::DNS4(_) => true,
             AddrComponent::DNS6(_) => true,
@@ -210,7 +210,7 @@ mod tests {
     use futures::future;
     use multiaddr::{AddrComponent, Multiaddr};
     use std::io::Error as IoError;
-    use swarm::{Transport, ListenerResult, DialResult};
+    use swarm::{Transport, TransportResult};
     use DnsConfig;
 
     #[test]
@@ -228,11 +228,11 @@ mod tests {
             fn listen_on(
                 &self,
                 _addr: Multiaddr,
-            ) -> ListenerResult<Self::Listener> {
+            ) -> TransportResult<(Self::Listener, Multiaddr)> {
                 unreachable!()
             }
 
-            fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+            fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
                 let addr = addr.iter().collect::<Vec<_>>();
                 assert_eq!(addr.len(), 2);
                 match addr[1] {

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -47,7 +47,7 @@ use multiaddr::{AddrComponent, Multiaddr};
 use std::fmt;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::net::IpAddr;
-use swarm::Transport;
+use swarm::{Transport, ListenerResult, DialResult};
 use tokio_dns::{CpuPoolResolver, Resolver};
 
 /// Represents the configuration for a DNS transport capability of libp2p.
@@ -103,7 +103,7 @@ where
     type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
 
     #[inline]
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
+    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self> {
         match self.inner.listen_on(addr) {
             Ok(r) => Ok(r),
             Err((inner, addr)) => Err((
@@ -116,7 +116,7 @@ where
         }
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
+    fn dial(self, addr: Multiaddr) -> DialResult<Self> {
         let contains_dns = addr.iter().any(|cmp| match cmp {
             AddrComponent::DNS4(_) => true,
             AddrComponent::DNS6(_) => true,
@@ -228,7 +228,7 @@ mod tests {
     use futures::future;
     use multiaddr::{AddrComponent, Multiaddr};
     use std::io::Error as IoError;
-    use swarm::Transport;
+    use swarm::{Transport, ListenerResult, DialResult};
     use DnsConfig;
 
     #[test]
@@ -246,11 +246,11 @@ mod tests {
             fn listen_on(
                 self,
                 _addr: Multiaddr,
-            ) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
+            ) -> ListenerResult<Self> {
                 unreachable!()
             }
 
-            fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
+            fn dial(self, addr: Multiaddr) -> DialResult<Self> {
                 let addr = addr.iter().collect::<Vec<_>>();
                 assert_eq!(addr.len(), 2);
                 match addr[1] {

--- a/transports/ratelimit/src/lib.rs
+++ b/transports/ratelimit/src/lib.rs
@@ -29,7 +29,7 @@ extern crate tokio_io;
 
 use aio_limited::{Limited, Limiter};
 use futures::prelude::*;
-use libp2p_core::{Multiaddr, Transport, ListenerResult, DialResult};
+use libp2p_core::{Multiaddr, Transport, TransportResult};
 use std::io;
 use tokio_executor::Executor;
 use tokio_io::{AsyncRead, AsyncWrite, io::{ReadHalf, WriteHalf}};
@@ -164,7 +164,7 @@ where
     type ListenerUpgrade = ListenerUpgrade<T>;
     type Dial = Box<Future<Item = (Connection<T::Output>, Self::MultiaddrFuture), Error = io::Error>>;
 
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener>
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)>
     where
         Self: Sized,
     {
@@ -177,7 +177,7 @@ where
             )
     }
 
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial>
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial>
     where
         Self: Sized,
     {

--- a/transports/ratelimit/src/lib.rs
+++ b/transports/ratelimit/src/lib.rs
@@ -29,7 +29,7 @@ extern crate tokio_io;
 
 use aio_limited::{Limited, Limiter};
 use futures::prelude::*;
-use libp2p_core::{Multiaddr, Transport};
+use libp2p_core::{Multiaddr, Transport, ListenerResult, DialResult};
 use std::io;
 use tokio_executor::Executor;
 use tokio_io::{AsyncRead, AsyncWrite, io::{ReadHalf, WriteHalf}};
@@ -164,7 +164,7 @@ where
     type ListenerUpgrade = ListenerUpgrade<T>;
     type Dial = Box<Future<Item = (Connection<T::Output>, Self::MultiaddrFuture), Error = io::Error>>;
 
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)>
+    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self>
     where
         Self: Sized,
     {
@@ -181,7 +181,7 @@ where
             .map_err(|(transport, a)| (RateLimited::from_parts(transport, r, w), a))
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)>
+    fn dial(self, addr: Multiaddr) -> DialResult<Self>
     where
         Self: Sized,
     {

--- a/transports/relay/src/transport.rs
+++ b/transports/relay/src/transport.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use core::transport::{Transport, ListenerResult, DialResult, TransportError};
+use core::transport::{Transport, TransportResult, TransportError};
 use futures::{stream, prelude::*};
 use message::{CircuitRelay, CircuitRelay_Peer, CircuitRelay_Type};
 use multiaddr::Multiaddr;
@@ -51,11 +51,11 @@ where
     type ListenerUpgrade = Box<Future<Item=(Self::Output, Self::MultiaddrFuture), Error=io::Error>>;
     type Dial = Box<Future<Item=(Self::Output, Self::MultiaddrFuture), Error=io::Error>>;
 
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         Err(TransportError::ListenNotSupported(addr))
     }
 
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
         match RelayAddr::parse(&addr) {
             RelayAddr::Malformed => {
                 let err = io::Error::new(io::ErrorKind::InvalidInput,

--- a/transports/relay/src/transport.rs
+++ b/transports/relay/src/transport.rs
@@ -110,8 +110,7 @@ where
     }
 
     // Relay to destination over any available relay node.
-    fn relay_to(&self, destination: &Peer)
-        -> Result<impl Future<Item=(T::Output, T::MultiaddrFuture), Error=io::Error>, io::Error> {
+    fn relay_to(&self, destination: &Peer) -> Result<impl Future<Item=(T::Output, T::MultiaddrFuture), Error=io::Error>, io::Error> {
         trace!("relay_to {:?}", destination.id);
         let mut dials = Vec::new();
         for relay in &*self.relays {

--- a/transports/tcp/src/lib.rs
+++ b/transports/tcp/src/lib.rs
@@ -58,7 +58,7 @@ use std::io::{Error as IoError, Read, Write};
 use std::iter;
 use std::net::SocketAddr;
 use std::time::Duration;
-use libp2p_core::transport::{Transport, TransportError, ListenerResult, DialResult};
+use libp2p_core::transport::{Transport, TransportError, TransportResult};
 use tk_listen::{ListenExt, SleepOnError};
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_tcp::{ConnectFuture, Incoming, TcpListener, TcpStream};
@@ -89,7 +89,7 @@ impl Transport for TcpConfig {
     type MultiaddrFuture = FutureResult<Multiaddr, IoError>;
     type Dial = TcpDialFut;
 
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         if let Ok(socket_addr) = multiaddr_to_socketaddr(&addr) {
             let listener = TcpListener::bind(&socket_addr);
             // We need to build the `Multiaddr` to return from this function. If an error happened,
@@ -117,7 +117,7 @@ impl Transport for TcpConfig {
         }
     }
 
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
         if let Ok(socket_addr) = multiaddr_to_socketaddr(&addr) {
             // As an optimization, we check that the address is not of the form `0.0.0.0`.
             // If so, we instantly refuse dialing instead of going through the kernel.

--- a/transports/tcp/src/lib.rs
+++ b/transports/tcp/src/lib.rs
@@ -89,7 +89,7 @@ impl Transport for TcpConfig {
     type MultiaddrFuture = FutureResult<Multiaddr, IoError>;
     type Dial = TcpDialFut;
 
-    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self> {
+    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
         if let Ok(socket_addr) = multiaddr_to_socketaddr(&addr) {
             let listener = TcpListener::bind(&socket_addr);
             // We need to build the `Multiaddr` to return from this function. If an error happened,
@@ -113,11 +113,11 @@ impl Transport for TcpConfig {
                 .map(move |l| l.incoming().sleep_on_error(sleep_on_error));
             Ok((TcpListenStream { inner }, new_addr))
         } else {
-            Err((self, TransportError::ListenNotSupported(addr)))
+            Err(TransportError::ListenNotSupported(addr))
         }
     }
 
-    fn dial(self, addr: Multiaddr) -> DialResult<Self> {
+    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
         if let Ok(socket_addr) = multiaddr_to_socketaddr(&addr) {
             // As an optimization, we check that the address is not of the form `0.0.0.0`.
             // If so, we instantly refuse dialing instead of going through the kernel.
@@ -129,10 +129,10 @@ impl Transport for TcpConfig {
                 })
             } else {
                 debug!("Instantly refusing dialing {}, as it is invalid", addr);
-                Err((self, TransportError::DialNotSupported(addr)))
+                Err(TransportError::DialNotSupported(addr))
             }
         } else {
-            Err((self, TransportError::DialNotSupported(addr)))
+            Err(TransportError::DialNotSupported(addr))
         }
     }
 

--- a/transports/timeout/src/lib.rs
+++ b/transports/timeout/src/lib.rs
@@ -31,7 +31,7 @@ extern crate log;
 extern crate tokio_timer;
 
 use futures::{Async, Future, Poll, Stream};
-use libp2p_core::{Multiaddr, MuxedTransport, Transport, ListenerResult, DialResult};
+use libp2p_core::{Multiaddr, MuxedTransport, Transport, TransportResult};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::time::Duration;
 use tokio_timer::Timeout;
@@ -90,7 +90,7 @@ where
     type ListenerUpgrade = TokioTimerMapErr<Timeout<InnerTrans::ListenerUpgrade>>;
     type Dial = TokioTimerMapErr<Timeout<InnerTrans::Dial>>;
 
-    fn listen_on(&self, addr: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, addr: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         self.inner.listen_on(addr).map(|(listener, addr)|
             (TimeoutListener {
                 inner: listener,
@@ -99,7 +99,7 @@ where
         )
     }
 
-    fn dial(&self, addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, addr: Multiaddr) -> TransportResult<Self::Dial> {
         self.inner.dial(addr).map(|dial|
             TokioTimerMapErr {
                 inner: Timeout::new(dial, self.outgoing_timeout),

--- a/transports/timeout/src/lib.rs
+++ b/transports/timeout/src/lib.rs
@@ -31,7 +31,7 @@ extern crate log;
 extern crate tokio_timer;
 
 use futures::{Async, Future, Poll, Stream};
-use libp2p_core::{Multiaddr, MuxedTransport, Transport};
+use libp2p_core::{Multiaddr, MuxedTransport, Transport, ListenerResult, DialResult};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::time::Duration;
 use tokio_timer::Timeout;
@@ -90,7 +90,7 @@ where
     type ListenerUpgrade = TokioTimerMapErr<Timeout<InnerTrans::ListenerUpgrade>>;
     type Dial = TokioTimerMapErr<Timeout<InnerTrans::Dial>>;
 
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
+    fn listen_on(self, addr: Multiaddr) -> ListenerResult<Self> {
         match self.inner.listen_on(addr) {
             Ok((listener, addr)) => {
                 let listener = TimeoutListener {
@@ -112,7 +112,7 @@ where
         }
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
+    fn dial(self, addr: Multiaddr) -> DialResult<Self> {
         match self.inner.dial(addr) {
             Ok(dial) => Ok(TokioTimerMapErr {
                 inner: Timeout::new(dial, self.outgoing_timeout),

--- a/transports/websocket/src/browser.rs
+++ b/transports/websocket/src/browser.rs
@@ -29,7 +29,7 @@ use std::iter;
 use std::sync::{Arc, Mutex};
 use stdweb::web::TypedArray;
 use stdweb::{self, Reference};
-use swarm::{MuxedTransport, Transport, ListenerResult, DialResult};
+use swarm::{MuxedTransport, Transport, TransportError, ListenerResult, DialResult};
 use tokio_io::{AsyncRead, AsyncWrite};
 
 /// Represents the configuration for a websocket transport capability for libp2p.

--- a/transports/websocket/src/browser.rs
+++ b/transports/websocket/src/browser.rs
@@ -29,7 +29,7 @@ use std::iter;
 use std::sync::{Arc, Mutex};
 use stdweb::web::TypedArray;
 use stdweb::{self, Reference};
-use transport::{MuxedTransport, Transport, ListenerResult, DialResult};
+use swarm::{MuxedTransport, Transport, ListenerResult, DialResult};
 use tokio_io::{AsyncRead, AsyncWrite};
 
 /// Represents the configuration for a websocket transport capability for libp2p.

--- a/transports/websocket/src/browser.rs
+++ b/transports/websocket/src/browser.rs
@@ -29,7 +29,7 @@ use std::iter;
 use std::sync::{Arc, Mutex};
 use stdweb::web::TypedArray;
 use stdweb::{self, Reference};
-use swarm::Transport;
+use transport::{MuxedTransport, Transport, ListenerResult, DialResult};
 use tokio_io::{AsyncRead, AsyncWrite};
 
 /// Represents the configuration for a websocket transport capability for libp2p.
@@ -60,12 +60,12 @@ impl Transport for BrowserWsConfig {
     type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
 
     #[inline]
-    fn listen_on(self, a: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
+    fn listen_on(self, a: Multiaddr) -> ListenerResult<Self> {
         // Listening is never supported.
         Err((self, a))
     }
 
-    fn dial(self, original_addr: Multiaddr) -> Result<Self::Dial, (Self, Multiaddr)> {
+    fn dial(self, original_addr: Multiaddr) -> DialResult<Self> {
         // Making sure we are initialized before we dial. Initialization is protected by a simple
         // boolean static variable, so it's not a problem to call it multiple times and the cost
         // is negligible.

--- a/transports/websocket/src/browser.rs
+++ b/transports/websocket/src/browser.rs
@@ -29,7 +29,7 @@ use std::iter;
 use std::sync::{Arc, Mutex};
 use stdweb::web::TypedArray;
 use stdweb::{self, Reference};
-use swarm::{MuxedTransport, Transport, TransportError, ListenerResult, DialResult};
+use swarm::{MuxedTransport, Transport, TransportError, TransportResult};
 use tokio_io::{AsyncRead, AsyncWrite};
 
 /// Represents the configuration for a websocket transport capability for libp2p.
@@ -60,12 +60,12 @@ impl Transport for BrowserWsConfig {
     type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
 
     #[inline]
-    fn listen_on(&self, a: Multiaddr) -> ListenerResult<Self::Listener> {
+    fn listen_on(&self, a: Multiaddr) -> TransportResult<(Self::Listener, Multiaddr)> {
         // Listening is never supported.
         Err(TransportError::ListenNotSupported(a))
     }
 
-    fn dial(&self, original_addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, original_addr: Multiaddr) -> TransportResult<Self::Dial> {
         // Making sure we are initialized before we dial. Initialization is protected by a simple
         // boolean static variable, so it's not a problem to call it multiple times and the cost
         // is negligible.

--- a/transports/websocket/src/desktop.rs
+++ b/transports/websocket/src/desktop.rs
@@ -22,7 +22,7 @@ use futures::{stream, Future, IntoFuture, Sink, Stream};
 use multiaddr::{AddrComponent, Multiaddr};
 use rw_stream_sink::RwStreamSink;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
-use swarm::{Transport, ListenerResult, DialResult, TransportError};
+use swarm::{Transport, TransportResult, TransportError};
 use tokio_io::{AsyncRead, AsyncWrite};
 use websocket::client::builder::ClientBuilder;
 use websocket::message::OwnedMessage;
@@ -73,7 +73,7 @@ where
     fn listen_on(
         &self,
         original_addr: Multiaddr,
-    ) -> ListenerResult<Self::Listener> {
+    ) -> TransportResult<(Self::Listener, Multiaddr)> {
         let mut inner_addr = original_addr.clone();
         match inner_addr.pop() {
             Some(AddrComponent::WS) => {}
@@ -145,7 +145,7 @@ where
         Ok((listen, new_addr))
     }
 
-    fn dial(&self, original_addr: Multiaddr) -> DialResult<Self::Dial> {
+    fn dial(&self, original_addr: Multiaddr) -> TransportResult<Self::Dial> {
         let mut inner_addr = original_addr.clone();
         let is_wss = match inner_addr.pop() {
             Some(AddrComponent::WS) => false,


### PR DESCRIPTION
 - create `TransportError`-Type with custom Errors
 - adds type aliases for readability `DialResult` and `ListenerResult`
 - implement `TransportError` for new aliases
 - implement new aliases and Error everywhere else
 - replacing consuming with referencing `dial` and `listen_to` on `Transport` to simplify return values.

fixes #367