### PR TITLE
Rename all the network behaviours to more basic names

### DIFF
--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -76,7 +76,7 @@ fn main() {
 
     // Create a Swarm to manage peers and events
     let mut swarm = {
-        let mut behaviour = libp2p::floodsub::FloodsubBehaviour::new(local_pub_key.clone().into_peer_id());
+        let mut behaviour = libp2p::floodsub::Floodsub::new(local_pub_key.clone().into_peer_id());
         behaviour.subscribe(floodsub_topic.clone());
         libp2p::Swarm::new(transport, behaviour, libp2p::core::topology::MemoryTopology::empty(), local_pub_key)
     };

--- a/misc/core-derive/tests/test.rs
+++ b/misc/core-derive/tests/test.rs
@@ -38,7 +38,7 @@ fn one_field() {
     #[allow(dead_code)]
     #[derive(NetworkBehaviour)]
     struct Foo<TSubstream> {
-        ping: libp2p::ping::PeriodicPingBehaviour<TSubstream>,
+        ping: libp2p::ping::PeriodicPing<TSubstream>,
     }
 
     fn foo<TSubstream: libp2p::tokio_io::AsyncRead + libp2p::tokio_io::AsyncWrite>() {
@@ -51,8 +51,8 @@ fn two_fields() {
     #[allow(dead_code)]
     #[derive(NetworkBehaviour)]
     struct Foo<TSubstream> {
-        ping_dialer: libp2p::ping::PeriodicPingBehaviour<TSubstream>,
-        ping_listener: libp2p::ping::PingListenBehaviour<TSubstream>,
+        ping_dialer: libp2p::ping::PeriodicPing<TSubstream>,
+        ping_listener: libp2p::ping::PingListen<TSubstream>,
     }
 }
 
@@ -61,8 +61,8 @@ fn three_fields() {
     #[allow(dead_code)]
     #[derive(NetworkBehaviour)]
     struct Foo<TSubstream> {
-        ping_dialer: libp2p::ping::PeriodicPingBehaviour<TSubstream>,
-        ping_listener: libp2p::ping::PingListenBehaviour<TSubstream>,
+        ping_dialer: libp2p::ping::PeriodicPing<TSubstream>,
+        ping_listener: libp2p::ping::PingListen<TSubstream>,
         identify: libp2p::identify::PeriodicIdentifyBehaviour<TSubstream>,
         #[behaviour(ignore)]
         foo: String,
@@ -101,7 +101,7 @@ fn custom_polling() {
     #[derive(NetworkBehaviour)]
     #[behaviour(poll_method = "foo")]
     struct Foo<TSubstream> {
-        ping: libp2p::ping::PeriodicPingBehaviour<TSubstream>,
+        ping: libp2p::ping::PeriodicPing<TSubstream>,
         identify: libp2p::identify::PeriodicIdentifyBehaviour<TSubstream>,
     }
 
@@ -120,7 +120,7 @@ fn custom_event_no_polling() {
     #[derive(NetworkBehaviour)]
     #[behaviour(out_event = "String")]
     struct Foo<TSubstream> {
-        ping: libp2p::ping::PeriodicPingBehaviour<TSubstream>,
+        ping: libp2p::ping::PeriodicPing<TSubstream>,
         identify: libp2p::identify::PeriodicIdentifyBehaviour<TSubstream>,
     }
 
@@ -135,7 +135,7 @@ fn custom_event_and_polling() {
     #[derive(NetworkBehaviour)]
     #[behaviour(poll_method = "foo", out_event = "String")]
     struct Foo<TSubstream> {
-        ping: libp2p::ping::PeriodicPingBehaviour<TSubstream>,
+        ping: libp2p::ping::PeriodicPing<TSubstream>,
         identify: libp2p::identify::PeriodicIdentifyBehaviour<TSubstream>,
     }
 

--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -33,7 +33,7 @@ use topic::{Topic, TopicHash};
 
 /// Network behaviour that automatically identifies nodes periodically, and returns information
 /// about them.
-pub struct FloodsubBehaviour<TSubstream> {
+pub struct Floodsub<TSubstream> {
     /// Events that need to be yielded to the outside when polling.
     events: VecDeque<NetworkBehaviourAction<FloodsubRpc, FloodsubMessage>>,
 
@@ -57,10 +57,10 @@ pub struct FloodsubBehaviour<TSubstream> {
     marker: PhantomData<TSubstream>,
 }
 
-impl<TSubstream> FloodsubBehaviour<TSubstream> {
-    /// Creates a `FloodsubBehaviour`.
+impl<TSubstream> Floodsub<TSubstream> {
+    /// Creates a `Floodsub`.
     pub fn new(local_peer_id: PeerId) -> Self {
-        FloodsubBehaviour {
+        Floodsub {
             events: VecDeque::new(),
             local_peer_id,
             connected_peers: HashMap::new(),
@@ -71,7 +71,7 @@ impl<TSubstream> FloodsubBehaviour<TSubstream> {
     }
 }
 
-impl<TSubstream> FloodsubBehaviour<TSubstream> {
+impl<TSubstream> Floodsub<TSubstream> {
     /// Subscribes to a topic.
     ///
     /// Returns true if the subscription worked. Returns false if we were already subscribed.
@@ -172,7 +172,7 @@ impl<TSubstream> FloodsubBehaviour<TSubstream> {
     }
 }
 
-impl<TSubstream, TTopology> NetworkBehaviour<TTopology> for FloodsubBehaviour<TSubstream>
+impl<TSubstream, TTopology> NetworkBehaviour<TTopology> for Floodsub<TSubstream>
 where
     TSubstream: AsyncRead + AsyncWrite,
 {

--- a/protocols/floodsub/src/lib.rs
+++ b/protocols/floodsub/src/lib.rs
@@ -31,13 +31,12 @@ extern crate tokio_codec;
 extern crate tokio_io;
 extern crate unsigned_varint;
 
-mod handler;
+pub mod handler;
+pub mod protocol;
+
 mod layer;
-mod protocol;
 mod rpc_proto;
 mod topic;
 
-pub use self::handler::FloodsubHandler;
-pub use self::layer::FloodsubBehaviour;
-pub use self::protocol::*; // TODO: exact reexports
+pub use self::layer::Floodsub;
 pub use self::topic::{Topic, TopicBuilder, TopicHash};

--- a/protocols/identify/src/lib.rs
+++ b/protocols/identify/src/lib.rs
@@ -82,17 +82,14 @@ extern crate unsigned_varint;
 extern crate void;
 
 pub use self::id_transport::IdentifyTransport;
-pub use self::listen_handler::IdentifyListenHandler;
 pub use self::listen_layer::IdentifyListen;
-pub use self::periodic_id_handler::{PeriodicIdentification, PeriodicIdentificationEvent};
 pub use self::periodic_id_layer::{PeriodicIdentifyBehaviour, PeriodicIdentifyBehaviourEvent};
-pub use self::protocol::{IdentifyInfo, RemoteInfo};
-pub use self::protocol::{IdentifyProtocolConfig, IdentifySender, IdentifySenderFuture};
+
+pub mod listen_handler;
+pub mod periodic_id_handler;
+pub mod protocol;
 
 mod id_transport;
-mod listen_handler;
 mod listen_layer;
-mod periodic_id_handler;
 mod periodic_id_layer;
-mod protocol;
 mod structs_proto;

--- a/protocols/identify/src/listen_handler.rs
+++ b/protocols/identify/src/listen_handler.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::{IdentifySender, IdentifyProtocolConfig};
+use crate::protocol::{IdentifySender, IdentifyProtocolConfig};
 use futures::prelude::*;
 use libp2p_core::{
     protocols_handler::{ProtocolsHandler, ProtocolsHandlerEvent},

--- a/protocols/identify/src/listen_layer.rs
+++ b/protocols/identify/src/listen_layer.rs
@@ -18,6 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use crate::protocol::{IdentifyInfo, IdentifySenderFuture};
+use crate::listen_handler::IdentifyListenHandler;
 use futures::prelude::*;
 use libp2p_core::swarm::{ConnectedPoint, NetworkBehaviour, NetworkBehaviourAction, PollParameters};
 use libp2p_core::{protocols_handler::ProtocolsHandler, Multiaddr, PeerId};
@@ -25,7 +27,6 @@ use smallvec::SmallVec;
 use std::collections::HashMap;
 use tokio_io::{AsyncRead, AsyncWrite};
 use void::Void;
-use {IdentifyListenHandler, IdentifyInfo, IdentifySenderFuture};
 
 /// Network behaviour that automatically identifies nodes periodically, and returns information
 /// about them.

--- a/protocols/identify/src/periodic_id_handler.rs
+++ b/protocols/identify/src/periodic_id_handler.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::{RemoteInfo, IdentifyProtocolConfig};
+use crate::protocol::{RemoteInfo, IdentifyProtocolConfig};
 use futures::prelude::*;
 use libp2p_core::{
     protocols_handler::{ProtocolsHandler, ProtocolsHandlerEvent},

--- a/protocols/identify/src/periodic_id_layer.rs
+++ b/protocols/identify/src/periodic_id_layer.rs
@@ -18,12 +18,13 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use crate::periodic_id_handler::{PeriodicIdentification, PeriodicIdentificationEvent};
+use crate::protocol::IdentifyInfo;
 use futures::prelude::*;
 use libp2p_core::swarm::{ConnectedPoint, NetworkBehaviour, NetworkBehaviourAction, PollParameters};
 use libp2p_core::{protocols_handler::ProtocolsHandler, Multiaddr, PeerId};
 use std::{collections::VecDeque, marker::PhantomData};
 use tokio_io::{AsyncRead, AsyncWrite};
-use {IdentifyInfo, PeriodicIdentification, PeriodicIdentificationEvent};
 
 /// Network behaviour that automatically identifies nodes periodically, and returns information
 /// about them.

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -256,13 +256,13 @@ mod tests {
     extern crate libp2p_tcp_transport;
     extern crate tokio;
 
+    use crate::protocol::{IdentifyInfo, RemoteInfo, IdentifyProtocolConfig};
     use self::tokio::runtime::current_thread::Runtime;
     use self::libp2p_tcp_transport::TcpConfig;
     use futures::{Future, Stream};
     use libp2p_core::{PublicKey, Transport, upgrade::{apply_outbound, apply_inbound}};
     use std::sync::mpsc;
     use std::thread;
-    use {IdentifyInfo, RemoteInfo, IdentifyProtocolConfig};
 
     #[test]
     fn correct_transfer() {

--- a/protocols/ping/src/dial_layer.rs
+++ b/protocols/ping/src/dial_layer.rs
@@ -18,37 +18,37 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use crate::dial_handler::PeriodicPingHandler;
 use futures::prelude::*;
 use libp2p_core::swarm::{ConnectedPoint, NetworkBehaviour, NetworkBehaviourAction, PollParameters};
 use libp2p_core::{protocols_handler::ProtocolsHandler, PeerId};
 use std::marker::PhantomData;
 use tokio_io::{AsyncRead, AsyncWrite};
 use void::Void;
-use PeriodicPingHandler;
 
 /// Network behaviour that handles receiving pings sent by other nodes.
-pub struct PeriodicPingBehaviour<TSubstream> {
+pub struct PeriodicPing<TSubstream> {
     /// Marker to pin the generics.
     marker: PhantomData<TSubstream>,
 }
 
-impl<TSubstream> PeriodicPingBehaviour<TSubstream> {
-    /// Creates a `PeriodicPingBehaviour`.
+impl<TSubstream> PeriodicPing<TSubstream> {
+    /// Creates a `PeriodicPing`.
     pub fn new() -> Self {
-        PeriodicPingBehaviour {
+        PeriodicPing {
             marker: PhantomData,
         }
     }
 }
 
-impl<TSubstream> Default for PeriodicPingBehaviour<TSubstream> {
+impl<TSubstream> Default for PeriodicPing<TSubstream> {
     #[inline]
     fn default() -> Self {
-        PeriodicPingBehaviour::new()
+        PeriodicPing::new()
     }
 }
 
-impl<TSubstream, TTopology> NetworkBehaviour<TTopology> for PeriodicPingBehaviour<TSubstream>
+impl<TSubstream, TTopology> NetworkBehaviour<TTopology> for PeriodicPing<TSubstream>
 where
     TSubstream: AsyncRead + AsyncWrite,
 {

--- a/protocols/ping/src/lib.rs
+++ b/protocols/ping/src/lib.rs
@@ -94,14 +94,12 @@ extern crate tokio_io;
 extern crate tokio_timer;
 extern crate void;
 
-pub use self::dial_handler::PeriodicPingHandler;
-pub use self::dial_layer::PeriodicPingBehaviour;
-pub use self::listen_handler::PingListenHandler;
-pub use self::listen_layer::PingListenBehaviour;
+pub use self::dial_layer::PeriodicPing;
+pub use self::listen_layer::PingListen;
 
+pub mod dial_handler;
+pub mod listen_handler;
 pub mod protocol;
 
-mod dial_handler;
 mod dial_layer;
-mod listen_handler;
 mod listen_layer;

--- a/protocols/ping/src/listen_layer.rs
+++ b/protocols/ping/src/listen_layer.rs
@@ -18,37 +18,37 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use crate::listen_handler::PingListenHandler;
 use futures::prelude::*;
 use libp2p_core::swarm::{ConnectedPoint, NetworkBehaviour, NetworkBehaviourAction, PollParameters};
 use libp2p_core::{protocols_handler::ProtocolsHandler, PeerId};
 use std::marker::PhantomData;
 use tokio_io::{AsyncRead, AsyncWrite};
 use void::Void;
-use PingListenHandler;
 
 /// Network behaviour that handles receiving pings sent by other nodes.
-pub struct PingListenBehaviour<TSubstream> {
+pub struct PingListen<TSubstream> {
     /// Marker to pin the generics.
     marker: PhantomData<TSubstream>,
 }
 
-impl<TSubstream> PingListenBehaviour<TSubstream> {
-    /// Creates a `PingListenBehaviour`.
+impl<TSubstream> PingListen<TSubstream> {
+    /// Creates a `PingListen`.
     pub fn new() -> Self {
-        PingListenBehaviour {
+        PingListen {
             marker: PhantomData,
         }
     }
 }
 
-impl<TSubstream> Default for PingListenBehaviour<TSubstream> {
+impl<TSubstream> Default for PingListen<TSubstream> {
     #[inline]
     fn default() -> Self {
-        PingListenBehaviour::new()
+        PingListen::new()
     }
 }
 
-impl<TSubstream, TTopology> NetworkBehaviour<TTopology> for PingListenBehaviour<TSubstream>
+impl<TSubstream, TTopology> NetworkBehaviour<TTopology> for PingListen<TSubstream>
 where
     TSubstream: AsyncRead + AsyncWrite,
 {


### PR DESCRIPTION
And no longer expose upgrades and handlers at the root of the protocol libraries.
Makes it easier for users to figure out what to use.

cc #596 