### PR TITLE
Use upstream rust-secp256k1

### DIFF
--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -12,7 +12,7 @@ libp2p-core = { path = "../../core" }
 log = "0.4.1"
 protobuf = "2.0.2"
 rand = "0.5"
-eth-secp256k1 = { git = "https://github.com/paritytech/rust-secp256k1", optional = true }
+secp256k1 = {version = "0.11", optional = true }
 aes-ctr = "0.1.0"
 aesni = { version = "0.4.1", features = ["nocheck"], optional = true }
 twofish = "0.1.0"
@@ -34,7 +34,6 @@ stdweb = { version = "0.4.8", default-features = false }
 [features]
 default = ["rsa", "secp256k1"]
 rsa = ["ring/rsa_signing"]
-secp256k1 = ["eth-secp256k1"]
 aes-all = ["aesni", "lazy_static"]
 
 [dev-dependencies]

--- a/protocols/secio/src/handshake.rs
+++ b/protocols/secio/src/handshake.rs
@@ -399,10 +399,9 @@ where
                             let data_to_sign = Sha256::digest(&data_to_sign);
                             let message = secp256k1::Message::from_slice(data_to_sign.as_ref())
                                 .expect("digest output length doesn't match secp256k1 input length");
-                            let secp256k1 = secp256k1::Secp256k1::with_caps(secp256k1::ContextFlag::SignOnly);
+                            let secp256k1 = secp256k1::Secp256k1::signing_only();
                             secp256k1
                                 .sign(&message, private)
-                                .expect("failed to sign message")
                                 .serialize_der(&secp256k1)
                         },
                     }
@@ -493,7 +492,7 @@ where
                     let data_to_verify = Sha256::digest(&data_to_verify);
                     let message = secp256k1::Message::from_slice(data_to_verify.as_ref())
                         .expect("digest output length doesn't match secp256k1 input length");
-                    let secp256k1 = secp256k1::Secp256k1::with_caps(secp256k1::ContextFlag::VerifyOnly);
+                    let secp256k1 = secp256k1::Secp256k1::verification_only();
                     let signature = secp256k1::Signature::from_der(&secp256k1, remote_exch.get_signature());
                     let remote_public_key = secp256k1::key::PublicKey::from_slice(&secp256k1, remote_public_key);
                     if let (Ok(signature), Ok(remote_public_key)) = (signature, remote_public_key) {
@@ -525,7 +524,7 @@ where
             Ok((remote_exch, socket, context))
         })
         // Generate a key from the local ephemeral private key and the remote ephemeral public key,
-        // derive from it a ciper key, an iv, and a hmac key, and build the encoder/decoder.
+        // derive from it a cipher key, an iv, and a hmac key, and build the encoder/decoder.
         .and_then(|(remote_exch, socket, context)| {
             let (context, local_priv_key) = context.take_private_key();
             let key_size = context.state.remote.chosen_hash.num_bytes();
@@ -533,7 +532,7 @@ where
                 .map(move |key_material| (socket, context, key_material))
         })
         // Generate a key from the local ephemeral private key and the remote ephemeral public key,
-        // derive from it a ciper key, an iv, and a hmac key, and build the encoder/decoder.
+        // derive from it a cipher key, an iv, and a hmac key, and build the encoder/decoder.
         .and_then(|(socket, context, key_material)| {
             let chosen_cipher = context.state.remote.chosen_cipher;
             let cipher_key_size = chosen_cipher.key_size();


### PR DESCRIPTION
The question implied here is: why did we fork `rust-secp256k1` and are those reasons still valid? Can we get back to the mainline crate? There is [ongoing work on our fork](https://github.com/paritytech/rust-secp256k1/pull/16) to make it `no_std` but I'm not sure what the end-goal of that effort is.


Part of https://github.com/libp2p/rust-libp2p/issues/593