### PR TITLE
Fix custom derive when using a where clause

### DIFF
--- a/misc/core-derive/src/lib.rs
+++ b/misc/core-derive/src/lib.rs
@@ -112,7 +112,7 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
         additional.push(quote!{#substream_generic: ::libp2p::tokio_io::AsyncWrite});
 
         if let Some(where_clause) = where_clause {
-            Some(quote!{#where_clause #(#additional),*})
+            Some(quote!{#where_clause, #(#additional),*})
         } else {
             Some(quote!{where #(#additional),*})
         }

--- a/misc/core-derive/tests/test.rs
+++ b/misc/core-derive/tests/test.rs
@@ -190,3 +190,24 @@ fn custom_event_and_polling() {
         require_net_behaviour::<Foo<TSubstream>>();
     }
 }
+
+#[test]
+fn where_clause() {
+    #[allow(dead_code)]
+    #[derive(NetworkBehaviour)]
+    struct Foo<TSubstream> where TSubstream: std::fmt::Debug {
+        ping: libp2p::ping::Ping<TSubstream>,
+    }
+
+    #[allow(dead_code)]
+    #[derive(NetworkBehaviour)]
+    struct Bar<TSubstream: std::fmt::Debug> {
+        ping: libp2p::ping::Ping<TSubstream>,
+    }
+
+    #[allow(dead_code)]
+    #[derive(NetworkBehaviour)]
+    struct Qux<TSubstream: std::fmt::Debug> where TSubstream: Clone {
+        ping: libp2p::ping::Ping<TSubstream>,
+    }
+}


### PR DESCRIPTION
When injecting the users where clause we need to ensure a comma is
inserted between the users where clause and ours.

Fixes: #754 