### PR TITLE
Rename libp2p-tcp-transport to libp2p-tcp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tokio-io = "0.1"
 [target.'cfg(not(target_os = "emscripten"))'.dependencies]
 libp2p-dns = { path = "./transports/dns" }
 libp2p-mdns = { path = "./misc/mdns" }
-libp2p-tcp-transport = { path = "./transports/tcp" }
+libp2p-tcp = { path = "./transports/tcp" }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
 stdweb = { version = "0.1.3", default-features = false }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,7 +29,7 @@ void = "1"
 
 [dev-dependencies]
 libp2p-ping = { path = "../protocols/ping" }
-libp2p-tcp-transport = { path = "../transports/tcp" }
+libp2p-tcp = { path = "../transports/tcp" }
 libp2p-mplex = { path = "../muxers/mplex" }
 rand = "0.6"
 tokio = "0.1"

--- a/core/src/nodes/listeners.rs
+++ b/core/src/nodes/listeners.rs
@@ -41,13 +41,13 @@ use std::collections::VecDeque;
 /// ```no_run
 /// # extern crate futures;
 /// # extern crate libp2p_core;
-/// # extern crate libp2p_tcp_transport;
+/// # extern crate libp2p_tcp;
 /// # extern crate tokio;
 /// # fn main() {
 /// use futures::prelude::*;
 /// use libp2p_core::nodes::listeners::{ListenersEvent, ListenersStream};
 ///
-/// let mut listeners = ListenersStream::new(libp2p_tcp_transport::TcpConfig::new());
+/// let mut listeners = ListenersStream::new(libp2p_tcp::TcpConfig::new());
 ///
 /// // Ask the `listeners` to start listening on the given multiaddress.
 /// listeners.listen_on("/ip4/0.0.0.0/tcp/0".parse().unwrap()).unwrap();
@@ -274,7 +274,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    extern crate libp2p_tcp_transport;
+    extern crate libp2p_tcp;
 
     use super::*;
     use transport;

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -20,5 +20,5 @@ tokio-io = "0.1"
 unsigned-varint = { version = "0.2.1", features = ["codec"] }
 
 [dev-dependencies]
-libp2p-tcp-transport = { path = "../../transports/tcp" }
+libp2p-tcp = { path = "../../transports/tcp" }
 tokio = "0.1"

--- a/muxers/mplex/tests/two_peers.rs
+++ b/muxers/mplex/tests/two_peers.rs
@@ -22,7 +22,7 @@ extern crate bytes;
 extern crate futures;
 extern crate libp2p_mplex as multiplex;
 extern crate libp2p_core as swarm;
-extern crate libp2p_tcp_transport as tcp;
+extern crate libp2p_tcp as tcp;
 extern crate tokio;
 
 use futures::prelude::*;

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -25,5 +25,5 @@ unsigned-varint = { version = "0.2.1", features = ["codec"] }
 void = "1.0"
 
 [dev-dependencies]
-libp2p-tcp-transport = { path = "../../transports/tcp" }
+libp2p-tcp = { path = "../../transports/tcp" }
 tokio = "0.1"

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -253,12 +253,12 @@ fn parse_proto_msg(msg: BytesMut) -> Result<(IdentifyInfo, Multiaddr), IoError> 
 
 #[cfg(test)]
 mod tests {
-    extern crate libp2p_tcp_transport;
+    extern crate libp2p_tcp;
     extern crate tokio;
 
     use crate::protocol::{IdentifyInfo, RemoteInfo, IdentifyProtocolConfig};
     use self::tokio::runtime::current_thread::Runtime;
-    use self::libp2p_tcp_transport::TcpConfig;
+    use self::libp2p_tcp::TcpConfig;
     use futures::{Future, Stream};
     use libp2p_core::{PublicKey, Transport, upgrade::{apply_outbound, apply_inbound}};
     use std::sync::mpsc;

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -32,5 +32,5 @@ unsigned-varint = { version = "0.2.1", features = ["codec"] }
 void = "1.0"
 
 [dev-dependencies]
-libp2p-tcp-transport = { path = "../../transports/tcp" }
+libp2p-tcp = { path = "../../transports/tcp" }
 tokio = "0.1"

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -455,11 +455,11 @@ fn proto_to_resp_msg(
 
 #[cfg(test)]
 mod tests {
-    extern crate libp2p_tcp_transport;
+    extern crate libp2p_tcp;
     extern crate tokio;
 
     /*// TODO: restore
-    use self::libp2p_tcp_transport::TcpConfig;
+    use self::libp2p_tcp::TcpConfig;
     use self::tokio::runtime::current_thread::Runtime;
     use futures::{Future, Sink, Stream};
     use libp2p_core::{PeerId, PublicKey, Transport};

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -24,6 +24,6 @@ tokio-timer = "0.2.6"
 void = "1.0"
 
 [dev-dependencies]
-libp2p-tcp-transport = { path = "../../transports/tcp" }
+libp2p-tcp = { path = "../../transports/tcp" }
 tokio = "0.1"
 tokio-tcp = "0.1"

--- a/protocols/ping/src/lib.rs
+++ b/protocols/ping/src/lib.rs
@@ -52,7 +52,7 @@
 //! extern crate futures;
 //! extern crate libp2p_ping;
 //! extern crate libp2p_core;
-//! extern crate libp2p_tcp_transport;
+//! extern crate libp2p_tcp;
 //! extern crate tokio;
 //!
 //! use futures::{Future, Stream};
@@ -61,7 +61,7 @@
 //! use tokio::runtime::current_thread::Runtime;
 //!
 //! # fn main() {
-//! let ping_dialer = libp2p_tcp_transport::TcpConfig::new()
+//! let ping_dialer = libp2p_tcp::TcpConfig::new()
 //!     .and_then(|socket, _| {
 //!         apply_outbound(socket, Ping::default()).map_err(|e| e.into_io_error())
 //!     })

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -41,6 +41,6 @@ rsa = ["ring/rsa_signing"]
 aes-all = ["aesni", "lazy_static"]
 
 [dev-dependencies]
-libp2p-tcp-transport = { path = "../../transports/tcp" }
+libp2p-tcp = { path = "../../transports/tcp" }
 tokio = "0.1"
 tokio-tcp = "0.1"

--- a/protocols/secio/src/lib.rs
+++ b/protocols/secio/src/lib.rs
@@ -34,14 +34,14 @@
 //! extern crate tokio_io;
 //! extern crate libp2p_core;
 //! extern crate libp2p_secio;
-//! extern crate libp2p_tcp_transport;
+//! extern crate libp2p_tcp;
 //!
 //! # fn main() {
 //! use futures::Future;
 //! use libp2p_secio::{SecioConfig, SecioKeyPair, SecioOutput};
 //! use libp2p_core::{Multiaddr, upgrade::apply_inbound};
 //! use libp2p_core::transport::Transport;
-//! use libp2p_tcp_transport::TcpConfig;
+//! use libp2p_tcp::TcpConfig;
 //! use tokio_io::io::write_all;
 //! use tokio::runtime::current_thread::Runtime;
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,9 @@
 //!
 //! ```rust
 //! use libp2p::{Multiaddr, Transport, tcp::TcpConfig};
-//! let tcp_transport = TcpConfig::new();
+//! let tcp = TcpConfig::new();
 //! let addr: Multiaddr = "/ip4/98.97.96.95/tcp/20500".parse().expect("invalid multiaddr");
-//! let _outgoing_connec = tcp_transport.dial(addr);
+//! let _outgoing_connec = tcp.dial(addr);
 //! // Note that `_outgoing_connec` is a `Future`, and therefore doesn't do anything by itself
 //! // unless it is run through a tokio runtime.
 //! ```
@@ -77,9 +77,9 @@
 //! ```rust
 //! # #[cfg(all(not(target_os = "emscripten"), feature = "libp2p-secio"))] {
 //! use libp2p::{Transport, tcp::TcpConfig, secio::{SecioConfig, SecioKeyPair}};
-//! let tcp_transport = TcpConfig::new();
+//! let tcp = TcpConfig::new();
 //! let secio_upgrade = SecioConfig::new(SecioKeyPair::ed25519_generated().unwrap());
-//! let with_security = tcp_transport.with_upgrade(secio_upgrade);
+//! let with_security = tcp.with_upgrade(secio_upgrade);
 //! // let _ = with_security.dial(...);
 //! // `with_security` also implements the `Transport` trait, and all the connections opened
 //! // through it will automatically negotiate the `secio` protocol.
@@ -153,7 +153,7 @@ pub extern crate libp2p_plaintext as plaintext;
 pub extern crate libp2p_ratelimit as ratelimit;
 pub extern crate libp2p_secio as secio;
 #[cfg(not(target_os = "emscripten"))]
-pub extern crate libp2p_tcp_transport as tcp;
+pub extern crate libp2p_tcp as tcp;
 pub extern crate libp2p_transport_timeout as transport_timeout;
 pub extern crate libp2p_uds as uds;
 #[cfg(feature = "libp2p-websocket")]

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -17,5 +17,5 @@ tokio-dns-unofficial = "0.4"
 tokio-io = "0.1"
 
 [dev-dependencies]
-libp2p-tcp-transport = { path = "../../transports/tcp" }
+libp2p-tcp = { path = "../../transports/tcp" }
 tokio = "0.1"

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -279,8 +279,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    extern crate libp2p_tcp_transport;
-    use self::libp2p_tcp_transport::TcpConfig;
+    extern crate libp2p_tcp;
+    use self::libp2p_tcp::TcpConfig;
     use futures::future;
     use swarm::Transport;
     use multiaddr::{Protocol, Multiaddr};

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "libp2p-tcp-transport"
+name = "libp2p-tcp"
 description = "TCP/IP transport protocol for libp2p"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/transports/tcp/src/lib.rs
+++ b/transports/tcp/src/lib.rs
@@ -27,8 +27,8 @@
 //! Example:
 //!
 //! ```
-//! extern crate libp2p_tcp_transport;
-//! use libp2p_tcp_transport::TcpConfig;
+//! extern crate libp2p_tcp;
+//! use libp2p_tcp::TcpConfig;
 //!
 //! # fn main() {
 //! let tcp = TcpConfig::new();

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -23,5 +23,5 @@ websocket = { version = "0.21.0", default-features = false, features = ["async",
 stdweb = { version = "0.1.3", default-features = false }
 
 [target.'cfg(not(target_os = "emscripten"))'.dev-dependencies]
-libp2p-tcp-transport = { path = "../tcp" }
+libp2p-tcp = { path = "../tcp" }
 tokio = "0.1"

--- a/transports/websocket/src/desktop.rs
+++ b/transports/websocket/src/desktop.rs
@@ -258,7 +258,7 @@ fn client_addr_to_ws(client_addr: &Multiaddr, is_wss: bool) -> String {
 
 #[cfg(test)]
 mod tests {
-    extern crate libp2p_tcp_transport as tcp;
+    extern crate libp2p_tcp as tcp;
     extern crate tokio;
     use self::tokio::runtime::current_thread::Runtime;
     use futures::{Future, Stream};

--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -53,11 +53,11 @@
 //!
 //! ```
 //! extern crate libp2p_core;
-//! extern crate libp2p_tcp_transport;
+//! extern crate libp2p_tcp;
 //! extern crate libp2p_websocket;
 //!
 //! use libp2p_core::{Multiaddr, Transport};
-//! use libp2p_tcp_transport::TcpConfig;
+//! use libp2p_tcp::TcpConfig;
 //! use libp2p_websocket::WsConfig;
 //!
 //! # fn main() {


### PR DESCRIPTION
For consistency with the other crate names.