### PR TITLE
Fix stack overflow when printing a SubstreamRef

### DIFF
--- a/core/src/muxing.rs
+++ b/core/src/muxing.rs
@@ -268,9 +268,10 @@ impl<P> fmt::Debug for SubstreamRef<P>
 where
     P: Deref,
     P::Target: StreamMuxer,
+    <P::Target as StreamMuxer>::Substream: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "Substream({:?})", self)
+        write!(f, "Substream({:?})", self.substream)
     }
 }
 

--- a/core/src/nodes/node.rs
+++ b/core/src/nodes/node.rs
@@ -347,7 +347,7 @@ where
 }
 
 impl<TMuxer, TUserData> fmt::Debug for NodeEvent<TMuxer, TUserData>
-where 
+where
     TMuxer: muxing::StreamMuxer,
     TMuxer::Substream: fmt::Debug,
     TUserData: fmt::Debug,

--- a/core/src/nodes/node.rs
+++ b/core/src/nodes/node.rs
@@ -349,19 +349,20 @@ where
 impl<TMuxer, TUserData> fmt::Debug for NodeEvent<TMuxer, TUserData>
 where 
     TMuxer: muxing::StreamMuxer,
-    TUserData: fmt::Debug
+    TMuxer::Substream: fmt::Debug,
+    TUserData: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            NodeEvent::InboundSubstream { .. } => {
+            NodeEvent::InboundSubstream { substream } => {
                 f.debug_struct("NodeEvent::OutboundClosed")
-                    .field("substream", &"...")
+                    .field("substream", substream)
                     .finish()
             },
-            NodeEvent::OutboundSubstream { user_data, .. } => {
+            NodeEvent::OutboundSubstream { user_data, substream } => {
                 f.debug_struct("NodeEvent::OutboundSubstream")
                     .field("user_data", user_data)
-                    .field("substream", &"...")
+                    .field("substream", substream)
                     .finish()
             },
             NodeEvent::OutboundClosed { user_data } => {

--- a/core/src/nodes/node.rs
+++ b/core/src/nodes/node.rs
@@ -80,7 +80,6 @@ enum StreamState {
 }
 
 /// Event that can happen on the `NodeStream`.
-#[derive(Debug)]
 pub enum NodeEvent<TMuxer, TUserData>
 where
     TMuxer: muxing::StreamMuxer,
@@ -347,32 +346,36 @@ where
     }
 }
 
-// TODO:
-/*impl<TTrans> fmt::Debug for NodeEvent<TTrans>
-where TTrans: Transport,
-      <TTrans::Listener as Stream>::Error: fmt::Debug,
+impl<TMuxer, TUserData> fmt::Debug for NodeEvent<TMuxer, TUserData>
+where 
+    TMuxer: muxing::StreamMuxer,
+    TUserData: fmt::Debug
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            NodeEvent::Incoming { ref listen_addr, .. } => {
-                f.debug_struct("NodeEvent::Incoming")
-                    .field("listen_addr", listen_addr)
+            NodeEvent::InboundSubstream { .. } => {
+                f.debug_struct("NodeEvent::OutboundClosed")
+                    .field("substream", &"...")
                     .finish()
             },
-            NodeEvent::Closed { ref listen_addr, .. } => {
-                f.debug_struct("NodeEvent::Closed")
-                    .field("listen_addr", listen_addr)
+            NodeEvent::OutboundSubstream { user_data, .. } => {
+                f.debug_struct("NodeEvent::OutboundSubstream")
+                    .field("user_data", user_data)
+                    .field("substream", &"...")
                     .finish()
             },
-            NodeEvent::Error { ref listen_addr, ref error, .. } => {
-                f.debug_struct("NodeEvent::Error")
-                    .field("listen_addr", listen_addr)
-                    .field("error", error)
+            NodeEvent::OutboundClosed { user_data } => {
+                f.debug_struct("NodeEvent::OutboundClosed")
+                    .field("user_data", user_data)
+                    .finish()
+            },
+            NodeEvent::InboundClosed => {
+                f.debug_struct("NodeEvent::InboundClosed")
                     .finish()
             },
         }
     }
-}*/
+}
 
 #[cfg(test)]
 mod node_stream {

--- a/core/src/tests/dummy_muxer.rs
+++ b/core/src/tests/dummy_muxer.rs
@@ -29,9 +29,11 @@ use muxing::{StreamMuxer, Shutdown};
 use futures::prelude::*;
 
 /// Substream type
+#[derive(Debug)]
 pub struct DummySubstream {}
 
 /// OutboundSubstream type
+#[derive(Debug)]
 pub struct DummyOutboundSubstream {}
 
 /// Control the muxer state by setting the "connection" state as to set up a mock


### PR DESCRIPTION
Does the same as #562 but the way I imagined it.