### PR TITLE
Fix rust-libp2p issue #429 (floodsub fails to decode PeerId)

### DIFF
--- a/protocols/floodsub/src/lib.rs
+++ b/protocols/floodsub/src/lib.rs
@@ -593,7 +593,7 @@ fn handle_packet_received(
             continue;
         }
 
-        let peer_id = match PeerId::from_bytes(bytes.to_vec()) {
+        let peer_id = match PeerId::from_bytes(from.clone()) {
             Ok(id) => id,
             Err(err) => {
                 trace!("Parsing PeerId failed: {:?}. Skipping.", err);


### PR DESCRIPTION
Fixes #429 