### PR TITLE
The SwarmFuture is now a Stream

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -252,7 +252,7 @@ pub use self::multiaddr::{AddrComponent, Multiaddr};
 pub use self::muxing::StreamMuxer;
 pub use self::peer_id::PeerId;
 pub use self::public_key::PublicKey;
-pub use self::swarm::{swarm, SwarmController, SwarmFuture};
+pub use self::swarm::{swarm, SwarmController, SwarmEvents};
 pub use self::transport::{MuxedTransport, Transport};
 pub use self::unique::{UniqueConnec, UniqueConnecFuture, UniqueConnecState};
 pub use self::upgrade::{ConnectionUpgrade, Endpoint};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -177,7 +177,7 @@
 //! extern crate libp2p_tcp_transport;
 //! extern crate tokio_current_thread;
 //!
-//! use futures::Future;
+//! use futures::{Future, Stream};
 //! use libp2p_ping::{Ping, PingOutput};
 //! use libp2p_core::Transport;
 //!
@@ -200,7 +200,7 @@
 //! swarm_controller.listen_on("/ip4/0.0.0.0/tcp/0".parse().unwrap());
 //!
 //! // Runs until everything is finished.
-//! tokio_current_thread::block_on_all(swarm_future).unwrap();
+//! tokio_current_thread::block_on_all(swarm_future.for_each(|_| Ok(()))).unwrap();
 //! # }
 //! ```
 

--- a/core/src/swarm.rs
+++ b/core/src/swarm.rs
@@ -224,7 +224,6 @@ where
 }
 
 /// Future that must be driven to completion in order for the swarm to work.
-// TODO: rename to `SwarmStream`
 pub struct SwarmEvents<T, F, H>
 where
     T: MuxedTransport + 'static, // TODO: 'static :-/
@@ -339,7 +338,6 @@ where
                     notifier(Ok(()));
                 }
                 Err(error) => {
-                    // TODO: pass an error to the event
                     return Ok(Async::Ready(Some(SwarmEvent::DialFailed {
                         client_addr,
                         error,

--- a/core/src/swarm.rs
+++ b/core/src/swarm.rs
@@ -262,9 +262,8 @@ where
                         (out, Box::new(maf) as Box<Future<Item = Multiaddr, Error = IoError>>)
                     });
                     shared.listeners_upgrade.push(Box::new(connec) as Box<_>);
-                    break;
                 }
-                Ok(Async::NotReady) => (),
+                Ok(Async::NotReady) => break,
                 Err(err) => {
                     // TODO: should that stop everything?
                     debug!("Error in multiplexed incoming connection: {:?}", err);

--- a/core/src/swarm.rs
+++ b/core/src/swarm.rs
@@ -38,7 +38,7 @@ use {Multiaddr, MuxedTransport, Transport};
 pub fn swarm<T, H, F>(
     transport: T,
     handler: H,
-) -> (SwarmController<T, F::Future>, SwarmFuture<T, F::Future, H>)
+) -> (SwarmController<T, F::Future>, SwarmEvents<T, F::Future, H>)
 where
     T: MuxedTransport + Clone + 'static, // TODO: 'static :-/
     H: FnMut(T::Output, Box<Future<Item = Multiaddr, Error = IoError>>) -> F,
@@ -53,7 +53,7 @@ where
         task_to_notify: None,
     }));
 
-    let future = SwarmFuture {
+    let future = SwarmEvents {
         transport: transport.clone(),
         shared: shared.clone(),
         handler: handler,
@@ -225,7 +225,7 @@ where
 
 /// Future that must be driven to completion in order for the swarm to work.
 // TODO: rename to `SwarmStream`
-pub struct SwarmFuture<T, F, H>
+pub struct SwarmEvents<T, F, H>
 where
     T: MuxedTransport + 'static, // TODO: 'static :-/
 {
@@ -239,7 +239,7 @@ where
     handler: H,
 }
 
-impl<T, H, If, F> Stream for SwarmFuture<T, F, H>
+impl<T, H, If, F> Stream for SwarmEvents<T, F, H>
 where
     T: MuxedTransport + Clone + 'static, // TODO: 'static :-/,
     H: FnMut(T::Output, Box<Future<Item = Multiaddr, Error = IoError>>) -> If,

--- a/core/src/transport/memory.rs
+++ b/core/src/transport/memory.rs
@@ -264,7 +264,9 @@ mod tests {
             .map(|_| ())
             .map_err(|((), _)| io::Error::new(io::ErrorKind::Other, "receive error"));
 
-        let future = future.select(finish_rx)
+        let future = future
+            .for_each(|_| Ok(()))
+            .select(finish_rx)
             .map(|_| ())
             .map_err(|(e, _)| e);
 

--- a/core/src/unique.rs
+++ b/core/src/unique.rs
@@ -425,7 +425,7 @@ pub enum UniqueConnecState {
 
 #[cfg(test)]
 mod tests {
-    use futures::{future, sync::oneshot, Future};
+    use futures::{future, sync::oneshot, Future, Stream};
     use transport::DeniedTransport;
     use std::io::Error as IoError;
     use std::sync::{Arc, atomic};
@@ -455,7 +455,7 @@ mod tests {
             .map(|val| { assert_eq!(val, 12); });
         assert_eq!(unique_connec.state(), UniqueConnecState::Pending);
 
-        let future = dial_success.select(swarm_future).map_err(|(err, _)| err);
+        let future = dial_success.select(swarm_future.for_each(|_| Ok(()))).map_err(|(err, _)| err);
         current_thread::Runtime::new().unwrap().block_on(future).unwrap();
         assert_eq!(unique_connec.state(), UniqueConnecState::Full);
     }
@@ -525,8 +525,8 @@ mod tests {
             });
 
         let future = dial_success
-            .select(swarm_future2).map(|_| ()).map_err(|(err, _)| err)
-            .select(swarm_future1).map(|_| ()).map_err(|(err, _)| err);
+            .select(swarm_future2.for_each(|_| Ok(()))).map(|_| ()).map_err(|(err, _)| err)
+            .select(swarm_future1.for_each(|_| Ok(()))).map(|_| ()).map_err(|(err, _)| err);
 
         current_thread::Runtime::new().unwrap().block_on(future).unwrap();
         assert!(unique_connec.is_alive());
@@ -556,7 +556,7 @@ mod tests {
         swarm_ctrl.dial("/memory".parse().unwrap(), tx)
             .unwrap();
 
-        let future = dial_success.select(swarm_future).map_err(|(err, _)| err);
+        let future = dial_success.select(swarm_future.for_each(|_| Ok(()))).map_err(|(err, _)| err);
         current_thread::Runtime::new().unwrap().block_on(future).unwrap();
         assert_eq!(unique_connec.poll(), Some(13));
     }
@@ -600,8 +600,8 @@ mod tests {
             });
 
         let future = dial_success
-            .select(swarm_future1).map(|_| ()).map_err(|(err, _)| err)
-            .select(swarm_future2).map(|_| ()).map_err(|(err, _)| err);
+            .select(swarm_future1.for_each(|_| Ok(()))).map(|_| ()).map_err(|(err, _)| err)
+            .select(swarm_future2.for_each(|_| Ok(()))).map(|_| ()).map_err(|(err, _)| err);
 
         current_thread::Runtime::new().unwrap().block_on(future).unwrap();
         assert!(!unique_connec.is_alive());
@@ -653,8 +653,8 @@ mod tests {
             });
 
         let future = dial_success
-            .select(swarm_future1).map(|_| ()).map_err(|(err, _)| err)
-            .select(swarm_future2).map(|_| ()).map_err(|(err, _)| err);
+            .select(swarm_future1.for_each(|_| Ok(()))).map(|_| ()).map_err(|(err, _)| err)
+            .select(swarm_future2.for_each(|_| Ok(()))).map(|_| ()).map_err(|(err, _)| err);
 
         current_thread::Runtime::new().unwrap().block_on(future).unwrap();
         assert!(!unique_connec.is_alive());
@@ -698,8 +698,8 @@ mod tests {
             });
 
         let future = dial_success
-            .select(swarm_future1).map(|_| ()).map_err(|(err, _)| err)
-            .select(swarm_future2).map(|_| ()).map_err(|(err, _)| err);
+            .select(swarm_future1.for_each(|_| Ok(()))).map(|_| ()).map_err(|(err, _)| err)
+            .select(swarm_future2.for_each(|_| Ok(()))).map(|_| ()).map_err(|(err, _)| err);
 
         current_thread::Runtime::new().unwrap().block_on(future).unwrap();
     }
@@ -725,7 +725,7 @@ mod tests {
         drop(unique_connec);
 
         let future = dial_success
-            .select(swarm_future).map(|_| ()).map_err(|(err, _)| err);
+            .select(swarm_future.for_each(|_| Ok(()))).map(|_| ()).map_err(|(err, _)| err);
         current_thread::Runtime::new().unwrap().block_on(future).unwrap();
     }
 

--- a/core/src/unique.rs
+++ b/core/src/unique.rs
@@ -99,12 +99,13 @@ impl<T> UniqueConnec<T> {
     /// One critical property of this method, is that if a connection incomes and `tie_*` is
     /// called, then it will be returned by the returned future.
     #[inline]
-    pub fn dial<S, Du>(&self, swarm: &SwarmController<S>, multiaddr: &Multiaddr,
-                              transport: Du) -> UniqueConnecFuture<T>
+    pub fn dial<S, F, Du>(&self, swarm: &SwarmController<S, F>, multiaddr: &Multiaddr,
+                          transport: Du) -> UniqueConnecFuture<T>
         where T: Clone + 'static,       // TODO: 'static :-/
               Du: Transport + 'static, // TODO: 'static :-/
               Du::Output: Into<S::Output>,
               S: Clone + MuxedTransport,
+              F: 'static,
     {
         self.dial_inner(swarm, multiaddr, transport, true)
     }
@@ -112,23 +113,25 @@ impl<T> UniqueConnec<T> {
     /// Same as `dial`, except that the future will produce an error if an earlier attempt to dial
     /// has errored.
     #[inline]
-    pub fn dial_if_empty<S, Du>(&self, swarm: &SwarmController<S>, multiaddr: &Multiaddr,
-                              transport: Du) -> UniqueConnecFuture<T>
+    pub fn dial_if_empty<S, F, Du>(&self, swarm: &SwarmController<S, F>, multiaddr: &Multiaddr,
+                                   transport: Du) -> UniqueConnecFuture<T>
         where T: Clone + 'static,       // TODO: 'static :-/
               Du: Transport + 'static, // TODO: 'static :-/
               Du::Output: Into<S::Output>,
               S: Clone + MuxedTransport,
+              F: 'static,
     {
         self.dial_inner(swarm, multiaddr, transport, false)
     }
 
     /// Inner implementation of `dial_*`.
-    fn dial_inner<S, Du>(&self, swarm: &SwarmController<S>, multiaddr: &Multiaddr,
-                         transport: Du, dial_if_err: bool) -> UniqueConnecFuture<T>
+    fn dial_inner<S, F, Du>(&self, swarm: &SwarmController<S, F>, multiaddr: &Multiaddr,
+                            transport: Du, dial_if_err: bool) -> UniqueConnecFuture<T>
         where T: Clone + 'static,       // TODO: 'static :-/
               Du: Transport + 'static, // TODO: 'static :-/
               Du::Output: Into<S::Output>,
               S: Clone + MuxedTransport,
+              F: 'static,
     {
         let mut inner = self.inner.lock();
         match &*inner {

--- a/core/tests/lots_of_connec.rs
+++ b/core/tests/lots_of_connec.rs
@@ -27,7 +27,7 @@ extern crate rand;
 extern crate tokio_current_thread;
 extern crate tokio_io;
 
-use futures::{future, future::Future};
+use futures::{future, future::Future, Stream};
 use libp2p_core::Transport;
 use libp2p_tcp_transport::TcpConfig;
 use std::sync::{atomic, Arc};
@@ -52,7 +52,7 @@ fn lots_of_swarms() {
         );
 
         swarm_controllers.push(ctrl);
-        swarm_futures.push(fut);
+        swarm_futures.push(fut.for_each(|_| Ok(())));
     }
 
     let mut addresses = Vec::new();

--- a/examples/echo-dialer.rs
+++ b/examples/echo-dialer.rs
@@ -131,6 +131,7 @@ fn main() {
     // actually started yet. Because we created the `TcpConfig` with tokio, we need to run the
     // future through the tokio core.
     let final_future = swarm_future
+        .for_each(|_| Ok(()))
         .select(finished_rx.map_err(|_| unreachable!()))
         .map(|_| ())
         .map_err(|(err, _)| err);

--- a/examples/echo-server.rs
+++ b/examples/echo-server.rs
@@ -139,5 +139,5 @@ fn main() {
     // `swarm_future` is a future that contains all the behaviour that we want, but nothing has
     // actually started yet. Because we created the `TcpConfig` with tokio, we need to run the
     // future through the tokio core.
-    tokio_current_thread::block_on_all(swarm_future).unwrap();
+    tokio_current_thread::block_on_all(swarm_future.for_each(|_| Ok(()))).unwrap();
 }

--- a/examples/floodsub.rs
+++ b/examples/floodsub.rs
@@ -147,6 +147,7 @@ fn main() {
     };
 
     let final_fut = swarm_future
+        .for_each(|_| Ok(()))
         .select(floodsub_rx)
         .map(|_| ())
         .map_err(|e| e.0)

--- a/examples/kademlia.rs
+++ b/examples/kademlia.rs
@@ -227,7 +227,7 @@ fn main() {
     // future through the tokio core.
     tokio_current_thread::block_on_all(
         finish_enum
-            .select(swarm_future)
+            .select(swarm_future.for_each(|_| Ok(())))
             .map(|(n, _)| n)
             .map_err(|(err, _)| err),
     ).unwrap();

--- a/examples/kademlia.rs
+++ b/examples/kademlia.rs
@@ -18,6 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+#![type_length_limit = "2097152"]
+
 extern crate bigint;
 extern crate bytes;
 extern crate env_logger;

--- a/examples/kademlia.rs
+++ b/examples/kademlia.rs
@@ -20,7 +20,7 @@
 
 // Libp2p's code unfortunately produces very large types. Rust's default length limit for type
 // names is not large enough, therefore we need this attribute.
-#![type_length_limit = "2097152"]
+#![type_length_limit = "4194304"]
 
 extern crate bigint;
 extern crate bytes;

--- a/examples/kademlia.rs
+++ b/examples/kademlia.rs
@@ -18,6 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+// Libp2p's code unfortunately produces very large types. Rust's default length limit for type
+// names is not large enough, therefore we need this attribute.
 #![type_length_limit = "2097152"]
 
 extern crate bigint;

--- a/examples/ping-client.rs
+++ b/examples/ping-client.rs
@@ -25,7 +25,7 @@ extern crate libp2p;
 extern crate tokio_current_thread;
 extern crate tokio_io;
 
-use futures::Future;
+use futures::{Future, Stream};
 use futures::sync::oneshot;
 use std::env;
 use libp2p::core::Transport;
@@ -110,7 +110,7 @@ fn main() {
     // actually started yet. Because we created the `TcpConfig` with tokio, we need to run the
     // future through the tokio core.
     tokio_current_thread::block_on_all(
-        rx.select(swarm_future.map_err(|_| unreachable!()))
+        rx.select(swarm_future.for_each(|_| Ok(())).map_err(|_| unreachable!()))
             .map_err(|(e, _)| e)
             .map(|_| ()),
     ).unwrap();

--- a/examples/relay.rs
+++ b/examples/relay.rs
@@ -150,7 +150,7 @@ fn run_dialer(opts: DialerOpts) -> Result<(), Box<Error>> {
 
     control.dial(address, transport.with_upgrade(echo)).map_err(|_| "failed to dial")?;
 
-    tokio_current_thread::block_on_all(future).map_err(From::from)
+    tokio_current_thread::block_on_all(future.for_each(|_| Ok(()))).map_err(From::from)
 }
 
 fn run_listener(opts: ListenerOpts) -> Result<(), Box<Error>> {
@@ -202,7 +202,7 @@ fn run_listener(opts: ListenerOpts) -> Result<(), Box<Error>> {
     });
 
     control.listen_on(opts.listen).map_err(|_| "failed to listen")?;
-    tokio_current_thread::block_on_all(future).map_err(From::from)
+    tokio_current_thread::block_on_all(future.for_each(|_| Ok(()))).map_err(From::from)
 }
 
 // Custom parsers ///////////////////////////////////////////////////////////


### PR DESCRIPTION
The future returned by `swarm()` is now a stream of events that happen during the process of the stream.

This allows the user to know more precisely what happens.
