### PR TITLE
Update to tokio 0.1.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,8 @@ libp2p-secio = { version = "0.1.0", path = "./protocols/secio", default-features
 libp2p-uds = { version = "0.1.0", path = "./transports/uds" }
 libp2p-websocket = { version = "0.1.0", path = "./transports/websocket", optional = true }
 libp2p-yamux = { version = "0.1.0", path = "./muxers/yamux" }
-tokio-codec = "0.1"
+tokio = { version = "0.1.14", default-features = false, features = ["codec", "io"] }
 tokio-executor = "0.1"
-tokio-io = "0.1"
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "unknown")))'.dependencies]
 libp2p-dns = { version = "0.1.0", path = "./transports/dns" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,9 +23,8 @@ protobuf = "2.0.2"
 quick-error = "1.2"
 rw-stream-sink = { version = "0.1.0", path = "../misc/rw-stream-sink" }
 smallvec = "0.6"
+tokio = { version = "0.1.14", default-features = false, features = ["io", "timer"] }
 tokio-executor = "0.1.4"
-tokio-io = "0.1"
-tokio-timer = "0.2"
 void = "1"
 
 [dev-dependencies]
@@ -34,7 +33,5 @@ libp2p-tcp = { version = "0.1.0", path = "../transports/tcp" }
 libp2p-mplex = { version = "0.1.0", path = "../muxers/mplex" }
 rand = "0.6"
 tokio = "0.1"
-tokio-codec = "0.1"
-tokio-timer = "0.2"
 assert_matches = "1.3"
 tokio-mock-task = "0.1"

--- a/core/src/either.rs
+++ b/core/src/either.rs
@@ -21,7 +21,7 @@
 use crate::{muxing::{Shutdown, StreamMuxer}, Multiaddr, ProtocolName};
 use futures::prelude::*;
 use std::{fmt, io::{Error as IoError, Read, Write}};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 #[derive(Debug, Copy, Clone)]
 pub enum EitherError<A, B> {

--- a/core/src/muxing.rs
+++ b/core/src/muxing.rs
@@ -58,7 +58,7 @@ use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read, Write};
 use std::ops::Deref;
 use std::fmt;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 /// Ways to shutdown a substream or stream muxer.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/core/src/protocols_handler/dummy.rs
+++ b/core/src/protocols_handler/dummy.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 use futures::prelude::*;
 use std::marker::PhantomData;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use void::Void;
 
 /// Implementation of `ProtocolsHandler` that doesn't handle anything.

--- a/core/src/protocols_handler/mod.rs
+++ b/core/src/protocols_handler/mod.rs
@@ -40,7 +40,7 @@ use crate::upgrade::{
 };
 use futures::prelude::*;
 use std::{error, fmt, time::Duration};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 pub use self::dummy::DummyProtocolsHandler;
 pub use self::map_in::MapInEvent;

--- a/core/src/protocols_handler/node_handler.rs
+++ b/core/src/protocols_handler/node_handler.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 use futures::prelude::*;
 use std::time::{Duration, Instant};
-use tokio_timer::{Delay, Timeout};
+use tokio::timer::{Delay, Timeout};
 
 /// Prototype for a `NodeHandlerWrapper`.
 pub struct NodeHandlerWrapperBuilder<TProtoHandler>

--- a/core/src/protocols_handler/select.rs
+++ b/core/src/protocols_handler/select.rs
@@ -31,7 +31,7 @@ use crate::{
     }
 };
 use futures::prelude::*;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 /// Implementation of `ProtocolsHandler` that combines two protocols into one.
 #[derive(Debug, Clone)]

--- a/core/src/transport/mod.rs
+++ b/core/src/transport/mod.rs
@@ -31,7 +31,7 @@ use futures::prelude::*;
 use multiaddr::Multiaddr;
 use std::io::Error as IoError;
 use std::time::Duration;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 pub mod and_then;
 pub mod boxed;

--- a/core/src/transport/timeout.rs
+++ b/core/src/transport/timeout.rs
@@ -28,8 +28,7 @@ use futures::{try_ready, Async, Future, Poll, Stream};
 use log::debug;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::time::Duration;
-use tokio_timer::Timeout;
-use tokio_timer::timeout::Error as TimeoutError;
+use tokio::timer::{Timeout, timeout::Error as TimeoutError};
 
 /// Wraps around a `Transport` and adds a timeout to all the incoming and outgoing connections.
 ///

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 use futures::{future::Either, prelude::*, try_ready};
 use multiaddr::Multiaddr;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 #[derive(Debug, Copy, Clone)]
 pub struct Upgrade<T, U> { inner: T, upgrade: U }

--- a/core/src/upgrade/apply.rs
+++ b/core/src/upgrade/apply.rs
@@ -24,7 +24,7 @@ use futures::{future::Either, prelude::*};
 use log::debug;
 use multistream_select::{self, DialerSelectFuture, ListenerSelectFuture};
 use std::mem;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 /// Applies an upgrade to the inbound and outbound direction of a connection or substream.
 pub fn apply<C, U>(conn: C, up: U, cp: ConnectedPoint)

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -20,7 +20,7 @@
 
 //! A basic chat application demonstrating libp2p and the mDNS and floodsub protocols.
 //!
-//! Using two terminal windows, start two instances. If you local network allows mDNS, 
+//! Using two terminal windows, start two instances. If you local network allows mDNS,
 //! they will automatically connect. Type a message in either terminal and hit return: the
 //! message is sent and printed in the other terminal. Close with Ctrl-c.
 //!
@@ -47,7 +47,7 @@
 //! cargo run --example chat -- /ip4/127.0.0.1/tcp/24915
 //! ```
 //!
-//! The two nodes then connect. 
+//! The two nodes then connect.
 
 extern crate env_logger;
 extern crate futures;
@@ -59,7 +59,7 @@ use futures::prelude::*;
 use libp2p::{
     NetworkBehaviour,
     secio,
-    tokio_codec::{FramedRead, LinesCodec}
+    tokio::codec::{FramedRead, LinesCodec}
 };
 
 fn main() {
@@ -79,18 +79,18 @@ fn main() {
     // We create a custom network behaviour that combines floodsub and mDNS.
     // In the future, we want to improve libp2p to make this easier to do.
     #[derive(NetworkBehaviour)]
-    struct MyBehaviour<TSubstream: libp2p::tokio_io::AsyncRead + libp2p::tokio_io::AsyncWrite> {
+    struct MyBehaviour<TSubstream: libp2p::tokio::io::AsyncRead + libp2p::tokio::io::AsyncWrite> {
         floodsub: libp2p::floodsub::Floodsub<TSubstream>,
         mdns: libp2p::mdns::Mdns<TSubstream>,
     }
 
-    impl<TSubstream: libp2p::tokio_io::AsyncRead + libp2p::tokio_io::AsyncWrite> libp2p::core::swarm::NetworkBehaviourEventProcess<void::Void> for MyBehaviour<TSubstream> {
+    impl<TSubstream: libp2p::tokio::io::AsyncRead + libp2p::tokio::io::AsyncWrite> libp2p::core::swarm::NetworkBehaviourEventProcess<void::Void> for MyBehaviour<TSubstream> {
         fn inject_event(&mut self, _ev: void::Void) {
             void::unreachable(_ev)
         }
     }
 
-    impl<TSubstream: libp2p::tokio_io::AsyncRead + libp2p::tokio_io::AsyncWrite> libp2p::core::swarm::NetworkBehaviourEventProcess<libp2p::floodsub::FloodsubEvent> for MyBehaviour<TSubstream> {
+    impl<TSubstream: libp2p::tokio::io::AsyncRead + libp2p::tokio::io::AsyncWrite> libp2p::core::swarm::NetworkBehaviourEventProcess<libp2p::floodsub::FloodsubEvent> for MyBehaviour<TSubstream> {
         // Called when `floodsub` produces an event.
         fn inject_event(&mut self, message: libp2p::floodsub::FloodsubEvent) {
             if let libp2p::floodsub::FloodsubEvent::Message(message) = message {
@@ -145,7 +145,7 @@ fn main() {
         loop {
             match swarm.poll().expect("Error while polling swarm") {
                 Async::Ready(Some(_)) => {
-                    
+
                 },
                 Async::Ready(None) | Async::NotReady => break,
             }

--- a/misc/core-derive/src/lib.rs
+++ b/misc/core-derive/src/lib.rs
@@ -107,8 +107,8 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
             })
             .collect::<Vec<_>>();
 
-        additional.push(quote!{#substream_generic: ::libp2p::tokio_io::AsyncRead});
-        additional.push(quote!{#substream_generic: ::libp2p::tokio_io::AsyncWrite});
+        additional.push(quote!{#substream_generic: ::libp2p::tokio::io::AsyncRead});
+        additional.push(quote!{#substream_generic: ::libp2p::tokio::io::AsyncWrite});
 
         if let Some(where_clause) = where_clause {
             Some(quote!{#where_clause #(#additional),*})

--- a/misc/core-derive/tests/test.rs
+++ b/misc/core-derive/tests/test.rs
@@ -47,7 +47,7 @@ fn one_field() {
         }
     }
 
-    fn foo<TSubstream: libp2p::tokio_io::AsyncRead + libp2p::tokio_io::AsyncWrite>() {
+    fn foo<TSubstream: libp2p::tokio::io::AsyncRead + libp2p::tokio::io::AsyncWrite>() {
         require_net_behaviour::<Foo<TSubstream>>();
     }
 }
@@ -71,7 +71,7 @@ fn two_fields() {
         }
     }
 
-    fn foo<TSubstream: libp2p::tokio_io::AsyncRead + libp2p::tokio_io::AsyncWrite>() {
+    fn foo<TSubstream: libp2p::tokio::io::AsyncRead + libp2p::tokio::io::AsyncWrite>() {
         require_net_behaviour::<Foo<TSubstream>>();
     }
 }
@@ -103,7 +103,7 @@ fn three_fields() {
         }
     }
 
-    fn foo<TSubstream: libp2p::tokio_io::AsyncRead + libp2p::tokio_io::AsyncWrite>() {
+    fn foo<TSubstream: libp2p::tokio::io::AsyncRead + libp2p::tokio::io::AsyncWrite>() {
         require_net_behaviour::<Foo<TSubstream>>();
     }
 }
@@ -132,7 +132,7 @@ fn custom_polling() {
         fn foo<T>(&mut self) -> libp2p::futures::Async<libp2p::core::swarm::NetworkBehaviourAction<T, ()>> { libp2p::futures::Async::NotReady }
     }
 
-    fn foo<TSubstream: libp2p::tokio_io::AsyncRead + libp2p::tokio_io::AsyncWrite>() {
+    fn foo<TSubstream: libp2p::tokio::io::AsyncRead + libp2p::tokio::io::AsyncWrite>() {
         require_net_behaviour::<Foo<TSubstream>>();
     }
 }
@@ -157,7 +157,7 @@ fn custom_event_no_polling() {
         }
     }
 
-    fn foo<TSubstream: libp2p::tokio_io::AsyncRead + libp2p::tokio_io::AsyncWrite>() {
+    fn foo<TSubstream: libp2p::tokio::io::AsyncRead + libp2p::tokio::io::AsyncWrite>() {
         require_net_behaviour::<Foo<TSubstream>>();
     }
 }
@@ -186,7 +186,7 @@ fn custom_event_and_polling() {
         fn foo<T>(&mut self) -> libp2p::futures::Async<libp2p::core::swarm::NetworkBehaviourAction<T, String>> { libp2p::futures::Async::NotReady }
     }
 
-    fn foo<TSubstream: libp2p::tokio_io::AsyncRead + libp2p::tokio_io::AsyncWrite>() {
+    fn foo<TSubstream: libp2p::tokio::io::AsyncRead + libp2p::tokio::io::AsyncWrite>() {
         require_net_behaviour::<Foo<TSubstream>>();
     }
 }

--- a/misc/mdns/Cargo.toml
+++ b/misc/mdns/Cargo.toml
@@ -17,10 +17,7 @@ multiaddr = { package = "parity-multiaddr", version = "0.1.0", path = "../multia
 net2 = "0.2"
 rand = "0.6"
 smallvec = "0.6"
-tokio-io = "0.1"
-tokio-reactor = "0.1"
-tokio-timer = "0.2"
-tokio-udp = "0.1"
+tokio = { version = "0.1.14", default-features = false, features = ["io", "reactor", "timer", "udp"] }
 void = "1.0"
 
 [dev-dependencies]

--- a/misc/mdns/src/behaviour.rs
+++ b/misc/mdns/src/behaviour.rs
@@ -25,7 +25,7 @@ use libp2p_core::swarm::{ConnectedPoint, NetworkBehaviour, NetworkBehaviourActio
 use libp2p_core::{Multiaddr, PeerId, multiaddr::Protocol, topology::MemoryTopology, topology::Topology};
 use smallvec::SmallVec;
 use std::{fmt, io, iter, marker::PhantomData, time::Duration};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use void::{self, Void};
 
 /// A `NetworkBehaviour` for mDNS. Automatically discovers peers on the local network and adds

--- a/misc/mdns/src/lib.rs
+++ b/misc/mdns/src/lib.rs
@@ -38,14 +38,8 @@ extern crate multiaddr;
 extern crate net2;
 extern crate rand;
 extern crate smallvec;
-extern crate tokio_io;
-extern crate tokio_reactor;
-extern crate tokio_timer;
-extern crate tokio_udp;
-extern crate void;
-
-#[cfg(test)]
 extern crate tokio;
+extern crate void;
 
 /// Hardcoded name of the mDNS service. Part of the mDNS libp2p specifications.
 const SERVICE_NAME: &'static [u8] = b"_p2p._udp.local";

--- a/misc/mdns/src/service.rs
+++ b/misc/mdns/src/service.rs
@@ -25,11 +25,6 @@ extern crate libp2p_core;
 extern crate multiaddr;
 extern crate net2;
 extern crate rand;
-extern crate tokio_reactor;
-extern crate tokio_timer;
-extern crate tokio_udp;
-
-#[cfg(test)]
 extern crate tokio;
 
 use crate::{SERVICE_NAME, META_QUERY_SERVICE, dns};
@@ -38,9 +33,9 @@ use futures::{prelude::*, task};
 use libp2p_core::{Multiaddr, PeerId};
 use multiaddr::Protocol;
 use std::{fmt, io, net::Ipv4Addr, net::SocketAddr, str, time::Duration, time::Instant};
-use tokio_reactor::Handle;
-use tokio_timer::Interval;
-use tokio_udp::UdpSocket;
+use tokio::reactor::Handle;
+use tokio::timer::Interval;
+use tokio::net::udp::UdpSocket;
 
 pub use dns::MdnsResponseError;
 
@@ -48,7 +43,7 @@ pub use dns::MdnsResponseError;
 /// the local network.
 ///
 /// # Usage
-/// 
+///
 /// In order to use mDNS to discover peers on the local network, use the `MdnsService`. This is
 /// done by creating a `MdnsService` then polling it in the same way as you would poll a stream.
 ///
@@ -185,7 +180,7 @@ impl MdnsService {
                 }
             }
             Ok(Async::NotReady) => (),
-            _ => unreachable!("A tokio_timer::Interval never errors"), // TODO: is that true?
+            _ => unreachable!("A tokio::timer::Interval never errors"), // TODO: is that true?
         };
 
         // Flush the send buffer of the main socket.

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -14,10 +14,8 @@ bytes = "0.4"
 futures = { version = "0.1" }
 log = "0.4"
 smallvec = "0.6"
-tokio-codec = "0.1"
-tokio-io = "0.1"
+tokio = { version = "0.1.14", default-features = false, features = ["codec", "io"] }
 unsigned-varint = { version = "0.2.1", features = ["codec"] }
 
 [dev-dependencies]
 tokio = "0.1"
-tokio-tcp = "0.1"

--- a/misc/multistream-select/src/dialer_select.rs
+++ b/misc/multistream-select/src/dialer_select.rs
@@ -30,7 +30,7 @@ use crate::protocol::{
 };
 use log::trace;
 use std::mem;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use crate::ProtocolChoiceError;
 
 /// Future, returned by `dialer_select_proto`, which selects a protocol and dialer

--- a/misc/multistream-select/src/length_delimited.rs
+++ b/misc/multistream-select/src/length_delimited.rs
@@ -22,8 +22,8 @@ use bytes::Bytes;
 use futures::{Async, Poll, Sink, StartSend, Stream};
 use smallvec::SmallVec;
 use std::{io, u16};
-use tokio_codec::{Encoder, FramedWrite};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::codec::{Encoder, FramedWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use unsigned_varint::decode;
 
 /// `Stream` and `Sink` wrapping some `AsyncRead + AsyncWrite` object to read

--- a/misc/multistream-select/src/lib.rs
+++ b/misc/multistream-select/src/lib.rs
@@ -46,7 +46,7 @@
 //! use bytes::Bytes;
 //! use multistream_select::dialer_select_proto;
 //! use futures::{Future, Sink, Stream};
-//! use tokio_tcp::TcpStream;
+//! use tokio::net::tcp::TcpStream;
 //! use tokio::runtime::current_thread::Runtime;
 //!
 //! #[derive(Debug, Copy, Clone)]

--- a/misc/multistream-select/src/listener_select.rs
+++ b/misc/multistream-select/src/listener_select.rs
@@ -30,7 +30,7 @@ use crate::protocol::{
 };
 use log::{debug, trace};
 use std::mem;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use crate::ProtocolChoiceError;
 
 /// Helps selecting a protocol amongst the ones supported.

--- a/misc/multistream-select/src/protocol/dialer.rs
+++ b/misc/multistream-select/src/protocol/dialer.rs
@@ -28,8 +28,8 @@ use crate::protocol::MultistreamSelectError;
 use crate::protocol::MULTISTREAM_PROTOCOL_WITH_LF;
 use futures::{prelude::*, sink, Async, StartSend, try_ready};
 use std::io;
-use tokio_codec::Encoder;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::codec::Encoder;
+use tokio::io::{AsyncRead, AsyncWrite};
 use unsigned_varint::{decode, codec::Uvi};
 
 /// Wraps around a `AsyncRead+AsyncWrite`.
@@ -206,7 +206,7 @@ impl<N: AsRef<[u8]>> Encoder for MessageEncoder<N> {
 mod tests {
     use crate::protocol::{Dialer, DialerToListenerMessage, MultistreamSelectError};
     use tokio::runtime::current_thread::Runtime;
-    use tokio_tcp::{TcpListener, TcpStream};
+    use tokio::net::tcp::{TcpListener, TcpStream};
     use futures::Future;
     use futures::{Sink, Stream};
 

--- a/misc/multistream-select/src/protocol/listener.rs
+++ b/misc/multistream-select/src/protocol/listener.rs
@@ -29,8 +29,8 @@ use crate::protocol::MULTISTREAM_PROTOCOL_WITH_LF;
 use futures::{prelude::*, sink, stream::StreamFuture};
 use log::{debug, trace};
 use std::{io, mem};
-use tokio_codec::Encoder;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::codec::Encoder;
+use tokio::io::{AsyncRead, AsyncWrite};
 use unsigned_varint::{encode, codec::Uvi};
 
 /// Wraps around a `AsyncRead+AsyncWrite`. Assumes that we're on the listener's side. Produces and
@@ -243,7 +243,7 @@ impl<N: AsRef<[u8]>> Encoder for MessageEncoder<N> {
 #[cfg(test)]
 mod tests {
     use tokio::runtime::current_thread::Runtime;
-    use tokio_tcp::{TcpListener, TcpStream};
+    use tokio::net::tcp::{TcpListener, TcpStream};
     use bytes::Bytes;
     use futures::Future;
     use futures::{Sink, Stream};

--- a/misc/multistream-select/src/tests.rs
+++ b/misc/multistream-select/src/tests.rs
@@ -28,7 +28,7 @@ use crate::protocol::{Dialer, DialerToListenerMessage, Listener, ListenerToDiale
 use crate::{dialer_select_proto, listener_select_proto};
 use futures::prelude::*;
 use tokio::runtime::current_thread::Runtime;
-use tokio_tcp::{TcpListener, TcpStream};
+use tokio::net::tcp::{TcpListener, TcpStream};
 
 /// Holds a `Vec` and satifies the iterator requirements of `listener_select_proto`.
 struct VecRefIntoIter<T>(Vec<T>);

--- a/misc/rw-stream-sink/Cargo.toml
+++ b/misc/rw-stream-sink/Cargo.toml
@@ -11,4 +11,4 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 bytes = "0.4"
 futures = "0.1"
-tokio-io = "0.1"
+tokio = { version = "0.1.14", default-features = false, features = ["io"] }

--- a/misc/rw-stream-sink/src/lib.rs
+++ b/misc/rw-stream-sink/src/lib.rs
@@ -29,7 +29,7 @@
 
 extern crate bytes;
 extern crate futures;
-extern crate tokio_io;
+extern crate tokio;
 
 use bytes::{Buf, IntoBuf};
 use futures::{Async, AsyncSink, Poll, Sink, Stream};
@@ -37,7 +37,7 @@ use std::cmp;
 use std::io::Error as IoError;
 use std::io::ErrorKind as IoErrorKind;
 use std::io::{Read, Write};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 /// Wraps around a `Stream + Sink` whose items are buffers. Implements `AsyncRead` and `AsyncWrite`.
 pub struct RwStreamSink<S>

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -16,8 +16,7 @@ futures = "0.1"
 libp2p-core = { version = "0.1.0", path = "../../core" }
 log = "0.4"
 parking_lot = "0.7"
-tokio-codec = "0.1"
-tokio-io = "0.1"
+tokio = { version = "0.1.14", default-features = false, features = ["codec", "io"] }
 unsigned-varint = { version = "0.2.1", features = ["codec"] }
 
 [dev-dependencies]

--- a/muxers/mplex/src/codec.rs
+++ b/muxers/mplex/src/codec.rs
@@ -22,7 +22,7 @@ use libp2p_core::Endpoint;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::mem;
 use bytes::{BufMut, Bytes, BytesMut};
-use tokio_io::codec::{Decoder, Encoder};
+use tokio::codec::{Decoder, Encoder};
 use unsigned_varint::{codec, encode};
 
 // Maximum size for a packet: 1MB as per the spec.

--- a/muxers/mplex/src/lib.rs
+++ b/muxers/mplex/src/lib.rs
@@ -34,8 +34,8 @@ use log::{debug, trace};
 use parking_lot::Mutex;
 use fnv::{FnvHashMap, FnvHashSet};
 use futures::{prelude::*, executor, future, stream::Fuse, task, task_local, try_ready};
-use tokio_codec::Framed;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::codec::Framed;
+use tokio::io::{AsyncRead, AsyncWrite};
 
 /// Configuration for the multiplexer.
 #[derive(Debug, Clone)]

--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -13,5 +13,5 @@ categories = ["network-programming", "asynchronous"]
 futures = "0.1"
 libp2p-core = { version = "0.1.0", path = "../../core" }
 log = "0.4"
-tokio-io = "0.1"
+tokio = { version = "0.1.14", default-features = false, features = ["io"] }
 yamux = "0.1.1"

--- a/muxers/yamux/src/lib.rs
+++ b/muxers/yamux/src/lib.rs
@@ -26,8 +26,7 @@ use libp2p_core::{muxing::Shutdown, upgrade::{InboundUpgrade, OutboundUpgrade, U
 use log::error;
 use std::{io, iter};
 use std::io::{Error as IoError};
-use tokio_io::{AsyncRead, AsyncWrite};
-
+use tokio::io::{AsyncRead, AsyncWrite};
 
 pub struct Yamux<C>(yamux::Connection<C>);
 

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -18,6 +18,5 @@ libp2p-core = { version = "0.1.0", path = "../../core" }
 protobuf = "2.0.2"
 rand = "0.6"
 smallvec = "0.6.5"
-tokio-codec = "0.1"
-tokio-io = "0.1"
+tokio = { version = "0.1.14", default-features = false, features = ["codec", "io"] }
 unsigned-varint = { version = "0.2.1", features = ["codec"] }

--- a/protocols/floodsub/src/handler.rs
+++ b/protocols/floodsub/src/handler.rs
@@ -27,8 +27,8 @@ use libp2p_core::{
 };
 use smallvec::SmallVec;
 use std::{fmt, io};
-use tokio_codec::Framed;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::codec::Framed;
+use tokio::io::{AsyncRead, AsyncWrite};
 
 /// Protocol handler that handles communication with the remote for the floodsub protocol.
 ///

--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -28,7 +28,7 @@ use rand;
 use smallvec::SmallVec;
 use std::{collections::VecDeque, iter, marker::PhantomData};
 use std::collections::hash_map::{DefaultHasher, HashMap};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use topic::{Topic, TopicHash};
 
 /// Network behaviour that automatically identifies nodes periodically, and returns information

--- a/protocols/floodsub/src/lib.rs
+++ b/protocols/floodsub/src/lib.rs
@@ -30,8 +30,7 @@ extern crate libp2p_core;
 extern crate protobuf;
 extern crate rand;
 extern crate smallvec;
-extern crate tokio_codec;
-extern crate tokio_io;
+extern crate tokio;
 extern crate unsigned_varint;
 
 pub mod handler;

--- a/protocols/floodsub/src/protocol.rs
+++ b/protocols/floodsub/src/protocol.rs
@@ -24,8 +24,8 @@ use futures::future;
 use libp2p_core::{InboundUpgrade, OutboundUpgrade, UpgradeInfo, PeerId};
 use protobuf::Message as ProtobufMessage;
 use std::{io, iter};
-use tokio_codec::{Decoder, Encoder, Framed};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::codec::{Decoder, Encoder, Framed};
+use tokio::io::{AsyncRead, AsyncWrite};
 use topic::TopicHash;
 use unsigned_varint::codec;
 

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -18,9 +18,7 @@ multiaddr = { package = "parity-multiaddr", version = "0.1.0", path = "../../mis
 parking_lot = "0.7"
 protobuf = "2.0.2"
 smallvec = "0.6"
-tokio-codec = "0.1"
-tokio-io = "0.1.0"
-tokio-timer = "0.2.6"
+tokio = { version = "0.1.14", default-features = false, features = ["codec", "io", "timer"] }
 unsigned-varint = { version = "0.2.1", features = ["codec"] }
 void = "1.0"
 

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -28,7 +28,7 @@ use libp2p_core::swarm::{ConnectedPoint, NetworkBehaviour, NetworkBehaviourActio
 use libp2p_core::{Multiaddr, PeerId, either::EitherOutput};
 use smallvec::SmallVec;
 use std::{collections::HashMap, collections::VecDeque, io};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use void::Void;
 
 /// Network behaviour that automatically identifies nodes periodically, returns information

--- a/protocols/identify/src/lib.rs
+++ b/protocols/identify/src/lib.rs
@@ -75,9 +75,7 @@ extern crate multiaddr;
 extern crate parking_lot;
 extern crate protobuf;
 extern crate smallvec;
-extern crate tokio_codec;
-extern crate tokio_io;
-extern crate tokio_timer;
+extern crate tokio;
 extern crate unsigned_varint;
 extern crate void;
 

--- a/protocols/identify/src/listen_handler.rs
+++ b/protocols/identify/src/listen_handler.rs
@@ -25,7 +25,7 @@ use libp2p_core::{
     upgrade::{DeniedUpgrade, InboundUpgrade, OutboundUpgrade}
 };
 use smallvec::SmallVec;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use void::{Void, unreachable};
 
 /// Protocol handler that identifies the remote at a regular period.

--- a/protocols/identify/src/periodic_id_handler.rs
+++ b/protocols/identify/src/periodic_id_handler.rs
@@ -25,8 +25,8 @@ use libp2p_core::{
     upgrade::{DeniedUpgrade, OutboundUpgrade}
 };
 use std::{io, marker::PhantomData, time::{Duration, Instant}};
-use tokio_io::{AsyncRead, AsyncWrite};
-use tokio_timer::{self, Delay};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::timer::Delay;
 use void::{Void, unreachable};
 
 /// Delay between the moment we connect and the first time we identify.
@@ -85,7 +85,7 @@ where
 {
     type InEvent = Void;
     type OutEvent = PeriodicIdHandlerEvent;
-    type Error = tokio_timer::Error;
+    type Error = tokio::timer::Error;
     type Substream = TSubstream;
     type InboundProtocol = DeniedUpgrade;
     type OutboundProtocol = IdentifyProtocolConfig;

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -31,8 +31,8 @@ use protobuf::RepeatedField;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::iter;
 use structs_proto;
-use tokio_codec::Framed;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::codec::Framed;
+use tokio::io::{AsyncRead, AsyncWrite};
 use unsigned_varint::codec;
 
 /// Configuration for an upgrade to the identity protocol.
@@ -253,11 +253,10 @@ fn parse_proto_msg(msg: BytesMut) -> Result<(IdentifyInfo, Multiaddr), IoError> 
 #[cfg(test)]
 mod tests {
     extern crate libp2p_tcp;
-    extern crate tokio;
 
     use crate::protocol::{IdentifyInfo, RemoteInfo, IdentifyProtocolConfig};
-    use self::tokio::runtime::current_thread::Runtime;
     use self::libp2p_tcp::TcpConfig;
+    use tokio::runtime::current_thread::Runtime;
     use futures::{Future, Stream};
     use libp2p_core::{PublicKey, Transport, upgrade::{apply_outbound, apply_inbound}};
     use std::sync::mpsc;

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -25,9 +25,7 @@ parking_lot = "0.7"
 protobuf = "2.0.2"
 rand = "0.6.0"
 smallvec = "0.6"
-tokio-codec = "0.1"
-tokio-io = "0.1"
-tokio-timer = "0.2.6"
+tokio = { version = "0.1.14", default-features = false, features = ["codec", "io", "timer"] }
 unsigned-varint = { version = "0.2.1", features = ["codec"] }
 void = "1.0"
 

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -29,8 +29,8 @@ use query::{QueryConfig, QueryState, QueryStatePollOut, QueryTarget};
 use rand;
 use smallvec::SmallVec;
 use std::{cmp::Ordering, marker::PhantomData, time::Duration, time::Instant};
-use tokio_io::{AsyncRead, AsyncWrite};
-use tokio_timer::Interval;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::timer::Interval;
 use topology::KademliaTopology;
 
 /// Network behaviour that handles Kademlia.

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -27,7 +27,7 @@ use protocol::{
     KademliaProtocolConfig,
 };
 use std::{error, fmt, io};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 /// Protocol handler that handles Kademlia communications with the remote.
 ///

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -73,14 +73,9 @@ extern crate parking_lot;
 extern crate protobuf;
 extern crate rand;
 extern crate smallvec;
-extern crate tokio_codec;
-extern crate tokio_io;
-extern crate tokio_timer;
+extern crate tokio;
 extern crate unsigned_varint;
 extern crate void;
-
-#[cfg(test)]
-extern crate tokio;
 
 pub use self::behaviour::{Kademlia, KademliaOut};
 pub use self::kbucket::KBucketsPeerId;

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -34,8 +34,8 @@ use protobuf::{self, Message};
 use protobuf_structs;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::iter;
-use tokio_codec::Framed;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::codec::Framed;
+use tokio::io::{AsyncRead, AsyncWrite};
 use unsigned_varint::codec;
 
 /// Status of our connection to a node reported by the Kademlia protocol.
@@ -454,7 +454,6 @@ fn proto_to_resp_msg(
 #[cfg(test)]
 mod tests {
     extern crate libp2p_tcp;
-    extern crate tokio;
 
     /*// TODO: restore
     use self::libp2p_tcp::TcpConfig;

--- a/protocols/kad/src/query.rs
+++ b/protocols/kad/src/query.rs
@@ -30,7 +30,7 @@ use libp2p_core::PeerId;
 use multihash::Multihash;
 use smallvec::SmallVec;
 use std::time::{Duration, Instant};
-use tokio_timer::Delay;
+use tokio::timer::Delay;
 
 /// State of a query iterative process.
 ///

--- a/protocols/observed/Cargo.toml
+++ b/protocols/observed/Cargo.toml
@@ -12,8 +12,7 @@ categories = ["network-programming", "asynchronous"]
 bytes = "0.4"
 futures = "0.1"
 libp2p-core = { version = "0.1.0", path = "../../core" }
-tokio-codec = "0.1"
-tokio-io = "0.1"
+tokio = { version = "0.1.14", default-features = false, features = ["codec", "io"] }
 unsigned-varint = { version = "0.2.1", features = ["codec"] }
 
 [dev-dependencies]

--- a/protocols/observed/src/lib.rs
+++ b/protocols/observed/src/lib.rs
@@ -24,16 +24,15 @@
 extern crate bytes;
 extern crate futures;
 extern crate libp2p_core;
-extern crate tokio_codec;
-extern crate tokio_io;
+extern crate tokio;
 extern crate unsigned_varint;
 
 use bytes::Bytes;
 use futures::{future, prelude::*};
 use libp2p_core::{Multiaddr, upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo}};
 use std::{io, iter};
-use tokio_codec::{FramedRead, FramedWrite};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::codec::{FramedRead, FramedWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use unsigned_varint::codec::UviBytes;
 
 /// The connection upgrade type to retrieve or report externally visible addresses.
@@ -107,8 +106,6 @@ impl<C: AsyncWrite> Sender<C> {
 
 #[cfg(test)]
 mod tests {
-    extern crate tokio;
-
     use libp2p_core::{Multiaddr, upgrade::{InboundUpgrade, OutboundUpgrade}};
     use self::tokio::runtime::current_thread;
     use self::tokio::net::{TcpListener, TcpStream};

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -19,12 +19,9 @@ multistream-select = { version = "0.1.0", path = "../../misc/multistream-select"
 futures = "0.1"
 parking_lot = "0.7"
 rand = "0.6"
-tokio-codec = "0.1"
-tokio-io = "0.1"
-tokio-timer = "0.2.6"
+tokio = { version = "0.1.14", default-features = false, features = ["codec", "io", "timer"] }
 void = "1.0"
 
 [dev-dependencies]
 libp2p-tcp = { version = "0.1.0", path = "../../transports/tcp" }
 tokio = "0.1"
-tokio-tcp = "0.1"

--- a/protocols/ping/src/dial_handler.rs
+++ b/protocols/ping/src/dial_handler.rs
@@ -32,8 +32,8 @@ use std::{
     io, mem,
     time::{Duration, Instant},
 };
-use tokio_io::{AsyncRead, AsyncWrite};
-use tokio_timer::{self, Delay};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::timer::Delay;
 use void::{Void, unreachable};
 
 /// Protocol handler that handles pinging the remote at a regular period.
@@ -219,7 +219,7 @@ where
         ProtocolsHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Self::OutEvent>,
         io::Error,
     > {
-        // Shortcut for polling a `tokio_timer::Delay`
+        // Shortcut for polling a `tokio::timer::Delay`
         macro_rules! poll_delay {
             ($delay:expr => { NotReady => $notready:expr, Ready => $ready:expr, }) => (
                 match $delay.poll() {

--- a/protocols/ping/src/lib.rs
+++ b/protocols/ping/src/lib.rs
@@ -40,7 +40,7 @@ use libp2p_core::either::EitherOutput;
 use libp2p_core::swarm::{ConnectedPoint, NetworkBehaviour, NetworkBehaviourAction, PollParameters};
 use libp2p_core::{protocols_handler::ProtocolsHandler, protocols_handler::ProtocolsHandlerSelect, PeerId};
 use std::{marker::PhantomData, time::Duration};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 /// Network behaviour that handles receiving pings sent by other nodes and periodically pings the
 /// nodes we are connected to.

--- a/protocols/ping/src/listen_handler.rs
+++ b/protocols/ping/src/listen_handler.rs
@@ -30,7 +30,7 @@ use libp2p_core::{
     upgrade::DeniedUpgrade
 };
 use log::warn;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use void::{Void, unreachable};
 
 /// Handler for handling pings received from a remote.

--- a/protocols/ping/src/protocol.rs
+++ b/protocols/ping/src/protocol.rs
@@ -26,8 +26,8 @@ use rand::{distributions::Standard, prelude::*, rngs::EntropyRng};
 use std::collections::VecDeque;
 use std::io::Error as IoError;
 use std::{iter, marker::PhantomData, mem};
-use tokio_codec::{Decoder, Encoder, Framed};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::codec::{Decoder, Encoder, Framed};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 /// Represents a prototype for an upgrade to handle the ping protocol.
 ///
@@ -320,7 +320,7 @@ impl Encoder for Codec {
 
 #[cfg(test)]
 mod tests {
-    use tokio_tcp::{TcpListener, TcpStream};
+    use tokio::net::tcp::{TcpListener, TcpStream};
     use super::Ping;
     use futures::{Future, Stream};
     use libp2p_core::upgrade::{InboundUpgrade, OutboundUpgrade};

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -24,7 +24,7 @@ twofish = "0.1.0"
 ctr = "0.1"
 lazy_static = { version = "1.2.0", optional = true }
 rw-stream-sink = { version = "0.1.0", path = "../../misc/rw-stream-sink" }
-tokio-io = "0.1.0"
+tokio = { version = "0.1.14", default-features = false, features = ["io"] }
 sha2 = "0.7.1"
 ed25519-dalek = "0.8.0"
 hmac = "0.6.3"
@@ -44,4 +44,3 @@ aes-all = ["aesni", "lazy_static"]
 [dev-dependencies]
 libp2p-tcp = { version = "0.1.0", path = "../../transports/tcp" }
 tokio = "0.1"
-tokio-tcp = "0.1"

--- a/protocols/secio/src/lib.rs
+++ b/protocols/secio/src/lib.rs
@@ -35,7 +35,7 @@
 //! use libp2p_core::{Multiaddr, upgrade::apply_inbound};
 //! use libp2p_core::transport::Transport;
 //! use libp2p_tcp::TcpConfig;
-//! use tokio_io::io::write_all;
+//! use tokio::io::write_all;
 //! use tokio::runtime::current_thread::Runtime;
 //!
 //! let dialer = TcpConfig::new()
@@ -85,7 +85,7 @@ pub use self::error::SecioError;
 
 #[cfg(feature = "secp256k1")]
 use asn1_der::{traits::FromDerEncoded, traits::FromDerObject, DerObject};
-use bytes::BytesMut;
+use bytes::Bytes;
 use ed25519_dalek::Keypair as Ed25519KeyPair;
 use futures::stream::MapErr as StreamMapErr;
 use futures::{Future, Poll, Sink, StartSend, Stream};
@@ -98,7 +98,7 @@ use std::error::Error;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::iter;
 use std::sync::Arc;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 #[cfg(all(feature = "rsa", not(any(target_os = "emscripten", target_os = "unknown"))))]
 use untrusted::Input;
 
@@ -404,7 +404,7 @@ impl<S> Sink for SecioMiddleware<S>
 where
     S: AsyncRead + AsyncWrite,
 {
-    type SinkItem = BytesMut;
+    type SinkItem = Bytes;
     type SinkError = IoError;
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! The `Swarm` struct contains all active and pending connections to remotes and manages the
 //! state of all the substreams that have been opened, and all the upgrades that were built upon
 //! these substreams.
-//! 
+//!
 //! It combines a `Transport`, a `NetworkBehaviour` and a `Topology` together.
 //!
 //! See the documentation of the `libp2p-core` crate for more details about creating a swarm.
@@ -133,8 +133,7 @@ pub extern crate bytes;
 pub extern crate futures;
 pub extern crate multiaddr;
 pub extern crate multihash;
-pub extern crate tokio_io;
-pub extern crate tokio_codec;
+pub extern crate tokio;
 
 extern crate libp2p_core_derive;
 extern crate tokio_executor;

--- a/src/simple.rs
+++ b/src/simple.rs
@@ -22,7 +22,7 @@ use bytes::Bytes;
 use core::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use futures::{future::FromErr, prelude::*};
 use std::{iter, io::Error as IoError, sync::Arc};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 /// Implementation of `ConnectionUpgrade`. Convenient to use with small protocols.
 #[derive(Debug)]

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -14,7 +14,6 @@ log = "0.4.1"
 futures = "0.1"
 multiaddr = { package = "parity-multiaddr", version = "0.1.0", path = "../../misc/multiaddr" }
 tokio-dns-unofficial = "0.4"
-tokio-io = "0.1"
 
 [dev-dependencies]
 libp2p-tcp = { version = "0.1.0", path = "../../transports/tcp" }

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -39,7 +39,6 @@ extern crate libp2p_core as swarm;
 extern crate log;
 extern crate multiaddr;
 extern crate tokio_dns;
-extern crate tokio_io;
 
 use futures::{future::{self, Either, FutureResult, JoinAll}, prelude::*, try_ready};
 use log::Level;

--- a/transports/ratelimit/Cargo.toml
+++ b/transports/ratelimit/Cargo.toml
@@ -13,5 +13,5 @@ aio-limited = "0.1"
 futures = "0.1"
 libp2p-core = { version = "0.1.0", path = "../../core" }
 log = "0.4"
+tokio = { version = "0.1.14", default-features = false, features = ["io"] }
 tokio-executor = "0.1"
-tokio-io = "0.1"

--- a/transports/ratelimit/src/lib.rs
+++ b/transports/ratelimit/src/lib.rs
@@ -25,14 +25,14 @@ extern crate libp2p_core;
 #[macro_use]
 extern crate log;
 extern crate tokio_executor;
-extern crate tokio_io;
+extern crate tokio;
 
 use aio_limited::{Limited, Limiter};
 use futures::prelude::*;
 use libp2p_core::{Multiaddr, Transport};
 use std::io;
+use tokio::io::{AsyncRead, AsyncWrite, ReadHalf, WriteHalf};
 use tokio_executor::Executor;
-use tokio_io::{AsyncRead, AsyncWrite, io::{ReadHalf, WriteHalf}};
 
 #[derive(Clone)]
 pub struct RateLimited<T> {

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -14,8 +14,7 @@ log = "0.4.1"
 futures = "0.1"
 multiaddr = { package = "parity-multiaddr", version = "0.1.0", path = "../../misc/multiaddr" }
 tk-listen = "0.2.0"
-tokio-io = "0.1"
-tokio-tcp = "0.1"
+tokio = { version = "0.1.14", default-features = false, features = ["io", "tcp"] }
 
 [dev-dependencies]
 tokio = "0.1"

--- a/transports/tcp/src/lib.rs
+++ b/transports/tcp/src/lib.rs
@@ -44,8 +44,7 @@ extern crate libp2p_core as swarm;
 extern crate log;
 extern crate multiaddr;
 extern crate tk_listen;
-extern crate tokio_io;
-extern crate tokio_tcp;
+extern crate tokio;
 
 use futures::{future, future::FutureResult, prelude::*, Async, Poll};
 use multiaddr::{Protocol, Multiaddr, ToMultiaddr};
@@ -55,8 +54,8 @@ use std::net::SocketAddr;
 use std::time::Duration;
 use swarm::Transport;
 use tk_listen::{ListenExt, SleepOnError};
-use tokio_io::{AsyncRead, AsyncWrite};
-use tokio_tcp::{ConnectFuture, Incoming, TcpListener, TcpStream};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::tcp::{ConnectFuture, Incoming, TcpListener, TcpStream};
 
 /// Represents the configuration for a TCP/IP transport capability for libp2p.
 ///
@@ -391,8 +390,7 @@ impl Drop for TcpTransStream {
 
 #[cfg(test)]
 mod tests {
-    extern crate tokio;
-    use self::tokio::runtime::current_thread::Runtime;
+    use tokio::runtime::current_thread::Runtime;
     use super::{multiaddr_to_socketaddr, TcpConfig};
     use futures::stream::Stream;
     use futures::Future;
@@ -400,7 +398,6 @@ mod tests {
     use std;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use swarm::Transport;
-    use tokio_io;
 
     #[test]
     fn multiaddr_to_tcp_conversion() {
@@ -464,7 +461,7 @@ mod tests {
                 sock.and_then(|sock| {
                     // Define what to do with the socket that just connected to us
                     // Which in this case is read 3 bytes
-                    let handle_conn = tokio_io::io::read_exact(sock, [0; 3])
+                    let handle_conn = tokio::io::read_exact(sock, [0; 3])
                         .map(|(_, buf)| assert_eq!(buf, [1, 2, 3]))
                         .map_err(|err| panic!("IO error {:?}", err));
 

--- a/transports/uds/Cargo.toml
+++ b/transports/uds/Cargo.toml
@@ -13,9 +13,8 @@ libp2p-core = { version = "0.1.0", path = "../../core" }
 log = "0.4.1"
 futures = "0.1"
 multiaddr = { package = "parity-multiaddr", version = "0.1.0", path = "../../misc/multiaddr" }
-tokio-uds = "0.2"
+tokio = { version = "0.1.14", default-features = false, features = ["uds"] }
 
 [target.'cfg(all(unix, any(target_os = "emscripten", target_os = "unknown")))'.dev-dependencies]
 tempfile = "3.0"
 tokio = "0.1"
-tokio-io = "0.1"

--- a/transports/uds/src/lib.rs
+++ b/transports/uds/src/lib.rs
@@ -51,14 +51,10 @@ extern crate libp2p_core;
 #[macro_use]
 extern crate log;
 extern crate multiaddr;
-extern crate tokio_uds;
+extern crate tokio;
 
 #[cfg(test)]
 extern crate tempfile;
-#[cfg(test)]
-extern crate tokio_io;
-#[cfg(test)]
-extern crate tokio;
 
 use futures::{future::{self, FutureResult}, prelude::*, try_ready};
 use futures::stream::Stream;
@@ -66,7 +62,7 @@ use multiaddr::{Protocol, Multiaddr};
 use std::io::Error as IoError;
 use std::path::PathBuf;
 use libp2p_core::Transport;
-use tokio_uds::{UnixListener, UnixStream};
+use tokio::net::uds::{UnixListener, UnixStream};
 
 /// Represents the configuration for a Unix domain sockets transport capability for libp2p.
 ///
@@ -86,9 +82,9 @@ impl UdsConfig {
 
 impl Transport for UdsConfig {
     type Output = UnixStream;
-    type Listener = ListenerStream<tokio_uds::Incoming>;
+    type Listener = ListenerStream<tokio::net::uds::Incoming>;
     type ListenerUpgrade = FutureResult<Self::Output, IoError>;
-    type Dial = tokio_uds::ConnectFuture;
+    type Dial = tokio::net::uds::ConnectFuture;
 
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), (Self, Multiaddr)> {
         if let Ok(path) = multiaddr_to_path(&addr) {
@@ -187,7 +183,6 @@ mod tests {
     use std::{self, borrow::Cow, path::Path};
     use libp2p_core::Transport;
     use tempfile;
-    use tokio_io;
 
     #[test]
     fn multiaddr_to_path_conversion() {
@@ -223,7 +218,7 @@ mod tests {
                 sock.and_then(|sock| {
                     // Define what to do with the socket that just connected to us
                     // Which in this case is read 3 bytes
-                    let handle_conn = tokio_io::io::read_exact(sock, [0; 3])
+                    let handle_conn = tokio::io::read_exact(sock, [0; 3])
                         .map(|(_, buf)| assert_eq!(buf, [1, 2, 3]))
                         .map_err(|err| panic!("IO error {:?}", err));
 

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.1"
 multiaddr = { package = "parity-multiaddr", version = "0.1.0", path = "../../misc/multiaddr" }
 log = "0.4.1"
 rw-stream-sink = { version = "0.1.0", path = "../../misc/rw-stream-sink" }
-tokio-io = "0.1"
+tokio = { version = "0.1.14", default-features = false, features = ["io"] }
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "unknown")))'.dependencies]
 websocket = { version = "0.21.0", default-features = false, features = ["async", "async-ssl"] }
@@ -24,4 +24,4 @@ stdweb = { version = "0.4", default-features = false }
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "unknown")))'.dev-dependencies]
 libp2p-tcp = { version = "0.1.0", path = "../tcp" }
-tokio = "0.1"
+tokio = { version = "0.1.14", default-features = false, features = ["io"] }

--- a/transports/websocket/src/browser.rs
+++ b/transports/websocket/src/browser.rs
@@ -30,7 +30,7 @@ use std::sync::{Arc, Mutex};
 use stdweb::web::TypedArray;
 use stdweb::{self, Reference};
 use swarm::Transport;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 /// Represents the configuration for a websocket transport capability for libp2p.
 ///

--- a/transports/websocket/src/desktop.rs
+++ b/transports/websocket/src/desktop.rs
@@ -23,7 +23,7 @@ use multiaddr::{Protocol, Multiaddr};
 use rw_stream_sink::RwStreamSink;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use swarm::Transport;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite};
 use websocket::client::builder::ClientBuilder;
 use websocket::message::OwnedMessage;
 use websocket::server::upgrade::async::IntoWs;

--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -74,7 +74,7 @@ extern crate libp2p_core as swarm;
 extern crate log;
 extern crate multiaddr;
 extern crate rw_stream_sink;
-extern crate tokio_io;
+extern crate tokio;
 
 #[cfg(any(target_os = "emscripten", target_os = "unknown"))]
 #[macro_use]


### PR DESCRIPTION
This version of tokio made most dependencies optional via feature flags. The most signifcant changes are in `secio` which switches to `tokio::codec::length_delimited` instead of the deprecated `tokio_codec::length_delimited` which makes `cargo check` finally run without warnings again.