### PR TITLE
Improve doc aesthetics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "libp2p"
+edition = "2018"
 description = "Peer-to-peer networking library"
 version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! The `Swarm` struct contains all active and pending connections to remotes and manages the
 //! state of all the substreams that have been opened, and all the upgrades that were built upon
 //! these substreams.
-//! 
+//!
 //! It combines a `Transport`, a `NetworkBehaviour` and a `Topology` together.
 //!
 //! See the documentation of the `libp2p-core` crate for more details about creating a swarm.
@@ -129,6 +129,9 @@
 //! - This swarm can now be polled with the `tokio` library in order to start the network.
 //!
 
+#![doc(html_logo_url = "https://libp2p.io/img/logo_small.png")]
+#![doc(html_favicon_url = "https://libp2p.io/img/favicon.png")]
+
 pub extern crate bytes;
 pub extern crate futures;
 pub extern crate multiaddr;
@@ -139,25 +142,40 @@ pub extern crate tokio_codec;
 extern crate libp2p_core_derive;
 extern crate tokio_executor;
 
-pub extern crate libp2p_core as core;
+#[doc(inline)]
+pub use libp2p_core as core;
 #[cfg(not(any(target_os = "emscripten", target_os = "unknown")))]
-pub extern crate libp2p_dns as dns;
-pub extern crate libp2p_identify as identify;
-pub extern crate libp2p_kad as kad;
-pub extern crate libp2p_floodsub as floodsub;
-pub extern crate libp2p_mplex as mplex;
+#[doc(inline)]
+pub use libp2p_dns as dns;
+#[doc(inline)]
+pub use libp2p_identify as identify;
+#[doc(inline)]
+pub use libp2p_kad as kad;
+#[doc(inline)]
+pub use libp2p_floodsub as floodsub;
+#[doc(inline)]
+pub use libp2p_mplex as mplex;
 #[cfg(not(any(target_os = "emscripten", target_os = "unknown")))]
-pub extern crate libp2p_mdns as mdns;
-pub extern crate libp2p_ping as ping;
-pub extern crate libp2p_plaintext as plaintext;
-pub extern crate libp2p_ratelimit as ratelimit;
-pub extern crate libp2p_secio as secio;
+#[doc(inline)]
+pub use libp2p_mdns as mdns;
+#[doc(inline)]
+pub use libp2p_ping as ping;
+#[doc(inline)]
+pub use libp2p_plaintext as plaintext;
+#[doc(inline)]
+pub use libp2p_ratelimit as ratelimit;
+#[doc(inline)]
+pub use libp2p_secio as secio;
 #[cfg(not(any(target_os = "emscripten", target_os = "unknown")))]
-pub extern crate libp2p_tcp as tcp;
-pub extern crate libp2p_uds as uds;
+#[doc(inline)]
+pub use libp2p_tcp as tcp;
+#[doc(inline)]
+pub use libp2p_uds as uds;
 #[cfg(feature = "libp2p-websocket")]
-pub extern crate libp2p_websocket as websocket;
-pub extern crate libp2p_yamux as yamux;
+#[doc(inline)]
+pub use libp2p_websocket as websocket;
+#[doc(inline)]
+pub use libp2p_yamux as yamux;
 
 mod transport_ext;
 

--- a/src/simple.rs
+++ b/src/simple.rs
@@ -18,8 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use crate::core::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use bytes::Bytes;
-use core::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use futures::{future::FromErr, prelude::*};
 use std::{iter, io::Error as IoError, sync::Arc};
 use tokio_io::{AsyncRead, AsyncWrite};

--- a/src/transport_ext.rs
+++ b/src/transport_ext.rs
@@ -20,10 +20,9 @@
 
 //! Provides the `TransportExt` trait.
 
-use ratelimit::RateLimited;
+use crate::{ratelimit::RateLimited, Transport};
 use std::io;
 use tokio_executor::DefaultExecutor;
-use Transport;
 
 /// Trait automatically implemented on all objects that implement `Transport`. Provides some
 /// additional utilities.


### PR DESCRIPTION
Switches the facade crate to edition 2018 and improves the appearance of the generated documentation.

The documentation will now inline the documentation of the sub-crates (`core`, `mplex`, `ping`, etc.) instead of just showing a line saying `extern crate libp2p_core as core;`

Also added the libp2p icon.