### PR TITLE
Add a setter for `split_send_size`

### DIFF
--- a/muxers/mplex/src/lib.rs
+++ b/muxers/mplex/src/lib.rs
@@ -85,6 +85,12 @@ impl MplexConfig {
         self
     }
 
+    /// Sets the frame size used when sending data
+    pub fn split_send_size(&mut self, size: usize) -> &mut Self {
+        self.split_send_size = size;
+        self
+    }
+
     #[inline]
     fn upgrade<C>(self, i: C, endpoint: Endpoint) -> Multiplex<C>
     where


### PR DESCRIPTION
When sending data over the wire the data is split into frame sized according to this setting. There is currently no way for applications to set this value. This PR adds a setter to `MplexConfig`.