### PR TITLE
Fix the dialing priority system

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,6 +33,7 @@ void = "1"
 libp2p-ping = { version = "0.3.0", path = "../protocols/ping" }
 libp2p-tcp = { version = "0.3.0", path = "../transports/tcp" }
 libp2p-mplex = { version = "0.3.0", path = "../muxers/mplex" }
+libp2p-secio = { version = "0.3.0", path = "../protocols/secio" }
 rand = "0.6"
 tokio = "0.1"
 tokio-codec = "0.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,6 +30,7 @@ unsigned-varint = "0.2"
 void = "1"
 
 [dev-dependencies]
+env_logger = "0.6"
 libp2p-ping = { version = "0.3.0", path = "../protocols/ping" }
 libp2p-tcp = { version = "0.3.0", path = "../transports/tcp" }
 libp2p-mplex = { version = "0.3.0", path = "../muxers/mplex" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-core"
 edition = "2018"
 description = "Core traits and structs of libp2p"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/core/src/nodes/raw_swarm.rs
+++ b/core/src/nodes/raw_swarm.rs
@@ -27,7 +27,6 @@ use crate::{
             CollectionNodeAccept,
             CollectionReachEvent,
             CollectionStream,
-            PeerMut as CollecPeerMut,
             ReachAttemptId
         },
         handled_node::{
@@ -48,6 +47,7 @@ use std::{
     error,
     fmt,
     hash::Hash,
+    num::NonZeroUsize,
 };
 
 mod tests;
@@ -92,6 +92,7 @@ struct ReachAttempts<TPeerId> {
     local_peer_id: TPeerId,
 
     /// Attempts to reach a peer.
+    /// May contain nodes we are already connected to, because we don't cancel outgoing attempts.
     out_reach_attempts: FnvHashMap<TPeerId, OutReachAttempt>,
 
     /// Reach attempts for incoming connections, and outgoing connections for which we don't know
@@ -99,6 +100,7 @@ struct ReachAttempts<TPeerId> {
     other_reach_attempts: Vec<(ReachAttemptId, ConnectedPoint)>,
 
     /// For each peer ID we're connected to, contains the endpoint we're connected to.
+    /// Always in sync with `active_nodes`.
     connected_points: FnvHashMap<TPeerId, ConnectedPoint>,
 }
 
@@ -201,10 +203,8 @@ where
 
     /// Failed to reach a peer that we were trying to dial.
     DialError {
-        /// Returns the number of multiaddresses that still need to be attempted. If this is
-        /// non-zero, then there's still a chance we can connect to this node. If this is zero,
-        /// then we have definitely failed.
-        remain_addrs_attempt: usize,
+        /// New state of a peer.
+        new_state: PeerState,
 
         /// Id of the peer we were trying to dial.
         peer_id: TPeerId,
@@ -293,9 +293,9 @@ where
                     .field("error", error)
                     .finish()
             }
-            RawSwarmEvent::DialError { ref remain_addrs_attempt, ref peer_id, ref multiaddr, ref error } => {
+            RawSwarmEvent::DialError { ref new_state, ref peer_id, ref multiaddr, ref error } => {
                 f.debug_struct("DialError")
-                    .field("remain_addrs_attempt", remain_addrs_attempt)
+                    .field("new_state", new_state)
                     .field("peer_id", peer_id)
                     .field("multiaddr", multiaddr)
                     .field("error", error)
@@ -362,6 +362,20 @@ where
             InternalReachErr::FoundLocalPeerId => None,
         }
     }
+}
+
+/// State of a peer.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum PeerState {
+    /// We are connected to this peer.
+    Connected,
+    /// We are currently trying to reach this peer.
+    Dialing {
+        /// Number of addresses we are trying to dial.
+        num_pending_addresses: NonZeroUsize,
+    },
+    /// We are not connected to this peer.
+    NotConnected,
 }
 
 /// Error that can happen when trying to reach a node.
@@ -839,19 +853,18 @@ where
         // the borrow checker yells at us.
 
         if self.active_nodes.peer_mut(&peer_id).is_some() {
-            debug_assert!(!self.reach_attempts.out_reach_attempts.contains_key(&peer_id));
             return Peer::Connected(PeerConnected {
-                peer: self
-                    .active_nodes
-                    .peer_mut(&peer_id)
-                    .expect("we checked for Some just above"),
+                active_nodes: &mut self.active_nodes,
                 peer_id,
                 connected_points: &mut self.reach_attempts.connected_points,
+                out_reach_attempts: &mut self.reach_attempts.out_reach_attempts,
             });
         }
 
+        // The state of `connected_points` always follows `self.active_nodes`.
+        debug_assert!(!self.reach_attempts.connected_points.contains_key(&peer_id));
+
         if self.reach_attempts.out_reach_attempts.get_mut(&peer_id).is_some() {
-            debug_assert!(!self.reach_attempts.connected_points.contains_key(&peer_id));
             return Peer::PendingConnect(PeerPendingConnect {
                 attempt: match self.reach_attempts.out_reach_attempts.entry(peer_id.clone()) {
                     Entry::Occupied(e) => e,
@@ -861,7 +874,6 @@ where
             });
         }
 
-        debug_assert!(!self.reach_attempts.connected_points.contains_key(&peer_id));
         Peer::NotConnected(PeerNotConnected {
             nodes: self,
             peer_id,
@@ -974,9 +986,8 @@ where
         match self.active_nodes.poll() {
             Async::NotReady => return Async::NotReady,
             Async::Ready(CollectionEvent::NodeReached(reach_event)) => {
-                let (a, e) = handle_node_reached(&mut self.reach_attempts, reach_event);
-                action = a;
-                out_event = e;
+                out_event = handle_node_reached(&mut self.reach_attempts, reach_event);
+                action = Default::default();
             }
             Async::Ready(CollectionEvent::ReachError { id, error, handler }) => {
                 let (a, e) = handle_reach_error(&mut self.reach_attempts, id, error, handler);
@@ -993,7 +1004,6 @@ where
                              underlying API is guaranteed to always deliver a connection \
                              closed message after it has been opened, and no two closed \
                              messages; QED");
-                debug_assert!(!self.reach_attempts.out_reach_attempts.contains_key(&peer_id));
                 action = Default::default();
                 out_event = RawSwarmEvent::NodeError {
                     peer_id,
@@ -1008,7 +1018,6 @@ where
                              underlying API is guaranteed to always deliver a connection \
                              closed message after it has been opened, and no two closed \
                              messages; QED");
-                debug_assert!(!self.reach_attempts.out_reach_attempts.contains_key(&peer_id));
                 action = Default::default();
                 out_event = RawSwarmEvent::NodeClosed { peer_id, endpoint };
             }
@@ -1022,18 +1031,6 @@ where
             self.start_dial_out(peer_id, handler, first, rest);
         }
 
-        if let Some(interrupt) = action.interrupt {
-            // TODO: improve proof or remove; this is too complicated right now
-            self.active_nodes
-                .interrupt(interrupt)
-                .expect("interrupt is guaranteed to be gathered from `out_reach_attempts`;
-                         we insert in out_reach_attempts only when we call \
-                         active_nodes.add_reach_attempt, and we remove only when we call \
-                         interrupt or when a reach attempt succeeds or errors; therefore the \
-                         out_reach_attempts should always be in sync with the actual \
-                         attempts; QED");
-        }
-
         Async::Ready(out_event)
     }
 }
@@ -1043,14 +1040,12 @@ where
 #[must_use]
 struct ActionItem<THandler, TPeerId> {
     start_dial_out: Option<(TPeerId, THandler, Multiaddr, Vec<Multiaddr>)>,
-    interrupt: Option<ReachAttemptId>,
 }
 
 impl<THandler, TPeerId> Default for ActionItem<THandler, TPeerId> {
     fn default() -> Self {
         ActionItem {
             start_dial_out: None,
-            interrupt: None,
         }
     }
 }
@@ -1064,7 +1059,7 @@ impl<THandler, TPeerId> Default for ActionItem<THandler, TPeerId> {
 fn handle_node_reached<'a, TTrans, TMuxer, TInEvent, TOutEvent, THandler, THandlerErr, TPeerId>(
     reach_attempts: &mut ReachAttempts<TPeerId>,
     event: CollectionReachEvent<TInEvent, TOutEvent, THandler, InternalReachErr<TTrans::Error, TPeerId>, THandlerErr, TPeerId>,
-) -> (ActionItem<THandler, TPeerId>, RawSwarmEvent<'a, TTrans, TInEvent, TOutEvent, THandler, THandlerErr, TPeerId>)
+) -> RawSwarmEvent<'a, TTrans, TInEvent, TOutEvent, THandler, THandlerErr, TPeerId>
 where
     TTrans: Transport<Output = (TPeerId, TMuxer)> + Clone,
     TMuxer: StreamMuxer + Send + Sync + 'static,
@@ -1088,11 +1083,11 @@ where
         if event.would_replace() && has_dial_prio(&reach_attempts.local_peer_id, event.peer_id()) {
             if let Some(ConnectedPoint::Dialer { .. }) = reach_attempts.connected_points.get(event.peer_id()) {
                 if let ConnectedPoint::Listener { listen_addr, send_back_addr } = opened_endpoint {
-                    return (Default::default(), RawSwarmEvent::IncomingConnectionError {
+                    return RawSwarmEvent::IncomingConnectionError {
                         listen_addr,
                         send_back_addr,
                         error: IncomingError::DeniedLowerPriority,
-                    });
+                    };
                 }
             }
         }
@@ -1100,16 +1095,15 @@ where
         // Set the endpoint for this peer.
         let closed_endpoint = reach_attempts.connected_points.insert(event.peer_id().clone(), opened_endpoint.clone());
 
-        // Cancel any outgoing attempt to this peer.
-        let action = if let Some(attempt) = reach_attempts.out_reach_attempts.remove(&event.peer_id()) {
+        // We keep the current outgoing attempt because it may already have succeeded without us
+        // knowing. It is possible that the remote has already closed its ougoing attempt because
+        // it sees our outgoing attempt as a success.
+        // However we cancel any further multiaddress to attempt.
+        // TODO: cancel if we don't have dial priority? we should write tests first
+        if let Some(attempt) = reach_attempts.out_reach_attempts.get_mut(&event.peer_id()) {
             debug_assert_ne!(attempt.id, event.reach_attempt_id());
-            ActionItem {
-                interrupt: Some(attempt.id),
-                .. Default::default()
-            }
-        } else {
-            ActionItem::default()
-        };
+            attempt.next_attempts.clear();
+        }
 
         let (outcome, peer_id) = event.accept();
         if outcome == CollectionNodeAccept::ReplacedExisting {
@@ -1118,13 +1112,13 @@ where
                          remove only when a connection is closed; the underlying API is \
                          guaranteed to always deliver a connection closed message after it has \
                          been opened, and no two closed messages; QED");
-            return (action, RawSwarmEvent::Replaced {
+            return RawSwarmEvent::Replaced {
                 peer_id,
                 endpoint: opened_endpoint,
                 closed_endpoint,
-            });
+            };
         } else {
-            return (action, RawSwarmEvent::Connected { peer_id, endpoint: opened_endpoint });
+            return RawSwarmEvent::Connected { peer_id, endpoint: opened_endpoint };
         }
     }
 
@@ -1156,13 +1150,13 @@ where
                         remove only when a connection is closed; the underlying API is guaranteed \
                         to always deliver a connection closed message after it has been opened, \
                         and no two closed messages; QED");
-            return (Default::default(), RawSwarmEvent::Replaced {
+            return RawSwarmEvent::Replaced {
                 peer_id,
                 endpoint: opened_endpoint,
                 closed_endpoint,
-            });
+            };
         } else {
-            return (Default::default(), RawSwarmEvent::Connected { peer_id, endpoint: opened_endpoint });
+            return RawSwarmEvent::Connected { peer_id, endpoint: opened_endpoint };
         }
     }
 
@@ -1217,6 +1211,17 @@ where
         let num_remain = attempt.next_attempts.len();
         let failed_addr = attempt.cur_attempted.clone();
 
+        let new_state = if reach_attempts.connected_points.contains_key(&peer_id) {
+            PeerState::Connected
+        } else if num_remain == 0 {
+            PeerState::NotConnected
+        } else {
+            PeerState::Dialing {
+                num_pending_addresses: NonZeroUsize::new(num_remain)
+                    .expect("We check that num_remain is not 0 right above; QED"),
+            }
+        };
+
         let action = if !attempt.next_attempts.is_empty() {
             let mut attempt = attempt;
             let next_attempt = attempt.next_attempts.remove(0);
@@ -1240,7 +1245,7 @@ where
         };
 
         return (action, RawSwarmEvent::DialError {
-            remain_addrs_attempt: num_remain,
+            new_state,
             peer_id,
             multiaddr: failed_addr,
             error,
@@ -1304,7 +1309,7 @@ where
     TTrans: Transport,
 {
     /// We are connected to this peer.
-    Connected(PeerConnected<'a, TInEvent, TPeerId>),
+    Connected(PeerConnected<'a, TTrans, TInEvent, TOutEvent, THandler, THandlerErr, TPeerId>),
 
     /// We are currently attempting to connect to this peer.
     PendingConnect(PeerPendingConnect<'a, TTrans, TInEvent, TOutEvent, THandler, THandlerErr, TPeerId>),
@@ -1371,7 +1376,7 @@ where
 {
     /// If we are connected, returns the `PeerConnected`.
     #[inline]
-    pub fn into_connected(self) -> Option<PeerConnected<'a, TInEvent, TPeerId>> {
+    pub fn into_connected(self) -> Option<PeerConnected<'a, TTrans, TInEvent, TOutEvent, THandler, THandlerErr, TPeerId>> {
         match self {
             Peer::Connected(peer) => Some(peer),
             _ => None,
@@ -1440,7 +1445,7 @@ where
     TTrans: Transport
 {
     /// We are connected to this peer.
-    Connected(PeerConnected<'a, TInEvent, TPeerId>),
+    Connected(PeerConnected<'a, TTrans, TInEvent, TOutEvent, THandler, THandlerErr, TPeerId>),
 
     /// We are currently attempting to connect to this peer.
     PendingConnect(PeerPendingConnect<'a, TTrans, TInEvent, TOutEvent, THandler, THandlerErr, TPeerId>),
@@ -1464,7 +1469,7 @@ where
 
     /// If we are connected, returns the `PeerConnected`.
     #[inline]
-    pub fn into_connected(self) -> Option<PeerConnected<'a, TInEvent, TPeerId>> {
+    pub fn into_connected(self) -> Option<PeerConnected<'a, TTrans, TInEvent, TOutEvent, THandler, THandlerErr, TPeerId>> {
         match self {
             PeerPotentialConnect::Connected(peer) => Some(peer),
             _ => None,
@@ -1482,16 +1487,22 @@ where
 }
 
 /// Access to a peer we are connected to.
-pub struct PeerConnected<'a, TInEvent: 'a, TPeerId: 'a> {
-    peer: CollecPeerMut<'a, TInEvent, TPeerId>,
+pub struct PeerConnected<'a, TTrans: 'a, TInEvent: 'a, TOutEvent: 'a, THandler: 'a, THandlerErr: 'a, TPeerId: 'a>
+where TTrans: Transport,
+{
+    /// Reference to the `active_nodes` of the parent.
+    active_nodes: &'a mut CollectionStream<TInEvent, TOutEvent, THandler, InternalReachErr<TTrans::Error, TPeerId>, THandlerErr, TPeerId>,
     /// Reference to the `connected_points` field of the parent.
     connected_points: &'a mut FnvHashMap<TPeerId, ConnectedPoint>,
+    /// Reference to the `out_reach_attempts` field of the parent.
+    out_reach_attempts: &'a mut FnvHashMap<TPeerId, OutReachAttempt>,
     peer_id: TPeerId,
 }
 
-impl<'a, TInEvent, TPeerId> PeerConnected<'a, TInEvent, TPeerId>
+impl<'a, TTrans, TInEvent, TOutEvent, THandler, THandlerErr, TPeerId> PeerConnected<'a, TTrans, TInEvent, TOutEvent, THandler, THandlerErr, TPeerId>
 where
-    TPeerId: Eq + Hash,
+    TTrans: Transport,
+    TPeerId: Eq + Hash + Clone,
 {
     /// Closes the connection to this node.
     ///
@@ -1499,8 +1510,16 @@ where
     // TODO: consider returning a `PeerNotConnected`; however this makes all the borrows things
     // much more annoying to deal with
     pub fn close(self) {
+        if let Some(reach_attempt) = self.out_reach_attempts.remove(&self.peer_id) {
+            self.active_nodes
+                .interrupt(reach_attempt.id)
+                .expect("Elements in out_reach_attempts are in sync with active_nodes; QED");
+        }
+
         self.connected_points.remove(&self.peer_id);
-        self.peer.close()
+        self.active_nodes.peer_mut(&self.peer_id)
+            .expect("A PeerConnected is always created with a PeerId in active_nodes; QED")
+            .close();
     }
 
     /// Returns the endpoint we're connected to.
@@ -1516,7 +1535,9 @@ where
     /// Sends an event to the node.
     #[inline]
     pub fn send_event(&mut self, event: TInEvent) {
-        self.peer.send_event(event)
+        self.active_nodes.peer_mut(&self.peer_id)
+            .expect("A PeerConnected is always created with a PeerId in active_nodes; QED")
+            .send_event(event)
     }
 }
 

--- a/core/src/nodes/raw_swarm/tests.rs
+++ b/core/src/nodes/raw_swarm/tests.rs
@@ -328,7 +328,7 @@ fn known_peer_that_is_unreachable_yields_dial_error() {
                 Async::Ready(event) => {
                     let failed_peer_id = assert_matches!(
                         event,
-                        RawSwarmEvent::DialError { remain_addrs_attempt: _, peer_id: failed_peer_id, .. } => failed_peer_id
+                        RawSwarmEvent::DialError { new_state: _, peer_id: failed_peer_id, .. } => failed_peer_id
                     );
                     assert_eq!(peer_id, failed_peer_id);
                     Ok(Async::Ready(false))

--- a/core/tests/raw_swarm_simult.rs
+++ b/core/tests/raw_swarm_simult.rs
@@ -1,0 +1,210 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use futures::{future, prelude::*};
+use libp2p_core::nodes::raw_swarm::{RawSwarm, RawSwarmEvent, IncomingError};
+use libp2p_core::{Transport, upgrade, upgrade::OutboundUpgradeExt};
+use libp2p_core::protocols_handler::{ProtocolsHandler, KeepAlive, ProtocolsHandlerEvent, ProtocolsHandlerUpgrErr};
+use std::io;
+
+// TODO: replace with DummyProtocolsHandler after https://github.com/servo/rust-smallvec/issues/139 ?
+struct TestHandler<TSubstream>(std::marker::PhantomData<TSubstream>, bool);
+
+impl<TSubstream> Default for TestHandler<TSubstream> {
+    fn default() -> Self {
+        TestHandler(std::marker::PhantomData, false)
+    }
+}
+
+impl<TSubstream> ProtocolsHandler for TestHandler<TSubstream>
+where
+    TSubstream: tokio_io::AsyncRead + tokio_io::AsyncWrite
+{
+    type InEvent = ();      // TODO: cannot be Void (https://github.com/servo/rust-smallvec/issues/139)
+    type OutEvent = ();      // TODO: cannot be Void (https://github.com/servo/rust-smallvec/issues/139)
+    type Error = io::Error;
+    type Substream = TSubstream;
+    type InboundProtocol = upgrade::DeniedUpgrade;
+    type OutboundProtocol = upgrade::DeniedUpgrade;
+    type OutboundOpenInfo = ();      // TODO: cannot be Void (https://github.com/servo/rust-smallvec/issues/139)
+
+    fn listen_protocol(&self) -> Self::InboundProtocol {
+        upgrade::DeniedUpgrade
+    }
+
+    fn inject_fully_negotiated_inbound(
+        &mut self,
+        _: <Self::InboundProtocol as upgrade::InboundUpgrade<Self::Substream>>::Output
+    ) { panic!() }
+
+    fn inject_fully_negotiated_outbound(
+        &mut self,
+        _: <Self::OutboundProtocol as upgrade::OutboundUpgrade<Self::Substream>>::Output,
+        _: Self::OutboundOpenInfo
+    ) { panic!() }
+
+    fn inject_event(&mut self, _: Self::InEvent) {
+        panic!()
+    }
+
+    fn inject_dial_upgrade_error(&mut self, _: Self::OutboundOpenInfo, _: ProtocolsHandlerUpgrErr<<Self::OutboundProtocol as upgrade::OutboundUpgrade<Self::Substream>>::Error>) {
+
+    }
+
+    fn inject_inbound_closed(&mut self) {}
+
+    fn connection_keep_alive(&self) -> KeepAlive { KeepAlive::Now }
+
+    fn shutdown(&mut self) { self.1 = true; }
+
+    fn poll(&mut self) -> Poll<ProtocolsHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Self::OutEvent>, Self::Error> {
+        if self.1 {
+            Ok(Async::Ready(ProtocolsHandlerEvent::Shutdown))
+        } else {
+            Ok(Async::NotReady)
+        }
+    }
+}
+
+
+#[test]
+fn raw_swarm_simultaneous_connect() {
+    // Checks whether two swarms dialing each other simultaneously properly works.
+
+    // When two swarms A and B dial each other, the following can happen:
+    //
+    // - A and B both successfully open a dialing connection simultaneously, then either A or B
+    //   (but not both) closes its dialing connection and get a `Replaced` event to replace the
+    //   dialing connection with the listening one. The other one gets an `IncomingConnectionError`.
+    // - A successfully dials B; B doesn't have dialing priority and thus cancels its dialing
+    //   attempt. If A receives B's dialing attempt, it gets an `IncomingConnectionError`.
+    // - A successfully dials B; B does have dialing priority and thus continues dialing; then B
+    //   successfully dials A; A and B both get a `Replaced` event to replace the dialing
+    //   connection with the listening one.
+    //
+
+    // TODO: make creating the transport more elegant ; literaly half of the code of the test
+    //       is about creating the transport
+    let mut swarm1 = {
+        let local_key = libp2p_secio::SecioKeyPair::ed25519_generated().unwrap();
+        let local_public_key = local_key.to_public_key();
+        let transport = libp2p_tcp::TcpConfig::new()
+            .with_upgrade(libp2p_secio::SecioConfig::new(local_key))
+            .and_then(move |out, _| {
+                let peer_id = out.remote_key.into_peer_id();
+                let upgrade =
+                    libp2p_mplex::MplexConfig::new().map_outbound(move |muxer| (peer_id, muxer));
+                upgrade::apply_outbound(out.stream, upgrade)
+            });
+        RawSwarm::new(transport, local_public_key.into_peer_id())
+    };
+
+    let mut swarm2 = {
+        let local_key = libp2p_secio::SecioKeyPair::ed25519_generated().unwrap();
+        let local_public_key = local_key.to_public_key();
+        let transport = libp2p_tcp::TcpConfig::new()
+            .with_upgrade(libp2p_secio::SecioConfig::new(local_key))
+            .and_then(move |out, _| {
+                let peer_id = out.remote_key.into_peer_id();
+                let upgrade =
+                    libp2p_mplex::MplexConfig::new().map_outbound(move |muxer| (peer_id, muxer));
+                upgrade::apply_outbound(out.stream, upgrade)
+            });
+        RawSwarm::new(transport, local_public_key.into_peer_id())
+    };
+
+    let swarm1_listen = swarm1.listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
+    let swarm2_listen = swarm2.listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
+
+    let mut reactor = tokio::runtime::current_thread::Runtime::new().unwrap();
+
+    for _ in 0 .. 100 {
+        let handler1 = TestHandler::default().into_node_handler_builder();
+        let handler2 = TestHandler::default().into_node_handler_builder();
+
+        swarm1.peer(swarm2.local_peer_id().clone()).into_not_connected().unwrap()
+            .connect(swarm2_listen.clone(), handler1);
+        swarm2.peer(swarm1.local_peer_id().clone()).into_not_connected().unwrap()
+            .connect(swarm1_listen.clone(), handler2);
+
+        let mut swarm1_step = 0;
+        let mut swarm2_step = 0;
+
+        let future = future::poll_fn(|| -> Poll<(), io::Error> {
+            loop {
+                let mut swarm1_not_ready = false;
+                match swarm1.poll() {
+                    Async::Ready(RawSwarmEvent::IncomingConnectionError { error: IncomingError::DeniedLowerPriority, .. }) => {
+                        assert_eq!(swarm1_step, 1);
+                        swarm1_step = 2;
+                    },
+                    Async::Ready(RawSwarmEvent::Connected { peer_id, .. }) => {
+                        assert_eq!(peer_id, *swarm2.local_peer_id());
+                        assert_eq!(swarm1_step, 0);
+                        swarm1_step = 1;
+                    },
+                    Async::Ready(RawSwarmEvent::Replaced { peer_id, .. }) => {
+                        assert_eq!(peer_id, *swarm2.local_peer_id());
+                        assert_eq!(swarm1_step, 1);
+                        swarm1_step = 2;
+                    },
+                    Async::Ready(RawSwarmEvent::IncomingConnection(inc)) => {
+                        inc.accept(TestHandler::default().into_node_handler_builder());
+                    },
+                    Async::Ready(_) => unreachable!(),
+                    Async::NotReady => { swarm1_not_ready = true; }
+                }
+
+                match swarm2.poll() {
+                    Async::Ready(RawSwarmEvent::IncomingConnectionError { error: IncomingError::DeniedLowerPriority, .. }) => {
+                        assert_eq!(swarm2_step, 1);
+                        swarm2_step = 2;
+                    },
+                    Async::Ready(RawSwarmEvent::Connected { peer_id, .. }) => {
+                        assert_eq!(peer_id, *swarm1.local_peer_id());
+                        assert_eq!(swarm2_step, 0);
+                        swarm2_step = 1;
+                    },
+                    Async::Ready(RawSwarmEvent::Replaced { peer_id, .. }) => {
+                        assert_eq!(peer_id, *swarm1.local_peer_id());
+                        assert_eq!(swarm2_step, 1);
+                        swarm2_step = 2;
+                    },
+                    Async::Ready(RawSwarmEvent::IncomingConnection(inc)) => {
+                        inc.accept(TestHandler::default().into_node_handler_builder());
+                    },
+                    Async::Ready(_) => unreachable!(),
+                    Async::NotReady if swarm1_not_ready => return Ok(Async::NotReady),
+                    Async::NotReady => (),
+                }
+
+                if swarm1_step == 2 && swarm2_step == 2 {
+                    return Ok(Async::Ready(()));
+                }
+            }
+        });
+
+        reactor.block_on(future).unwrap();
+
+        // We now disconnect them again.
+        swarm1.peer(swarm2.local_peer_id().clone()).into_connected().unwrap().close();
+        swarm2.peer(swarm1.local_peer_id().clone()).into_connected().unwrap().close();
+    }
+}

--- a/core/tests/raw_swarm_simult.rs
+++ b/core/tests/raw_swarm_simult.rs
@@ -213,7 +213,7 @@ fn raw_swarm_simultaneous_connect() {
                         return Ok(Async::Ready(()));
                     }
 
-                    if swarm1_not_ready && swarm2_not_ready {
+                    if swarm1_step != 0 && swarm2_step != 0 && swarm1_not_ready && swarm2_not_ready {
                         return Ok(Async::NotReady);
                     }
                 }


### PR DESCRIPTION
Fixes maybe #883, I'm not sure.

Right now, when we dial a node and receive an incoming connection from that same node, we cancel the outgoing attempt.
The problem is that this outgoing attempt may have already succeeded (and we don't know yet), in which case the remote has maybe cancelled its own connection. The outcome is no connection at all.

There is a dialing priority system in place, but it applied only if we receive a new connection from a node we are already connected to.

This PR does the following:

- We no longer cancel outgoing attempts when we receiving an incoming connection. However we remove the addresses in the queue.
- Closing an open connection also cancels the outgoing connection attempt.
- We can now receive `DialError` events from nodes we are connected to. In order to clarify this, I changed the `remaining_addresses` field (indicating the number of addresses in queue) into a `new_state` field that indicates the state of the peer.
