### PR TITLE
multistream-select: Use `FramedWrite` from `tokio-codec`.

### DIFF
--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -9,6 +9,7 @@ bytes = "0.4"
 futures = { version = "0.1" }
 log = "0.4"
 smallvec = "0.6"
+tokio-codec = "0.1"
 tokio-io = "0.1"
 unsigned-varint = { version = "0.2.1", features = ["codec"] }
 

--- a/misc/multistream-select/src/lib.rs
+++ b/misc/multistream-select/src/lib.rs
@@ -118,6 +118,7 @@ extern crate futures;
 #[macro_use]
 extern crate log;
 extern crate smallvec;
+extern crate tokio_codec;
 extern crate tokio_io;
 extern crate unsigned_varint;
 

--- a/misc/multistream-select/src/protocol/dialer.rs
+++ b/misc/multistream-select/src/protocol/dialer.rs
@@ -20,15 +20,13 @@
 
 //! Contains the `Dialer` wrapper, which allows raw communications with a listener.
 
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use futures::{prelude::*, sink, Async, AsyncSink, StartSend};
-use length_delimited::LengthDelimitedFramedRead;
+use length_delimited::LengthDelimited;
 use protocol::DialerToListenerMessage;
 use protocol::ListenerToDialerMessage;
 use protocol::MultistreamSelectError;
 use protocol::MULTISTREAM_PROTOCOL_WITH_LF;
-use tokio_io::codec::length_delimited::Builder as LengthDelimitedBuilder;
-use tokio_io::codec::length_delimited::FramedWrite as LengthDelimitedFramedWrite;
 use tokio_io::{AsyncRead, AsyncWrite};
 use unsigned_varint::decode;
 
@@ -36,7 +34,7 @@ use unsigned_varint::decode;
 /// Wraps around a `AsyncRead+AsyncWrite`. Assumes that we're on the dialer's side. Produces and
 /// accepts messages.
 pub struct Dialer<R> {
-    inner: LengthDelimitedFramedRead<Bytes, LengthDelimitedFramedWrite<R, BytesMut>>,
+    inner: LengthDelimited<Bytes, R>,
     handshake_finished: bool,
 }
 
@@ -47,17 +45,16 @@ where
     /// Takes ownership of a socket and starts the handshake. If the handshake succeeds, the
     /// future returns a `Dialer`.
     pub fn new(inner: R) -> DialerFuture<R> {
-        let write = LengthDelimitedBuilder::new().length_field_length(1).new_write(inner);
-        let sender = LengthDelimitedFramedRead::new(write);
+        let sender = LengthDelimited::new(inner);
         DialerFuture {
-            inner: sender.send(BytesMut::from(MULTISTREAM_PROTOCOL_WITH_LF))
+            inner: sender.send(Bytes::from(MULTISTREAM_PROTOCOL_WITH_LF))
         }
     }
 
     /// Grants back the socket. Typically used after a `ProtocolAck` has been received.
     #[inline]
     pub fn into_inner(self) -> R {
-        self.inner.into_inner().into_inner()
+        self.inner.into_inner()
     }
 }
 
@@ -74,14 +71,13 @@ where
                 if !name.starts_with(b"/") {
                     return Err(MultistreamSelectError::WrongProtocolName);
                 }
-                let mut protocol = BytesMut::from(name);
+                let mut protocol = Bytes::from(name);
                 protocol.extend_from_slice(&[b'\n']);
                 match self.inner.start_send(protocol) {
                     Ok(AsyncSink::Ready) => Ok(AsyncSink::Ready),
                     Ok(AsyncSink::NotReady(mut protocol)) => {
                         let protocol_len = protocol.len();
                         protocol.truncate(protocol_len - 1);
-                        let protocol = protocol.freeze();
                         Ok(AsyncSink::NotReady(
                             DialerToListenerMessage::ProtocolRequest { name: protocol },
                         ))
@@ -91,7 +87,7 @@ where
             }
 
             DialerToListenerMessage::ProtocolsListRequest => {
-                match self.inner.start_send(BytesMut::from(&b"ls\n"[..])) {
+                match self.inner.start_send(Bytes::from(&b"ls\n"[..])) {
                     Ok(AsyncSink::Ready) => Ok(AsyncSink::Ready),
                     Ok(AsyncSink::NotReady(_)) => Ok(AsyncSink::NotReady(
                         DialerToListenerMessage::ProtocolsListRequest,
@@ -171,7 +167,7 @@ where
 
 /// Future, returned by `Dialer::new`, which send the handshake and returns the actual `Dialer`.
 pub struct DialerFuture<T: AsyncWrite> {
-    inner: sink::Send<LengthDelimitedFramedRead<Bytes, LengthDelimitedFramedWrite<T, BytesMut>>>
+    inner: sink::Send<LengthDelimited<Bytes, T>>
 }
 
 impl<T: AsyncWrite> Future for DialerFuture<T> {


### PR DESCRIPTION
Motivated by the recent deprecation of `tokio_io::codec::length_delimited`.