### PR TITLE
Implement Send everywhere

### DIFF
--- a/core/src/transport/and_then.rs
+++ b/core/src/transport/and_then.rs
@@ -40,15 +40,18 @@ pub struct AndThen<T, C> {
 impl<T, C, F, O, Maf> Transport for AndThen<T, C>
 where
     T: Transport + 'static,
-    C: FnOnce(T::Output, Endpoint, T::MultiaddrFuture) -> F + Clone + 'static,
-    F: Future<Item = (O, Maf), Error = IoError> + 'static,
+    T::Dial: Send,
+    T::Listener: Send,
+    T::ListenerUpgrade: Send,
+    C: FnOnce(T::Output, Endpoint, T::MultiaddrFuture) -> F + Clone + Send + 'static,
+    F: Future<Item = (O, Maf), Error = IoError> + Send + 'static,
     Maf: Future<Item = Multiaddr, Error = IoError> + 'static,
 {
     type Output = O;
     type MultiaddrFuture = Maf;
-    type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = IoError>>;
-    type ListenerUpgrade = Box<Future<Item = (O, Self::MultiaddrFuture), Error = IoError>>;
-    type Dial = Box<Future<Item = (O, Self::MultiaddrFuture), Error = IoError>>;
+    type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = IoError> + Send>;
+    type ListenerUpgrade = Box<Future<Item = (O, Self::MultiaddrFuture), Error = IoError> + Send>;
+    type Dial = Box<Future<Item = (O, Self::MultiaddrFuture), Error = IoError> + Send>;
 
     #[inline]
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
@@ -116,12 +119,17 @@ where
 impl<T, C, F, O, Maf> MuxedTransport for AndThen<T, C>
 where
     T: MuxedTransport + 'static,
-    C: FnOnce(T::Output, Endpoint, T::MultiaddrFuture) -> F + Clone + 'static,
-    F: Future<Item = (O, Maf), Error = IoError> + 'static,
+    T::Dial: Send,
+    T::Listener: Send,
+    T::ListenerUpgrade: Send,
+    T::Incoming: Send,
+    T::IncomingUpgrade: Send,
+    C: FnOnce(T::Output, Endpoint, T::MultiaddrFuture) -> F + Clone + Send + 'static,
+    F: Future<Item = (O, Maf), Error = IoError> + Send + 'static,
     Maf: Future<Item = Multiaddr, Error = IoError> + 'static,
 {
-    type Incoming = Box<Future<Item = Self::IncomingUpgrade, Error = IoError>>;
-    type IncomingUpgrade = Box<Future<Item = (O, Self::MultiaddrFuture), Error = IoError>>;
+    type Incoming = Box<Future<Item = Self::IncomingUpgrade, Error = IoError> + Send>;
+    type IncomingUpgrade = Box<Future<Item = (O, Self::MultiaddrFuture), Error = IoError> + Send>;
 
     #[inline]
     fn next_incoming(self) -> Self::Incoming {
@@ -134,7 +142,7 @@ where
                 upgrade(connection, Endpoint::Listener, client_addr)
             });
 
-            Box::new(future) as Box<Future<Item = _, Error = _>>
+            Box::new(future) as Box<Future<Item = _, Error = _> + Send>
         });
 
         Box::new(future) as Box<_>

--- a/core/src/transport/map.rs
+++ b/core/src/transport/map.rs
@@ -42,13 +42,16 @@ impl<T, F> Map<T, F> {
 impl<T, F, D> Transport for Map<T, F>
 where
     T: Transport + 'static,                  // TODO: 'static :-/
-    F: FnOnce(T::Output, Endpoint) -> D + Clone + 'static, // TODO: 'static :-/
+    T::Dial: Send,
+    T::Listener: Send,
+    T::ListenerUpgrade: Send,
+    F: FnOnce(T::Output, Endpoint) -> D + Clone + Send + 'static, // TODO: 'static :-/
 {
     type Output = D;
     type MultiaddrFuture = T::MultiaddrFuture;
-    type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = IoError>>;
-    type ListenerUpgrade = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
-    type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
+    type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = IoError> + Send>;
+    type ListenerUpgrade = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError> + Send>;
+    type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError> + Send>;
 
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
         let map = self.map;
@@ -91,10 +94,15 @@ where
 impl<T, F, D> MuxedTransport for Map<T, F>
 where
     T: MuxedTransport + 'static,             // TODO: 'static :-/
-    F: FnOnce(T::Output, Endpoint) -> D + Clone + 'static, // TODO: 'static :-/
+    T::Dial: Send,
+    T::Listener: Send,
+    T::ListenerUpgrade: Send,
+    T::Incoming: Send,
+    T::IncomingUpgrade: Send,
+    F: FnOnce(T::Output, Endpoint) -> D + Clone + Send + 'static, // TODO: 'static :-/
 {
-    type Incoming = Box<Future<Item = Self::IncomingUpgrade, Error = IoError>>;
-    type IncomingUpgrade = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
+    type Incoming = Box<Future<Item = Self::IncomingUpgrade, Error = IoError> + Send>;
+    type IncomingUpgrade = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError> + Send>;
 
     fn next_incoming(self) -> Self::Incoming {
         let map = self.map;

--- a/core/src/transport/map_err_dial.rs
+++ b/core/src/transport/map_err_dial.rs
@@ -41,13 +41,14 @@ impl<T, F> MapErrDial<T, F> {
 impl<T, F> Transport for MapErrDial<T, F>
 where
     T: Transport + 'static,                          // TODO: 'static :-/
-    F: FnOnce(IoError, Multiaddr) -> IoError + Clone + 'static, // TODO: 'static :-/
+    T::Dial: Send,
+    F: FnOnce(IoError, Multiaddr) -> IoError + Clone + Send + 'static, // TODO: 'static :-/
 {
     type Output = T::Output;
     type MultiaddrFuture = T::MultiaddrFuture;
     type Listener = T::Listener;
     type ListenerUpgrade = T::ListenerUpgrade;
-    type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
+    type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError> + Send>;
 
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
         match self.transport.listen_on(addr) {
@@ -77,7 +78,8 @@ where
 impl<T, F> MuxedTransport for MapErrDial<T, F>
 where
     T: MuxedTransport + 'static,                     // TODO: 'static :-/
-    F: FnOnce(IoError, Multiaddr) -> IoError + Clone + 'static, // TODO: 'static :-/
+    T::Dial: Send,
+    F: FnOnce(IoError, Multiaddr) -> IoError + Clone + Send + 'static, // TODO: 'static :-/
 {
     type Incoming = T::Incoming;
     type IncomingUpgrade = T::IncomingUpgrade;

--- a/core/src/unique.rs
+++ b/core/src/unique.rs
@@ -101,10 +101,17 @@ impl<T> UniqueConnec<T> {
     #[inline]
     pub fn dial<S, F, Du>(&self, swarm: &SwarmController<S, F>, multiaddr: &Multiaddr,
                           transport: Du) -> UniqueConnecFuture<T>
-        where T: Clone + 'static,       // TODO: 'static :-/
+        where T: Clone + Send + 'static,       // TODO: 'static :-/
               Du: Transport + 'static, // TODO: 'static :-/
               Du::Output: Into<S::Output>,
+              Du::Dial: Send,
+              Du::MultiaddrFuture: Send,
               S: Clone + MuxedTransport,
+              S::Dial: Send,
+              S::Listener: Send,
+              S::ListenerUpgrade: Send,
+              S::Output: Send,
+              S::MultiaddrFuture: Send,
               F: 'static,
     {
         self.dial_inner(swarm, multiaddr, transport, true)
@@ -115,10 +122,17 @@ impl<T> UniqueConnec<T> {
     #[inline]
     pub fn dial_if_empty<S, F, Du>(&self, swarm: &SwarmController<S, F>, multiaddr: &Multiaddr,
                                    transport: Du) -> UniqueConnecFuture<T>
-        where T: Clone + 'static,       // TODO: 'static :-/
+        where T: Clone + Send + 'static,       // TODO: 'static :-/
               Du: Transport + 'static, // TODO: 'static :-/
               Du::Output: Into<S::Output>,
+              Du::Dial: Send,
+              Du::MultiaddrFuture: Send,
               S: Clone + MuxedTransport,
+              S::Dial: Send,
+              S::Listener: Send,
+              S::ListenerUpgrade: Send,
+              S::Output: Send,
+              S::MultiaddrFuture: Send,
               F: 'static,
     {
         self.dial_inner(swarm, multiaddr, transport, false)
@@ -127,10 +141,17 @@ impl<T> UniqueConnec<T> {
     /// Inner implementation of `dial_*`.
     fn dial_inner<S, F, Du>(&self, swarm: &SwarmController<S, F>, multiaddr: &Multiaddr,
                             transport: Du, dial_if_err: bool) -> UniqueConnecFuture<T>
-        where T: Clone + 'static,       // TODO: 'static :-/
+        where T: Clone + Send + 'static,       // TODO: 'static :-/
               Du: Transport + 'static, // TODO: 'static :-/
               Du::Output: Into<S::Output>,
+              Du::Dial: Send,
+              Du::MultiaddrFuture: Send,
               S: Clone + MuxedTransport,
+              S::Dial: Send,
+              S::Listener: Send,
+              S::ListenerUpgrade: Send,
+              S::Output: Send,
+              S::MultiaddrFuture: Send,
               F: 'static,
     {
         let mut inner = self.inner.lock();

--- a/core/src/upgrade/map.rs
+++ b/core/src/upgrade/map.rs
@@ -39,9 +39,9 @@ pub struct Map<U, F> {
 impl<C, U, F, O, Maf> ConnectionUpgrade<C, Maf> for Map<U, F>
 where
     U: ConnectionUpgrade<C, Maf>,
-    U::Future: 'static,     // TODO: 'static :(
+    U::Future: Send + 'static,     // TODO: 'static :(
     C: AsyncRead + AsyncWrite,
-    F: FnOnce(U::Output) -> O + 'static,     // TODO: 'static :(
+    F: FnOnce(U::Output) -> O + Send + 'static,     // TODO: 'static :(
 {
     type NamesIter = U::NamesIter;
     type UpgradeIdentifier = U::UpgradeIdentifier;
@@ -52,7 +52,7 @@ where
 
     type Output = O;
     type MultiaddrFuture = U::MultiaddrFuture;
-    type Future = Box<Future<Item = (O, Self::MultiaddrFuture), Error = IoError>>;
+    type Future = Box<Future<Item = (O, Self::MultiaddrFuture), Error = IoError> + Send>;
 
     fn upgrade(
         self,

--- a/core/src/upgrade/map_addr.rs
+++ b/core/src/upgrade/map_addr.rs
@@ -42,11 +42,11 @@ pub struct MapAddr<U, F> {
 impl<C, U, F, O, Maf> ConnectionUpgrade<C, Maf> for MapAddr<U, F>
 where
     U: ConnectionUpgrade<C, Maf>,
-    U::Future: 'static,     // TODO: 'static :(
-    U::MultiaddrFuture: Future<Item = Multiaddr, Error = IoError> + 'static,    // TODO: 'static :(
-    U::Output: 'static,     // TODO: 'static :(
+    U::Future: Send + 'static,     // TODO: 'static :(
+    U::MultiaddrFuture: Future<Item = Multiaddr, Error = IoError> + Send + 'static,    // TODO: 'static :(
+    U::Output: Send + 'static,     // TODO: 'static :(
     C: AsyncRead + AsyncWrite,
-    F: FnOnce(U::Output, &Multiaddr) -> O + 'static,     // TODO: 'static :(
+    F: FnOnce(U::Output, &Multiaddr) -> O + Send + 'static,     // TODO: 'static :(
 {
     type NamesIter = U::NamesIter;
     type UpgradeIdentifier = U::UpgradeIdentifier;
@@ -57,7 +57,7 @@ where
 
     type Output = O;
     type MultiaddrFuture = future::FutureResult<Multiaddr, IoError>;
-    type Future = Box<Future<Item = (O, Self::MultiaddrFuture), Error = IoError>>;
+    type Future = Box<Future<Item = (O, Self::MultiaddrFuture), Error = IoError> + Send>;
 
     fn upgrade(
         self,

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -10,7 +10,7 @@ futures = { version = "0.1" }
 log = "0.4"
 smallvec = "0.5"
 tokio-io = "0.1"
-unsigned-varint = { version = "0.2", features = ["codec"] }
+unsigned-varint = { version = "0.2.1", features = ["codec"] }
 
 [dev-dependencies]
 tokio-current-thread = "0.1"

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.4"
 parking_lot = "0.6"
 tokio-codec = "0.1"
 tokio-io = "0.1"
-unsigned-varint = { version = "0.2", features = ["codec"] }
+unsigned-varint = { version = "0.2.1", features = ["codec"] }
 
 [dev-dependencies]
 libp2p-tcp-transport = { path = "../../transports/tcp" }

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -18,4 +18,4 @@ protobuf = "2.0.2"
 smallvec = "0.6.0"
 tokio-codec = "0.1"
 tokio-io = "0.1"
-unsigned-varint = { version = "0.2", features = ["codec"] }
+unsigned-varint = { version = "0.2.1", features = ["codec"] }

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -16,7 +16,7 @@ parking_lot = "0.6"
 protobuf = "2.0.2"
 tokio-codec = "0.1"
 tokio-io = "0.1.0"
-unsigned-varint = { version = "0.2", features = ["codec"] }
+unsigned-varint = { version = "0.2.1", features = ["codec"] }
 
 [dev-dependencies]
 libp2p-tcp-transport = { path = "../../transports/tcp" }

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -61,7 +61,7 @@ pub struct IdentifySender<T> {
 
 impl<'a, T> IdentifySender<T>
 where
-    T: AsyncWrite + 'a,
+    T: AsyncWrite + Send + 'a,
 {
     /// Sends back information to the client. Returns a future that is signalled whenever the
     /// info have been sent.
@@ -69,7 +69,7 @@ where
         self,
         info: IdentifyInfo,
         observed_addr: &Multiaddr,
-    ) -> Box<Future<Item = (), Error = IoError> + 'a> {
+    ) -> Box<Future<Item = (), Error = IoError> + Send + 'a> {
         debug!("Sending identify info to client");
         trace!("Sending: {:?}", info);
 
@@ -113,14 +113,14 @@ pub struct IdentifyInfo {
 
 impl<C, Maf> ConnectionUpgrade<C, Maf> for IdentifyProtocolConfig
 where
-    C: AsyncRead + AsyncWrite + 'static,
-    Maf: Future<Item = Multiaddr, Error = IoError> + 'static,
+    C: AsyncRead + AsyncWrite + Send + 'static,
+    Maf: Future<Item = Multiaddr, Error = IoError> + Send + 'static,
 {
     type NamesIter = iter::Once<(Bytes, Self::UpgradeIdentifier)>;
     type UpgradeIdentifier = ();
     type Output = IdentifyOutput<C>;
     type MultiaddrFuture = future::Either<future::FutureResult<Multiaddr, IoError>, Maf>;
-    type Future = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
+    type Future = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError> + Send>;
 
     #[inline]
     fn protocol_names(&self) -> Self::NamesIter {

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -24,7 +24,7 @@ smallvec = "0.5"
 tokio-codec = "0.1"
 tokio-io = "0.1"
 tokio-timer = "0.2.6"
-unsigned-varint = { version = "0.2", features = ["codec"] }
+unsigned-varint = { version = "0.2.1", features = ["codec"] }
 
 [dev-dependencies]
 libp2p-tcp-transport = { path = "../../transports/tcp" }

--- a/protocols/kad/src/query.rs
+++ b/protocols/kad/src/query.rs
@@ -59,10 +59,10 @@ pub enum QueryEvent<TOut> {
 pub fn find_node<'a, FBuckets, FFindNode>(
     query_params: QueryParams<FBuckets, FFindNode>,
     searched_key: PeerId,
-) -> Box<Stream<Item = QueryEvent<Vec<PeerId>>, Error = IoError> + 'a>
+) -> Box<Stream<Item = QueryEvent<Vec<PeerId>>, Error = IoError> + Send + 'a>
 where
     FBuckets: Fn(PeerId) -> Vec<PeerId> + 'a + Clone,
-    FFindNode: Fn(Multiaddr, PeerId) -> Box<Future<Item = Vec<protocol::Peer>, Error = IoError>> + 'a + Clone,
+    FFindNode: Fn(Multiaddr, PeerId) -> Box<Future<Item = Vec<protocol::Peer>, Error = IoError> + Send> + 'a + Clone,
 {
     query(query_params, searched_key, 20) // TODO: constant
 }
@@ -74,10 +74,10 @@ where
 pub fn refresh<'a, FBuckets, FFindNode>(
     query_params: QueryParams<FBuckets, FFindNode>,
     bucket_num: usize,
-) -> Box<Stream<Item = QueryEvent<()>, Error = IoError> + 'a>
+) -> Box<Stream<Item = QueryEvent<()>, Error = IoError> + Send + 'a>
 where
     FBuckets: Fn(PeerId) -> Vec<PeerId> + 'a + Clone,
-    FFindNode: Fn(Multiaddr, PeerId) -> Box<Future<Item = Vec<protocol::Peer>, Error = IoError>> + 'a + Clone,
+    FFindNode: Fn(Multiaddr, PeerId) -> Box<Future<Item = Vec<protocol::Peer>, Error = IoError> + Send> + 'a + Clone,
 {
     let peer_id = match gen_random_id(&query_params.local_id, bucket_num) {
         Ok(p) => p,
@@ -132,10 +132,10 @@ fn query<'a, FBuckets, FFindNode>(
     query_params: QueryParams<FBuckets, FFindNode>,
     searched_key: PeerId,
     num_results: usize,
-) -> Box<Stream<Item = QueryEvent<Vec<PeerId>>, Error = IoError> + 'a>
+) -> Box<Stream<Item = QueryEvent<Vec<PeerId>>, Error = IoError> + Send + 'a>
 where
     FBuckets: Fn(PeerId) -> Vec<PeerId> + 'a + Clone,
-    FFindNode: Fn(Multiaddr, PeerId) -> Box<Future<Item = Vec<protocol::Peer>, Error = IoError>> + 'a + Clone,
+    FFindNode: Fn(Multiaddr, PeerId) -> Box<Future<Item = Vec<protocol::Peer>, Error = IoError> + Send> + 'a + Clone,
 {
     debug!("Start query for {:?} ; num results = {}", searched_key, num_results);
 
@@ -147,7 +147,7 @@ where
         result: Vec<PeerId>,
         // For each open connection, a future with the response of the remote.
         // Note that don't use a `SmallVec` here because `select_all` produces a `Vec`.
-        current_attempts_fut: Vec<Box<Future<Item = Vec<protocol::Peer>, Error = IoError> + 'a>>,
+        current_attempts_fut: Vec<Box<Future<Item = Vec<protocol::Peer>, Error = IoError> + Send + 'a>>,
         // For each open connection, the peer ID that we are connected to.
         // Must always have the same length as `current_attempts_fut`.
         current_attempts_addrs: SmallVec<[PeerId; 32]>,

--- a/protocols/secio/src/handshake.rs
+++ b/protocols/secio/src/handshake.rs
@@ -59,9 +59,9 @@ use {SecioKeyPair, SecioKeyPairInner};
 pub fn handshake<'a, S: 'a>(
     socket: S,
     local_key: SecioKeyPair,
-) -> Box<Future<Item = (FullCodec<S>, PublicKey, Vec<u8>), Error = SecioError> + 'a>
+) -> Box<Future<Item = (FullCodec<S>, PublicKey, Vec<u8>), Error = SecioError> + Send + 'a>
 where
-    S: AsyncRead + AsyncWrite,
+    S: AsyncRead + AsyncWrite + Send,
 {
     // TODO: could be rewritten as a coroutine once coroutines land in stable Rust
 

--- a/protocols/secio/src/lib.rs
+++ b/protocols/secio/src/lib.rs
@@ -289,12 +289,12 @@ where
 
 impl<S, Maf> libp2p_core::ConnectionUpgrade<S, Maf> for SecioConfig
 where
-    S: AsyncRead + AsyncWrite + 'static, // TODO: 'static :(
-    Maf: 'static,                        // TODO: 'static :(
+    S: AsyncRead + AsyncWrite + Send + 'static, // TODO: 'static :(
+    Maf: Send + 'static,                        // TODO: 'static :(
 {
     type Output = SecioOutput<S>;
     type MultiaddrFuture = Maf;
-    type Future = Box<Future<Item = (Self::Output, Maf), Error = IoError>>;
+    type Future = Box<Future<Item = (Self::Output, Maf), Error = IoError> + Send>;
     type NamesIter = iter::Once<(Bytes, ())>;
     type UpgradeIdentifier = ();
 
@@ -342,7 +342,7 @@ pub struct SecioMiddleware<S> {
 
 impl<S> SecioMiddleware<S>
 where
-    S: AsyncRead + AsyncWrite,
+    S: AsyncRead + AsyncWrite + Send,
 {
     /// Attempts to perform a handshake on the given socket.
     ///
@@ -351,7 +351,7 @@ where
     pub fn handshake<'a>(
         socket: S,
         key_pair: SecioKeyPair,
-    ) -> Box<Future<Item = (SecioMiddleware<S>, PublicKey, Vec<u8>), Error = SecioError> + 'a>
+    ) -> Box<Future<Item = (SecioMiddleware<S>, PublicKey, Vec<u8>), Error = SecioError> + Send + 'a>
     where
         S: 'a,
     {

--- a/src/simple.rs
+++ b/src/simple.rs
@@ -62,8 +62,8 @@ where
     C: AsyncRead + AsyncWrite,
     F: Fn(C) -> O,
     O: IntoFuture<Error = IoError>,
-    O::Future: 'static,
-    Maf: 'static,
+    O::Future: Send + 'static,
+    Maf: Send + 'static,
 {
     type NamesIter = iter::Once<(Bytes, ())>;
     type UpgradeIdentifier = ();
@@ -75,7 +75,7 @@ where
 
     type Output = O::Item;
     type MultiaddrFuture = Maf;
-    type Future = Box<Future<Item = (O::Item, Self::MultiaddrFuture), Error = IoError>>;
+    type Future = Box<Future<Item = (O::Item, Self::MultiaddrFuture), Error = IoError> + Send>;
 
     #[inline]
     fn upgrade(self, socket: C, _: (), _: Endpoint, client_addr: Maf) -> Self::Future {

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -94,13 +94,14 @@ where
 
 impl<T> Transport for DnsConfig<T>
 where
-    T: Transport + 'static, // TODO: 'static :-/
+    T: Transport + Send + 'static, // TODO: 'static :-/
+    T::Dial: Send,
 {
     type Output = T::Output;
     type MultiaddrFuture = T::MultiaddrFuture;
     type Listener = T::Listener;
     type ListenerUpgrade = T::ListenerUpgrade;
-    type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
+    type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError> + Send>;
 
     #[inline]
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {

--- a/transports/ratelimit/src/lib.rs
+++ b/transports/ratelimit/src/lib.rs
@@ -157,13 +157,15 @@ where
 impl<T> Transport for RateLimited<T>
 where
     T: Transport + 'static,
-    T::Output: AsyncRead + AsyncWrite,
+    T::Dial: Send,
+    T::MultiaddrFuture: Send,
+    T::Output: AsyncRead + AsyncWrite + Send,
 {
     type Output = Connection<T::Output>;
     type MultiaddrFuture = T::MultiaddrFuture;
     type Listener = Listener<T>;
     type ListenerUpgrade = ListenerUpgrade<T>;
-    type Dial = Box<Future<Item = (Connection<T::Output>, Self::MultiaddrFuture), Error = io::Error>>;
+    type Dial = Box<Future<Item = (Connection<T::Output>, Self::MultiaddrFuture), Error = io::Error> + Send>;
 
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)>
     where

--- a/transports/relay/Cargo.toml
+++ b/transports/relay/Cargo.toml
@@ -15,4 +15,4 @@ protobuf = "2.0.2"
 rand = "0.4"
 tokio-codec = "0.1"
 tokio-io = "0.1"
-unsigned-varint = { version = "0.2", features = ["codec"] }
+unsigned-varint = { version = "0.2.1", features = ["codec"] }

--- a/transports/relay/src/transport.rs
+++ b/transports/relay/src/transport.rs
@@ -39,17 +39,21 @@ pub struct RelayTransport<T, P> {
 
 impl<T, P, S> Transport for RelayTransport<T, P>
 where
-    T: Transport + Clone + 'static,
-    T::Output: AsyncRead + AsyncWrite,
+    T: Transport + Send + Clone + 'static,
+    T::Dial: Send,
+    T::Listener: Send,
+    T::ListenerUpgrade: Send,
+    T::MultiaddrFuture: Send,
+    T::Output: AsyncRead + AsyncWrite + Send,
     P: Deref<Target=S> + Clone + 'static,
     S: 'static,
     for<'a> &'a S: Peerstore
 {
     type Output = T::Output;
     type MultiaddrFuture = T::MultiaddrFuture;
-    type Listener = Box<Stream<Item=Self::ListenerUpgrade, Error=io::Error>>;
-    type ListenerUpgrade = Box<Future<Item=(Self::Output, Self::MultiaddrFuture), Error=io::Error>>;
-    type Dial = Box<Future<Item=(Self::Output, Self::MultiaddrFuture), Error=io::Error>>;
+    type Listener = Box<Stream<Item=Self::ListenerUpgrade, Error=io::Error> + Send>;
+    type ListenerUpgrade = Box<Future<Item=(Self::Output, Self::MultiaddrFuture), Error=io::Error> + Send>;
+    type Dial = Box<Future<Item=(Self::Output, Self::MultiaddrFuture), Error=io::Error> + Send>;
 
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
         Err((self, addr))
@@ -85,7 +89,11 @@ where
 impl<T, P, S> RelayTransport<T, P>
 where
     T: Transport + Clone + 'static,
-    T::Output: AsyncRead + AsyncWrite,
+    T::Dial: Send,
+    T::Listener: Send,
+    T::ListenerUpgrade: Send,
+    T::MultiaddrFuture: Send,
+    T::Output: AsyncRead + AsyncWrite + Send,
     P: Deref<Target=S> + Clone + 'static,
     for<'a> &'a S: Peerstore
 {

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -13,7 +13,9 @@ rw-stream-sink = { path = "../../misc/rw-stream-sink" }
 tokio-io = "0.1"
 
 [target.'cfg(not(target_os = "emscripten"))'.dependencies]
-websocket = { version = "0.20.2", default-features = false, features = ["async", "async-ssl"] }
+# TODO: restore the upstream version once the branch is merged
+websocket = { git = "https://github.com/tomaka/rust-websocket", branch = "send", default-features = false, features = ["async", "async-ssl"] }
+#websocket = { version = "0.20.2", default-features = false, features = ["async", "async-ssl"] }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
 stdweb = { version = "0.1.3", default-features = false }

--- a/transports/websocket/src/browser.rs
+++ b/transports/websocket/src/browser.rs
@@ -54,10 +54,10 @@ impl BrowserWsConfig {
 impl Transport for BrowserWsConfig {
     type Output = BrowserWsConn;
     type MultiaddrFuture = FutureResult<Multiaddr, IoError>;
-    type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = IoError>>; // TODO: use `!`
+    type Listener = Box<Stream<Item = Self::ListenerUpgrade, Error = IoError> + Send>; // TODO: use `!`
     type ListenerUpgrade =
-        Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>; // TODO: use `!`
-    type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError>>;
+        Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError> + Send>; // TODO: use `!`
+    type Dial = Box<Future<Item = (Self::Output, Self::MultiaddrFuture), Error = IoError> + Send>;
 
     #[inline]
     fn listen_on(self, a: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {


### PR DESCRIPTION
cc #369 

This forces most types to implement `Send`, and adds ` + Send` to all the `Box<Future>` and `Box<Stream>` of the library.