### PR TITLE
eg. -> e.g.; ie. -> i.e. via repren

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! The main trait that this crate provides is `Transport`, which provides the `dial` and
 //! `listen_on` methods and can be used to dial or listen on a multiaddress. The `swarm` crate
-//! itself does not provide any concrete (ie. non-dummy, non-adapter) implementation of this trait.
+//! itself does not provide any concrete (i.e. non-dummy, non-adapter) implementation of this trait.
 //! It is implemented on structs that are provided by external crates, such as `TcpConfig` from
 //! `tcp-transport`, `UdpConfig`, or `WebsocketConfig` (note: as of the writing of this
 //! documentation, the last two structs don't exist yet).

--- a/core/src/transport/mod.rs
+++ b/core/src/transport/mod.rs
@@ -55,7 +55,7 @@ pub use self::upgrade::UpgradedNode;
 /// A transport is an object that can be used to produce connections by listening or dialing a
 /// peer.
 ///
-/// This trait is implemented on concrete transports (eg. TCP, UDP, etc.), but also on wrappers
+/// This trait is implemented on concrete transports (e.g. TCP, UDP, etc.), but also on wrappers
 /// around them.
 ///
 /// > **Note**: The methods of this trait use `self` and not `&self` or `&mut self`. In other
@@ -74,7 +74,7 @@ pub trait Transport {
     type Listener: Stream<Item = (Self::ListenerUpgrade, Multiaddr), Error = IoError>;
 
     /// After a connection has been received, we may need to do some asynchronous pre-processing
-    /// on it (eg. an intermediary protocol negotiation). While this pre-processing takes place, we
+    /// on it (e.g. an intermediary protocol negotiation). While this pre-processing takes place, we
     /// want to be able to continue polling on the listener.
     type ListenerUpgrade: Future<Item = Self::Output, Error = IoError>;
 

--- a/core/src/upgrade/traits.rs
+++ b/core/src/upgrade/traits.rs
@@ -73,7 +73,7 @@ pub trait ConnectionUpgrade<C> {
 
     /// This method is called after protocol negotiation has been performed.
     ///
-    /// Because performing the upgrade may not be instantaneous (eg. it may require a handshake),
+    /// Because performing the upgrade may not be instantaneous (e.g. it may require a handshake),
     /// this function returns a future instead of the direct output.
     fn upgrade(self, socket: C, id: Self::UpgradeIdentifier, ty: Endpoint) -> Self::Future;
 }

--- a/misc/multiaddr/src/protocol.rs
+++ b/misc/multiaddr/src/protocol.rs
@@ -180,7 +180,7 @@ impl<'a> Protocol<'a> {
                 let mut rdr = Cursor::new(data);
                 let mut seg = [0_u16; 8];
 
-                for x in seg.iter_mut() {
+                for x in se.g.iter_mut() {
                     *x = rdr.read_u16::<BigEndian>()?;
                 }
 

--- a/misc/multiaddr/src/protocol.rs
+++ b/misc/multiaddr/src/protocol.rs
@@ -180,7 +180,7 @@ impl<'a> Protocol<'a> {
                 let mut rdr = Cursor::new(data);
                 let mut seg = [0_u16; 8];
 
-                for x in se.g.iter_mut() {
+                for x in seg.iter_mut() {
                     *x = rdr.read_u16::<BigEndian>()?;
                 }
 

--- a/misc/multistream-select/src/length_delimited.rs
+++ b/misc/multistream-select/src/length_delimited.rs
@@ -81,7 +81,7 @@ where
     /// # Panic
     ///
     /// Will panic if called while there is data inside the buffer. **This can only happen if
-    /// you call `poll()` manually**. Using this struct as it is intended to be used (ie. through
+    /// you call `poll()` manually**. Using this struct as it is intended to be used (i.e. through
     /// the modifiers provided by the `futures` crate) will always leave the object in a state in
     /// which `into_inner()` will not panic.
     #[inline]

--- a/misc/multistream-select/src/lib.rs
+++ b/misc/multistream-select/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! Whenever a new connection or a new multiplexed substream is opened, libp2p uses
 //! `multistream-select` to negotiate with the remote which protocol to use. After a protocol has
-//! been successfully negotiated, the stream (ie. the connection or the multiplexed substream)
+//! been successfully negotiated, the stream (i.e. the connection or the multiplexed substream)
 //! immediately stops using `multistream-select` and starts using the negotiated protocol.
 //!
 //! ## Protocol explanation

--- a/misc/multistream-select/src/listener_select.rs
+++ b/misc/multistream-select/src/listener_select.rs
@@ -31,7 +31,7 @@ use ProtocolChoiceError;
 /// Helps selecting a protocol amongst the ones supported.
 ///
 /// This function expects a socket and an iterator of the list of supported protocols. The iterator
-/// must be clonable (ie. iterable multiple times), because the list may need to be accessed
+/// must be clonable (i.e. iterable multiple times), because the list may need to be accessed
 /// multiple times.
 ///
 /// The iterator must produce tuples of the name of the protocol that is advertised to the remote,

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -99,14 +99,14 @@ where
 pub struct IdentifyInfo {
     /// Public key of the node.
     pub public_key: PublicKey,
-    /// Version of the "global" protocol, eg. `ipfs/1.0.0` or `polkadot/1.0.0`.
+    /// Version of the "global" protocol, e.g. `ipfs/1.0.0` or `polkadot/1.0.0`.
     pub protocol_version: String,
     /// Name and version of the client. Can be thought as similar to the `User-Agent` header
     /// of HTTP.
     pub agent_version: String,
     /// Addresses that the node is listening on.
     pub listen_addrs: Vec<Multiaddr>,
-    /// Protocols supported by the node, eg. `/ipfs/ping/1.0.0`.
+    /// Protocols supported by the node, e.g. `/ipfs/ping/1.0.0`.
     pub protocols: Vec<String>,
 }
 

--- a/protocols/kad/src/kad_server.rs
+++ b/protocols/kad/src/kad_server.rs
@@ -96,7 +96,7 @@ where
 pub struct KadConnecController {
     // In order to send a request, we use this sender to send a tuple. The first element of the
     // tuple is the message to send to the remote, and the second element is what is used to
-    // receive the response. If the query doesn't expect a response (eg. `PUT_VALUE`), then the
+    // receive the response. If the query doesn't expect a response (e.g. `PUT_VALUE`), then the
     // one-shot sender will be dropped without being used.
     inner: mpsc::UnboundedSender<(KadMsg, oneshot::Sender<KadMsg>)>,
 }

--- a/stores/peerstore/src/lib.rs
+++ b/stores/peerstore/src/lib.rs
@@ -31,7 +31,7 @@
 //! - `MemoryPeerstore`: Stores the information in memory.
 //!
 //! Note that the peerstore implementations do not consider information inside a peer store to be
-//! critical. In case of an error (eg. corrupted file, disk error, etc.) they will prefer to lose
+//! critical. In case of an error (e.g. corrupted file, disk error, etc.) they will prefer to lose
 //! data rather than returning the error.
 //!
 //! # Example

--- a/stores/peerstore/src/peerstore.rs
+++ b/stores/peerstore/src/peerstore.rs
@@ -24,7 +24,7 @@ use {PeerId, TTL};
 
 /// Implemented on objects that store peers.
 ///
-/// Note that the methods of this trait take by ownership (ie. `self` instead of `&self` or
+/// Note that the methods of this trait take by ownership (i.e. `self` instead of `&self` or
 /// `&mut self`). This was made so that the associated types could hold `self` internally and
 /// because Rust doesn't have higher-ranked trait bounds yet.
 ///


### PR DESCRIPTION
What I did:
```bash
sudo python3.7 get-pip.py7;
sudo pip2.7 install repren # add a hyphen with pip-2.7 if not using Ubuntu or Arch Linux / Manjaro.
repren -n  -p ../repren/eg-ie.txt --literal --full . # dry run
repren -p ../repren/eg-ie.txt --literal --full .
```
eg-ie.txt:
```
eg.	e.g.
ie.	i.e.
Eg.	E.g.
Ie.	I.e.

```