### PR TITLE
Fix compilation of ring

### DIFF
--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -30,7 +30,7 @@ ed25519-dalek = "0.8.0"
 hmac = "0.6.3"
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "unknown")))'.dependencies]
-ring = { version = "0.13", default-features = false }
+ring = { version = "0.13", features = ["use_heap"], default-features = false }
 untrusted = { version = "0.6" }
 
 [target.'cfg(any(target_os = "emscripten", target_os = "unknown"))'.dependencies]


### PR DESCRIPTION
Apparently `ring` doesn't compile with this feature, but we enable it indirectly with our `rsa` feature and therefore we don't notice.