### PR TITLE
Reexport multihash from the facade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ secio-secp256k1 = ["libp2p-secio/secp256k1"]
 bytes = "0.4"
 futures = "0.1"
 multiaddr = { path = "./misc/multiaddr" }
+multihash = { path = "./misc/multihash" }
 libp2p-mplex = { path = "./muxers/mplex" }
 libp2p-identify = { path = "./protocols/identify" }
 libp2p-kad = { path = "./protocols/kad" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ pub extern crate futures;
 #[cfg(not(target_os = "emscripten"))]
 pub extern crate tokio_current_thread;
 pub extern crate multiaddr;
+pub extern crate multihash;
 pub extern crate tokio_io;
 pub extern crate tokio_codec;
 


### PR DESCRIPTION
We're exposing the `Multihash` type in the API, so we should reexport the crate.