### PR TITLE
Fix mapping of upgrade.

### DIFF
--- a/core/src/protocols_handler.rs
+++ b/core/src/protocols_handler.rs
@@ -771,7 +771,7 @@ where
         upgrade::OrUpgrade<
             upgrade::Toggleable<
                 upgrade::MapUpgradeErr<
-                    upgrade::MapUpgrade<
+                    upgrade::MapInboundUpgrade<
                         TProto1::InboundProtocol,
                         fn(TProto1Out) -> EitherOutput<TProto1Out, TProto2Out>
                     >,
@@ -784,7 +784,7 @@ where
             >,
             upgrade::Toggleable<
                 upgrade::MapUpgradeErr<
-                    upgrade::MapUpgrade<
+                    upgrade::MapInboundUpgrade<
                         TProto2::InboundProtocol,
                         fn(TProto2Out) -> EitherOutput<TProto1Out, TProto2Out>
                     >,
@@ -801,7 +801,7 @@ where
         upgrade::OrUpgrade<
             upgrade::Toggleable<
                 upgrade::MapUpgradeErr<
-                    upgrade::MapUpgrade<
+                    upgrade::MapOutboundUpgrade<
                         TProto1::OutboundProtocol,
                         fn(TProto1Out) -> EitherOutput<TProto1Out, TProto2Out>
                     >,
@@ -814,7 +814,7 @@ where
             >,
             upgrade::Toggleable<
                 upgrade::MapUpgradeErr<
-                    upgrade::MapUpgrade<
+                    upgrade::MapOutboundUpgrade<
                         TProto2::OutboundProtocol,
                         fn(TProto2Out) -> EitherOutput<TProto1Out, TProto2Out>
                     >,

--- a/core/src/upgrade/mod.rs
+++ b/core/src/upgrade/mod.rs
@@ -71,7 +71,7 @@ pub use self::{
     apply::{apply_inbound, apply_outbound, InboundUpgradeApply, OutboundUpgradeApply},
     denied::DeniedUpgrade,
     error::UpgradeError,
-    map::{MapUpgrade, MapUpgradeErr},
+    map::{MapInboundUpgrade, MapOutboundUpgrade, MapUpgradeErr},
     or::OrUpgrade,
     toggleable::{toggleable, Toggleable}
 };
@@ -110,12 +110,12 @@ pub trait InboundUpgrade<C>: UpgradeInfo {
 /// `InboundUpgrade`.
 pub trait InboundUpgradeExt<C>: InboundUpgrade<C> {
     /// Returns a new object that wraps around `Self` and applies a closure to the `Output`.
-    fn map_inbound<F, T>(self, f: F) -> MapUpgrade<Self, F>
+    fn map_inbound<F, T>(self, f: F) -> MapInboundUpgrade<Self, F>
     where
         Self: Sized,
         F: FnOnce(Self::Output) -> T
     {
-        MapUpgrade::new(self, f)
+        MapInboundUpgrade::new(self, f)
     }
 
     /// Returns a new object that wraps around `Self` and applies a closure to the `Error`.
@@ -160,12 +160,12 @@ pub trait OutboundUpgrade<C>: UpgradeInfo {
 /// `OutboundUpgrade`.
 pub trait OutboundUpgradeExt<C>: OutboundUpgrade<C> {
     /// Returns a new object that wraps around `Self` and applies a closure to the `Output`.
-    fn map_outbound<F, T>(self, f: F) -> MapUpgrade<Self, F>
+    fn map_outbound<F, T>(self, f: F) -> MapOutboundUpgrade<Self, F>
     where
         Self: Sized,
         F: FnOnce(Self::Output) -> T
     {
-        MapUpgrade::new(self, f)
+        MapOutboundUpgrade::new(self, f)
     }
 
     /// Returns a new object that wraps around `Self` and applies a closure to the `Error`.


### PR DESCRIPTION
The current implementation of `MapUpgrade` implements `InboundUpgrade` and `OutboundUpgrade` and applies the transformation in both cases which means that mapping is always applied to inbound and outbound upgrades. This commit uses separate `MapInboundUpgrade` and `MapOutboundUpgrade` types which implements both traits but only map in one direction.