### PR TITLE
core: Add phantom type to `OrUpgrade`.

### DIFF
--- a/core/src/protocols_handler/select.rs
+++ b/core/src/protocols_handler/select.rs
@@ -65,7 +65,7 @@ where
     type InEvent = EitherOutput<TProto1::InEvent, TProto2::InEvent>;
     type OutEvent = EitherOutput<TProto1::OutEvent, TProto2::OutEvent>;
     type Substream = TSubstream;
-    type InboundProtocol = OrUpgrade<TProto1::InboundProtocol, TProto2::InboundProtocol>;
+    type InboundProtocol = OrUpgrade<TSubstream, TProto1::InboundProtocol, TProto2::InboundProtocol>;
     type OutboundProtocol = EitherUpgrade<TProto1::OutboundProtocol, TProto2::OutboundProtocol>;
     type OutboundOpenInfo = EitherOutput<TProto1::OutboundOpenInfo, TProto2::OutboundOpenInfo>;
 

--- a/core/src/upgrade/mod.rs
+++ b/core/src/upgrade/mod.rs
@@ -129,7 +129,7 @@ pub trait InboundUpgradeExt<C>: InboundUpgrade<C> {
 
     /// Returns a new object that combines `Self` and another upgrade to support both at the same
     /// time.
-    fn or_inbound<U>(self, upgrade: U) -> OrUpgrade<Self, U>
+    fn or_inbound<U>(self, upgrade: U) -> OrUpgrade<C, Self, U>
     where
         Self: Sized,
         U: InboundUpgrade<C>
@@ -179,7 +179,7 @@ pub trait OutboundUpgradeExt<C>: OutboundUpgrade<C> {
 
     /// Returns a new object that combines `Self` and another upgrade to support both at the same
     /// time.
-    fn or_outbound<U>(self, upgrade: U) -> OrUpgrade<Self, U>
+    fn or_outbound<U>(self, upgrade: U) -> OrUpgrade<C, Self, U>
     where
         Self: Sized,
         U: OutboundUpgrade<C>

--- a/core/src/upgrade/or.rs
+++ b/core/src/upgrade/or.rs
@@ -24,24 +24,25 @@ use crate::{
     either::{EitherOutput, EitherError, EitherFuture2},
     upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo}
 };
+use std::marker::PhantomData;
 
 /// Upgrade that combines two upgrades into one. Supports all the protocols supported by either
 /// sub-upgrade.
 ///
 /// The protocols supported by the first element have a higher priority.
 #[derive(Debug, Clone)]
-pub struct OrUpgrade<A, B>(A, B);
+pub struct OrUpgrade<T, A, B>(A, B, PhantomData<T>);
 
-impl<A, B> OrUpgrade<A, B> {
+impl<T, A, B> OrUpgrade<T, A, B> {
     /// Combines two upgrades into an `OrUpgrade`.
     ///
     /// The protocols supported by the first element have a higher priority.
     pub fn new(a: A, b: B) -> Self {
-        OrUpgrade(a, b)
+        OrUpgrade(a, b, PhantomData)
     }
 }
 
-impl<A, B> UpgradeInfo for OrUpgrade<A, B>
+impl<T, A, B> UpgradeInfo for OrUpgrade<T, A, B>
 where
     A: UpgradeInfo,
     B: UpgradeInfo
@@ -54,7 +55,7 @@ where
     }
 }
 
-impl<C, A, B, TA, TB, EA, EB> InboundUpgrade<C> for OrUpgrade<A, B>
+impl<C, A, B, TA, TB, EA, EB> InboundUpgrade<C> for OrUpgrade<C, A, B>
 where
     A: InboundUpgrade<C, Output = TA, Error = EA>,
     B: InboundUpgrade<C, Output = TB, Error = EB>,
@@ -71,7 +72,7 @@ where
     }
 }
 
-impl<C, A, B, TA, TB, EA, EB> OutboundUpgrade<C> for OrUpgrade<A, B>
+impl<C, A, B, TA, TB, EA, EB> OutboundUpgrade<C> for OrUpgrade<C, A, B>
 where
     A: OutboundUpgrade<C, Output = TA, Error = EA>,
     B: OutboundUpgrade<C, Output = TB, Error = EB>,


### PR DESCRIPTION
Aid type-inference by retaining the `{Inbound,Outbound}Upgrade`'s type parameter.