### PR TITLE
Fix compilation with syn 0.15.23

### DIFF
--- a/misc/core-derive/Cargo.toml
+++ b/misc/core-derive/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "0.15", default-features = false, features = ["derive", "parsing", "printing", "proc-macro"] }
+syn = { version = "0.15.22", default-features = false, features = ["clone-impls", "derive", "parsing", "printing", "proc-macro"] }
 quote = "0.6"
 
 [dev-dependencies]


### PR DESCRIPTION
Right now `libp2p-core-derive` is using `syn` with `default-features=false` and doesn't enable the `clone-impls` feature even though it needs it to compile.

However in practice it always compiles because it has an indirect dependency on `serde-device`, which depends on `syn` with `clone-impls` enabled. Hence why we have never realized the problem.