### PR TITLE
Skip self address in dialing

### DIFF
--- a/core/src/swarm.rs
+++ b/core/src/swarm.rs
@@ -164,12 +164,18 @@ where TBehaviour: NetworkBehaviour<TTopology>,
     }
 
     /// Tries to reach the given peer using the elements in the topology.
+    /// Silently returns if address was associated with the `Self`
     ///
     /// Has no effect if we are already connected to that peer, or if no address is known for the
     /// peer.
     #[inline]
     pub fn dial(me: &mut Self, peer_id: PeerId) {
         let addrs = me.topology.addresses_of_peer(&peer_id);
+        for a in addrs.iter() {
+          if me.listened_addrs.iter().find(|addr| addr == &a).is_some() {
+            return;
+          }
+        }
         let handler = me.behaviour.new_handler().into_node_handler();
         if let Some(peer) = me.raw_swarm.peer(peer_id).as_not_connected() {
             let _ = peer.connect_iter(addrs, handler);

--- a/core/src/swarm.rs
+++ b/core/src/swarm.rs
@@ -171,10 +171,12 @@ where TBehaviour: NetworkBehaviour<TTopology>,
     #[inline]
     pub fn dial(me: &mut Self, peer_id: PeerId) {
         let addrs = me.topology.addresses_of_peer(&peer_id);
-        for a in addrs.iter() {
-          if me.listened_addrs.iter().find(|addr| addr == &a).is_some() {
+        let is_dialling_self = addrs.iter().any(|addr| {
+            me.listened_addrs.iter().any(|my_addr| my_addr == addr)
+        });
+        if is_dialling_self {
+            trace!("can't dial self!");
             return;
-          }
         }
         let handler = me.behaviour.new_handler().into_node_handler();
         if let Some(peer) = me.raw_swarm.peer(peer_id).as_not_connected() {


### PR DESCRIPTION
Resolves #773 

It have O(n^2) complexity, though as number of peer addresses is usually considered small, that shouldn't be a problem, should it? Also it might be handy to use [itertools](https://docs.rs/itertools/0.8.0/itertools/trait.Itertools.html#method.cartesian_product) crate, but that might be too much for just one function. Also I've spent for about 10 minutes lurking the code so I'm completely unfamiliar with it (and might miss other important changes).

p.s: hey from rustrush