### PR TITLE
Add a few more methods to Swarm and PollParameters

### DIFF
--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -56,10 +56,11 @@ use libp2p::{
 
 fn main() {
     env_logger::init();
+
     // Create a random PeerId
     let local_key = secio::SecioKeyPair::ed25519_generated().unwrap();
-    let local_peer_id = local_key.to_peer_id();
-    println!("Local peer id: {:?}", local_peer_id);
+    let local_pub_key = local_key.to_public_key();
+    println!("Local peer id: {:?}", local_pub_key.clone().into_peer_id());
 
     // Set up a an encrypted DNS-enabled TCP Transport over the Mplex protocol
     let transport = libp2p::CommonTransport::new()
@@ -75,9 +76,9 @@ fn main() {
 
     // Create a Swarm to manage peers and events
     let mut swarm = {
-        let mut behaviour = libp2p::floodsub::FloodsubBehaviour::new(local_peer_id);
+        let mut behaviour = libp2p::floodsub::FloodsubBehaviour::new(local_pub_key.clone().into_peer_id());
         behaviour.subscribe(floodsub_topic.clone());
-        libp2p::Swarm::new(transport, behaviour, libp2p::core::topology::MemoryTopology::empty())
+        libp2p::Swarm::new(transport, behaviour, libp2p::core::topology::MemoryTopology::empty(), local_pub_key)
     };
 
     // Listen on all interfaces and whatever port the OS assigns

--- a/examples/ipfs-kad.rs
+++ b/examples/ipfs-kad.rs
@@ -40,7 +40,7 @@ use libp2p::{
 fn main() {
     // Create a random key for ourselves.
     let local_key = secio::SecioKeyPair::ed25519_generated().unwrap();
-    let local_peer_id = local_key.to_peer_id();
+    let local_pub_key = local_key.to_public_key();
 
     // Set up a an encrypted DNS-enabled TCP Transport over the Mplex protocol
     let transport = libp2p::CommonTransport::new()
@@ -70,8 +70,8 @@ fn main() {
         // to insert our local node in the DHT. However here we use `without_init` because this
         // example is very ephemeral and we don't want to pollute the DHT. In a real world
         // application, you want to use `new` instead.
-        let mut behaviour = libp2p::kad::Kademlia::without_init(local_peer_id);
-        libp2p::core::Swarm::new(transport, behaviour, topology)
+        let mut behaviour = libp2p::kad::Kademlia::without_init(local_pub_key.clone().into_peer_id());
+        libp2p::core::Swarm::new(transport, behaviour, topology, local_pub_key)
     };
 
     // Order Kademlia to search for a peer.


### PR DESCRIPTION
Adds `Swarm::local_peer_id`, `PollParameters::listened_addresses`, `PollParameters::local_public_key`, `PollParameters::local_peer_id`.

The consequence is that the user now needs to pass the `PublicKey` when creating the `Swarm`.