### PR TITLE
Cleanup.

### DIFF
--- a/core/src/either.rs
+++ b/core/src/either.rs
@@ -47,10 +47,10 @@ where
     A: fmt::Debug + std::error::Error,
     B: fmt::Debug + std::error::Error
 {
-    fn cause(&self) -> Option<&dyn std::error::Error> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            EitherError::A(a) => a.cause(),
-            EitherError::B(b) => b.cause()
+            EitherError::A(a) => a.source(),
+            EitherError::B(b) => b.source()
         }
     }
 }

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -25,7 +25,7 @@ use crate::topology::IdentifyTopology;
 use futures::prelude::*;
 use libp2p_core::protocols_handler::{ProtocolsHandler, ProtocolsHandlerSelect, ProtocolsHandlerUpgrErr};
 use libp2p_core::swarm::{ConnectedPoint, NetworkBehaviour, NetworkBehaviourAction, PollParameters};
-use libp2p_core::{Multiaddr, PeerId, either::EitherOutput, topology::Topology};
+use libp2p_core::{Multiaddr, PeerId, either::EitherOutput};
 use smallvec::SmallVec;
 use std::{collections::HashMap, collections::VecDeque, io};
 use tokio_io::{AsyncRead, AsyncWrite};


### PR DESCRIPTION
- Use `Error::source` instead of `Error::cause`.
- Remove unused import.