### PR TITLE
Inject event by value in ProtocolsHandler

### DIFF
--- a/core/src/nodes/protocols_handler.rs
+++ b/core/src/nodes/protocols_handler.rs
@@ -103,7 +103,7 @@ pub trait ProtocolsHandler {
     );
 
     /// Injects an event coming from the outside in the handler.
-    fn inject_event(&mut self, event: &Self::InEvent);
+    fn inject_event(&mut self, event: Self::InEvent);
 
     /// Indicates to the handler that upgrading a substream to the given protocol has failed.
     fn inject_dial_upgrade_error(&mut self, info: Self::OutboundOpenInfo, error: io::Error);
@@ -299,7 +299,7 @@ where
     }
 
     #[inline]
-    fn inject_event(&mut self, _: &Self::InEvent) {}
+    fn inject_event(&mut self, _: Self::InEvent) {}
 
     #[inline]
     fn inject_dial_upgrade_error(&mut self, _: Self::OutboundOpenInfo, _: io::Error) {}
@@ -337,7 +337,7 @@ pub struct MapInEvent<TProtoHandler, TNewIn, TMap> {
 impl<TProtoHandler, TMap, TNewIn> ProtocolsHandler for MapInEvent<TProtoHandler, TNewIn, TMap>
 where
     TProtoHandler: ProtocolsHandler,
-    TMap: Fn(&TNewIn) -> Option<&TProtoHandler::InEvent>,
+    TMap: Fn(TNewIn) -> Option<TProtoHandler::InEvent>,
 {
     type InEvent = TNewIn;
     type OutEvent = TProtoHandler::OutEvent;
@@ -360,7 +360,7 @@ where
     }
 
     #[inline]
-    fn inject_event(&mut self, event: &TNewIn) {
+    fn inject_event(&mut self, event: TNewIn) {
         if let Some(event) = (self.map)(event) {
             self.inner.inject_event(event);
         }
@@ -424,7 +424,7 @@ where
     }
 
     #[inline]
-    fn inject_event(&mut self, event: &Self::InEvent) {
+    fn inject_event(&mut self, event: Self::InEvent) {
         self.inner.inject_event(event)
     }
 
@@ -608,7 +608,7 @@ where
 
     #[inline]
     fn inject_event(&mut self, event: Self::InEvent) {
-        self.handler.inject_event(&event);
+        self.handler.inject_event(event);
     }
 
     #[inline]

--- a/protocols/identify/src/periodic_id_handler.rs
+++ b/protocols/identify/src/periodic_id_handler.rs
@@ -123,7 +123,7 @@ where
     }
 
     #[inline]
-    fn inject_event(&mut self, _: &Self::InEvent) {}
+    fn inject_event(&mut self, _: Self::InEvent) {}
 
     #[inline]
     fn inject_inbound_closed(&mut self) {}

--- a/protocols/ping/src/dial_handler.rs
+++ b/protocols/ping/src/dial_handler.rs
@@ -184,7 +184,7 @@ where
         }
     }
 
-    fn inject_event(&mut self, _: &Self::InEvent) {}
+    fn inject_event(&mut self, _: Self::InEvent) {}
 
     fn inject_inbound_closed(&mut self) {}
 

--- a/protocols/ping/src/listen_handler.rs
+++ b/protocols/ping/src/listen_handler.rs
@@ -98,7 +98,7 @@ where
     }
 
     #[inline]
-    fn inject_event(&mut self, _: &Self::InEvent) {}
+    fn inject_event(&mut self, _: Self::InEvent) {}
 
     #[inline]
     fn inject_inbound_closed(&mut self) {}


### PR DESCRIPTION
I was initially considering passing an event by reference so that multiple handlers can be combined and the same event sent to multiple handlers.

In practice, however, it is unlikely or even harmful for multiple handlers to process the same event.

In practice, as well, combining two handlers in a generic way consists in dispatching the event to the correct handler and not sending it to both.

For these reasons, let's change injecting events to taking the event by value.
