### PR TITLE
Make it possible to accept/deny nodes in CollectionsStream

### DIFF
--- a/core/src/nodes/collection.rs
+++ b/core/src/nodes/collection.rs
@@ -32,7 +32,6 @@ use {Multiaddr, PeerId};
 // TODO: make generic over PeerId
 
 /// Implementation of `Stream` that handles a collection of nodes.
-// TODO: implement Debug
 pub struct CollectionStream<TInEvent, TOutEvent> {
     /// Object that handles the tasks.
     inner: HandledNodesTasks<TInEvent, TOutEvent>,
@@ -42,6 +41,23 @@ pub struct CollectionStream<TInEvent, TOutEvent> {
     /// List of tasks and their state. If `Connected`, then a corresponding entry must be present
     /// in `nodes`.
     tasks: FnvHashMap<TaskId, TaskState>,
+}
+
+impl<TInEvent, TOutEvent> fmt::Debug for CollectionStream<TInEvent, TOutEvent> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let mut list = f.debug_list();
+        for (id, task) in &self.tasks {
+            match *task {
+                TaskState::Pending => {
+                    list.entry(&format!("Pending({:?})", ReachAttemptId(*id)))
+                },
+                TaskState::Connected(ref peer_id) => {
+                    list.entry(&format!("Connected({:?})", peer_id))
+                }
+            };
+        }
+        list.finish()
+    }
 }
 
 /// State of a task.

--- a/core/src/nodes/collection.rs
+++ b/core/src/nodes/collection.rs
@@ -233,7 +233,12 @@ impl<'a, TInEvent, TOutEvent> Drop for CollectionReachEvent<'a, TInEvent, TOutEv
     fn drop(&mut self) {
         let task_state = self.parent.tasks.remove(&self.id);
         debug_assert!(if let Some(TaskState::Pending) = task_state { true } else { false });
-        self.parent.inner.task(self.id).unwrap().close();       // TODO: prove the unwrap
+        self.parent.inner.task(self.id)
+            .expect("we create the CollectionReachEvent with a valid task id ; the \
+                     CollectionReachEvent mutably borrows the collection, therefore nothing \
+                     can delete this task during the lifetime of the CollectionReachEvent ; \
+                     therefore the task is still valid when we delete it ; qed")
+            .close();
     }
 }
 

--- a/core/src/nodes/collection.rs
+++ b/core/src/nodes/collection.rs
@@ -70,7 +70,7 @@ enum TaskState {
 }
 
 /// Event that can happen on the `CollectionStream`.
-pub enum CollectionEvent<'a, TInEvent, TOutEvent> {
+pub enum CollectionEvent<'a, TInEvent:'a , TOutEvent: 'a> {
     /// A connection to a node has succeeded. You must use the provided event in order to accept
     /// the connection.
     NodeReached(CollectionReachEvent<'a, TInEvent, TOutEvent>),

--- a/core/src/nodes/handled_node.rs
+++ b/core/src/nodes/handled_node.rs
@@ -28,6 +28,9 @@ use Multiaddr;
 ///
 /// > Note: When implementing the various methods, don't forget that you have to register the
 /// > task that was the latest to poll and notify it.
+// TODO: right now it is possible for a node handler to be built, then shut down right after if we
+//       realize we dialed the wrong peer for example ; this could be surprising and should either
+//       be documented or changed (favouring the "documented" right now)
 pub trait NodeHandler<TSubstream> {
     /// Custom event that can be received from the outside.
     type InEvent;

--- a/core/src/nodes/handled_node_tasks.rs
+++ b/core/src/nodes/handled_node_tasks.rs
@@ -26,7 +26,7 @@ use nodes::handled_node::{HandledNode, NodeHandler};
 use smallvec::SmallVec;
 use std::collections::hash_map::{Entry, OccupiedEntry};
 use std::io::Error as IoError;
-use std::mem;
+use std::{fmt, mem};
 use tokio_executor;
 use void::Void;
 use {Multiaddr, PeerId};
@@ -69,6 +69,14 @@ pub struct HandledNodesTasks<TInEvent, TOutEvent> {
     events_tx: mpsc::UnboundedSender<(InToExtMessage<TOutEvent>, TaskId)>,
     /// Receiver side for the events.
     events_rx: mpsc::UnboundedReceiver<(InToExtMessage<TOutEvent>, TaskId)>,
+}
+
+impl<TInEvent, TOutEvent> fmt::Debug for HandledNodesTasks<TInEvent, TOutEvent> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        f.debug_list()
+            .entries(self.tasks.keys().cloned())
+            .finish()
+    }
 }
 
 /// Event that can happen on the `HandledNodesTasks`.
@@ -273,6 +281,14 @@ impl<'a, TInEvent> Task<'a, TInEvent> {
     }
 }
 
+impl<'a, TInEvent> fmt::Debug for Task<'a, TInEvent> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        f.debug_tuple("Task")
+            .field(&self.id())
+            .finish()
+    }
+}
+
 impl<TInEvent, TOutEvent> Stream for HandledNodesTasks<TInEvent, TOutEvent> {
     type Item = HandledNodesEvent<TOutEvent>;
     type Error = Void; // TODO: use ! once stable
@@ -284,6 +300,7 @@ impl<TInEvent, TOutEvent> Stream for HandledNodesTasks<TInEvent, TOutEvent> {
 }
 
 /// Message to transmit from a task to the public API.
+#[derive(Debug)]
 enum InToExtMessage<TOutEvent> {
     /// A connection to a node has succeeded.
     NodeReached(PeerId),

--- a/core/src/nodes/swarm.rs
+++ b/core/src/nodes/swarm.rs
@@ -22,7 +22,7 @@ use fnv::FnvHashMap;
 use futures::{prelude::*, future};
 use muxing::StreamMuxer;
 use nodes::collection::{
-    CollectionEvent, CollectionStream, PeerMut as CollecPeerMut, ReachAttemptId,
+    CollectionEvent, CollectionNodeAccept, CollectionReachEvent, CollectionStream, PeerMut as CollecPeerMut, ReachAttemptId,
 };
 use nodes::handled_node::NodeHandler;
 use nodes::listeners::{ListenersEvent, ListenersStream};
@@ -43,6 +43,15 @@ where
     /// The nodes currently active.
     active_nodes: CollectionStream<TInEvent, TOutEvent>,
 
+    /// The reach attempts of the swarm.
+    /// This needs to be a separate struct in order to handle multiple mutable borrows issues.
+    reach_attempts: ReachAttempts,
+
+    /// Object that builds new handlers.
+    handler_build: THandlerBuild,
+}
+
+struct ReachAttempts {
     /// Attempts to reach a peer.
     out_reach_attempts: FnvHashMap<PeerId, OutReachAttempt>,
 
@@ -52,9 +61,6 @@ where
 
     /// For each peer ID we're connected to, contains the multiaddress we're connected to.
     connected_multiaddresses: FnvHashMap<PeerId, Multiaddr>,
-
-    /// Object that builds new handlers.
-    handler_build: THandlerBuild,
 }
 
 /// Attempt to reach a peer.
@@ -271,9 +277,11 @@ where
         Swarm {
             listeners: ListenersStream::new(transport),
             active_nodes: CollectionStream::new(),
-            out_reach_attempts: Default::default(),
-            other_reach_attempts: Vec::new(),
-            connected_multiaddresses: Default::default(),
+            reach_attempts: ReachAttempts {
+                out_reach_attempts: Default::default(),
+                other_reach_attempts: Vec::new(),
+                connected_multiaddresses: Default::default(),
+            },
             handler_build: Default::default,
         }
     }
@@ -285,9 +293,11 @@ where
         Swarm {
             listeners: ListenersStream::new(transport),
             active_nodes: CollectionStream::new(),
-            out_reach_attempts: Default::default(),
-            other_reach_attempts: Vec::new(),
-            connected_multiaddresses: Default::default(),
+            reach_attempts: ReachAttempts {
+                out_reach_attempts: Default::default(),
+                other_reach_attempts: Vec::new(),
+                connected_multiaddresses: Default::default(),
+            },
             handler_build,
         }
     }
@@ -347,7 +357,7 @@ where
         };
 
         let reach_id = self.active_nodes.add_reach_attempt(future, self.handler_build.new_handler());
-        self.other_reach_attempts
+        self.reach_attempts.other_reach_attempts
             .push((reach_id, ConnectedPoint::Dialer { address: addr }));
         Ok(())
     }
@@ -361,7 +371,7 @@ where
     // a lot of API changes
     #[inline]
     pub fn num_incoming_negotiated(&self) -> usize {
-        self.other_reach_attempts
+        self.reach_attempts.other_reach_attempts
             .iter()
             .filter(|&(_, endpoint)| endpoint.is_listener())
             .count()
@@ -382,21 +392,21 @@ where
         // the borrow checker yells at us.
 
         if self.active_nodes.peer_mut(&peer_id).is_some() {
-            debug_assert!(!self.out_reach_attempts.contains_key(&peer_id));
+            debug_assert!(!self.reach_attempts.out_reach_attempts.contains_key(&peer_id));
             return Peer::Connected(PeerConnected {
                 peer: self
                     .active_nodes
                     .peer_mut(&peer_id)
                     .expect("we checked for Some just above"),
                 peer_id,
-                connected_multiaddresses: &mut self.connected_multiaddresses,
+                connected_multiaddresses: &mut self.reach_attempts.connected_multiaddresses,
             });
         }
 
-        if self.out_reach_attempts.get_mut(&peer_id).is_some() {
-            debug_assert!(!self.connected_multiaddresses.contains_key(&peer_id));
+        if self.reach_attempts.out_reach_attempts.get_mut(&peer_id).is_some() {
+            debug_assert!(!self.reach_attempts.connected_multiaddresses.contains_key(&peer_id));
             return Peer::PendingConnect(PeerPendingConnect {
-                attempt: match self.out_reach_attempts.entry(peer_id.clone()) {
+                attempt: match self.reach_attempts.out_reach_attempts.entry(peer_id.clone()) {
                     Entry::Occupied(e) => e,
                     Entry::Vacant(_) => panic!("we checked for Some just above"),
                 },
@@ -404,25 +414,19 @@ where
             });
         }
 
-        debug_assert!(!self.connected_multiaddresses.contains_key(&peer_id));
+        debug_assert!(!self.reach_attempts.connected_multiaddresses.contains_key(&peer_id));
         Peer::NotConnected(PeerNotConnected {
             nodes: self,
             peer_id,
         })
     }
 
-    /// Handles a node reached event from the collection.
+    /// Starts dialing out a multiaddress. `rest` is the list of multiaddresses to attempt if
+    /// `first` fails.
     ///
-    /// Returns an event to return from the stream.
-    ///
-    /// > **Note**: The event **must** have been produced by the collection of nodes, otherwise
-    /// >           panics will likely happen.
-    fn handle_node_reached(
-        &mut self,
-        peer_id: PeerId,
-        reach_id: ReachAttemptId,
-        replaced: bool,
-    ) -> SwarmEvent<TTrans, TOutEvent>
+    /// It is a logic error to call this method if we already have an outgoing attempt to the
+    /// given peer.
+    fn start_dial_out(&mut self, peer_id: PeerId, first: Multiaddr, rest: Vec<Multiaddr>)
     where
         TTrans: Transport<Output = (PeerId, TMuxer)> + Clone,
         TTrans::Dial: Send + 'static,
@@ -433,214 +437,25 @@ where
         TInEvent: Send + 'static,
         TOutEvent: Send + 'static,
     {
-        // We first start looking in the incoming attempts. While this makes the code less optimal,
-        // it also makes the logic easier.
-        if let Some(in_pos) = self
-            .other_reach_attempts
-            .iter()
-            .position(|i| i.0 == reach_id)
-        {
-            let (_, endpoint) = self.other_reach_attempts.swap_remove(in_pos);
-
-            // Clear the known multiaddress for this peer.
-            let closed_multiaddr = self.connected_multiaddresses.remove(&peer_id);
-            // Cancel any outgoing attempt to this peer.
-            if let Some(attempt) = self.out_reach_attempts.remove(&peer_id) {
-                debug_assert_ne!(attempt.id, reach_id);
-                self.active_nodes
-                    .interrupt(attempt.id)
-                    .expect("We insert in out_reach_attempts only when we call \
-                             active_nodes.add_reach_attempt, and we remove only when we call \
-                             interrupt or when a reach attempt succeeds or errors. Therefore the \
-                             out_reach_attempts should always be in sync with the actual attempts");
-            }
-
-            if replaced {
-                return SwarmEvent::Replaced {
-                    peer_id,
-                    endpoint,
-                    closed_multiaddr,
-                };
-            } else {
-                return SwarmEvent::Connected { peer_id, endpoint };
-            }
-        }
-
-        // Otherwise, try for outgoing attempts.
-        let is_outgoing_and_ok = if let Some(attempt) = self.out_reach_attempts.get(&peer_id) {
-            attempt.id == reach_id
-        } else {
-            false
+        let reach_id = match self.transport().clone().dial(first.clone()) {
+            Ok(fut) => self.active_nodes.add_reach_attempt(fut, self.handler_build.new_handler()),
+            Err((_, addr)) => {
+                let msg = format!("unsupported multiaddr {}", addr);
+                let fut = future::err(IoError::new(IoErrorKind::Other, msg));
+                self.active_nodes.add_reach_attempt::<_, _, future::FutureResult<Multiaddr, IoError>, _>(fut, self.handler_build.new_handler())
+            },
         };
 
-        // We only remove the attempt from `out_reach_attempts` if it both matches the reach id
-        // and the expected peer id.
-        if is_outgoing_and_ok {
-            let attempt = self.out_reach_attempts.remove(&peer_id)
-                .expect("is_outgoing_and_ok is true only if self.out_reach_attempts.get(&peer_id) \
-                         returned Some");
+        let former = self.reach_attempts.out_reach_attempts.insert(
+            peer_id,
+            OutReachAttempt {
+                id: reach_id,
+                cur_attempted: first,
+                next_attempts: rest,
+            },
+        );
 
-            let closed_multiaddr = self.connected_multiaddresses
-                .insert(peer_id.clone(), attempt.cur_attempted.clone());
-            let endpoint = ConnectedPoint::Dialer {
-                address: attempt.cur_attempted,
-            };
-
-            if replaced {
-                return SwarmEvent::Replaced {
-                    peer_id,
-                    endpoint,
-                    closed_multiaddr,
-                };
-            } else {
-                return SwarmEvent::Connected { peer_id, endpoint };
-            }
-        }
-
-        // If in neither, check outgoing reach attempts again as we may have a public
-        // key mismatch.
-        let expected_peer_id = self
-            .out_reach_attempts
-            .iter()
-            .find(|(_, a)| a.id == reach_id)
-            .map(|(p, _)| p.clone());
-        if let Some(expected_peer_id) = expected_peer_id {
-            let attempt = self.out_reach_attempts.remove(&expected_peer_id)
-                .expect("expected_peer_id is a key that is grabbed from out_reach_attempts");
-
-            let num_remain = attempt.next_attempts.len();
-            let failed_addr = attempt.cur_attempted.clone();
-
-            // Since the `peer_id` (the unexpected peer id) is now successfully connected, we have
-            // to drop it from active_nodes.
-            // TODO: at the moment, a peer id mismatch can drop a legitimate connection, which is
-            // why we have to purge `connected_multiaddresses`.
-            // See https://github.com/libp2p/rust-libp2p/issues/502
-            self.connected_multiaddresses.remove(&peer_id);
-            self.active_nodes.peer_mut(&peer_id)
-                .expect("When we receive a NodeReached or NodeReplaced event from active_nodes, \
-                         it is guaranteed that the PeerId is valid and therefore that \
-                         active_nodes.peer_mut succeeds with this ID. handle_node_reached is \
-                         called only to handle these events.")
-                .close();
-
-            if !attempt.next_attempts.is_empty() {
-                let mut attempt = attempt;
-                attempt.cur_attempted = attempt.next_attempts.remove(0);
-                attempt.id = match self.transport().clone().dial(attempt.cur_attempted.clone()) {
-                    Ok(fut) => self.active_nodes.add_reach_attempt(fut, self.handler_build.new_handler()),
-                    Err((_, addr)) => {
-                        let msg = format!("unsupported multiaddr {}", addr);
-                        let fut = future::err(IoError::new(IoErrorKind::Other, msg));
-                        self.active_nodes.add_reach_attempt::<_, _, future::FutureResult<Multiaddr, IoError>, _>(fut, self.handler_build.new_handler())
-                    },
-                };
-
-                self.out_reach_attempts.insert(expected_peer_id.clone(), attempt);
-            }
-
-            return SwarmEvent::PublicKeyMismatch {
-                remain_addrs_attempt: num_remain,
-                expected_peer_id,
-                actual_peer_id: peer_id,
-                multiaddr: failed_addr,
-            };
-        }
-
-        // We didn't find any entry in neither the outgoing connections not ingoing connections.
-        panic!("The API of collection guarantees that the id sent back in NodeReached and \
-                NodeReplaced events (which is where we call handle_node_reached) is one that was \
-                passed to add_reach_attempt. Whenever we call add_reach_attempt, we also insert \
-                at the same time an entry either in out_reach_attempts or in \
-                other_reach_attempts. It is therefore guaranteed that we find back this ID in \
-                either of these two sets");
-    }
-
-    /// Handles a reach error event from the collection.
-    ///
-    /// Optionally returns an event to return from the stream.
-    ///
-    /// > **Note**: The event **must** have been produced by the collection of nodes, otherwise
-    /// >           panics will likely happen.
-    fn handle_reach_error(
-        &mut self,
-        reach_id: ReachAttemptId,
-        error: IoError,
-    ) -> Option<SwarmEvent<TTrans, TOutEvent>>
-    where
-        TTrans: Transport<Output = (PeerId, TMuxer)> + Clone,
-        TTrans::Dial: Send + 'static,
-        TTrans::MultiaddrFuture: Send + 'static,
-        TMuxer: StreamMuxer + Send + Sync + 'static,
-        TMuxer::OutboundSubstream: Send,
-        TMuxer::Substream: Send,
-        TInEvent: Send + 'static,
-        TOutEvent: Send + 'static,
-    {
-        // Search for the attempt in `out_reach_attempts`.
-        // TODO: could be more optimal than iterating over everything
-        let out_reach_peer_id = self
-            .out_reach_attempts
-            .iter()
-            .find(|(_, a)| a.id == reach_id)
-            .map(|(p, _)| p.clone());
-        if let Some(peer_id) = out_reach_peer_id {
-            let mut attempt = self.out_reach_attempts.remove(&peer_id)
-                .expect("out_reach_peer_id is a key that is grabbed from out_reach_attempts");
-
-            let num_remain = attempt.next_attempts.len();
-            let failed_addr = attempt.cur_attempted.clone();
-
-            if !attempt.next_attempts.is_empty() {
-                let mut attempt = attempt;
-                attempt.cur_attempted = attempt.next_attempts.remove(0);
-                attempt.id = match self.transport().clone().dial(attempt.cur_attempted.clone()) {
-                    Ok(fut) => self.active_nodes.add_reach_attempt(fut, self.handler_build.new_handler()),
-                    Err((_, addr)) => {
-                        let msg = format!("unsupported multiaddr {}", addr);
-                        let fut = future::err(IoError::new(IoErrorKind::Other, msg));
-                        self.active_nodes.add_reach_attempt::<_, _, future::FutureResult<Multiaddr, IoError>, _>(fut, self.handler_build.new_handler())
-                    },
-                };
-
-                self.out_reach_attempts.insert(peer_id.clone(), attempt);
-            }
-
-            return Some(SwarmEvent::DialError {
-                remain_addrs_attempt: num_remain,
-                peer_id,
-                multiaddr: failed_addr,
-                error,
-            });
-        }
-
-        // If this is not an outgoing reach attempt, check the incoming reach attempts.
-        if let Some(in_pos) = self
-            .other_reach_attempts
-            .iter()
-            .position(|i| i.0 == reach_id)
-        {
-            let (_, endpoint) = self.other_reach_attempts.swap_remove(in_pos);
-            match endpoint {
-                ConnectedPoint::Dialer { address } => {
-                    return Some(SwarmEvent::UnknownPeerDialError {
-                        multiaddr: address,
-                        error,
-                    });
-                }
-                ConnectedPoint::Listener { listen_addr } => {
-                    return Some(SwarmEvent::IncomingConnectionError { listen_addr, error });
-                }
-            }
-        }
-
-        // The id was neither in the outbound list nor the inbound list.
-        panic!("The API of collection guarantees that the id sent back in ReachError events \
-                (which is where we call handle_reach_error) is one that was passed to \
-                add_reach_attempt. Whenever we call add_reach_attempt, we also insert \
-                at the same time an entry either in out_reach_attempts or in \
-                other_reach_attempts. It is therefore guaranteed that we find back this ID in \
-                either of these two sets");
+        debug_assert!(former.is_none());
     }
 
     /// Provides an API similar to `Stream`, except that it cannot error.
@@ -667,7 +482,7 @@ where
                 listen_addr,
             })) => {
                 let id = self.active_nodes.add_reach_attempt(upgrade, self.handler_build.new_handler());
-                self.other_reach_attempts.push((
+                self.reach_attempts.other_reach_attempts.push((
                     id,
                     ConnectedPoint::Listener {
                         listen_addr: listen_addr.clone(),
@@ -693,50 +508,281 @@ where
 
         // Poll the existing nodes.
         loop {
+            let (action, out_event);
             match self.active_nodes.poll() {
                 Async::NotReady => break,
-                Async::Ready(Some(CollectionEvent::NodeReached { peer_id, id })) => {
-                    let event = self.handle_node_reached(peer_id, id, false);
-                    return Async::Ready(Some(event));
-                }
-                Async::Ready(Some(CollectionEvent::NodeReplaced {
-                    peer_id,
-                    id,
-                })) => {
-                    let event = self.handle_node_reached(peer_id, id, true);
-                    return Async::Ready(Some(event));
+                Async::Ready(Some(CollectionEvent::NodeReached(reach_event))) => {
+                    let (a, e) = handle_node_reached(&mut self.reach_attempts, reach_event);
+                    action = a;
+                    out_event = e;
                 }
                 Async::Ready(Some(CollectionEvent::ReachError { id, error })) => {
-                    if let Some(event) = self.handle_reach_error(id, error) {
-                        return Async::Ready(Some(event));
-                    }
+                    let (a, e) = handle_reach_error(&mut self.reach_attempts, id, error);
+                    action = a;
+                    out_event = e;
                 }
                 Async::Ready(Some(CollectionEvent::NodeError {
                     peer_id,
                     error,
                 })) => {
-                    let address = self.connected_multiaddresses.remove(&peer_id);
-                    debug_assert!(!self.out_reach_attempts.contains_key(&peer_id));
-                    return Async::Ready(Some(SwarmEvent::NodeError {
+                    let address = self.reach_attempts.connected_multiaddresses.remove(&peer_id);
+                    debug_assert!(!self.reach_attempts.out_reach_attempts.contains_key(&peer_id));
+                    action = Default::default();
+                    out_event = SwarmEvent::NodeError {
                         peer_id,
                         address,
                         error,
-                    }));
+                    };
                 }
                 Async::Ready(Some(CollectionEvent::NodeClosed { peer_id })) => {
-                    let address = self.connected_multiaddresses.remove(&peer_id);
-                    debug_assert!(!self.out_reach_attempts.contains_key(&peer_id));
-                    return Async::Ready(Some(SwarmEvent::NodeClosed { peer_id, address }));
+                    let address = self.reach_attempts.connected_multiaddresses.remove(&peer_id);
+                    debug_assert!(!self.reach_attempts.out_reach_attempts.contains_key(&peer_id));
+                    action = Default::default();
+                    out_event = SwarmEvent::NodeClosed { peer_id, address };
                 }
                 Async::Ready(Some(CollectionEvent::NodeEvent { peer_id, event })) => {
-                    return Async::Ready(Some(SwarmEvent::NodeEvent { peer_id, event }));
+                    action = Default::default();
+                    out_event = SwarmEvent::NodeEvent { peer_id, event };
                 }
                 Async::Ready(None) => unreachable!("CollectionStream never ends"),
+            };
+
+            if let Some((peer_id, first, rest)) = action.start_dial_out {
+                self.start_dial_out(peer_id, first, rest);
             }
+
+            if let Some(interrupt) = action.interrupt {
+                // TODO: improve proof or remove ; this is too complicated right now
+                self.active_nodes
+                    .interrupt(interrupt)
+                    .expect("interrupt is guaranteed to be gathered from `out_reach_attempts` ;
+                             we insert in out_reach_attempts only when we call \
+                             active_nodes.add_reach_attempt, and we remove only when we call \
+                             interrupt or when a reach attempt succeeds or errors ; therefore the \
+                             out_reach_attempts should always be in sync with the actual \
+                             attempts ; qed");
+            }
+
+            return Async::Ready(Some(out_event));
         }
 
         Async::NotReady
     }
+}
+
+/// Internal struct indicating an action to perform of the swarm.
+#[derive(Debug, Default)]
+#[must_use]
+struct ActionItem {
+    start_dial_out: Option<(PeerId, Multiaddr, Vec<Multiaddr>)>,
+    interrupt: Option<ReachAttemptId>,
+}
+
+/// Handles a node reached event from the collection.
+///
+/// Returns an event to return from the stream.
+///
+/// > **Note**: The event **must** have been produced by the collection of nodes, otherwise
+/// >           panics will likely happen.
+fn handle_node_reached<TTrans, TMuxer, TInEvent, TOutEvent>(
+    reach_attempts: &mut ReachAttempts,
+    event: CollectionReachEvent<TInEvent, TOutEvent>
+) -> (ActionItem, SwarmEvent<TTrans, TOutEvent>)
+where
+    TTrans: Transport<Output = (PeerId, TMuxer)> + Clone,
+    TTrans::Dial: Send + 'static,
+    TTrans::MultiaddrFuture: Send + 'static,
+    TMuxer: StreamMuxer + Send + Sync + 'static,
+    TMuxer::OutboundSubstream: Send,
+    TMuxer::Substream: Send,
+    TInEvent: Send + 'static,
+    TOutEvent: Send + 'static,
+{
+    // We first start looking in the incoming attempts. While this makes the code less optimal,
+    // it also makes the logic easier.
+    if let Some(in_pos) = reach_attempts
+        .other_reach_attempts
+        .iter()
+        .position(|i| i.0 == event.reach_attempt_id())
+    {
+        let (_, endpoint) = reach_attempts.other_reach_attempts.swap_remove(in_pos);
+
+        // Clear the known multiaddress for this peer.
+        let closed_multiaddr = reach_attempts.connected_multiaddresses.remove(&event.peer_id());
+        // Cancel any outgoing attempt to this peer.
+        let action = if let Some(attempt) = reach_attempts.out_reach_attempts.remove(&event.peer_id()) {
+            debug_assert_ne!(attempt.id, event.reach_attempt_id());
+            ActionItem {
+                interrupt: Some(attempt.id),
+                .. Default::default()
+            }
+        } else {
+            ActionItem::default()
+        };
+
+        let (outcome, peer_id) = event.accept();
+        if outcome == CollectionNodeAccept::ReplacedExisting {
+            return (action, SwarmEvent::Replaced {
+                peer_id,
+                endpoint,
+                closed_multiaddr,
+            });
+        } else {
+            return (action, SwarmEvent::Connected { peer_id, endpoint });
+        }
+    }
+
+    // Otherwise, try for outgoing attempts.
+    let is_outgoing_and_ok = if let Some(attempt) = reach_attempts.out_reach_attempts.get(event.peer_id()) {
+        attempt.id == event.reach_attempt_id()
+    } else {
+        false
+    };
+
+    // We only remove the attempt from `out_reach_attempts` if it both matches the reach id
+    // and the expected peer id.
+    if is_outgoing_and_ok {
+        let attempt = reach_attempts.out_reach_attempts.remove(event.peer_id())
+            .expect("is_outgoing_and_ok is true only if reach_attempts.out_reach_attempts.get(event.peer_id()) \
+                        returned Some");
+
+        let closed_multiaddr = reach_attempts.connected_multiaddresses
+            .insert(event.peer_id().clone(), attempt.cur_attempted.clone());
+        let endpoint = ConnectedPoint::Dialer {
+            address: attempt.cur_attempted,
+        };
+
+        let (outcome, peer_id) = event.accept();
+        if outcome == CollectionNodeAccept::ReplacedExisting {
+            return (Default::default(), SwarmEvent::Replaced {
+                peer_id,
+                endpoint,
+                closed_multiaddr,
+            });
+        } else {
+            return (Default::default(), SwarmEvent::Connected { peer_id, endpoint });
+        }
+    }
+
+    // If in neither, check outgoing reach attempts again as we may have a public
+    // key mismatch.
+    let expected_peer_id = reach_attempts
+        .out_reach_attempts
+        .iter()
+        .find(|(_, a)| a.id == event.reach_attempt_id())
+        .map(|(p, _)| p.clone());
+    if let Some(expected_peer_id) = expected_peer_id {
+        debug_assert_ne!(&expected_peer_id, event.peer_id());
+        let attempt = reach_attempts.out_reach_attempts.remove(&expected_peer_id)
+            .expect("expected_peer_id is a key that is grabbed from out_reach_attempts");
+
+        let num_remain = attempt.next_attempts.len();
+        let failed_addr = attempt.cur_attempted.clone();
+
+        let peer_id = event.deny();
+
+        let action = if !attempt.next_attempts.is_empty() {
+            let mut attempt = attempt;
+            let next = attempt.next_attempts.remove(0);
+            ActionItem {
+                start_dial_out: Some((expected_peer_id.clone(), next, attempt.next_attempts)),
+                .. Default::default()
+            }
+        } else {
+            Default::default()
+        };
+
+        return (action, SwarmEvent::PublicKeyMismatch {
+            remain_addrs_attempt: num_remain,
+            expected_peer_id,
+            actual_peer_id: peer_id,
+            multiaddr: failed_addr,
+        });
+    }
+
+    // We didn't find any entry in neither the outgoing connections not ingoing connections.
+    // TODO: improve proof or remove ; this is too complicated right now
+    panic!("The API of collection guarantees that the id sent back in NodeReached (which is where \
+            we call handle_node_reached) is one that was passed to add_reach_attempt. Whenever we \
+            call add_reach_attempt, we also insert at the same time an entry either in \
+            out_reach_attempts or in other_reach_attempts. It is therefore guaranteed that we \
+            find back this ID in either of these two sets");
+}
+
+/// Handles a reach error event from the collection.
+///
+/// Optionally returns an event to return from the stream.
+///
+/// > **Note**: The event **must** have been produced by the collection of nodes, otherwise
+/// >           panics will likely happen.
+fn handle_reach_error<TTrans, TOutEvent>(
+    reach_attempts: &mut ReachAttempts,
+    reach_id: ReachAttemptId,
+    error: IoError,
+) -> (ActionItem, SwarmEvent<TTrans, TOutEvent>)
+where TTrans: Transport
+{
+    // Search for the attempt in `out_reach_attempts`.
+    // TODO: could be more optimal than iterating over everything
+    let out_reach_peer_id = reach_attempts
+        .out_reach_attempts
+        .iter()
+        .find(|(_, a)| a.id == reach_id)
+        .map(|(p, _)| p.clone());
+    if let Some(peer_id) = out_reach_peer_id {
+        let mut attempt = reach_attempts.out_reach_attempts.remove(&peer_id)
+            .expect("out_reach_peer_id is a key that is grabbed from out_reach_attempts");
+
+        let num_remain = attempt.next_attempts.len();
+        let failed_addr = attempt.cur_attempted.clone();
+
+        let action = if !attempt.next_attempts.is_empty() {
+            let mut attempt = attempt;
+            let next_attempt = attempt.next_attempts.remove(0);
+            ActionItem {
+                start_dial_out: Some((peer_id.clone(), next_attempt, attempt.next_attempts)),
+                .. Default::default()
+            }
+        } else {
+            Default::default()
+        };
+
+        return (action, SwarmEvent::DialError {
+            remain_addrs_attempt: num_remain,
+            peer_id,
+            multiaddr: failed_addr,
+            error,
+        });
+    }
+
+    // If this is not an outgoing reach attempt, check the incoming reach attempts.
+    if let Some(in_pos) = reach_attempts
+        .other_reach_attempts
+        .iter()
+        .position(|i| i.0 == reach_id)
+    {
+        let (_, endpoint) = reach_attempts.other_reach_attempts.swap_remove(in_pos);
+        match endpoint {
+            ConnectedPoint::Dialer { address } => {
+                return (Default::default(), SwarmEvent::UnknownPeerDialError {
+                    multiaddr: address,
+                    error,
+                });
+            }
+            ConnectedPoint::Listener { listen_addr } => {
+                return (Default::default(), SwarmEvent::IncomingConnectionError { listen_addr, error });
+            }
+        }
+    }
+
+    // The id was neither in the outbound list nor the inbound list.
+    // TODO: improve proof or remove ; this is too complicated right now
+    panic!("The API of collection guarantees that the id sent back in ReachError events \
+            (which is where we call handle_reach_error) is one that was passed to \
+            add_reach_attempt. Whenever we call add_reach_attempt, we also insert \
+            at the same time an entry either in out_reach_attempts or in \
+            other_reach_attempts. It is therefore guaranteed that we find back this ID in \
+            either of these two sets");
 }
 
 /// State of a peer in the system.
@@ -933,6 +979,7 @@ impl<'a, TInEvent, TOutEvent> PeerPendingConnect<'a, TInEvent, TOutEvent> {
     pub fn interrupt(self) {
         let attempt = self.attempt.remove();
         if let Err(_) = self.active_nodes.interrupt(attempt.id) {
+            // TODO: improve proof or remove ; this is too complicated right now
             panic!("We retreived this attempt.id from out_reach_attempts. We insert in \
                     out_reach_attempts only at the same time as we call add_reach_attempt. \
                     Whenever we receive a NodeReached, NodeReplaced or ReachError event, which \
@@ -1042,25 +1089,10 @@ where
         TInEvent: Send + 'static,
         TOutEvent: Send + 'static,
     {
-        let future = match self.nodes.transport().clone().dial(first.clone()) {
-            Ok(fut) => fut,
-            Err(_) => return Err(self),
-        };
-
-        let reach_id = self.nodes.active_nodes.add_reach_attempt(future, self.nodes.handler_build.new_handler());
-
-        let former = self.nodes.out_reach_attempts.insert(
-            self.peer_id.clone(),
-            OutReachAttempt {
-                id: reach_id,
-                cur_attempted: first,
-                next_attempts: rest,
-            },
-        );
-        debug_assert!(former.is_none());
+        self.nodes.start_dial_out(self.peer_id.clone(), first, rest);
 
         Ok(PeerPendingConnect {
-            attempt: match self.nodes.out_reach_attempts.entry(self.peer_id) {
+            attempt: match self.nodes.reach_attempts.out_reach_attempts.entry(self.peer_id) {
                 Entry::Occupied(e) => e,
                 Entry::Vacant(_) => {
                     panic!("We called out_reach_attempts.insert with this peer id just above")


### PR DESCRIPTION
Modifies the API of `CollectionStream`. Whenever we successfully reach a node, the node goes into a "pending" state and first needs to be accepted before its events are propagated.

This is enforced by making `poll()` mutably borrow the collection stream, and generate a `CollectionReachEvent` struct with an `accept()` method. If the `CollectionReachEvent` is dropped before being accepted, the node is denied and the connection is dropped without generating any further event. It is only when accepting that we can potentially replace an existing connection.

In practice, this means that the swarm can check whether there is a public key mismatch before an existing connection is replaced. This therefore fixes #502 

Under the hood, a node being denied still spawns a task and starts processing. If a node is denied, then its events are simply ignored. Denying a node is supposed to be rare enough that this is not a problem, and we don't really want to block a background task waiting for another task to give the green light.

This PR also implements `Debug` on various struct. Implementing Debug depends on this change, so I didn't really want to extract this to a separate PR.