### PR TITLE
Report the entire peers after a result

### DIFF
--- a/examples/kademlia.rs
+++ b/examples/kademlia.rs
@@ -204,10 +204,10 @@ fn main() {
         })
         .filter_map(move |event| {
             match event {
-                KadQueryEvent::NewKnownMultiaddrs(peers) => {
-                    for (peer, addrs) in peers {
-                        peer_store.peer_or_create(&peer)
-                            .add_addrs(addrs, Duration::from_secs(3600));
+                KadQueryEvent::PeersReported(peers) => {
+                    for peer in peers {
+                        peer_store.peer_or_create(&peer.node_id)
+                            .add_addrs(peer.multiaddrs, Duration::from_secs(3600));
                     }
                     None
                 },

--- a/protocols/kad/src/query.rs
+++ b/protocols/kad/src/query.rs
@@ -49,7 +49,7 @@ pub struct QueryParams<FBuckets, FFindNode> {
 #[derive(Debug, Clone)]
 pub enum QueryEvent<TOut> {
     /// Learned about new mutiaddresses for the given peers.
-    NewKnownMultiaddrs(Vec<(PeerId, Vec<Multiaddr>)>),
+    PeersReported(Vec<(PeerId, Vec<Multiaddr>)>),
     /// Finished the processing of the query. Contains the result.
     Finished(TOut),
 }
@@ -86,7 +86,7 @@ where
 
     let stream = find_node(query_params, peer_id).map(|event| {
         match event {
-            QueryEvent::NewKnownMultiaddrs(peers) => QueryEvent::NewKnownMultiaddrs(peers),
+            QueryEvent::PeersReported(peers) => QueryEvent::PeersReported(peers),
             QueryEvent::Finished(_) => QueryEvent::Finished(()),
         }
     });
@@ -355,7 +355,7 @@ where
                 }
             }
 
-            future::ok((Some(QueryEvent::NewKnownMultiaddrs(new_known_multiaddrs)), state))
+            future::ok((Some(QueryEvent::PeersReported(new_known_multiaddrs)), state))
         });
 
         Some(future::Either::B(future))


### PR DESCRIPTION
This allows knowing whether a remote is connected to a peer or not.