### PR TITLE
Add cargo feature flag to allow rename dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["rename-dependency"]
+
 [package]
 name = "libp2p"
 edition = "2018"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["rename-dependency"]
+
 [package]
 name = "libp2p-core"
 edition = "2018"

--- a/misc/mdns/Cargo.toml
+++ b/misc/mdns/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["rename-dependency"]
+
 [package]
 name = "libp2p-mdns"
 version = "0.2.0"

--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["rename-dependency"]
+
 [package]
 name = "parity-multiaddr"
 authors = ["dignifiedquire <dignifiedquire@gmail.com>", "Parity Technologies <admin@parity.io>"]

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["rename-dependency"]
+
 [package]
 name = "libp2p-identify"
 description = "Nodes identifcation protocol for libp2p"

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["rename-dependency"]
+
 [package]
 name = "libp2p-kad"
 description = "Kademlia protocol for libp2p"

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["rename-dependency"]
+
 [package]
 name = "libp2p-ping"
 edition = "2018"

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["rename-dependency"]
+
 [package]
 name = "libp2p-dns"
 description = "DNS transport implementation for libp2p"

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["rename-dependency"]
+
 [package]
 name = "libp2p-tcp"
 description = "TCP/IP transport protocol for libp2p"

--- a/transports/uds/Cargo.toml
+++ b/transports/uds/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["rename-dependency"]
+
 [package]
 name = "libp2p-uds"
 description = "Unix domain sockets transport for libp2p"

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["rename-dependency"]
+
 [package]
 name = "libp2p-websocket"
 description = "WebSocket transport for libp2p"


### PR DESCRIPTION
On newest cargo version the build fails because it requires the `rename-dependency` flag in order to rename dependencies.