### PR TITLE
Add an IdentifyListen behaviour

### DIFF
--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -14,6 +14,7 @@ log = "0.4.1"
 multiaddr = { path = "../../misc/multiaddr" }
 parking_lot = "0.6"
 protobuf = "2.0.2"
+smallvec = "0.6"
 tokio-codec = "0.1"
 tokio-io = "0.1.0"
 tokio-timer = "0.2.6"

--- a/protocols/identify/src/lib.rs
+++ b/protocols/identify/src/lib.rs
@@ -75,6 +75,7 @@ extern crate log;
 extern crate multiaddr;
 extern crate parking_lot;
 extern crate protobuf;
+extern crate smallvec;
 extern crate tokio_codec;
 extern crate tokio_io;
 extern crate tokio_timer;
@@ -82,12 +83,16 @@ extern crate unsigned_varint;
 extern crate void;
 
 pub use self::id_transport::IdentifyTransport;
+pub use self::listen_handler::IdentifyListenHandler;
+pub use self::listen_layer::IdentifyListen;
 pub use self::periodic_id_handler::{PeriodicIdentification, PeriodicIdentificationEvent};
 pub use self::periodic_id_layer::{PeriodicIdentifyBehaviour, PeriodicIdentifyBehaviourEvent};
 pub use self::protocol::{IdentifyInfo, IdentifyOutput};
 pub use self::protocol::{IdentifyProtocolConfig, IdentifySender};
 
 mod id_transport;
+mod listen_handler;
+mod listen_layer;
 mod periodic_id_handler;
 mod periodic_id_layer;
 mod protocol;

--- a/protocols/identify/src/listen_handler.rs
+++ b/protocols/identify/src/listen_handler.rs
@@ -1,0 +1,124 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use futures::prelude::*;
+use libp2p_core::nodes::handled_node::NodeHandlerEndpoint;
+use libp2p_core::nodes::protocols_handler::{ProtocolsHandler, ProtocolsHandlerEvent};
+use libp2p_core::ConnectionUpgrade;
+use smallvec::SmallVec;
+use std::io;
+use tokio_io::{AsyncRead, AsyncWrite};
+use void::Void;
+use {IdentifySender, IdentifyOutput, IdentifyProtocolConfig};
+
+/// Protocol handler that identifies the remote at a regular period.
+pub struct IdentifyListenHandler<TSubstream> {
+    /// Configuration for the protocol.
+    config: IdentifyProtocolConfig,
+
+    /// List of senders to yield to the user.
+    pending_result: SmallVec<[IdentifySender<TSubstream>; 4]>,
+
+    /// True if `shutdown` has been called.
+    shutdown: bool,
+}
+
+impl<TSubstream> IdentifyListenHandler<TSubstream> {
+    /// Builds a new `IdentifyListenHandler`.
+    #[inline]
+    pub fn new() -> Self {
+        IdentifyListenHandler {
+            config: IdentifyProtocolConfig,
+            pending_result: SmallVec::new(),
+            shutdown: false,
+        }
+    }
+}
+
+impl<TSubstream> ProtocolsHandler for IdentifyListenHandler<TSubstream>
+where
+    TSubstream: AsyncRead + AsyncWrite + Send + Sync + 'static, // TODO: remove useless bounds
+{
+    type InEvent = Void;
+    type OutEvent = IdentifySender<TSubstream>;
+    type Substream = TSubstream;
+    type Protocol = IdentifyProtocolConfig;
+    type OutboundOpenInfo = ();
+
+    #[inline]
+    fn listen_protocol(&self) -> Self::Protocol {
+        self.config.clone()
+    }
+
+    fn inject_fully_negotiated(
+        &mut self,
+        protocol: <Self::Protocol as ConnectionUpgrade<TSubstream>>::Output,
+        endpoint: NodeHandlerEndpoint<Self::OutboundOpenInfo>,
+    ) {
+        match protocol {
+            IdentifyOutput::Sender { sender } => {
+                debug_assert!(if let NodeHandlerEndpoint::Listener = endpoint { true } else { false });
+                self.pending_result.push(sender);
+            }
+            IdentifyOutput::RemoteInfo { .. } => unreachable!(
+                "RemoteInfo can only be produced if we dial the protocol, but we never do that"
+            ),
+        }
+    }
+
+    #[inline]
+    fn inject_event(&mut self, _: Self::InEvent) {}
+
+    #[inline]
+    fn inject_inbound_closed(&mut self) {}
+
+    #[inline]
+    fn inject_dial_upgrade_error(&mut self, _: Self::OutboundOpenInfo, _: io::Error) {}
+
+    #[inline]
+    fn shutdown(&mut self) {
+        self.shutdown = true;
+    }
+
+    fn poll(
+        &mut self,
+    ) -> Poll<
+        Option<
+            ProtocolsHandlerEvent<
+                Self::Protocol,
+                Self::OutboundOpenInfo,
+                Self::OutEvent,
+            >,
+        >,
+        io::Error,
+    > {
+        if !self.pending_result.is_empty() {
+            return Ok(Async::Ready(Some(ProtocolsHandlerEvent::Custom(
+                self.pending_result.remove(0),
+            ))));
+        }
+
+        if self.shutdown {
+            Ok(Async::Ready(None))
+        } else {
+            Ok(Async::NotReady)
+        }
+    }
+}

--- a/protocols/identify/src/listen_layer.rs
+++ b/protocols/identify/src/listen_layer.rs
@@ -1,0 +1,117 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use futures::prelude::*;
+use libp2p_core::nodes::{ConnectedPoint, NetworkBehavior, NetworkBehaviorAction};
+use libp2p_core::{nodes::protocols_handler::ProtocolsHandler, Multiaddr, PeerId};
+use smallvec::SmallVec;
+use std::{collections::HashMap, io, marker::PhantomData};
+use tokio_io::{AsyncRead, AsyncWrite};
+use void::Void;
+use {IdentifyListenHandler, IdentifyInfo};
+
+/// Network behaviour that automatically identifies nodes periodically, and returns information
+/// about them.
+pub struct IdentifyListen<TSubstream> {
+    /// Information to send back to remotes.
+    send_back_info: IdentifyInfo,
+    /// For each peer we're connected to, the observed address to send back to it.
+    observed_addresses: HashMap<PeerId, Multiaddr>,
+    /// List of futures that send back information back to remotes.
+    futures: SmallVec<[Box<Future<Item = (), Error = io::Error> + Send>; 4]>,
+    /// Marker to pin the generics.
+    marker: PhantomData<TSubstream>,
+}
+
+impl<TSubstream> IdentifyListen<TSubstream> {
+    /// Creates a `IdentifyListen`.
+    pub fn new(info: IdentifyInfo) -> Self {
+        IdentifyListen {
+            send_back_info: info,
+            observed_addresses: HashMap::new(),
+            futures: SmallVec::new(),
+            marker: PhantomData,
+        }
+    }
+
+    /// Modifies the information to send back to remotes.
+    #[inline]
+    pub fn set_infos(&mut self, info: IdentifyInfo) {
+        self.send_back_info = info;
+    }
+}
+
+impl<TSubstream> NetworkBehavior for IdentifyListen<TSubstream>
+where
+    TSubstream: AsyncRead + AsyncWrite + Send + Sync + 'static,
+{
+    type ProtocolsHandler = IdentifyListenHandler<TSubstream>;
+    type OutEvent = Void;
+
+    fn new_handler(&mut self) -> Self::ProtocolsHandler {
+        IdentifyListenHandler::new()
+    }
+
+    fn inject_connected(&mut self, peer_id: PeerId, endpoint: ConnectedPoint) {
+        let observed = match endpoint {
+            ConnectedPoint::Dialer { address } => address,
+            ConnectedPoint::Listener { send_back_addr, .. } => send_back_addr,
+        };
+
+        self.observed_addresses.insert(peer_id, observed);
+    }
+
+    fn inject_disconnected(&mut self, peer_id: &PeerId, _: ConnectedPoint) {
+        self.observed_addresses.remove(peer_id);
+    }
+
+    fn inject_node_event(
+        &mut self,
+        peer_id: PeerId,
+        sender: <Self::ProtocolsHandler as ProtocolsHandler>::OutEvent,
+    ) {
+        let observed = self.observed_addresses.get(&peer_id)
+            .expect("We only receive events from nodes we're connected to ; we insert into the \
+                     hashmap when we connect to a node and remove only when we disconnect ; qed");
+        let future = sender.send(self.send_back_info.clone(), &observed);
+        self.futures.push(future);
+    }
+
+    fn poll(
+        &mut self,
+    ) -> Async<
+        NetworkBehaviorAction<
+            <Self::ProtocolsHandler as ProtocolsHandler>::InEvent,
+            Self::OutEvent,
+        >,
+    > {
+        // Removes each future one by one, and pushes them back if they're not ready.
+        for n in (0..self.futures.len()).rev() {
+            let mut future = self.futures.swap_remove(n);
+            match future.poll() {
+                Ok(Async::Ready(())) => {}
+                Ok(Async::NotReady) => self.futures.push(future),
+                Err(_) => {},
+            }
+        }
+
+        Async::NotReady
+    }
+}

--- a/protocols/identify/src/listen_layer.rs
+++ b/protocols/identify/src/listen_layer.rs
@@ -51,10 +51,16 @@ impl<TSubstream> IdentifyListen<TSubstream> {
         }
     }
 
+    /// Gets the information that is sent back to remotes.
+    #[inline]
+    pub fn infos(&self) -> &IdentifyInfo {
+        &self.send_back_info
+    }
+
     /// Modifies the information to send back to remotes.
     #[inline]
-    pub fn set_infos(&mut self, info: IdentifyInfo) {
-        self.send_back_info = info;
+    pub fn infos_mut(&mut self) -> &mut IdentifyInfo {
+        &mut self.send_back_info
     }
 }
 


### PR DESCRIPTION
I forgot to add it in #579 
This is the listening side. You set the information ahead of time, and the behaviour automatically handles requests.