### PR TITLE
Use rand 0.6.5 in libp2p-noise

### DIFF
--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.1"
 lazy_static = "1.2"
 libp2p-core = { version = "0.2.0", path = "../../core" }
 log = "0.4"
-rand = "0.6"
+rand = "0.6.5"
 snow = { version = "0.5.0-alpha1", default-features = false, features = ["ring-resolver"] }
 tokio-io = "0.1"
 


### PR DESCRIPTION
Compiling master failed for me, because `libp2p-noise` uses some features that were added in later versions of `rand`.