### PR TITLE
Merge the changes from polkadot-2 into master

### DIFF
--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -18,10 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use connection_reuse::ConnectionReuse;
 use futures::prelude::*;
 use multiaddr::Multiaddr;
-use muxing::StreamMuxer;
 use std::io::Error as IoError;
 use tokio_io::{AsyncRead, AsyncWrite};
 use transport::{MuxedTransport, Transport};
@@ -52,16 +50,6 @@ where
     T::Output: AsyncRead + AsyncWrite,
     C: ConnectionUpgrade<T::Output, T::MultiaddrFuture> + 'a,
 {
-    /// Turns this upgraded node into a `ConnectionReuse`. If the `Output` implements the
-    /// `StreamMuxer` trait, the returned object will implement `Transport` and `MuxedTransport`.
-    #[inline]
-    pub fn into_connection_reuse(self) -> ConnectionReuse<T, C>
-    where
-        C::Output: StreamMuxer,
-    {
-        From::from(self)
-    }
-
     /// Returns a reference to the inner `Transport`.
     #[inline]
     pub fn transport(&self) -> &T {

--- a/core/tests/multiplex.rs
+++ b/core/tests/multiplex.rs
@@ -78,7 +78,9 @@ fn client_to_server_outbound() {
     let bg_thread = thread::spawn(move || {
         let future = rx
             .with_upgrade(multiplex::MplexConfig::new())
+            .map(|val, _| ((), val))
             .into_connection_reuse()
+            .map(|((), val), _| val)
             .listen_on("/memory".parse().unwrap())
             .unwrap_or_else(|_| panic!()).0
             .into_future()
@@ -124,7 +126,9 @@ fn connection_reused_for_dialing() {
     let bg_thread = thread::spawn(move || {
         let future = OnlyOnce::from(rx)
             .with_upgrade(multiplex::MplexConfig::new())
+            .map(|val, _| ((), val))
             .into_connection_reuse()
+            .map(|((), val), _| val)
             .listen_on("/memory".parse().unwrap())
             .unwrap_or_else(|_| panic!()).0
             .into_future()
@@ -160,7 +164,9 @@ fn connection_reused_for_dialing() {
 
     let transport = OnlyOnce::from(tx)
         .with_upgrade(multiplex::MplexConfig::new())
-        .into_connection_reuse();
+        .map(|val, _| ((), val))
+        .into_connection_reuse()
+        .map(|((), val), _| val);
 
     let future = transport
         .clone()
@@ -229,7 +235,9 @@ fn use_opened_listen_to_dial() {
 
     let transport = OnlyOnce::from(tx)
         .with_upgrade(multiplex::MplexConfig::new())
-        .into_connection_reuse();
+        .map(|val, _| ((), val))
+        .into_connection_reuse()
+        .map(|((), val), _| val);
 
     let future = transport
         .clone()

--- a/examples/echo-dialer.rs
+++ b/examples/echo-dialer.rs
@@ -75,7 +75,9 @@ fn main() {
         // `Transport` because the output of the upgrade is not a stream but a controller for
         // muxing. We have to explicitly call `into_connection_reuse()` in order to turn this into
         // a `Transport`.
-        .into_connection_reuse();
+        .map(|val, _| ((), val))
+        .into_connection_reuse()
+        .map(|((), val), _| val);
 
     // Building a struct that represents the protocol that we are going to use for dialing.
     let proto = SimpleProtocol::new("/echo/1.0.0", |socket| {

--- a/examples/echo-server.rs
+++ b/examples/echo-server.rs
@@ -75,7 +75,9 @@ fn main() {
         // `Transport` because the output of the upgrade is not a stream but a controller for
         // muxing. We have to explicitly call `into_connection_reuse()` in order to turn this into
         // a `Transport`.
-        .into_connection_reuse();
+        .map(|val, _| ((), val))
+        .into_connection_reuse()
+        .map(|((), val), _| val);
 
     // We now have a `transport` variable that can be used either to dial nodes or listen to
     // incoming connections, and that will automatically apply secio and multiplex on top

--- a/examples/floodsub.rs
+++ b/examples/floodsub.rs
@@ -76,7 +76,9 @@ fn main() {
         // `Transport` because the output of the upgrade is not a stream but a controller for
         // muxing. We have to explicitly call `into_connection_reuse()` in order to turn this into
         // a `Transport`.
-        .into_connection_reuse();
+        .map(|val, _| ((), val))
+        .into_connection_reuse()
+        .map(|((), val), _| val);
 
     // We now have a `transport` variable that can be used either to dial nodes or listen to
     // incoming connections, and that will automatically apply secio and multiplex on top

--- a/examples/kademlia.rs
+++ b/examples/kademlia.rs
@@ -18,6 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+#![type_length_limit = "2097152"]
+
 extern crate bigint;
 extern crate bytes;
 extern crate env_logger;
@@ -84,7 +86,9 @@ fn main() {
         // `Transport` because the output of the upgrade is not a stream but a controller for
         // muxing. We have to explicitly call `into_connection_reuse()` in order to turn this into
         // a `Transport`.
-        .into_connection_reuse();
+        .map(|val, _| ((), val))
+        .into_connection_reuse()
+        .map(|((), val), _| val);
 
     let addr_resolver = {
         let peer_store = peer_store.clone();

--- a/examples/ping-client.rs
+++ b/examples/ping-client.rs
@@ -68,7 +68,9 @@ fn main() {
         // `Transport` because the output of the upgrade is not a stream but a controller for
         // muxing. We have to explicitly call `into_connection_reuse()` in order to turn this into
         // a `Transport`.
-        .into_connection_reuse();
+        .map(|val, _| ((), val))
+        .into_connection_reuse()
+        .map(|((), val), _| val);
 
     // Let's put this `transport` into a *swarm*. The swarm will handle all the incoming
     // connections for us. The second parameter we pass is the connection upgrade that is accepted

--- a/examples/relay.rs
+++ b/examples/relay.rs
@@ -128,7 +128,9 @@ fn run_dialer(opts: DialerOpts) -> Result<(), Box<Error>> {
     let transport = {
         let tcp = TcpConfig::new()
             .with_upgrade(libp2p_yamux::Config::default())
-            .into_connection_reuse();
+            .map(|val, _| ((), val))
+            .into_connection_reuse()
+            .map(|((), val), _| val);
         RelayTransport::new(opts.me, tcp, store, iter::once(opts.relay)).with_dummy_muxing()
     };
 
@@ -161,7 +163,9 @@ fn run_listener(opts: ListenerOpts) -> Result<(), Box<Error>> {
 
     let transport = TcpConfig::new()
         .with_upgrade(libp2p_yamux::Config::default())
-        .into_connection_reuse();
+        .map(|val, _| ((), val))
+        .into_connection_reuse()
+        .map(|((), val), _| val);
 
     let relay = RelayConfig::new(opts.me, transport.clone(), store);
 


### PR DESCRIPTION
As per IRL discussion, we decided to merge the changes I made for substrate into master.
This is more or less the same as #355 plus some changes to `UniqueConnec` and connection reuse's API.

This is a breaking change, as the methods of `UniqueConnec` changed name, and `ConnectionReuse` now requires the input to be of the format `(a, muxer)` and will produce a `(a, substream)`. The `a` is simply cloned around and can be used to pass data through (such as the node's public key).