### PR TITLE
Remove assertions in kad protocol

### DIFF
--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -315,7 +315,6 @@ fn resp_msg_to_proto(kad_msg: KadResponseMsg) -> protobuf_structs::dht::Message 
             msg
         }
         KadResponseMsg::FindNode { closer_peers } => {
-            assert!(!closer_peers.is_empty());
             let mut msg = protobuf_structs::dht::Message::new();
             msg.set_field_type(protobuf_structs::dht::Message_MessageType::FIND_NODE);
             msg.set_clusterLevelRaw(9);
@@ -328,7 +327,6 @@ fn resp_msg_to_proto(kad_msg: KadResponseMsg) -> protobuf_structs::dht::Message 
             closer_peers,
             provider_peers,
         } => {
-            assert!(!closer_peers.is_empty());
             let mut msg = protobuf_structs::dht::Message::new();
             msg.set_field_type(protobuf_structs::dht::Message_MessageType::GET_PROVIDERS);
             msg.set_clusterLevelRaw(9);


### PR DESCRIPTION
Now that the Kademlia protocol is unidirectional, let's remove these assertions.