### PR TITLE
mplex: fix destroy_substream

### DIFF
--- a/muxers/mplex/src/lib.rs
+++ b/muxers/mplex/src/lib.rs
@@ -506,7 +506,9 @@ where C: AsyncRead + AsyncWrite
 
     fn destroy_substream(&self, mut substream: Self::Substream) {
         let _ = self.shutdown_substream(&mut substream);        // TODO: this doesn't necessarily send the close message
-        self.inner.lock().buffer.retain(|elem| elem.substream_id() != substream.num);
+        self.inner.lock().buffer.retain(|elem| {
+            elem.substream_id() != substream.num || elem.endpoint() == Some(substream.endpoint)
+        })
     }
 }
 


### PR DESCRIPTION
Retain all incoming buffer elements with different substream ID or equal Endpoint. The latter was previously not considered which could result in the removal of data for another substream with same ID but opposite Endpoint.