### PR TITLE
derive(NetworkBehaviour) handles trailing commas

### DIFF
--- a/misc/core-derive/src/lib.rs
+++ b/misc/core-derive/src/lib.rs
@@ -112,7 +112,11 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
         additional.push(quote!{#substream_generic: ::libp2p::tokio_io::AsyncWrite});
 
         if let Some(where_clause) = where_clause {
-            Some(quote!{#where_clause, #(#additional),*})
+            if where_clause.predicates.trailing_punct() {
+                Some(quote!{#where_clause #(#additional),*})
+            } else {
+                Some(quote!{#where_clause, #(#additional),*})
+            }
         } else {
             Some(quote!{where #(#additional),*})
         }

--- a/misc/core-derive/tests/test.rs
+++ b/misc/core-derive/tests/test.rs
@@ -207,6 +207,12 @@ fn where_clause() {
 
     #[allow(dead_code)]
     #[derive(NetworkBehaviour)]
+    struct Baz<TSubstream> where TSubstream: std::fmt::Debug + Clone, {
+        ping: libp2p::ping::Ping<TSubstream>,
+    }
+
+    #[allow(dead_code)]
+    #[derive(NetworkBehaviour)]
     struct Qux<TSubstream: std::fmt::Debug> where TSubstream: Clone {
         ping: libp2p::ping::Ping<TSubstream>,
     }


### PR DESCRIPTION
Properly handle trailing commas in `derive(NetworkBehaviour)`

Fixes: #861 