### PR TITLE
Upgrade smallvec version

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@ parking_lot = "0.6"
 protobuf = "2.0.2"
 quick-error = "1.2"
 rw-stream-sink = { path = "../misc/rw-stream-sink" }
-smallvec = "0.5"
+smallvec = "0.6"
 tokio-executor = "0.1.4"
 tokio-io = "0.1"
 void = "1"

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 bytes = "0.4"
 futures = { version = "0.1" }
 log = "0.4"
-smallvec = "0.5"
+smallvec = "0.6"
 tokio-io = "0.1"
 unsigned-varint = { version = "0.2.1", features = ["codec"] }
 

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4.1"
 multiaddr = { path = "../../misc/multiaddr" }
 parking_lot = "0.6"
 protobuf = "2.0.2"
-smallvec = "0.6.0"
+smallvec = "0.6"
 tokio-codec = "0.1"
 tokio-io = "0.1"
 unsigned-varint = { version = "0.2.1", features = ["codec"] }

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -20,7 +20,7 @@ multiaddr = { path = "../../misc/multiaddr" }
 parking_lot = "0.6"
 protobuf = "2.0.2"
 rand = "0.4.2"
-smallvec = "0.5"
+smallvec = "0.6"
 tokio-codec = "0.1"
 tokio-io = "0.1"
 tokio-timer = "0.2.6"


### PR DESCRIPTION
`smallvec 0.5.x` use `MPL-2.0` which is incompatible with `MIT`, upgrade to `smallvec 0.6.x` to fix this issue.