### PR TITLE
Cap the allocated buffer capacity in mplex

### DIFF
--- a/muxers/mplex/src/lib.rs
+++ b/muxers/mplex/src/lib.rs
@@ -133,7 +133,7 @@ where
                 error: Ok(()),
                 inner: Framed::new(i, codec::Codec::new()).fuse(),
                 config: self,
-                buffer: Vec::with_capacity(max_buffer_len),
+                buffer: Vec::with_capacity(cmp::min(max_buffer_len, 512)),
                 opened_substreams: Default::default(),
                 next_outbound_stream_id: if endpoint == Endpoint::Dialer { 0 } else { 1 },
                 to_notify: Default::default(),


### PR DESCRIPTION
A small practical change. Don't allocate too much space in the buffer, so that we can set the maximum buffer length to a very high value without any problem.