### PR TITLE
Update protocols and transport to 2018 edition

### DIFF
--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "libp2p-floodsub"
+edition = "2018"
 description = "Floodsub protocol for libp2p"
 version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/protocols/floodsub/src/handler.rs
+++ b/protocols/floodsub/src/handler.rs
@@ -157,7 +157,7 @@ where
     fn shutdown(&mut self) {
         self.shutting_down = true;
         for n in (0..self.substreams.len()).rev() {
-            let mut substream = self.substreams.swap_remove(n);
+            let substream = self.substreams.swap_remove(n);
             self.substreams.push(SubstreamState::Closing(substream.into_substream()));
         }
     }

--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -18,18 +18,18 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use crate::handler::FloodsubHandler;
+use crate::protocol::{FloodsubMessage, FloodsubRpc, FloodsubSubscription, FloodsubSubscriptionAction};
+use crate::topic::{Topic, TopicHash};
 use cuckoofilter::CuckooFilter;
 use futures::prelude::*;
-use handler::FloodsubHandler;
 use libp2p_core::swarm::{ConnectedPoint, NetworkBehaviour, NetworkBehaviourAction, PollParameters};
 use libp2p_core::{protocols_handler::ProtocolsHandler, PeerId};
-use protocol::{FloodsubMessage, FloodsubRpc, FloodsubSubscription, FloodsubSubscriptionAction};
 use rand;
 use smallvec::SmallVec;
 use std::{collections::VecDeque, iter, marker::PhantomData};
 use std::collections::hash_map::{DefaultHasher, HashMap};
 use tokio_io::{AsyncRead, AsyncWrite};
-use topic::{Topic, TopicHash};
 
 /// Network behaviour that automatically identifies nodes periodically, and returns information
 /// about them.
@@ -213,7 +213,7 @@ where
     ) {
         // Update connected peers topics
         for subscription in event.subscriptions {
-            let mut remote_peer_topics = self.connected_peers
+            let remote_peer_topics = self.connected_peers
                 .get_mut(&propagation_source)
                 .expect("connected_peers is kept in sync with the peers we are connected to; we are guaranteed to only receive events from connected peers; QED");
             match subscription.action {

--- a/protocols/floodsub/src/protocol.rs
+++ b/protocols/floodsub/src/protocol.rs
@@ -20,13 +20,13 @@
 
 use bytes::{BufMut, BytesMut};
 use crate::rpc_proto;
+use crate::topic::TopicHash;
 use futures::future;
 use libp2p_core::{InboundUpgrade, OutboundUpgrade, UpgradeInfo, PeerId};
 use protobuf::Message as ProtobufMessage;
 use std::{io, iter};
 use tokio_codec::{Decoder, Encoder, Framed};
 use tokio_io::{AsyncRead, AsyncWrite};
-use topic::TopicHash;
 use unsigned_varint::codec;
 
 /// Implementation of `ConnectionUpgrade` for the floodsub protocol.

--- a/protocols/floodsub/src/topic.rs
+++ b/protocols/floodsub/src/topic.rs
@@ -19,8 +19,8 @@
 // DEALINGS IN THE SOFTWARE.
 
 use bs58;
+use crate::rpc_proto;
 use protobuf::Message;
-use rpc_proto;
 
 /// Represents the hash of a topic.
 ///

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "libp2p-identify"
+edition = "2018"
 description = "Nodes identifcation protocol for libp2p"
 version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/protocols/identify/src/id_transport.rs
+++ b/protocols/identify/src/id_transport.rs
@@ -20,13 +20,13 @@
 
 //! Contains the `IdentifyTransport` type.
 
+use crate::protocol::{RemoteInfo, IdentifyProtocolConfig};
 use futures::{future, prelude::*, stream, AndThen, MapErr};
 use libp2p_core::{
     Multiaddr, PeerId, PublicKey, muxing, Transport,
     transport::{TransportError, upgrade::TransportUpgradeError},
     upgrade::{self, OutboundUpgradeApply, UpgradeError}
 };
-use protocol::{RemoteInfo, IdentifyProtocolConfig};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::mem;
 use std::sync::Arc;

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -19,6 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use bytes::BytesMut;
+use crate::structs_proto;
 use futures::{future::{self, FutureResult}, Async, AsyncSink, Future, Poll, Sink, Stream};
 use libp2p_core::{
     Multiaddr, PublicKey,
@@ -30,7 +31,6 @@ use protobuf::parse_from_bytes as protobuf_parse_from_bytes;
 use protobuf::RepeatedField;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::iter;
-use structs_proto;
 use tokio_codec::Framed;
 use tokio_io::{AsyncRead, AsyncWrite};
 use unsigned_varint::codec;

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "libp2p-kad"
+edition = "2018"
 description = "Kademlia protocol for libp2p"
 version = "0.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -18,20 +18,20 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use crate::handler::{KademliaHandler, KademliaHandlerEvent, KademliaHandlerIn, KademliaRequestId};
+use crate::protocol::{KadConnectionType, KadPeer};
+use crate::query::{QueryConfig, QueryState, QueryStatePollOut, QueryTarget};
+use crate::topology::KademliaTopology;
 use fnv::{FnvHashMap, FnvHashSet};
 use futures::{prelude::*, stream};
-use handler::{KademliaHandler, KademliaHandlerEvent, KademliaHandlerIn, KademliaRequestId};
 use libp2p_core::swarm::{ConnectedPoint, NetworkBehaviour, NetworkBehaviourAction, PollParameters};
 use libp2p_core::{protocols_handler::ProtocolsHandler, topology::Topology, Multiaddr, PeerId};
 use multihash::Multihash;
-use protocol::{KadConnectionType, KadPeer};
-use query::{QueryConfig, QueryState, QueryStatePollOut, QueryTarget};
 use rand;
 use smallvec::SmallVec;
 use std::{cmp::Ordering, marker::PhantomData, time::Duration, time::Instant};
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_timer::Interval;
-use topology::KademliaTopology;
 
 /// Network behaviour that handles Kademlia.
 pub struct Kademlia<TSubstream> {
@@ -178,7 +178,7 @@ impl<TSubstream> Kademlia<TSubstream> {
 
         match query {
             QueryTarget::FindPeer(key) => {
-                let mut topology = parameters.topology();
+                let topology = parameters.topology();
                 // TODO: insert local_kad_peer somewhere?
                 let closer_peers = topology
                     .closest_peers(key.as_ref(), self.num_results)
@@ -191,7 +191,7 @@ impl<TSubstream> Kademlia<TSubstream> {
                 }
             },
             QueryTarget::GetProviders(key) => {
-                let mut topology = parameters.topology();
+                let topology = parameters.topology();
                 // TODO: insert local_kad_peer somewhere?
                 let closer_peers = topology
                     .closest_peers(&key, self.num_results)

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -18,14 +18,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use crate::protocol::{
+    KadInStreamSink, KadOutStreamSink, KadPeer, KadRequestMsg, KadResponseMsg,
+    KademliaProtocolConfig,
+};
 use futures::prelude::*;
 use libp2p_core::protocols_handler::{ProtocolsHandler, ProtocolsHandlerEvent, ProtocolsHandlerUpgrErr};
 use libp2p_core::{upgrade, either::EitherOutput, InboundUpgrade, OutboundUpgrade, PeerId};
 use multihash::Multihash;
-use protocol::{
-    KadInStreamSink, KadOutStreamSink, KadPeer, KadRequestMsg, KadResponseMsg,
-    KademliaProtocolConfig,
-};
 use std::{error, fmt, io};
 use tokio_io::{AsyncRead, AsyncWrite};
 

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -323,7 +323,8 @@ impl<'a, Id: 'a, Val: 'a> Bucket<'a, Id, Val> {
 mod tests {
     extern crate rand;
     use self::rand::random;
-    use kbucket::{KBucketsPeerId, KBucketsTable, UpdateOutcome, MAX_NODES_PER_BUCKET};
+    use crate::kbucket::{KBucketsPeerId, KBucketsTable};
+    use crate::kbucket::{UpdateOutcome, MAX_NODES_PER_BUCKET};
     use multihash::{Multihash, Hash};
     use std::thread;
     use std::time::Duration;

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -27,11 +27,11 @@
 //! used to send messages.
 
 use bytes::BytesMut;
+use crate::protobuf_structs;
 use futures::{future, sink, stream, Sink, Stream};
 use libp2p_core::{InboundUpgrade, Multiaddr, OutboundUpgrade, PeerId, UpgradeInfo};
 use multihash::Multihash;
 use protobuf::{self, Message};
-use protobuf_structs;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::iter;
 use tokio_codec::Framed;
@@ -54,7 +54,9 @@ pub enum KadConnectionType {
 impl From<protobuf_structs::dht::Message_ConnectionType> for KadConnectionType {
     #[inline]
     fn from(raw: protobuf_structs::dht::Message_ConnectionType) -> KadConnectionType {
-        use protobuf_structs::dht::Message_ConnectionType::*;
+        use crate::protobuf_structs::dht::Message_ConnectionType::{
+            CAN_CONNECT, CANNOT_CONNECT, CONNECTED, NOT_CONNECTED
+        };
         match raw {
             NOT_CONNECTED => KadConnectionType::NotConnected,
             CONNECTED => KadConnectionType::Connected,
@@ -67,7 +69,9 @@ impl From<protobuf_structs::dht::Message_ConnectionType> for KadConnectionType {
 impl Into<protobuf_structs::dht::Message_ConnectionType> for KadConnectionType {
     #[inline]
     fn into(self) -> protobuf_structs::dht::Message_ConnectionType {
-        use protobuf_structs::dht::Message_ConnectionType::*;
+        use crate::protobuf_structs::dht::Message_ConnectionType::{
+            CAN_CONNECT, CANNOT_CONNECT, CONNECTED, NOT_CONNECTED
+        };
         match self {
             KadConnectionType::NotConnected => NOT_CONNECTED,
             KadConnectionType::Connected => CONNECTED,

--- a/protocols/kad/src/query.rs
+++ b/protocols/kad/src/query.rs
@@ -23,9 +23,9 @@
 //! This allows one to create queries that iterate on the DHT on nodes that become closer and
 //! closer to the target.
 
+use crate::handler::KademliaHandlerIn;
+use crate::kbucket::KBucketsPeerId;
 use futures::prelude::*;
-use handler::KademliaHandlerIn;
-use kbucket::KBucketsPeerId;
 use libp2p_core::PeerId;
 use multihash::Multihash;
 use smallvec::SmallVec;

--- a/protocols/kad/src/topology.rs
+++ b/protocols/kad/src/topology.rs
@@ -18,10 +18,10 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use kbucket::KBucketsPeerId;
+use crate::kbucket::KBucketsPeerId;
+use crate::protocol::KadConnectionType;
 use libp2p_core::{Multiaddr, PeerId, topology::MemoryTopology, topology::Topology};
 use multihash::Multihash;
-use protocol::KadConnectionType;
 use std::vec;
 
 /// Trait allowing retreival of information necessary for the Kadmelia system to work.

--- a/protocols/observed/Cargo.toml
+++ b/protocols/observed/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "libp2p-observed-address"
+edition = "2018"
 description = "Observed addresses protocol for libp2p"
 version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "libp2p-plaintext"
+edition = "2018"
 description = "Plaintext encryption dummy protocol for libp2p"
 version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "libp2p-dns"
+edition = "2018"
 description = "DNS transport implementation for libp2p"
 version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -327,7 +327,7 @@ mod tests {
     use futures::future;
     use swarm::{Transport, transport::TransportError};
     use multiaddr::{Protocol, Multiaddr};
-    use DnsConfig;
+    use super::DnsConfig;
 
     #[test]
     fn basic_resolve() {

--- a/transports/ratelimit/Cargo.toml
+++ b/transports/ratelimit/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "libp2p-ratelimit"
+edition = "2018"
 description = "Transfer rate limiting transport adapter for libp2p"
 version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "libp2p-tcp"
+edition = "2018"
 description = "TCP/IP transport protocol for libp2p"
 version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/transports/uds/Cargo.toml
+++ b/transports/uds/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "libp2p-uds"
+edition = "2018"
 description = "Unix domain sockets transport for libp2p"
 version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]


### PR DESCRIPTION
Update the protocols and transport subdirectories to the 2018 edition.

NB: The websocket transport cannot be moved to 2018 edition due to
websocket-rs's use of the keyword async as the name of a module.

Relates to: #866 