### PR TITLE
Avoid some warnings.

### DIFF
--- a/misc/mdns/src/lib.rs
+++ b/misc/mdns/src/lib.rs
@@ -569,7 +569,7 @@ mod tests {
 
                 match packet {
                     MdnsPacket::Query(query) => {
-                        query.respond(peer_id.clone(), None, Duration::from_secs(120));
+                        query.respond(peer_id.clone(), None, Duration::from_secs(120)).unwrap();
                     }
                     MdnsPacket::Response(response) => {
                         for peer in response.discovered_peers() {

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -458,6 +458,7 @@ mod tests {
     extern crate libp2p_tcp_transport;
     extern crate tokio;
 
+    /*// TODO: restore
     use self::libp2p_tcp_transport::TcpConfig;
     use self::tokio::runtime::current_thread::Runtime;
     use futures::{Future, Sink, Stream};
@@ -467,7 +468,6 @@ mod tests {
     use std::sync::mpsc;
     use std::thread;
 
-    /*// TODO: restore
     #[test]
     fn correct_transfer() {
         // We open a server and a client, send a message between the two, and check that they were


### PR DESCRIPTION
- mdns: unused `Result` which must be used
- kad: unused import
- mplex: use of deprecated item