### PR TITLE
Update connected peers' topics on NodeEvent

### DIFF
--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -218,7 +218,9 @@ where
     ) {
         // Update connected peers topics
         for subscription in event.subscriptions {
-            let mut remote_peer_topics = self.connected_peers.get_mut(&propagation_source).expect("This peer just sent us a message");
+            let mut remote_peer_topics = self.connected_peers
+                .get_mut(&propagation_source)
+                .expect("This peer just sent us a message");
             match subscription.action {
                 FloodsubSubscriptionAction::Subscribe => {
                     if !remote_peer_topics.contains(&subscription.topic) {

--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -216,6 +216,23 @@ where
         propagation_source: PeerId,
         event: FloodsubRpc,
     ) {
+        // Update connected peers topics
+        for subscription in event.subscriptions {
+            let mut remote_peer_topics = self.connected_peers.get_mut(&propagation_source).expect("This peer just sent us a message");
+            match subscription.action {
+                FloodsubSubscriptionAction::Subscribe => {
+                    if !remote_peer_topics.contains(&subscription.topic) {
+                        remote_peer_topics.push(subscription.topic);
+                    }
+                }
+                FloodsubSubscriptionAction::Unsubscribe => {
+                    if let Some(pos) = remote_peer_topics.iter().position(|t| t == &subscription.topic ) {
+                        remote_peer_topics.remove(pos);
+                    }
+                }
+            }
+        }
+
         // List of messages we're going to propagate on the network.
         let mut rpcs_to_dispatch: Vec<(PeerId, FloodsubRpc)> = Vec::new();
 

--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -220,7 +220,7 @@ where
         for subscription in event.subscriptions {
             let mut remote_peer_topics = self.connected_peers
                 .get_mut(&propagation_source)
-                .expect("connected_peers is kept in sync with the peers we are connected to ; we are guaranteed to only receive events from connected peers ; qed");
+                .expect("connected_peers is kept in sync with the peers we are connected to; we are guaranteed to only receive events from connected peers ; qed");
             match subscription.action {
                 FloodsubSubscriptionAction::Subscribe => {
                     if !remote_peer_topics.contains(&subscription.topic) {

--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -220,7 +220,7 @@ where
         for subscription in event.subscriptions {
             let mut remote_peer_topics = self.connected_peers
                 .get_mut(&propagation_source)
-                .expect("This peer just sent us a message");
+                .expect("connected_peers is kept in sync with the peers we are connected to ; we are guaranteed to only receive events from connected peers ; qed");
             match subscription.action {
                 FloodsubSubscriptionAction::Subscribe => {
                     if !remote_peer_topics.contains(&subscription.topic) {


### PR DESCRIPTION
After a peer connects they send us the list of the topics they're subscribed to. This causes a NodeEvent to be emitted. This PR makes sure we update the subscription info we have on the newly connected peer.