### PR TITLE
Remove readme = entries in Cargo.toml

### DIFF
--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -5,7 +5,6 @@ description = "Implementation of the multiaddr format"
 homepage = "https://github.com/libp2p/rust-libp2p"
 keywords = ["multiaddr", "ipfs"]
 license = "MIT"
-readme = "README.md"
 version = "0.1.0"
 
 [dependencies]

--- a/misc/multihash/Cargo.toml
+++ b/misc/multihash/Cargo.toml
@@ -6,7 +6,6 @@ keywords = ["multihash", "ipfs"]
 version = "0.1.0"
 authors = ["dignifiedquire <dignifiedquire@gmail.com>", "Parity Technologies <admin@parity.io>"]
 license = "MIT"
-readme = "README.md"
 documentation = "https://docs.rs/parity-multihash/"
 
 [dependencies]


### PR DESCRIPTION
The corresponding `README.md` files don't exist.