### PR TITLE
Revert "remove rustc-serialize (#359) (#386)"

### DIFF
--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -13,11 +13,7 @@ log = "0.4.1"
 protobuf = "2.0.2"
 rand = "0.3.17"
 ring = { version = "0.12", features = ["rsa_signing"] }
-aes-ctr = "0.1.0"
-aesni = { version = "0.4.1", features = ["nocheck"], optional = true }
-twofish = "0.1.0"
-ctr = "0.1"
-lazy_static = { version = "0.2.11", optional = true }
+rust-crypto = "^0.2"
 rw-stream-sink = { path = "../../misc/rw-stream-sink" }
 eth-secp256k1 = { git = "https://github.com/paritytech/rust-secp256k1", optional = true }
 tokio-io = "0.1.0"
@@ -26,7 +22,6 @@ untrusted = "0.5"
 [features]
 default = ["secp256k1"]
 secp256k1 = ["eth-secp256k1"]
-aes-all = ["aesni","lazy_static"]
 
 [dev-dependencies]
 libp2p-tcp-transport = { path = "../../transports/tcp" }

--- a/protocols/secio/src/algo_support.rs
+++ b/protocols/secio/src/algo_support.rs
@@ -85,11 +85,8 @@ supported_impl!(
 
 // TODO: the Go & JS implementations advertise Blowfish ; however doing so in Rust leads to
 //       runtime errors
-// TODO: the AES library we're using seems to have a bug causing data corruption from time to time,
-//       which is why we prioritize TwoFish
 supported_impl!(
     ciphers: Cipher,
-    "TwofishCTR" => Cipher::Twofish,
     "AES-128" => Cipher::Aes128,
     "AES-256" => Cipher::Aes256,
 );

--- a/protocols/secio/src/codec/decode.rs
+++ b/protocols/secio/src/codec/decode.rs
@@ -21,8 +21,7 @@
 //! Individual messages decoding.
 
 use bytes::BytesMut;
-use super::StreamCipher;
-
+use codec::StreamCipher;
 use error::SecioError;
 use futures::sink::Sink;
 use futures::stream::Stream;
@@ -88,24 +87,21 @@ where
             debug!("frame too short when decoding secio frame");
             return Err(SecioError::FrameTooShort);
         }
-        let content_length = frame.len() - hmac_num_bytes;
-        {
-            let (crypted_data, expected_hash) = frame.split_at(content_length);
-            debug_assert_eq!(expected_hash.len(), hmac_num_bytes);
 
-            if hmac::verify(&self.hmac_key, crypted_data, expected_hash).is_err() {
-                debug!("hmac mismatch when decoding secio frame");
-                return Err(SecioError::HmacNotMatching);
-            }
+        let (crypted_data, expected_hash) = frame.split_at(frame.len() - hmac_num_bytes);
+        debug_assert_eq!(expected_hash.len(), hmac_num_bytes);
+
+        if hmac::verify(&self.hmac_key, crypted_data, expected_hash).is_err() {
+            debug!("hmac mismatch when decoding secio frame");
+            return Err(SecioError::HmacNotMatching);
         }
 
-        let mut data_buf = frame.to_vec();
-        data_buf.truncate(content_length);
+        // Note that there is no way to decipher in place with rust-crypto right now.
+        let mut decrypted_data = crypted_data.to_vec();
         self.cipher_state
-            .try_apply_keystream(&mut data_buf)
-            .map_err::<SecioError,_>(|e|e.into())?;
+            .process(&crypted_data, &mut decrypted_data);
 
-        Ok(Async::Ready(Some(data_buf)))
+        Ok(Async::Ready(Some(decrypted_data)))
     }
 }
 

--- a/protocols/secio/src/error.rs
+++ b/protocols/secio/src/error.rs
@@ -20,7 +20,7 @@
 
 //! Defines the `SecioError` enum that groups all possible errors in SECIO.
 
-use aes_ctr::stream_cipher::LoopError;
+use crypto::symmetriccipher::SymmetricCipherError;
 use std::error;
 use std::fmt;
 use std::io::Error as IoError;
@@ -55,8 +55,8 @@ pub enum SecioError {
     /// The final check of the handshake failed.
     NonceVerificationFailed,
 
-    /// Error with block cipher.
-    CipherError(LoopError),
+    /// Error while decoding/encoding data.
+    CipherError(SymmetricCipherError),
 
     /// The received frame was of invalid length.
     FrameTooShort,
@@ -111,9 +111,9 @@ impl fmt::Display for SecioError {
     }
 }
 
-impl From<LoopError> for SecioError {
+impl From<SymmetricCipherError> for SecioError {
     #[inline]
-    fn from(err: LoopError) -> SecioError {
+    fn from(err: SymmetricCipherError) -> SecioError {
         SecioError::CipherError(err)
     }
 }

--- a/protocols/secio/src/handshake.rs
+++ b/protocols/secio/src/handshake.rs
@@ -484,8 +484,8 @@ where
                     (cipher, hmac)
                 };
 
-                Ok(full_codec(socket, encoding_cipher, encoding_hmac,
-                              decoding_cipher, decoding_hmac))
+                Ok(full_codec(socket, encoding_cipher, encoding_hmac, decoding_cipher,
+                              decoding_hmac))
             });
 
             match codec {

--- a/protocols/secio/src/lib.rs
+++ b/protocols/secio/src/lib.rs
@@ -78,11 +78,10 @@
 //! `SecioMiddleware` that implements `Sink` and `Stream` and can be used to send packets of data.
 //!
 
-extern crate aes_ctr;
 #[cfg(feature = "secp256k1")]
 extern crate asn1_der;
 extern crate bytes;
-extern crate ctr;
+extern crate crypto;
 extern crate futures;
 extern crate libp2p_core;
 #[macro_use]
@@ -94,12 +93,8 @@ extern crate rw_stream_sink;
 #[cfg(feature = "secp256k1")]
 extern crate secp256k1;
 extern crate tokio_io;
-extern crate twofish;
 extern crate untrusted;
 
-#[cfg(feature = "aes-all")]
-#[macro_use]
-extern crate lazy_static;
 pub use self::error::SecioError;
 
 #[cfg(feature = "secp256k1")]
@@ -122,8 +117,8 @@ mod algo_support;
 mod codec;
 mod error;
 mod handshake;
-mod structs_proto;
 mod stream_cipher;
+mod structs_proto;
 
 /// Implementation of the `ConnectionUpgrade` trait of `libp2p_core`. Automatically applies
 /// secio on any connection.

--- a/protocols/secio/src/stream_cipher.rs
+++ b/protocols/secio/src/stream_cipher.rs
@@ -19,17 +19,12 @@
 // DEALINGS IN THE SOFTWARE.
 
 use super::codec::StreamCipher;
-use aes_ctr::stream_cipher::generic_array::GenericArray;
-use aes_ctr::stream_cipher::NewFixStreamCipher;
-use aes_ctr::{Aes128Ctr, Aes256Ctr};
-use ctr::Ctr128;
-use twofish::Twofish;
+use crypto::{aessafe, blockmodes::CtrModeX8};
 
 #[derive(Clone, Copy)]
 pub enum Cipher {
     Aes128,
     Aes256,
-    Twofish,
 }
 
 impl Cipher {
@@ -38,7 +33,6 @@ impl Cipher {
         match *self {
             Cipher::Aes128 => 16,
             Cipher::Aes256 => 32,
-            Cipher::Twofish => 32,
         }
     }
 
@@ -50,114 +44,16 @@ impl Cipher {
 }
 
 /// Returns your stream cipher depending on `Cipher`.
-#[cfg(not(all(feature = "aes-all", any(target_arch = "x86_64", target_arch = "x86"))))]
-pub fn ctr(key_size: Cipher, key: &[u8], iv: &[u8]) -> StreamCipher {
-    ctr_int(key_size, key, iv)
-}
- 
-/// Returns your stream cipher depending on `Cipher`.
-#[cfg(all(feature = "aes-all", any(target_arch = "x86_64", target_arch = "x86")))]
-pub fn ctr(key_size: Cipher, key: &[u8], iv: &[u8]) -> StreamCipher {
-    if *aes_alt::AES_NI {
-        aes_alt::ctr_alt(key_size, key, iv)
-    } else {
-        ctr_int(key_size, key, iv)
-    }
-}
-
-
-#[cfg(all(feature = "aes-all", any(target_arch = "x86_64", target_arch = "x86")))]
-mod aes_alt {
-    extern crate aesni;
-    use ::codec::StreamCipher;
-    use ctr::Ctr128;
-    use self::aesni::{Aes128, Aes256};
-    use ctr::stream_cipher::NewFixStreamCipher;
-    use ctr::stream_cipher::generic_array::GenericArray;
-    use twofish::Twofish;
-    use super::Cipher;
-
-    lazy_static! {
-        pub static ref AES_NI: bool = is_x86_feature_detected!("aes")
-            && is_x86_feature_detected!("sse2")
-            && is_x86_feature_detected!("sse3");
-
-   }
-
-    /// AES-128 in CTR mode
-    pub type Aes128Ctr = Ctr128<Aes128>;
-    /// AES-256 in CTR mode
-    pub type Aes256Ctr = Ctr128<Aes256>;
-    /// Returns alternate stream cipher if target functionalities does not allow standard one.
-    /// Eg : aes without sse
-    pub fn ctr_alt(key_size: Cipher, key: &[u8], iv: &[u8]) -> StreamCipher {
-        match key_size {
-            Cipher::Aes128 => Box::new(Aes128Ctr::new(
-                GenericArray::from_slice(key),
-                GenericArray::from_slice(iv),
-            )),
-            Cipher::Aes256 => Box::new(Aes256Ctr::new(
-                GenericArray::from_slice(key),
-                GenericArray::from_slice(iv),
-            )),
-            Cipher::Twofish => Box::new(Ctr128::<Twofish>::new(
-                GenericArray::from_slice(key),
-                GenericArray::from_slice(iv),
-            )),
-        }
-    }
-
-}
-
 #[inline]
-fn ctr_int(key_size: Cipher, key: &[u8], iv: &[u8]) -> StreamCipher {
+pub fn ctr(key_size: Cipher, key: &[u8], iv: &[u8]) -> StreamCipher {
     match key_size {
-        Cipher::Aes128 => Box::new(Aes128Ctr::new(
-            GenericArray::from_slice(key),
-            GenericArray::from_slice(iv),
-        )),
-        Cipher::Aes256 => Box::new(Aes256Ctr::new(
-            GenericArray::from_slice(key),
-            GenericArray::from_slice(iv),
-        )),
-        Cipher::Twofish => Box::new(Ctr128::<Twofish>::new(
-            GenericArray::from_slice(key),
-            GenericArray::from_slice(iv),
-        )),
+        Cipher::Aes128 => {
+            let aes_dec = aessafe::AesSafe128EncryptorX8::new(key);
+            Box::new(CtrModeX8::new(aes_dec, iv))
+        },
+        Cipher::Aes256 => {
+            let aes_dec = aessafe::AesSafe256EncryptorX8::new(key);
+            Box::new(CtrModeX8::new(aes_dec, iv))
+        },
     }
 }
-
-#[cfg(all(
-        feature = "aes-all", 
-        any(target_arch = "x86_64", target_arch = "x86"),
-))]
-#[cfg(test)]
-mod tests {
-    use super::{Cipher, ctr};
-
-    #[test]
-    fn assert_non_native_run() {
-        // this test is for asserting aes unsuported opcode does not break on old cpu
-        let key = [0;16];
-        let iv = [0;16];
-     
-        let mut aes = ctr(Cipher::Aes128, &key, &iv);
-        let mut content = [0;16];
-        assert!(aes
-                .try_apply_keystream(&mut content).is_ok());
-         
-    }
-}
-
-// aesni compile check for aes-all (aes-all import aesni through aes_ctr only if those checks pass)
-#[cfg(all(
-    feature = "aes-all", 
-    any(target_arch = "x86_64", target_arch = "x86"),
-    any(target_feature = "aes", target_feature = "ssse3"),
-))]
-compile_error!(
-    "aes-all must be compile without aes and sse3 flags : currently \
-    is_x86_feature_detected macro will not detect feature correctly otherwhise. \
-    RUSTFLAGS=\"-C target-feature=+aes,+ssse3\" enviromental variable. \
-    For x86 target arch additionally enable sse2 target feature."
-);


### PR DESCRIPTION
With all the corrupt data issues we've been having, let's take the conservative approach to revert back to `rust-crypto` which we know was working.

This reverts commit 73996885cb2d645ee91361204c33e7039290aabc.
This is not a "strict revert", more like an "adjusted revert" where I kept the good parts and threw away the switch to the `rust_crypto` orga.

In the future when substrate is stable we can experiment locally by reverting this PR.