### PR TITLE
Add support for twofish cipher

### DIFF
--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -15,7 +15,8 @@ rand = "0.3.17"
 ring = { version = "0.12", features = ["rsa_signing"] }
 aes-ctr = "0.1.0"
 aesni = { version = "0.4.1", features = ["nocheck"], optional = true }
-ctr = { version = "0.1", optional = true }
+twofish = "0.1.0"
+ctr = "0.1"
 lazy_static = { version = "0.2.11", optional = true }
 rw-stream-sink = { path = "../../misc/rw-stream-sink" }
 eth-secp256k1 = { git = "https://github.com/paritytech/rust-secp256k1", optional = true }
@@ -25,7 +26,7 @@ untrusted = "0.5"
 [features]
 default = ["secp256k1"]
 secp256k1 = ["eth-secp256k1"]
-aes-all = ["ctr","aesni","lazy_static"]
+aes-all = ["aesni","lazy_static"]
 
 [dev-dependencies]
 libp2p-tcp-transport = { path = "../../transports/tcp" }

--- a/protocols/secio/src/algo_support.rs
+++ b/protocols/secio/src/algo_support.rs
@@ -28,7 +28,7 @@ macro_rules! supported_impl {
         pub mod $mod_name {
             use std::cmp::Ordering;
             #[allow(unused_imports)]
-            use stream_cipher::KeySize;
+            use stream_cipher::Cipher;
             #[allow(unused_imports)]
             use ring::{agreement, digest};
             use error::SecioError;
@@ -83,9 +83,10 @@ supported_impl!(
 // TODO: the Go & JS implementations advertise Blowfish ; however doing so in Rust leads to
 //       runtime errors
 supported_impl!(
-    ciphers: KeySize,
-    "AES-128" => KeySize::KeySize128,
-    "AES-256" => KeySize::KeySize256,
+    ciphers: Cipher,
+    "AES-128" => Cipher::Aes128,
+    "AES-256" => Cipher::Aes256,
+    "TwofishCTR" => Cipher::Twofish,
 );
 
 supported_impl!(

--- a/protocols/secio/src/codec/mod.rs
+++ b/protocols/secio/src/codec/mod.rs
@@ -64,7 +64,7 @@ mod tests {
     extern crate tokio_tcp;
     use self::tokio_tcp::TcpListener;
     use self::tokio_tcp::TcpStream;
-    use stream_cipher::{ctr, KeySize};
+    use stream_cipher::{ctr, Cipher};
     use super::full_codec;
     use super::DecoderMiddleware;
     use super::EncoderMiddleware;
@@ -93,12 +93,12 @@ mod tests {
 
         let encoder = EncoderMiddleware::new(
             data_tx,
-            ctr(KeySize::KeySize256, &cipher_key, &NULL_IV[..]),
+            ctr(Cipher::Aes256, &cipher_key, &NULL_IV[..]),
             SigningKey::new(&SHA256, &hmac_key),
         );
         let decoder = DecoderMiddleware::new(
             data_rx,
-            ctr(KeySize::KeySize256, &cipher_key, &NULL_IV[..]),
+            ctr(Cipher::Aes256, &cipher_key, &NULL_IV[..]),
             VerificationKey::new(&SHA256, &hmac_key),
             32,
         );
@@ -114,11 +114,11 @@ mod tests {
         assert_eq!(&decoded.unwrap()[..], &data[..]);
     }
 
-    #[test]
-    fn full_codec_encode_then_decode() {
+    fn full_codec_encode_then_decode(cipher: Cipher) {
         let cipher_key: [u8; 32] = rand::random();
         let cipher_key_clone = cipher_key.clone();
-        let hmac_key: [u8; 32] = rand::random();
+        let key_size = cipher.key_size();
+        let hmac_key: [u8; 16] = rand::random();
         let hmac_key_clone = hmac_key.clone();
         let data = b"hello world";
         let data_clone = data.clone();
@@ -132,9 +132,9 @@ mod tests {
 
                 full_codec(
                     connec,
-                    ctr(KeySize::KeySize256, &cipher_key, &NULL_IV[..]),
+                    ctr(cipher, &cipher_key[..key_size], &NULL_IV[..]),
                     SigningKey::new(&SHA256, &hmac_key),
-                    ctr(KeySize::KeySize256, &cipher_key, &NULL_IV[..]),
+                    ctr(cipher, &cipher_key[..key_size], &NULL_IV[..]),
                     VerificationKey::new(&SHA256, &hmac_key),
                 )
             },
@@ -147,9 +147,9 @@ mod tests {
 
                 full_codec(
                     stream,
-                    ctr(KeySize::KeySize256, &cipher_key_clone, &NULL_IV[..]),
+                    ctr(cipher, &cipher_key_clone[..key_size], &NULL_IV[..]),
                     SigningKey::new(&SHA256, &hmac_key_clone),
-                    ctr(KeySize::KeySize256, &cipher_key_clone, &NULL_IV[..]),
+                    ctr(cipher, &cipher_key_clone[..key_size], &NULL_IV[..]),
                     VerificationKey::new(&SHA256, &hmac_key_clone),
                 )
             });
@@ -168,5 +168,20 @@ mod tests {
 
         let received = tokio_current_thread::block_on_all(fin).unwrap();
         assert_eq!(received, data);
+    }
+
+    #[test]
+    fn full_codec_encode_then_decode_aes128() {
+        full_codec_encode_then_decode(Cipher::Aes128);
+    }
+
+    #[test]
+    fn full_codec_encode_then_decode_aes256() {
+        full_codec_encode_then_decode(Cipher::Aes256);
+    }
+
+    #[test]
+    fn full_codec_encode_then_decode_twofish() {
+        full_codec_encode_then_decode(Cipher::Twofish);
     }
 }

--- a/protocols/secio/src/lib.rs
+++ b/protocols/secio/src/lib.rs
@@ -82,6 +82,7 @@ extern crate aes_ctr;
 #[cfg(feature = "secp256k1")]
 extern crate asn1_der;
 extern crate bytes;
+extern crate ctr;
 extern crate futures;
 extern crate libp2p_core;
 #[macro_use]
@@ -93,6 +94,7 @@ extern crate rw_stream_sink;
 #[cfg(feature = "secp256k1")]
 extern crate secp256k1;
 extern crate tokio_io;
+extern crate twofish;
 extern crate untrusted;
 
 #[cfg(feature = "aes-all")]


### PR DESCRIPTION
Adds support for the twofish cipher mode.

There are random data corruption in polkadot right now, and that might be a problem in the `aes` library.
Let's add support for twofish in secio, and later, once it's deployed, we can try using it in our local node to see if the data corruption goes away.