### PR TITLE
Shut down yamux and fix mplex shutdown.

### DIFF
--- a/muxers/yamux/src/lib.rs
+++ b/muxers/yamux/src/lib.rs
@@ -108,7 +108,7 @@ where
 
     #[inline]
     fn shutdown(&self, _: Shutdown) -> Poll<(), IoError> {
-        Ok(Async::Ready(())) // TODO
+        self.0.lock().shutdown()
     }
 
     #[inline]


### PR DESCRIPTION
mplex gets a new flag `is_shutdown` to keep track of when `shutdown` has been called. We need to make certain that after the shutdown no more `Sink::poll_complete` or `Sink::start_send` calls are being made which may result in a panic.