### PR TITLE
Don't wrap yamux::Connection in a mutex

### DIFF
--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -9,6 +9,5 @@ bytes = "0.4"
 futures = "0.1"
 libp2p-core = { path = "../../core" }
 log = "0.4"
-parking_lot = "0.7"
 tokio-io = "0.1"
 yamux = "0.1"

--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -10,4 +10,4 @@ futures = "0.1"
 libp2p-core = { path = "../../core" }
 log = "0.4"
 tokio-io = "0.1"
-yamux = "0.1"
+yamux = "0.1.1"

--- a/muxers/yamux/src/lib.rs
+++ b/muxers/yamux/src/lib.rs
@@ -56,21 +56,7 @@ where
 
     #[inline]
     fn poll_inbound(&self) -> Poll<Option<Self::Substream>, IoError> {
-//        match self.0.lock().poll() {
-//        let mut inner = self.0.inner.lock();
-//        match inner.poll() {
-//        match self.0.make_mut().poll() {
-//        match self.0.get_inner_mut() {
-//        use std::ops::DerefMut;
-//        let &mut inner = self.0.inner.lock().deref_mut();
-//        use std::borrow::BorrowMut;
-//        let inner = self.0.borrow_mut();
-//        match inner.poll() {
-//        use std::sync::Arc;
-//        let x = Arc::make_mut(&mut self.0.inner);
-//        let mut x = self.0.clone();
-        match self.0.clone().poll() {
-//        match self.0.poll() {
+        match self.0.poll() {
             Err(e) => {
                 error!("connection error: {}", e);
                 Err(io::Error::new(io::ErrorKind::Other, e))

--- a/muxers/yamux/src/lib.rs
+++ b/muxers/yamux/src/lib.rs
@@ -23,14 +23,12 @@ extern crate futures;
 #[macro_use]
 extern crate log;
 extern crate libp2p_core;
-extern crate parking_lot;
 extern crate tokio_io;
 extern crate yamux;
 
 use bytes::Bytes;
 use futures::{future::{self, FutureResult}, prelude::*};
 use libp2p_core::{muxing::Shutdown, upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo}};
-use parking_lot::Mutex;
 use std::{io, iter};
 use std::io::{Error as IoError};
 use tokio_io::{AsyncRead, AsyncWrite};


### PR DESCRIPTION
Remove the need for an extra mutex. Requires https://github.com/paritytech/yamux/pull/24 for tests to pass.