### PR TITLE
Use unsigned-varints, add BLAKE2 support in multihash

### DIFF
--- a/misc/multihash/Cargo.toml
+++ b/misc/multihash/Cargo.toml
@@ -19,3 +19,4 @@ documentation = "https://docs.rs/multihash/"
 sha1 = "0.5"
 sha2 = { version = "0.7", default-features = false }
 tiny-keccak = "1.2"
+unsigned-varint = { version = "0.2", default-features = false }

--- a/misc/multihash/Cargo.toml
+++ b/misc/multihash/Cargo.toml
@@ -19,5 +19,5 @@ documentation = "https://docs.rs/multihash/"
 blake2 = { version = "0.7", default-features = false }
 sha1 = "0.5"
 sha2 = { version = "0.7", default-features = false }
-tiny-keccak = "1.2"
+tiny-keccak = "1.4"
 unsigned-varint = { version = "0.2", default-features = false }

--- a/misc/multihash/Cargo.toml
+++ b/misc/multihash/Cargo.toml
@@ -20,4 +20,4 @@ blake2 = { version = "0.7", default-features = false }
 sha1 = "0.5"
 sha2 = { version = "0.7", default-features = false }
 tiny-keccak = "1.4"
-unsigned-varint = { version = "0.2", default-features = false }
+unsigned-varint = "0.2"

--- a/misc/multihash/Cargo.toml
+++ b/misc/multihash/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 documentation = "https://docs.rs/multihash/"
 
 [dependencies]
+blake2 = { version = "0.7", default-features = false }
 sha1 = "0.5"
 sha2 = { version = "0.7", default-features = false }
 tiny-keccak = "1.2"

--- a/misc/multihash/src/errors.rs
+++ b/misc/multihash/src/errors.rs
@@ -1,4 +1,4 @@
-use std::{fmt, error};
+use std::{error, fmt};
 
 /// Error that can happen when encoding some bytes into a multihash.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -16,8 +16,7 @@ impl fmt::Display for EncodeError {
     }
 }
 
-impl error::Error for EncodeError {
-}
+impl error::Error for EncodeError {}
 
 /// Error that can happen when decoding some bytes.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -32,14 +31,13 @@ impl fmt::Display for DecodeError {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            DecodeError::BadInputLength =>  write!(f, "Not matching input length"),
+            DecodeError::BadInputLength => write!(f, "Not matching input length"),
             DecodeError::UnknownCode => write!(f, "Found unknown code"),
         }
     }
 }
 
-impl error::Error for DecodeError {
-}
+impl error::Error for DecodeError {}
 
 /// Error that can happen when decoding some bytes.
 ///
@@ -59,5 +57,4 @@ impl fmt::Display for DecodeOwnedError {
     }
 }
 
-impl error::Error for DecodeOwnedError {
-}
+impl error::Error for DecodeOwnedError {}

--- a/misc/multihash/src/hashes.rs
+++ b/misc/multihash/src/hashes.rs
@@ -1,4 +1,3 @@
-
 /// List of types currently supported in the multihash spec.
 ///
 /// Not all hash types are supported by this library.
@@ -26,15 +25,19 @@ pub enum Hash {
     Keccak384,
     /// Keccak-512 (64-byte hash size)
     Keccak512,
+    /// BLAKE2b-512 (64-byte hash size)
+    Blake2b512,
     /// Encoding unsupported
-    Blake2b,
+    Blake2b256,
+    /// BLAKE2s-256 (32-byte hash size)
+    Blake2s256,
     /// Encoding unsupported
-    Blake2s,
+    Blake2s128,
 }
 
 impl Hash {
     /// Get the corresponding hash code.
-    pub fn code(&self) -> u8 {
+    pub fn code(&self) -> u64 {
         match *self {
             Hash::SHA1 => 0x11,
             Hash::SHA2256 => 0x12,
@@ -47,8 +50,10 @@ impl Hash {
             Hash::Keccak256 => 0x1B,
             Hash::Keccak384 => 0x1C,
             Hash::Keccak512 => 0x1D,
-            Hash::Blake2b => 0x40,
-            Hash::Blake2s => 0x41,
+            Hash::Blake2b512 => 0xB240,
+            Hash::Blake2b256 => 0xB220,
+            Hash::Blake2s256 => 0xB260,
+            Hash::Blake2s128 => 0xB250,
         }
     }
 
@@ -66,13 +71,15 @@ impl Hash {
             Hash::Keccak256 => 32,
             Hash::Keccak384 => 48,
             Hash::Keccak512 => 64,
-            Hash::Blake2b => 64,
-            Hash::Blake2s => 32,
+            Hash::Blake2b512 => 64,
+            Hash::Blake2b256 => 32,
+            Hash::Blake2s256 => 32,
+            Hash::Blake2s128 => 16,
         }
     }
 
     /// Returns the algorithm corresponding to a code, or `None` if no algorith is matching.
-    pub fn from_code(code: u8) -> Option<Hash> {
+    pub fn from_code(code: u64) -> Option<Hash> {
         Some(match code {
             0x11 => Hash::SHA1,
             0x12 => Hash::SHA2256,
@@ -85,8 +92,10 @@ impl Hash {
             0x1B => Hash::Keccak256,
             0x1C => Hash::Keccak384,
             0x1D => Hash::Keccak512,
-            0x40 => Hash::Blake2b,
-            0x41 => Hash::Blake2s,
+            0xB240 => Hash::Blake2b512,
+            0xB220 => Hash::Blake2b256,
+            0xB260 => Hash::Blake2s256,
+            0xB250 => Hash::Blake2s128,
             _ => return None,
         })
     }

--- a/misc/multihash/src/hashes.rs
+++ b/misc/multihash/src/hashes.rs
@@ -37,7 +37,7 @@ pub enum Hash {
 
 impl Hash {
     /// Get the corresponding hash code.
-    pub fn code(&self) -> u64 {
+    pub fn code(&self) -> u16 {
         match *self {
             Hash::SHA1 => 0x11,
             Hash::SHA2256 => 0x12,
@@ -79,7 +79,7 @@ impl Hash {
     }
 
     /// Returns the algorithm corresponding to a code, or `None` if no algorith is matching.
-    pub fn from_code(code: u64) -> Option<Hash> {
+    pub fn from_code(code: u16) -> Option<Hash> {
         Some(match code {
             0x11 => Hash::SHA1,
             0x12 => Hash::SHA2256,

--- a/misc/multihash/src/hashes.rs
+++ b/misc/multihash/src/hashes.rs
@@ -78,7 +78,7 @@ impl Hash {
         }
     }
 
-    /// Returns the algorithm corresponding to a code, or `None` if no algorith is matching.
+    /// Returns the algorithm corresponding to a code, or `None` if no algorithm is matching.
     pub fn from_code(code: u16) -> Option<Hash> {
         Some(match code {
             0x11 => Hash::SHA1,

--- a/misc/multihash/src/lib.rs
+++ b/misc/multihash/src/lib.rs
@@ -9,34 +9,37 @@
 extern crate sha1;
 extern crate sha2;
 extern crate tiny_keccak;
+extern crate unsigned_varint;
 
 mod errors;
 mod hashes;
 
 use std::fmt::Write;
+
 use sha2::Digest;
 use tiny_keccak::Keccak;
+use unsigned_varint::{decode, encode};
 
+pub use errors::{DecodeError, DecodeOwnedError, EncodeError};
 pub use hashes::Hash;
-pub use errors::{EncodeError, DecodeError, DecodeOwnedError};
 
 // Helper macro for encoding input into output using sha1, sha2 or tiny_keccak
 macro_rules! encode {
-    (sha1, Sha1, $input:expr, $output:expr) => ({
+    (sha1, Sha1, $input:expr, $output:expr) => {{
         let mut hasher = sha1::Sha1::new();
         hasher.update($input);
         $output.copy_from_slice(&hasher.digest().bytes());
-    });
-    (sha2, $algorithm:ident, $input:expr, $output:expr) => ({
+    }};
+    (sha2, $algorithm:ident, $input:expr, $output:expr) => {{
         let mut hasher = sha2::$algorithm::default();
         hasher.input($input);
         $output.copy_from_slice(hasher.result().as_ref());
-    });
-    (tiny, $constructor:ident, $input:expr, $output:expr) => ({
+    }};
+    (tiny, $constructor:ident, $input:expr, $output:expr) => {{
         let mut kec = Keccak::$constructor();
         kec.update($input);
         kec.finalize($output);
-    });
+    }};
 }
 
 // And another one to keep the matching DRY
@@ -74,13 +77,18 @@ macro_rules! match_encoder {
 /// ```
 ///
 pub fn encode(hash: Hash, input: &[u8]) -> Result<Multihash, EncodeError> {
-    let size = hash.size();
-    let mut output = Vec::new();
-    output.resize(2 + size as usize, 0);
-    output[0] = hash.code();
-    output[1] = size;
+    let mut buf = encode::u64_buffer();
+    let code = encode::u64(hash.code(), &mut buf);
 
-    match_encoder!(hash for (input, &mut output[2..]) {
+    let header_len = code.len() + 1;
+    let size = hash.size();
+
+    let mut output = Vec::new();
+    output.resize(header_len + size as usize, 0);
+    output[..code.len()].copy_from_slice(code);
+    output[code.len()] = size;
+
+    match_encoder!(hash for (input, &mut output[header_len..]) {
         SHA1 => sha1::Sha1,
         SHA2256 => sha2::Sha256,
         SHA2512 => sha2::Sha512,
@@ -100,7 +108,7 @@ pub fn encode(hash: Hash, input: &[u8]) -> Result<Multihash, EncodeError> {
 /// Represents a valid multihash.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Multihash {
-    bytes: Vec<u8>
+    bytes: Vec<u8>,
 }
 
 impl Multihash {
@@ -158,7 +166,7 @@ impl<'a> PartialEq<MultihashRef<'a>> for Multihash {
 /// Represents a valid multihash.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct MultihashRef<'a> {
-    bytes: &'a [u8]
+    bytes: &'a [u8],
 }
 
 impl<'a> MultihashRef<'a> {
@@ -168,25 +176,19 @@ impl<'a> MultihashRef<'a> {
             return Err(DecodeError::BadInputLength);
         }
 
-        // TODO: note that `input[0]` and `input[1]` and technically variable-length integers,
-        // but there's no hashing algorithm implemented in this crate whose code or digest length
-        // is superior to 128
-        let code = input[0];
-
-        // TODO: see comment just above about varints
-        if input[0] >= 128 || input[1] >= 128 {
-            return Err(DecodeError::BadInputLength);
-        }
+        // NOTE: We choose u64 here because there is no hashing algorithm implemented in this crate
+        // whose length exceeds 2^63 - 1.
+        let (code, bytes) = decode::u64(&input).map_err(|_| DecodeError::BadInputLength)?;
 
         let alg = Hash::from_code(code).ok_or(DecodeError::UnknownCode)?;
         let hash_len = alg.size() as usize;
 
-        // length of input should be exactly hash_len + 2
-        if input.len() != hash_len + 2 {
+        // Length of input after hash code should be exactly hash_len + 1
+        if bytes.len() != hash_len + 1 {
             return Err(DecodeError::BadInputLength);
         }
 
-        if input[1] as usize != hash_len {
+        if bytes[0] as usize != hash_len {
             return Err(DecodeError::BadInputLength);
         }
 
@@ -196,13 +198,15 @@ impl<'a> MultihashRef<'a> {
     /// Returns which hashing algorithm is used in this multihash.
     #[inline]
     pub fn algorithm(&self) -> Hash {
-        Hash::from_code(self.bytes[0]).expect("multihash is known to be valid")
+        let (code, _) = decode::u64(&self.bytes).expect("multihash is known to be valid algorithm");
+        Hash::from_code(code).expect("multihash is known to be valid")
     }
 
     /// Returns the hashed data.
     #[inline]
     pub fn digest(&self) -> &'a [u8] {
-        &self.bytes[2..]
+        let (_, bytes) = decode::u64(&self.bytes).expect("multihash is known to be valid digest");
+        &bytes[1..]
     }
 
     /// Builds a `Multihash` that owns the data.
@@ -210,7 +214,9 @@ impl<'a> MultihashRef<'a> {
     /// This operation allocates.
     #[inline]
     pub fn into_owned(&self) -> Multihash {
-        Multihash { bytes: self.bytes.to_owned() }
+        Multihash {
+            bytes: self.bytes.to_owned(),
+        }
     }
 
     /// Returns the bytes representation of this multihash.

--- a/misc/multihash/src/lib.rs
+++ b/misc/multihash/src/lib.rs
@@ -82,8 +82,8 @@ macro_rules! match_encoder {
 /// ```
 ///
 pub fn encode(hash: Hash, input: &[u8]) -> Result<Multihash, EncodeError> {
-    let mut buf = encode::u64_buffer();
-    let code = encode::u64(hash.code(), &mut buf);
+    let mut buf = encode::u16_buffer();
+    let code = encode::u16(hash.code(), &mut buf);
 
     let header_len = code.len() + 1;
     let size = hash.size();
@@ -183,9 +183,9 @@ impl<'a> MultihashRef<'a> {
             return Err(DecodeError::BadInputLength);
         }
 
-        // NOTE: We choose u64 here because there is no hashing algorithm implemented in this crate
-        // whose length exceeds 2^63 - 1.
-        let (code, bytes) = decode::u64(&input).map_err(|_| DecodeError::BadInputLength)?;
+        // NOTE: We choose u16 here because there is no hashing algorithm implemented in this crate
+        // whose length exceeds 2^16 - 1.
+        let (code, bytes) = decode::u16(&input).map_err(|_| DecodeError::BadInputLength)?;
 
         let alg = Hash::from_code(code).ok_or(DecodeError::UnknownCode)?;
         let hash_len = alg.size() as usize;
@@ -205,14 +205,14 @@ impl<'a> MultihashRef<'a> {
     /// Returns which hashing algorithm is used in this multihash.
     #[inline]
     pub fn algorithm(&self) -> Hash {
-        let (code, _) = decode::u64(&self.bytes).expect("multihash is known to be valid algorithm");
+        let (code, _) = decode::u16(&self.bytes).expect("multihash is known to be valid algorithm");
         Hash::from_code(code).expect("multihash is known to be valid")
     }
 
     /// Returns the hashed data.
     #[inline]
     pub fn digest(&self) -> &'a [u8] {
-        let (_, bytes) = decode::u64(&self.bytes).expect("multihash is known to be valid digest");
+        let (_, bytes) = decode::u16(&self.bytes).expect("multihash is known to be valid digest");
         &bytes[1..]
     }
 

--- a/misc/multihash/tests/lib.rs
+++ b/misc/multihash/tests/lib.rs
@@ -7,11 +7,10 @@ fn hex_to_bytes(s: &str) -> Vec<u8> {
     let mut c = 0;
     let mut v = Vec::new();
     while c < s.len() {
-        v.push(u8::from_str_radix(&s[c..c+2], 16).unwrap());
+        v.push(u8::from_str_radix(&s[c..c + 2], 16).unwrap());
         c += 2;
     }
     v
-
 }
 
 macro_rules! assert_encode {
@@ -92,8 +91,8 @@ macro_rules! assert_roundtrip {
 #[test]
 fn assert_roundtrip() {
     assert_roundtrip!(
-        SHA1, SHA2256, SHA2512, SHA3224, SHA3256, SHA3384, SHA3512,
-        Keccak224, Keccak256, Keccak384, Keccak512
+        SHA1, SHA2256, SHA2512, SHA3224, SHA3256, SHA3384, SHA3512, Keccak224, Keccak256,
+        Keccak384, Keccak512
     );
 }
 

--- a/misc/multihash/tests/lib.rs
+++ b/misc/multihash/tests/lib.rs
@@ -40,6 +40,8 @@ fn multihash_encode() {
         Keccak256, b"hello world", "1B2047173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad";
         Keccak384, b"hello world", "1C3065fc99339a2a40e99d3c40d695b22f278853ca0f925cde4254bcae5e22ece47e6441f91b6568425adc9d95b0072eb49f";
         Keccak512, b"hello world", "1D403ee2b40047b8060f68c67242175660f4174d0af5c01d47168ec20ed619b0b7c42181f40aa1046f39e2ef9efc6910782a998e0013d172458957957fac9405b67d";
+        Blake2b512, b"hello world", "c0e40240021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0";
+        Blake2s256, b"hello world", "e0e402209aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b";
     }
 }
 
@@ -71,6 +73,8 @@ fn assert_decode() {
         Keccak256, "1B2047173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad";
         Keccak384, "1C3065fc99339a2a40e99d3c40d695b22f278853ca0f925cde4254bcae5e22ece47e6441f91b6568425adc9d95b0072eb49f";
         Keccak512, "1D403ee2b40047b8060f68c67242175660f4174d0af5c01d47168ec20ed619b0b7c42181f40aa1046f39e2ef9efc6910782a998e0013d172458957957fac9405b67d";
+        Blake2b512, "c0e40240021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbcc05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0";
+        Blake2s256, "e0e402209aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b";
     }
 }
 
@@ -92,7 +96,7 @@ macro_rules! assert_roundtrip {
 fn assert_roundtrip() {
     assert_roundtrip!(
         SHA1, SHA2256, SHA2512, SHA3224, SHA3256, SHA3384, SHA3512, Keccak224, Keccak256,
-        Keccak384, Keccak512
+        Keccak384, Keccak512, Blake2b512, Blake2s256
     );
 }
 

--- a/misc/multihash/tests/lib.rs
+++ b/misc/multihash/tests/lib.rs
@@ -98,5 +98,19 @@ fn assert_roundtrip() {
 
 #[test]
 fn hash_types() {
+    assert_eq!(Hash::SHA1.size(), 20);
     assert_eq!(Hash::SHA2256.size(), 32);
+    assert_eq!(Hash::SHA2512.size(), 64);
+    assert_eq!(Hash::SHA3224.size(), 28);
+    assert_eq!(Hash::SHA3256.size(), 32);
+    assert_eq!(Hash::SHA3384.size(), 48);
+    assert_eq!(Hash::SHA3512.size(), 64);
+    assert_eq!(Hash::Keccak224.size(), 28);
+    assert_eq!(Hash::Keccak256.size(), 32);
+    assert_eq!(Hash::Keccak384.size(), 48);
+    assert_eq!(Hash::Keccak512.size(), 64);
+    assert_eq!(Hash::Blake2b512.size(), 64);
+    assert_eq!(Hash::Blake2b256.size(), 32);
+    assert_eq!(Hash::Blake2s256.size(), 32);
+    assert_eq!(Hash::Blake2s128.size(), 16);
 }


### PR DESCRIPTION
### Added

* Depend on `unsigned-varint` 0.2 without default features.
* Depend on `blake2` crate 0.7 with no default features.
* Add support for BLAKE2b-512 and BLAKE2s-256.

### Fixed

* Fix hash codes and enum variants for BLAKE2 to follow the standard (see issue #524).
* Use proper unsigned variable integers to indicate hash algorithm instead of a single initial byte.

### Changed

* Change hash code type from `u8` to `u16`.
* Update included tests to check BLAKE2b-512 and BLAKE2s-256.
* Run `cargo fmt` on `multihash` crate.
* Bump `tiny-keccak` to version 1.4.

Fixes #524.