### PR TITLE
Make secio almost compile for asmjs/wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,9 @@ authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 
 [features]
-default = ["libp2p-secio", "libp2p-secio-secp256k1"]
-libp2p-secio-secp256k1 = ["libp2p-secio/secp256k1"]
+default = ["secio-rsa", "secio-secp256k1"]
+secio-rsa = ["libp2p-secio/rsa"]
+secio-secp256k1 = ["libp2p-secio/secp256k1"]
 
 [dependencies]
 bytes = "0.4"
@@ -21,6 +22,7 @@ libp2p-ping = { path = "./protocols/ping" }
 libp2p-ratelimit = { path = "./transports/ratelimit" }
 libp2p-relay = { path = "./transports/relay" }
 libp2p-core = { path = "./core" }
+libp2p-secio = { path = "./protocols/secio", default-features = false }
 libp2p-transport-timeout = { path = "./transports/timeout" }
 libp2p-uds = { path = "./transports/uds" }
 libp2p-websocket = { path = "./transports/websocket" }
@@ -30,7 +32,6 @@ tokio-io = "0.1"
 
 [target.'cfg(not(target_os = "emscripten"))'.dependencies]
 libp2p-dns = { path = "./transports/dns" }
-libp2p-secio = { path = "./protocols/secio", optional = true, default-features = false }
 libp2p-tcp-transport = { path = "./transports/tcp" }
 tokio-current-thread = "0.1"
 
@@ -48,23 +49,18 @@ tokio-stdin = "0.1"
 
 [[example]]
 name = "echo-dialer"
-required-features = ["libp2p-secio"]
 
 [[example]]
 name = "echo-server"
-required-features = ["libp2p-secio"]
 
 [[example]]
 name = "floodsub"
-required-features = ["libp2p-secio"]
 
 [[example]]
 name = "kademlia"
-required-features = ["libp2p-secio"]
 
 [[example]]
 name = "ping-client"
-required-features = ["libp2p-secio"]
 
 [[example]]
 name = "random_peerid"

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -11,7 +11,7 @@ futures = "0.1"
 libp2p-core = { path = "../../core" }
 log = "0.4.1"
 protobuf = "2.0.2"
-rand = "0.3.17"
+rand = "0.5"
 ring = { version = "0.12", features = ["rsa_signing"] }
 aes-ctr = "0.1.0"
 aesni = { version = "0.4.1", features = ["nocheck"], optional = true }
@@ -19,10 +19,12 @@ twofish = "0.1.0"
 ctr = "0.1"
 lazy_static = { version = "0.2.11", optional = true }
 rw-stream-sink = { path = "../../misc/rw-stream-sink" }
-eth-secp256k1 = { git = "https://github.com/paritytech/rust-secp256k1", optional = true }
+# TODO: use the paritytech repo after https://github.com/paritytech/rust-secp256k1/pull/14
+eth-secp256k1 = { git = "https://github.com/tomaka/rust-secp256k1", branch = "pub-rand", optional = true }
 tokio-io = "0.1.0"
 untrusted = "0.5"
 sha2 = "0.7.1"
+ed25519-dalek = "0.8.0"
 
 [features]
 default = ["secp256k1"]

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -22,13 +22,13 @@ rw-stream-sink = { path = "../../misc/rw-stream-sink" }
 # TODO: use the paritytech repo after https://github.com/paritytech/rust-secp256k1/pull/14
 eth-secp256k1 = { git = "https://github.com/tomaka/rust-secp256k1", branch = "pub-rand", optional = true }
 tokio-io = "0.1.0"
-untrusted = "0.5"
+untrusted = { version = "0.5", optional = true }
 sha2 = "0.7.1"
 ed25519-dalek = "0.8.0"
 
 [features]
 default = ["rsa", "secp256k1"]
-rsa = ["ring/rsa_signing"]
+rsa = ["ring/rsa_signing", "untrusted"]
 secp256k1 = ["eth-secp256k1"]
 aes-all = ["aesni", "lazy_static"]
 

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -19,13 +19,18 @@ twofish = "0.1.0"
 ctr = "0.1"
 lazy_static = { version = "0.2.11", optional = true }
 rw-stream-sink = { path = "../../misc/rw-stream-sink" }
-# TODO: use the paritytech repo after https://github.com/paritytech/rust-secp256k1/pull/14
-eth-secp256k1 = { git = "https://github.com/tomaka/rust-secp256k1", branch = "pub-rand", optional = true }
 tokio-io = "0.1.0"
 untrusted = { version = "0.5", optional = true }
 sha2 = "0.7.1"
 ed25519-dalek = "0.8.0"
 hmac = "0.6.3"
+
+[target.'cfg(not(target_os = "emscripten"))'.dependencies]
+# TODO: use the paritytech repo after https://github.com/paritytech/rust-secp256k1/pull/14
+eth-secp256k1 = { git = "https://github.com/tomaka/rust-secp256k1", branch = "pub-rand", optional = true }
+
+[target.'cfg(target_os = "emscripten")'.dependencies]
+stdweb = { version = "0.4.8", default-features = false }
 
 [features]
 default = ["rsa", "secp256k1"]

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -22,6 +22,7 @@ rw-stream-sink = { path = "../../misc/rw-stream-sink" }
 eth-secp256k1 = { git = "https://github.com/paritytech/rust-secp256k1", optional = true }
 tokio-io = "0.1.0"
 untrusted = "0.5"
+sha2 = "0.7.1"
 
 [features]
 default = ["secp256k1"]

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -25,6 +25,7 @@ tokio-io = "0.1.0"
 untrusted = { version = "0.5", optional = true }
 sha2 = "0.7.1"
 ed25519-dalek = "0.8.0"
+hmac = "0.6.3"
 
 [features]
 default = ["rsa", "secp256k1"]

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -12,7 +12,7 @@ libp2p-core = { path = "../../core" }
 log = "0.4.1"
 protobuf = "2.0.2"
 rand = "0.5"
-ring = { version = "0.12", features = ["rsa_signing"] }
+ring = { version = "0.12", default-features = false, optional = true }
 aes-ctr = "0.1.0"
 aesni = { version = "0.4.1", features = ["nocheck"], optional = true }
 twofish = "0.1.0"
@@ -27,9 +27,10 @@ sha2 = "0.7.1"
 ed25519-dalek = "0.8.0"
 
 [features]
-default = ["secp256k1"]
+default = ["rsa", "secp256k1"]
+rsa = ["ring/rsa_signing"]
 secp256k1 = ["eth-secp256k1"]
-aes-all = ["aesni","lazy_static"]
+aes-all = ["aesni", "lazy_static"]
 
 [dev-dependencies]
 libp2p-tcp-transport = { path = "../../transports/tcp" }

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -12,7 +12,8 @@ libp2p-core = { path = "../../core" }
 log = "0.4.1"
 protobuf = "2.0.2"
 rand = "0.5"
-ring = { version = "0.12", default-features = false, optional = true }
+# TODO: use the paritytech repo after https://github.com/paritytech/rust-secp256k1/pull/14
+eth-secp256k1 = { git = "https://github.com/tomaka/rust-secp256k1", branch = "pub-rand", optional = true }
 aes-ctr = "0.1.0"
 aesni = { version = "0.4.1", features = ["nocheck"], optional = true }
 twofish = "0.1.0"
@@ -26,8 +27,7 @@ ed25519-dalek = "0.8.0"
 hmac = "0.6.3"
 
 [target.'cfg(not(target_os = "emscripten"))'.dependencies]
-# TODO: use the paritytech repo after https://github.com/paritytech/rust-secp256k1/pull/14
-eth-secp256k1 = { git = "https://github.com/tomaka/rust-secp256k1", branch = "pub-rand", optional = true }
+ring = { version = "0.12", default-features = false, optional = true }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
 stdweb = { version = "0.4.8", default-features = false }

--- a/protocols/secio/src/algo_support.rs
+++ b/protocols/secio/src/algo_support.rs
@@ -24,6 +24,7 @@
 //! helps you with.
 
 use error::SecioError;
+#[cfg(feature = "ring")]
 use ring::digest;
 use std::cmp::Ordering;
 use stream_cipher::Cipher;
@@ -149,6 +150,17 @@ pub enum Digest {
     Sha512
 }
 
+impl Digest {
+    /// Returns the size in bytes of a digest of this kind.
+    #[inline]
+    pub fn num_bytes(&self) -> usize {
+        match *self {
+            Digest::Sha256 => 256 / 8,
+            Digest::Sha512 => 512 / 8,
+        }
+    }
+}
+
 /// Return a proposition string from the given sequence of `Digest` values.
 pub fn digests_proposition<'a, I>(digests: I) -> String
 where
@@ -192,6 +204,7 @@ pub fn select_digest<'a>(r: Ordering, ours: &str, theirs: &str) -> Result<Digest
     Err(SecioError::NoSupportIntersection)
 }
 
+#[cfg(feature = "ring")]
 impl Into<&'static digest::Algorithm> for Digest {
     #[inline]
     fn into(self) -> &'static digest::Algorithm {

--- a/protocols/secio/src/algo_support.rs
+++ b/protocols/secio/src/algo_support.rs
@@ -24,7 +24,7 @@
 //! helps you with.
 
 use error::SecioError;
-#[cfg(feature = "ring")]
+#[cfg(all(feature = "ring", not(target_os = "emscripten")))]
 use ring::digest;
 use std::cmp::Ordering;
 use stream_cipher::Cipher;
@@ -204,7 +204,7 @@ pub fn select_digest<'a>(r: Ordering, ours: &str, theirs: &str) -> Result<Digest
     Err(SecioError::NoSupportIntersection)
 }
 
-#[cfg(feature = "ring")]
+#[cfg(all(feature = "ring", not(target_os = "emscripten")))]
 impl Into<&'static digest::Algorithm> for Digest {
     #[inline]
     fn into(self) -> &'static digest::Algorithm {

--- a/protocols/secio/src/algo_support.rs
+++ b/protocols/secio/src/algo_support.rs
@@ -71,7 +71,7 @@ where
 ///
 /// The `Ordering` parameter determines which argument is preferred. If `Less` or `Equal` we
 /// try for each of `theirs` every one of `ours`, for `Greater` it's the other way around.
-pub fn select_agreement<'a>(r: Ordering, ours: &str, theirs: &str) -> Result<KeyAgreement, SecioError> {
+pub fn select_agreement(r: Ordering, ours: &str, theirs: &str) -> Result<KeyAgreement, SecioError> {
     let (a, b) = match r {
         Ordering::Less | Ordering::Equal => (theirs, ours),
         Ordering::Greater =>  (ours, theirs)
@@ -187,7 +187,7 @@ where
 ///
 /// The `Ordering` parameter determines which argument is preferred. If `Less` or `Equal` we
 /// try for each of `theirs` every one of `ours`, for `Greater` it's the other way around.
-pub fn select_digest<'a>(r: Ordering, ours: &str, theirs: &str) -> Result<Digest, SecioError> {
+pub fn select_digest(r: Ordering, ours: &str, theirs: &str) -> Result<Digest, SecioError> {
     let (a, b) = match r {
         Ordering::Less | Ordering::Equal => (theirs, ours),
         Ordering::Greater =>  (ours, theirs)

--- a/protocols/secio/src/algo_support.rs
+++ b/protocols/secio/src/algo_support.rs
@@ -182,7 +182,7 @@ where
 ///
 /// The `Ordering` parameter determines which argument is preferred. If `Less` or `Equal` we
 /// try for each of `theirs` every one of `ours`, for `Greater` it's the other way around.
-pub fn select_digest<'a>(r: Ordering, ours: &str, theirs: &str) -> Result<&'a digest::Algorithm, SecioError> {
+pub fn select_digest<'a>(r: Ordering, ours: &str, theirs: &str) -> Result<Digest, SecioError> {
     let (a, b) = match r {
         Ordering::Less | Ordering::Equal => (theirs, ours),
         Ordering::Greater =>  (ours, theirs)
@@ -190,8 +190,8 @@ pub fn select_digest<'a>(r: Ordering, ours: &str, theirs: &str) -> Result<&'a di
     for x in a.split(',') {
         if b.split(',').any(|y| x == y) {
             match x {
-                SHA_256 => return Ok(&digest::SHA256),
-                SHA_512 => return Ok(&digest::SHA512),
+                SHA_256 => return Ok(Digest::Sha256),
+                SHA_512 => return Ok(Digest::Sha512),
                 _ => continue
             }
         }
@@ -199,3 +199,12 @@ pub fn select_digest<'a>(r: Ordering, ours: &str, theirs: &str) -> Result<&'a di
     Err(SecioError::NoSupportIntersection)
 }
 
+impl Into<&'static digest::Algorithm> for Digest {
+    #[inline]
+    fn into(self) -> &'static digest::Algorithm {
+        match self {
+            Digest::Sha256 => &digest::SHA256,
+            Digest::Sha512 => &digest::SHA512,
+        }
+    }
+}

--- a/protocols/secio/src/codec/mod.rs
+++ b/protocols/secio/src/codec/mod.rs
@@ -60,9 +60,9 @@ impl Hmac {
         // TODO: it would be nice to tweak the hmac crate to add an equivalent to new_varkey that
         //       never errors
         match algorithm {
-            Digest::Sha256 => Hmac::Sha256(Hmac::new_varkey(key)
+            Digest::Sha256 => Hmac::Sha256(Mac::new_varkey(key)
                 .expect("Hmac::new_varkey accepts any key length")),
-            Digest::Sha512 => Hmac::Sha512(Hmac::new_varkey(key)
+            Digest::Sha512 => Hmac::Sha512(Mac::new_varkey(key)
                 .expect("Hmac::new_varkey accepts any key length")),
         }
     }

--- a/protocols/secio/src/codec/mod.rs
+++ b/protocols/secio/src/codec/mod.rs
@@ -25,7 +25,9 @@ use self::decode::DecoderMiddleware;
 use self::encode::EncoderMiddleware;
 
 use aes_ctr::stream_cipher::StreamCipherCore;
-use ring::hmac;
+use algo_support::Digest;
+use hmac::{self, Mac};
+use sha2::{Sha256, Sha512};
 use tokio_io::codec::length_delimited;
 use tokio_io::{AsyncRead, AsyncWrite};
 
@@ -37,6 +39,61 @@ pub type FullCodec<S> = DecoderMiddleware<EncoderMiddleware<length_delimited::Fr
 
 pub type StreamCipher = Box<dyn StreamCipherCore + Send>;
 
+#[derive(Debug, Clone)]
+pub enum Hmac {
+    Sha256(hmac::Hmac<Sha256>),
+    Sha512(hmac::Hmac<Sha512>),
+}
+
+impl Hmac {
+    /// Returns the size of the hash in bytes.
+    #[inline]
+    pub fn num_bytes(&self) -> usize {
+        match *self {
+            Hmac::Sha256(_) => 32,
+            Hmac::Sha512(_) => 64,
+        }
+    }
+
+    /// Builds a `Hmac` from an algorithm and key.
+    pub fn from_key(algorithm: Digest, key: &[u8]) -> Self {
+        // TODO: don't unwrap
+        match algorithm {
+            Digest::Sha256 => Hmac::Sha256(Mac::new_varkey(key).unwrap()),
+            Digest::Sha512 => Hmac::Sha512(Mac::new_varkey(key).unwrap()),
+        }
+    }
+
+    /// Signs the data.
+    // TODO: better return type?
+    pub fn sign(&mut self, crypted_data: &[u8]) -> Vec<u8> {
+        match *self {
+            Hmac::Sha256(ref mut hmac) => {
+                hmac.input(crypted_data);
+                hmac.result().code().to_vec()
+            },
+            Hmac::Sha512(ref mut hmac) => {
+                hmac.input(crypted_data);
+                hmac.result().code().to_vec()
+            },
+        }
+    }
+
+    /// Verifies that the data matches the expected hash.
+    // TODO: better error?
+    pub fn verify(&mut self, crypted_data: &[u8], expected_hash: &[u8]) -> Result<(), ()> {
+        match *self {
+            Hmac::Sha256(ref mut hmac) => {
+                hmac.input(crypted_data);
+                hmac.verify(expected_hash).map_err(|_| ())
+            },
+            Hmac::Sha512(ref mut hmac) => {
+                hmac.input(crypted_data);
+                hmac.verify(expected_hash).map_err(|_| ())
+            },
+        }
+    }
+}
 
 /// Takes control of `socket`. Returns an object that implements `future::Sink` and
 /// `future::Stream`. The `Stream` and `Sink` produce and accept `BytesMut` objects.
@@ -46,16 +103,15 @@ pub type StreamCipher = Box<dyn StreamCipherCore + Send>;
 pub fn full_codec<S>(
     socket: length_delimited::Framed<S>,
     cipher_encoding: StreamCipher,
-    encoding_hmac: hmac::SigningKey,
+    encoding_hmac: Hmac,
     cipher_decoder: StreamCipher,
-    decoding_hmac: hmac::VerificationKey,
+    decoding_hmac: Hmac,
 ) -> FullCodec<S>
 where
     S: AsyncRead + AsyncWrite,
 {
-    let hmac_num_bytes = encoding_hmac.digest_algorithm().output_len;
     let encoder = EncoderMiddleware::new(socket, cipher_encoding, encoding_hmac);
-    DecoderMiddleware::new(encoder, cipher_decoder, decoding_hmac, hmac_num_bytes)
+    DecoderMiddleware::new(encoder, cipher_decoder, decoding_hmac)
 }
 
 #[cfg(test)]
@@ -68,14 +124,13 @@ mod tests {
     use super::full_codec;
     use super::DecoderMiddleware;
     use super::EncoderMiddleware;
+    use super::Hmac;
+    use algo_support::Digest;
     use bytes::BytesMut;
     use error::SecioError;
     use futures::sync::mpsc::channel;
     use futures::{Future, Sink, Stream};
     use rand;
-    use ring::digest::SHA256;
-    use ring::hmac::SigningKey;
-    use ring::hmac::VerificationKey;
     use std::io::Error as IoError;
     use tokio_io::codec::length_delimited::Framed;
 
@@ -94,13 +149,12 @@ mod tests {
         let encoder = EncoderMiddleware::new(
             data_tx,
             ctr(Cipher::Aes256, &cipher_key, &NULL_IV[..]),
-            SigningKey::new(&SHA256, &hmac_key),
+            Hmac::from_key(Digest::Sha256, &hmac_key),
         );
         let decoder = DecoderMiddleware::new(
             data_rx,
             ctr(Cipher::Aes256, &cipher_key, &NULL_IV[..]),
-            VerificationKey::new(&SHA256, &hmac_key),
-            32,
+            Hmac::from_key(Digest::Sha256, &hmac_key),
         );
 
         let data = b"hello world";
@@ -133,9 +187,9 @@ mod tests {
                 full_codec(
                     connec,
                     ctr(cipher, &cipher_key[..key_size], &NULL_IV[..]),
-                    SigningKey::new(&SHA256, &hmac_key),
+                    Hmac::from_key(Digest::Sha256, &hmac_key),
                     ctr(cipher, &cipher_key[..key_size], &NULL_IV[..]),
-                    VerificationKey::new(&SHA256, &hmac_key),
+                    Hmac::from_key(Digest::Sha256, &hmac_key),
                 )
             },
         );
@@ -148,9 +202,9 @@ mod tests {
                 full_codec(
                     stream,
                     ctr(cipher, &cipher_key_clone[..key_size], &NULL_IV[..]),
-                    SigningKey::new(&SHA256, &hmac_key_clone),
+                    Hmac::from_key(Digest::Sha256, &hmac_key_clone),
                     ctr(cipher, &cipher_key_clone[..key_size], &NULL_IV[..]),
-                    VerificationKey::new(&SHA256, &hmac_key_clone),
+                    Hmac::from_key(Digest::Sha256, &hmac_key_clone),
                 )
             });
 

--- a/protocols/secio/src/codec/mod.rs
+++ b/protocols/secio/src/codec/mod.rs
@@ -57,10 +57,13 @@ impl Hmac {
 
     /// Builds a `Hmac` from an algorithm and key.
     pub fn from_key(algorithm: Digest, key: &[u8]) -> Self {
-        // TODO: don't unwrap
+        // TODO: it would be nice to tweak the hmac crate to add an equivalent to new_varkey that
+        //       never errors
         match algorithm {
-            Digest::Sha256 => Hmac::Sha256(Mac::new_varkey(key).unwrap()),
-            Digest::Sha512 => Hmac::Sha512(Mac::new_varkey(key).unwrap()),
+            Digest::Sha256 => Hmac::Sha256(Hmac::new_varkey(key)
+                .expect("Hmac::new_varkey accepts any key length")),
+            Digest::Sha512 => Hmac::Sha512(Hmac::new_varkey(key)
+                .expect("Hmac::new_varkey accepts any key length")),
         }
     }
 

--- a/protocols/secio/src/exchange.rs
+++ b/protocols/secio/src/exchange.rs
@@ -1,0 +1,70 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! This module handles the key agreement process. Typically ECDH.
+
+use futures::{future, prelude::*};
+use ring::agreement as ring_agreement;
+use ring::rand as ring_rand;
+use untrusted::Input as UntrustedInput;
+use {KeyAgreement, SecioError};
+
+impl Into<&'static ring_agreement::Algorithm> for KeyAgreement {
+    #[inline]
+    fn into(self) -> &'static ring_agreement::Algorithm {
+        match self {
+            KeyAgreement::EcdhP256 => &ring_agreement::ECDH_P256,
+            KeyAgreement::EcdhP384 => &ring_agreement::ECDH_P384,
+        }
+    }
+}
+
+/// Opaque private key type.
+pub type AgreementPrivateKey = ring_agreement::EphemeralPrivateKey;
+
+/// Generates a new key pair as part of the exchange.
+///
+/// Returns the opaque private key and the corresponding public key.
+pub fn generate_agreement(algorithm: KeyAgreement) -> impl Future<Item = (AgreementPrivateKey, Vec<u8>), Error = SecioError> {
+    let rng = ring_rand::SystemRandom::new(); // TODO: don't recreate that here?
+
+    match ring_agreement::EphemeralPrivateKey::generate(algorithm.into(), &rng) {
+        Ok(tmp_priv_key) => {
+            let mut tmp_pub_key: Vec<u8> = (0 .. tmp_priv_key.public_key_len()).map(|_| 0).collect();
+            tmp_priv_key.compute_public_key(&mut tmp_pub_key).unwrap();
+            future::ok((tmp_priv_key, tmp_pub_key))
+        },
+        Err(_) => {
+            debug!("failed to generate ECDH key");
+            future::err(SecioError::EphemeralKeyGenerationFailed)
+        },
+    }
+}
+
+/// Finish the agreement. On success, returns the shared key that both remote agreed upon.
+pub fn agree(algorithm: KeyAgreement, my_private_key: AgreementPrivateKey, other_public_key: &[u8])
+    -> impl Future<Item = Vec<u8>, Error = SecioError>
+{
+    ring_agreement::agree_ephemeral(my_private_key, algorithm.into(),
+                                    UntrustedInput::from(other_public_key),
+                                    SecioError::SecretGenerationFailed,
+                                    |key_material| Ok(key_material.to_vec()))
+        .into_future()
+}

--- a/protocols/secio/src/exchange/impl_ring.rs
+++ b/protocols/secio/src/exchange/impl_ring.rs
@@ -59,7 +59,7 @@ pub fn generate_agreement(algorithm: KeyAgreement) -> impl Future<Item = (Agreem
 }
 
 /// Finish the agreement. On success, returns the shared key that both remote agreed upon.
-pub fn agree(algorithm: KeyAgreement, my_private_key: AgreementPrivateKey, other_public_key: &[u8])
+pub fn agree(algorithm: KeyAgreement, my_private_key: AgreementPrivateKey, other_public_key: &[u8], _out_size: usize)
     -> impl Future<Item = Vec<u8>, Error = SecioError>
 {
     ring_agreement::agree_ephemeral(my_private_key, algorithm.into(),

--- a/protocols/secio/src/exchange/impl_ring.rs
+++ b/protocols/secio/src/exchange/impl_ring.rs
@@ -43,7 +43,7 @@ pub type AgreementPrivateKey = ring_agreement::EphemeralPrivateKey;
 ///
 /// Returns the opaque private key and the corresponding public key.
 pub fn generate_agreement(algorithm: KeyAgreement) -> impl Future<Item = (AgreementPrivateKey, Vec<u8>), Error = SecioError> {
-    let rng = ring_rand::SystemRandom::new(); // TODO: don't recreate that here?
+    let rng = ring_rand::SystemRandom::new();
 
     match ring_agreement::EphemeralPrivateKey::generate(algorithm.into(), &rng) {
         Ok(tmp_priv_key) => {

--- a/protocols/secio/src/exchange/impl_ring.rs
+++ b/protocols/secio/src/exchange/impl_ring.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! This module handles the key agreement process. Typically ECDH.
+//! Implementation of the key agreement process using the `ring` library.
 
 use futures::{future, prelude::*};
 use ring::agreement as ring_agreement;

--- a/protocols/secio/src/exchange/impl_webcrypto.rs
+++ b/protocols/secio/src/exchange/impl_webcrypto.rs
@@ -1,0 +1,132 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Implementation of the key agreement process using the WebCrypto API.
+
+use futures::prelude::*;
+use futures::sync::oneshot;
+use stdweb::{self, Reference, web::ArrayBuffer, web::TypedArray};
+use {KeyAgreement, SecioError};
+
+/// Opaque private key type.
+pub type AgreementPrivateKey = Reference;
+
+/// Generates a new key pair as part of the exchange.
+///
+/// Returns the opaque private key and the corresponding public key.
+pub fn generate_agreement(algorithm: KeyAgreement) -> impl Future<Item = (AgreementPrivateKey, Vec<u8>), Error = SecioError> {
+    // Making sure we are initialized before we dial. Initialization is protected by a simple
+    // boolean static variable, so it's not a problem to call it multiple times and the cost
+    // is negligible.
+    stdweb::initialize();
+
+    let (tx, rx) = oneshot::channel();
+    let mut tx = Some(tx);
+
+    let curve = match algorithm {
+        KeyAgreement::EcdhP256 => "P-256",
+        KeyAgreement::EcdhP384 => "P-384",
+    };
+
+    let send = move |private, public| {
+        let _ = tx.take()
+            .expect("JavaScript promise has been resolved twice")       // TODO: prove
+            .send((private, public));
+    };
+
+    js!{
+        var send = @{send};
+
+        let obj = {
+            name : "ECDH",
+            namedCurve: @{curve},
+        };
+
+        window.crypto.subtle
+            .generateKey("ECDH", true, ["deriveKey", "deriveBits"])
+            .then(function(key) {
+                window.crypto.subtle.exportKey("raw", key.publicKey)
+                    .then(function(pubkey) { send(key.privateKey, pubkey) })
+            });
+    };
+
+    rx
+        .map(move |(private, public): (AgreementPrivateKey, Reference)| {
+            let array = public.downcast::<ArrayBuffer>().unwrap();      // TODO: prove
+            (private, Vec::<u8>::from(array))
+        })
+        .map_err(|_| unreachable!())
+}
+
+/// Finish the agreement. On success, returns the shared key that both remote agreed upon.
+pub fn agree(algorithm: KeyAgreement, key: AgreementPrivateKey, other_public_key: &[u8], out_size: usize)
+    -> impl Future<Item = Vec<u8>, Error = SecioError>
+{
+    let (tx, rx) = oneshot::channel();
+    let mut tx = Some(tx);
+
+    let curve = match algorithm {
+        KeyAgreement::EcdhP256 => "P-256",
+        KeyAgreement::EcdhP384 => "P-384",
+    };
+
+    let other_public_key = TypedArray::from(other_public_key).buffer();
+
+    let out_size = out_size as u32;
+
+    let send = move |out: Reference| {
+        let _ = tx.take()
+            .expect("JavaScript promise has been resolved twice")       // TODO: prove
+            .send(out);
+    };
+
+    js!{
+        var key = @{key};
+        var other_public_key = @{other_public_key};
+        var send = @{send};
+        var curve = @{curve};
+        var out_size = @{out_size};
+
+        let import_params = {
+            name : "ECDH",
+            namedCurve: curve,
+        };
+
+        window.crypto.subtle.importKey("raw", other_public_key, import_params, false, ["deriveBits"])
+            .then(function(public_key) {
+                let derive_params = {
+                    name : "ECDH",
+                    namedCurve: curve,
+                    public: public_key,
+                };
+
+                window.crypto.subtle.deriveBits(derive_params, key, out_size)
+            })
+            .then(function(bits) {
+                send(new Uint8Array(bits));
+            });
+    };
+
+    rx
+        .map(move |buffer| {
+            Vec::<u8>::from(buffer.downcast::<ArrayBuffer>().unwrap())      // TODO: prove
+        })
+        .map_err(|_| unreachable!())
+}

--- a/protocols/secio/src/exchange/impl_webcrypto.rs
+++ b/protocols/secio/src/exchange/impl_webcrypto.rs
@@ -69,7 +69,9 @@ pub fn generate_agreement(algorithm: KeyAgreement) -> impl Future<Item = (Agreem
 
     rx
         .map(move |(private, public): (AgreementPrivateKey, Reference)| {
-            let array = public.downcast::<ArrayBuffer>().unwrap();      // TODO: prove
+            // TODO: is this actually true? the WebCrypto specs are blurry
+            let array = public.downcast::<ArrayBuffer>()
+                .expect("The output of crypto.subtle.exportKey is always an ArrayBuffer");
             (private, Vec::<u8>::from(array))
         })
         .map_err(|_| unreachable!())
@@ -126,7 +128,9 @@ pub fn agree(algorithm: KeyAgreement, key: AgreementPrivateKey, other_public_key
 
     rx
         .map(move |buffer| {
-            Vec::<u8>::from(buffer.downcast::<ArrayBuffer>().unwrap())      // TODO: prove
+            Vec::<u8>::from(buffer.downcast::<ArrayBuffer>().
+                expect("We put the bits into a Uint8Array, which can be casted into \
+                        an ArrayBuffer"))
         })
         .map_err(|_| unreachable!())
 }

--- a/protocols/secio/src/exchange/mod.rs
+++ b/protocols/secio/src/exchange/mod.rs
@@ -1,0 +1,54 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! This module handles the key agreement process. Typically ECDH.
+
+use futures::prelude::*;
+use SecioError;
+
+#[path = "impl_ring.rs"]
+mod platform;
+
+/// Possible key agreement algorithms.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum KeyAgreement {
+    EcdhP256,
+    EcdhP384
+}
+
+/// Opaque private key type.
+pub struct AgreementPrivateKey(platform::AgreementPrivateKey);
+
+/// Generates a new key pair as part of the exchange.
+///
+/// Returns the opaque private key and the corresponding public key.
+#[inline]
+pub fn generate_agreement(algorithm: KeyAgreement) -> impl Future<Item = (AgreementPrivateKey, Vec<u8>), Error = SecioError> {
+    platform::generate_agreement(algorithm).map(|(pr, pu)| (AgreementPrivateKey(pr), pu))
+}
+
+/// Finish the agreement. On success, returns the shared key that both remote agreed upon.
+#[inline]
+pub fn agree(algorithm: KeyAgreement, my_private_key: AgreementPrivateKey, other_public_key: &[u8])
+    -> impl Future<Item = Vec<u8>, Error = SecioError>
+{
+    platform::agree(algorithm, my_private_key.0, other_public_key)
+}
+

--- a/protocols/secio/src/exchange/mod.rs
+++ b/protocols/secio/src/exchange/mod.rs
@@ -24,6 +24,10 @@ use futures::prelude::*;
 use SecioError;
 
 #[path = "impl_ring.rs"]
+#[cfg(not(target_os = "emscripten"))]
+mod platform;
+#[path = "impl_webcrypto.rs"]
+#[cfg(target_os = "emscripten")]
 mod platform;
 
 /// Possible key agreement algorithms.
@@ -46,9 +50,9 @@ pub fn generate_agreement(algorithm: KeyAgreement) -> impl Future<Item = (Agreem
 
 /// Finish the agreement. On success, returns the shared key that both remote agreed upon.
 #[inline]
-pub fn agree(algorithm: KeyAgreement, my_private_key: AgreementPrivateKey, other_public_key: &[u8])
+pub fn agree(algorithm: KeyAgreement, my_private_key: AgreementPrivateKey, other_public_key: &[u8], out_size: usize)
     -> impl Future<Item = Vec<u8>, Error = SecioError>
 {
-    platform::agree(algorithm, my_private_key.0, other_public_key)
+    platform::agree(algorithm, my_private_key.0, other_public_key, out_size)
 }
 

--- a/protocols/secio/src/handshake.rs
+++ b/protocols/secio/src/handshake.rs
@@ -38,6 +38,7 @@ use ring::signature::{ED25519, RSASigningState, RSA_PKCS1_2048_8192_SHA256, RSA_
 use ring::{agreement, digest, rand};
 #[cfg(feature = "secp256k1")]
 use secp256k1;
+use sha2::{Digest, Sha256};
 use std::cmp::{self, Ordering};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::mem;
@@ -231,17 +232,17 @@ where
             // based on which hash is larger.
             context.hashes_ordering = {
                 let oh1 = {
-                    let mut ctx = digest::Context::new(&digest::SHA256);
-                    ctx.update(&context.remote_public_key_in_protobuf_bytes);
-                    ctx.update(&context.local_nonce);
-                    ctx.finish()
+                    let mut ctx = Sha256::new();
+                    ctx.input(&context.remote_public_key_in_protobuf_bytes);
+                    ctx.input(&context.local_nonce);
+                    ctx.result()
                 };
 
                 let oh2 = {
-                    let mut ctx = digest::Context::new(&digest::SHA256);
-                    ctx.update(&context.local_public_key_in_protobuf_bytes);
-                    ctx.update(&context.remote_nonce);
-                    ctx.finish()
+                    let mut ctx = Sha256::new();
+                    ctx.input(&context.local_public_key_in_protobuf_bytes);
+                    ctx.input(&context.remote_nonce);
+                    ctx.result()
                 };
 
                 oh1.as_ref().cmp(&oh2.as_ref())

--- a/protocols/secio/src/handshake.rs
+++ b/protocols/secio/src/handshake.rs
@@ -38,7 +38,7 @@ use ring::signature::{ED25519, RSASigningState, RSA_PKCS1_2048_8192_SHA256, RSA_
 use ring::{agreement, digest, rand};
 #[cfg(feature = "secp256k1")]
 use secp256k1;
-use sha2::{Digest as ShaDigestTrait, Sha256};
+use sha2::{Digest as ShaDigestTrait, Sha256, Sha512};
 use std::cmp::{self, Ordering};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::mem;
@@ -346,8 +346,8 @@ where
                             signature
                         },
                         SecioKeyPairInner::Ed25519 { ref key_pair } => {
-                            let signature = key_pair.sign(&data_to_sign);
-                            signature.as_ref().to_owned()
+                            let signature = key_pair.sign::<Sha512>(&data_to_sign);
+                            signature.to_bytes().to_vec()
                         },
                         #[cfg(feature = "secp256k1")]
                         SecioKeyPairInner::Secp256k1 { ref private } => {

--- a/protocols/secio/src/handshake.rs
+++ b/protocols/secio/src/handshake.rs
@@ -36,7 +36,8 @@ use rand::{self, RngCore};
 use ring::hmac::{SigningContext, SigningKey, VerificationKey};
 #[cfg(feature = "rsa")]
 use ring::signature::{RSASigningState, RSA_PKCS1_2048_8192_SHA256, RSA_PKCS1_SHA256, verify as ring_verify};
-use ring::{digest, rand::SystemRandom};
+#[cfg(feature = "rsa")]
+use ring::rand::SystemRandom;
 #[cfg(feature = "secp256k1")]
 use secp256k1;
 use sha2::{Digest as ShaDigestTrait, Sha256, Sha512};
@@ -345,7 +346,7 @@ where
                         },
                         #[cfg(feature = "secp256k1")]
                         SecioKeyPairInner::Secp256k1 { ref private } => {
-                            let data_to_sign = digest::digest(&digest::SHA256, &data_to_sign);
+                            let data_to_sign = Sha256::digest(&data_to_sign);
                             let message = secp256k1::Message::from_slice(data_to_sign.as_ref())
                                 .expect("digest output length doesn't match secp256k1 input length");
                             let secp256k1 = secp256k1::Secp256k1::with_caps(secp256k1::ContextFlag::SignOnly);
@@ -445,7 +446,7 @@ where
                 },
                 #[cfg(feature = "secp256k1")]
                 Some(PublicKey::Secp256k1(ref remote_public_key)) => {
-                    let data_to_verify = digest::digest(&digest::SHA256, &data_to_verify);
+                    let data_to_verify = Sha256::digest(&data_to_verify);
                     let message = secp256k1::Message::from_slice(data_to_verify.as_ref())
                         .expect("digest output length doesn't match secp256k1 input length");
                     let secp256k1 = secp256k1::Secp256k1::with_caps(secp256k1::ContextFlag::VerifyOnly);

--- a/protocols/secio/src/handshake.rs
+++ b/protocols/secio/src/handshake.rs
@@ -487,7 +487,8 @@ where
         .and_then(|(remote_exch, socket, mut context)| {
             let local_priv_key = context.local_tmp_priv_key.take()
                 .expect("we filled this Option earlier, and extract it now");
-            exchange::agree(context.chosen_exchange.unwrap(), local_priv_key, remote_exch.get_epubkey())
+            let key_size = context.chosen_hash.as_ref().unwrap().num_bytes();
+            exchange::agree(context.chosen_exchange.unwrap(), local_priv_key, remote_exch.get_epubkey(), key_size)
                 .map(move |key_material| (socket, context, key_material))
         })
 

--- a/protocols/secio/src/lib.rs
+++ b/protocols/secio/src/lib.rs
@@ -77,6 +77,8 @@
 //! `SecioMiddleware` that implements `Sink` and `Stream` and can be used to send packets of data.
 //!
 
+#![recursion_limit = "128"]
+
 extern crate aes_ctr;
 #[cfg(feature = "secp256k1")]
 extern crate asn1_der;
@@ -96,6 +98,9 @@ extern crate rw_stream_sink;
 #[cfg(feature = "secp256k1")]
 extern crate secp256k1;
 extern crate sha2;
+#[cfg(target_os = "emscripten")]
+#[macro_use]
+extern crate stdweb;
 extern crate tokio_io;
 extern crate twofish;
 #[cfg(feature = "rsa")]

--- a/protocols/secio/src/lib.rs
+++ b/protocols/secio/src/lib.rs
@@ -84,6 +84,7 @@ extern crate bytes;
 extern crate ctr;
 extern crate ed25519_dalek;
 extern crate futures;
+extern crate hmac;
 extern crate libp2p_core;
 #[macro_use]
 extern crate log;

--- a/protocols/secio/src/lib.rs
+++ b/protocols/secio/src/lib.rs
@@ -97,6 +97,7 @@ extern crate secp256k1;
 extern crate sha2;
 extern crate tokio_io;
 extern crate twofish;
+#[cfg(feature = "rsa")]
 extern crate untrusted;
 
 #[cfg(feature = "aes-all")]

--- a/protocols/secio/src/lib.rs
+++ b/protocols/secio/src/lib.rs
@@ -126,12 +126,22 @@ use untrusted::Input;
 mod algo_support;
 mod codec;
 mod error;
+mod exchange;
 mod handshake;
 mod structs_proto;
 mod stream_cipher;
 
-pub use algo_support::{Digest, KeyAgreement};
+pub use algo_support::Digest;
 pub use stream_cipher::Cipher;
+
+/// Possible key agreement algorithms.
+// Note that this is not in the `exchange` module because we want the list of supported algorithms
+// to be the same on all platforms.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum KeyAgreement {
+    EcdhP256,
+    EcdhP384
+}
 
 /// Implementation of the `ConnectionUpgrade` trait of `libp2p_core`. Automatically applies
 /// secio on any connection.

--- a/protocols/secio/src/lib.rs
+++ b/protocols/secio/src/lib.rs
@@ -132,16 +132,8 @@ mod structs_proto;
 mod stream_cipher;
 
 pub use algo_support::Digest;
+pub use exchange::KeyAgreement;
 pub use stream_cipher::Cipher;
-
-/// Possible key agreement algorithms.
-// Note that this is not in the `exchange` module because we want the list of supported algorithms
-// to be the same on all platforms.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum KeyAgreement {
-    EcdhP256,
-    EcdhP384
-}
 
 /// Implementation of the `ConnectionUpgrade` trait of `libp2p_core`. Automatically applies
 /// secio on any connection.

--- a/protocols/secio/src/lib.rs
+++ b/protocols/secio/src/lib.rs
@@ -89,6 +89,7 @@ extern crate libp2p_core;
 extern crate log;
 extern crate protobuf;
 extern crate rand;
+#[cfg(feature = "ring")]
 extern crate ring;
 extern crate rw_stream_sink;
 #[cfg(feature = "secp256k1")]
@@ -110,6 +111,7 @@ use ed25519_dalek::Keypair as Ed25519KeyPair;
 use futures::stream::MapErr as StreamMapErr;
 use futures::{Future, Poll, Sink, StartSend, Stream};
 use libp2p_core::{PeerId, PublicKey};
+#[cfg(feature = "rsa")]
 use ring::signature::RSAKeyPair;
 use rw_stream_sink::RwStreamSink;
 use std::error::Error;
@@ -117,6 +119,7 @@ use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::iter;
 use std::sync::Arc;
 use tokio_io::{AsyncRead, AsyncWrite};
+#[cfg(feature = "rsa")]
 use untrusted::Input;
 
 mod algo_support;
@@ -208,6 +211,7 @@ pub struct SecioKeyPair {
 
 impl SecioKeyPair {
     /// Builds a `SecioKeyPair` from a PKCS8 private key and public key.
+    #[cfg(feature = "rsa")]
     pub fn rsa_from_pkcs8<P>(
         private: &[u8],
         public: P,
@@ -282,6 +286,7 @@ impl SecioKeyPair {
     /// Returns the public key corresponding to this key pair.
     pub fn to_public_key(&self) -> PublicKey {
         match self.inner {
+            #[cfg(feature = "rsa")]
             SecioKeyPairInner::Rsa { ref public, .. } => PublicKey::Rsa(public.clone()),
             SecioKeyPairInner::Ed25519 { ref key_pair } => {
                 PublicKey::Ed25519(key_pair.public.as_bytes().to_vec())
@@ -308,6 +313,7 @@ impl SecioKeyPair {
 // Inner content of `SecioKeyPair`.
 #[derive(Clone)]
 enum SecioKeyPairInner {
+    #[cfg(feature = "rsa")]
     Rsa {
         public: Vec<u8>,
         // We use an `Arc` so that we can clone the enum.

--- a/protocols/secio/src/lib.rs
+++ b/protocols/secio/src/lib.rs
@@ -92,7 +92,7 @@ extern crate libp2p_core;
 extern crate log;
 extern crate protobuf;
 extern crate rand;
-#[cfg(feature = "ring")]
+#[cfg(all(feature = "ring", not(target_os = "emscripten")))]
 extern crate ring;
 extern crate rw_stream_sink;
 #[cfg(feature = "secp256k1")]
@@ -103,7 +103,7 @@ extern crate sha2;
 extern crate stdweb;
 extern crate tokio_io;
 extern crate twofish;
-#[cfg(feature = "rsa")]
+#[cfg(all(feature = "ring", not(target_os = "emscripten")))]
 extern crate untrusted;
 
 #[cfg(feature = "aes-all")]
@@ -118,7 +118,7 @@ use ed25519_dalek::Keypair as Ed25519KeyPair;
 use futures::stream::MapErr as StreamMapErr;
 use futures::{Future, Poll, Sink, StartSend, Stream};
 use libp2p_core::{PeerId, PublicKey};
-#[cfg(feature = "rsa")]
+#[cfg(all(feature = "ring", not(target_os = "emscripten")))]
 use ring::signature::RSAKeyPair;
 use rw_stream_sink::RwStreamSink;
 use std::error::Error;
@@ -126,7 +126,7 @@ use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::iter;
 use std::sync::Arc;
 use tokio_io::{AsyncRead, AsyncWrite};
-#[cfg(feature = "rsa")]
+#[cfg(all(feature = "ring", not(target_os = "emscripten")))]
 use untrusted::Input;
 
 mod algo_support;
@@ -220,7 +220,7 @@ pub struct SecioKeyPair {
 
 impl SecioKeyPair {
     /// Builds a `SecioKeyPair` from a PKCS8 private key and public key.
-    #[cfg(feature = "rsa")]
+    #[cfg(all(feature = "ring", not(target_os = "emscripten")))]
     pub fn rsa_from_pkcs8<P>(
         private: &[u8],
         public: P,
@@ -295,7 +295,7 @@ impl SecioKeyPair {
     /// Returns the public key corresponding to this key pair.
     pub fn to_public_key(&self) -> PublicKey {
         match self.inner {
-            #[cfg(feature = "rsa")]
+            #[cfg(all(feature = "ring", not(target_os = "emscripten")))]
             SecioKeyPairInner::Rsa { ref public, .. } => PublicKey::Rsa(public.clone()),
             SecioKeyPairInner::Ed25519 { ref key_pair } => {
                 PublicKey::Ed25519(key_pair.public.as_bytes().to_vec())
@@ -322,7 +322,7 @@ impl SecioKeyPair {
 // Inner content of `SecioKeyPair`.
 #[derive(Clone)]
 enum SecioKeyPairInner {
-    #[cfg(feature = "rsa")]
+    #[cfg(all(feature = "ring", not(target_os = "emscripten")))]
     Rsa {
         public: Vec<u8>,
         // We use an `Arc` so that we can clone the enum.

--- a/protocols/secio/src/lib.rs
+++ b/protocols/secio/src/lib.rs
@@ -92,6 +92,7 @@ extern crate ring;
 extern crate rw_stream_sink;
 #[cfg(feature = "secp256k1")]
 extern crate secp256k1;
+extern crate sha2;
 extern crate tokio_io;
 extern crate twofish;
 extern crate untrusted;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,6 @@ pub extern crate libp2p_peerstore as peerstore;
 pub extern crate libp2p_ping as ping;
 pub extern crate libp2p_ratelimit as ratelimit;
 pub extern crate libp2p_relay as relay;
-#[cfg(all(not(target_os = "emscripten"), feature = "libp2p-secio"))]
 pub extern crate libp2p_secio as secio;
 #[cfg(not(target_os = "emscripten"))]
 pub extern crate libp2p_tcp_transport as tcp;


### PR DESCRIPTION
Close #499 

~~Disclaimer: this doesn't actually compile because emscripten doesn't support i128 operations. However on the Rust side everything works, and one can argue that this PR is a good first step. I'm also fine with leaving this PR on ice for some time.~~
For some reason this works now.

Disclaimer: the crypto library I used (`ed25519-dalek`) is not audited, but neither is ring.

This PR replaces most of the usages of `ring` with the `ed25519-dalek`, `hmac` and `sha2` crates. The only remaining usage is for ECDH, because I'm not aware of any other library that supports this. For emscripten, the implementation uses `WebCrypto`. The `WebCrypto` path is unfortunately untested, as the code doesn't actually compile.

This adds a `rsa` feature to secio which makes it support RSA public keys. If we want to connect to IPFS nodes, this feature has to be enabled.
I also removed the `libp2p-secio` feature, making secio mandatory.