### PR TITLE
Fix core-derive

### DIFF
--- a/misc/core-derive/src/lib.rs
+++ b/misc/core-derive/src/lib.rs
@@ -107,7 +107,7 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
         additional.push(quote!{#substream_generic: ::libp2p::tokio_io::AsyncWrite});
 
         if let Some(where_clause) = where_clause {
-            Some(quote!{#where_clause, #(#additional),*})
+            Some(quote!{#where_clause #(#additional),*})
         } else {
             Some(quote!{where #(#additional),*})
         }

--- a/misc/core-derive/tests/test.rs
+++ b/misc/core-derive/tests/test.rs
@@ -73,8 +73,7 @@ fn three_fields() {
     }
 }
 
-// TODO: fix this example ; a Rust bug prevent us from doing so
-/*#[test]
+#[test]
 fn event_handler() {
     #[allow(dead_code)]
     #[derive(NetworkBehaviour)]
@@ -86,7 +85,7 @@ fn event_handler() {
     impl<TSubstream: libp2p::tokio_io::AsyncRead + libp2p::tokio_io::AsyncWrite> Foo<TSubstream> {
         // TODO: for some reason, the parameter cannot be `PeriodicIdentifyBehaviourEvent` or we
         //       get a compilation error ; figure out why or open an issue to Rust
-        fn foo(&mut self, ev: <libp2p::identify::PeriodicIdentifyBehaviour<TSubstream> as libp2p::core::swarm::NetworkBehaviour>::OutEvent) {
+        fn foo<TTopology>(&mut self, ev: <libp2p::identify::PeriodicIdentifyBehaviour<TSubstream> as libp2p::core::swarm::NetworkBehaviour<TTopology>>::OutEvent) {
             let libp2p::identify::PeriodicIdentifyBehaviourEvent::Identified { .. } = ev;
         }
     }
@@ -94,7 +93,7 @@ fn event_handler() {
     fn foo<TSubstream: libp2p::tokio_io::AsyncRead + libp2p::tokio_io::AsyncWrite>() {
         require_net_behaviour::<Foo<TSubstream>>();
     }
-}*/
+}
 
 #[test]
 fn custom_polling() {


### PR DESCRIPTION
Apparently we were accidentally outputting `impl ... for ... where, Foo: Bar` (notice the extra `,`).
The latest versions of Rust no longer accept that.

Also fixes the commented-out test.