### PR TITLE
multistream-select: Include `\n` in length.

### DIFF
--- a/misc/multistream-select/src/protocol/listener.rs
+++ b/misc/multistream-select/src/protocol/listener.rs
@@ -111,7 +111,7 @@ where
                 let mut buf = encode::usize_buffer();
                 let mut out_msg = Vec::from(encode::usize(list.len(), &mut buf));
                 for elem in &list {
-                    out_msg.extend(encode::usize(elem.len(), &mut buf));
+                    out_msg.extend(encode::usize(elem.len() + 1, &mut buf));
                     out_msg.extend_from_slice(elem);
                     out_msg.extend(iter::once(b'\n'));
                 }

--- a/misc/multistream-select/src/protocol/listener.rs
+++ b/misc/multistream-select/src/protocol/listener.rs
@@ -111,7 +111,7 @@ where
                 let mut buf = encode::usize_buffer();
                 let mut out_msg = Vec::from(encode::usize(list.len(), &mut buf));
                 for elem in &list {
-                    out_msg.extend(encode::usize(elem.len() + 1, &mut buf));
+                    out_msg.extend(encode::usize(elem.len() + 1, &mut buf)); // +1 for '\n'
                     out_msg.extend_from_slice(elem);
                     out_msg.extend(iter::once(b'\n'));
                 }

--- a/misc/multistream-select/src/tests.rs
+++ b/misc/multistream-select/src/tests.rs
@@ -142,7 +142,6 @@ fn no_protocol_found() {
 }
 
 #[test]
-#[ignore]       // TODO: not working
 fn select_proto_parallel() {
     let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let listener_addr = listener.local_addr().unwrap();


### PR DESCRIPTION
#438 did not consider the `\n` character for element lengths (cf. https://github.com/multiformats/multistream-select#ls-example-in-detail).