### PR TITLE
Also add the node's reported address in mDNS

### DIFF
--- a/misc/mdns/src/behaviour.rs
+++ b/misc/mdns/src/behaviour.rs
@@ -119,6 +119,7 @@ where
 
             match event {
                 MdnsPacket::Query(query) => {
+                    println!("rx q; {:?}", params.listened_addresses().cloned().collect::<Vec<_>>());
                     let _ = query.respond(
                         params.local_peer_id().clone(),
                         params.listened_addresses().cloned(),
@@ -140,13 +141,11 @@ where
                         }
 
                         for addr in peer.addresses() {
-                            let to_insert = if let Some(new_addr) = params.nat_traversal(&addr, &observed) {
-                                new_addr
-                            } else {
-                                addr
-                            };
+                            if let Some(new_addr) = params.nat_traversal(&addr, &observed) {
+                                params.topology().add_mdns_discovered_address(peer.id().clone(), new_addr);
+                            }
 
-                            params.topology().add_mdns_discovered_address(peer.id().clone(), to_insert);
+                            params.topology().add_mdns_discovered_address(peer.id().clone(), addr);
                         }
 
                         if let Some(ref mut to_connect_to) = self.to_connect_to {


### PR DESCRIPTION
cc #794 

This solves a practical problem:

- Nodes A and B both run on the same machine and listen on 127.0.0.1
- Node A receives an mDNS response from B indicating the address `/ip4/127.0.0.1/tcp/500`.
- Node A observes node B as `192.168.1.2`, even though A and B are on the same machine.
- Node A uses `nat_traversal()` and turns `/ip4/127.0.0.1/tcp/500` into `/ip4/192.168.1.2/tcp/500`.
- Node A tries to connect to B but the connection is refused because it uses the "wrong" IP.

This PR fixes it by adding `/ip4/127.0.0.1/tcp/500` to the topology as well.