### PR TITLE
Add NetworkBehaviour::inject_replaced

### DIFF
--- a/core/src/swarm.rs
+++ b/core/src/swarm.rs
@@ -252,8 +252,7 @@ where TBehaviour: NetworkBehaviour,
                     self.behaviour.inject_disconnected(&peer_id, endpoint);
                 },
                 Async::Ready(RawSwarmEvent::Replaced { peer_id, closed_endpoint, endpoint }) => {
-                    self.behaviour.inject_disconnected(&peer_id, closed_endpoint);
-                    self.behaviour.inject_connected(peer_id, endpoint);
+                    self.behaviour.inject_replaced(peer_id, closed_endpoint, endpoint);
                 },
                 Async::Ready(RawSwarmEvent::IncomingConnection(incoming)) => {
                     let handler = self.behaviour.new_handler();
@@ -332,6 +331,12 @@ pub trait NetworkBehaviour {
     /// Indicates the behaviour that we disconnected from the node with the given peer id. The
     /// endpoint is the one we used to be connected to.
     fn inject_disconnected(&mut self, peer_id: &PeerId, endpoint: ConnectedPoint);
+
+    /// Indicates the behaviour that we replace the connection from the node with another.
+    fn inject_replaced(&mut self, peer_id: PeerId, closed_endpoint: ConnectedPoint, new_endpoint: ConnectedPoint) {
+        self.inject_disconnected(&peer_id, closed_endpoint);
+        self.inject_connected(peer_id, new_endpoint);
+    }
 
     /// Indicates the behaviour that the node with the given peer id has generated an event for
     /// us.

--- a/misc/core-derive/src/lib.rs
+++ b/misc/core-derive/src/lib.rs
@@ -191,6 +191,28 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
         })
     };
 
+    // Build the list of statements to put in the body of `inject_replaced()`.
+    let inject_replaced_stmts = {
+        let num_fields = data_struct.fields.iter().filter(|f| !is_ignored(f)).count();
+        data_struct.fields.iter().enumerate().filter_map(move |(field_n, field)| {
+            if is_ignored(&field) {
+                return None;
+            }
+
+            Some(if field_n == num_fields - 1 {
+                match field.ident {
+                    Some(ref i) => quote!{ self.#i.inject_replaced(peer_id, closed_endpoint, new_endpoint); },
+                    None => quote!{ self.#field_n.inject_replaced(peer_id, closed_endpoint, new_endpoint); },
+                }
+            } else {
+                match field.ident {
+                    Some(ref i) => quote!{ self.#i.inject_replaced(peer_id.clone(), closed_endpoint.clone(), new_endpoint.clone()); },
+                    None => quote!{ self.#field_n.inject_replaced(peer_id.clone(), closed_endpoint.clone(), new_endpoint.clone()); },
+                }
+            })
+        })
+    };
+
     // Build the list of statements to put in the body of `inject_dial_failure()`.
     let inject_dial_failure_stmts = {
         data_struct.fields.iter().enumerate().filter_map(move |(field_n, field)| {
@@ -365,6 +387,11 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
             #[inline]
             fn inject_disconnected(&mut self, peer_id: &#peer_id, endpoint: #connected_point) {
                 #(#inject_disconnected_stmts);*
+            }
+
+            #[inline]
+            fn inject_replaced(&mut self, peer_id: #peer_id, closed_endpoint: #connected_point, new_endpoint: #connected_point) {
+                #(#inject_replaced_stmts);*
             }
 
             #[inline]

--- a/misc/core-derive/src/lib.rs
+++ b/misc/core-derive/src/lib.rs
@@ -206,8 +206,12 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
                 }
             } else {
                 match field.ident {
-                    Some(ref i) => quote!{ self.#i.inject_replaced(peer_id.clone(), closed_endpoint.clone(), new_endpoint.clone()); },
-                    None => quote!{ self.#field_n.inject_replaced(peer_id.clone(), closed_endpoint.clone(), new_endpoint.clone()); },
+                    Some(ref i) => quote!{
+                        self.#i.inject_replaced(peer_id.clone(), closed_endpoint.clone(), new_endpoint.clone());
+                    },
+                    None => quote!{
+                        self.#field_n.inject_replaced(peer_id.clone(), closed_endpoint.clone(), new_endpoint.clone());
+                    },
                 }
             })
         })

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -321,6 +321,18 @@ where
         }
     }
 
+    fn inject_replaced(&mut self, peer_id: PeerId, _: ConnectedPoint, _: ConnectedPoint) {
+        // We need to re-send the active queries.
+        for (query_id, (query, _, _)) in self.active_queries.iter() {
+            if query.is_waiting(&peer_id) {
+                self.queued_events.push(NetworkBehaviourAction::SendEvent {
+                    peer_id: peer_id.clone(),
+                    event: query.target().to_rpc_request(*query_id),
+                });
+            }
+        }
+    }
+
     fn inject_node_event(&mut self, source: PeerId, event: KademliaHandlerEvent<QueryId>) {
         match event {
             KademliaHandlerEvent::FindNodeReq { key, request_id } => {

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -291,7 +291,7 @@ where
             .unwrap_or_else(Vec::new)
     }
 
-    fn inject_connected(&mut self, id: PeerId, _: ConnectedPoint) {
+    fn inject_connected(&mut self, id: PeerId, endpoint: ConnectedPoint) {
         if let Some(pos) = self.pending_rpcs.iter().position(|(p, _)| p == &id) {
             let (_, rpc) = self.pending_rpcs.remove(pos);
             self.queued_events.push(NetworkBehaviourAction::SendEvent {
@@ -309,6 +309,14 @@ where
             _ => ()
         }
 
+        if let ConnectedPoint::Dialer { address } = endpoint {
+            if let Some(list) = self.kbuckets.entry_mut(&id) {
+                if list.iter().all(|a| *a != address) {
+                    list.push(address);
+                }
+            }
+        }
+
         self.connected_peers.insert(id);
     }
 
@@ -323,7 +331,7 @@ where
         self.kbuckets.set_disconnected(&id);
     }
 
-    fn inject_replaced(&mut self, peer_id: PeerId, _: ConnectedPoint, _: ConnectedPoint) {
+    fn inject_replaced(&mut self, peer_id: PeerId, _: ConnectedPoint, new_endpoint: ConnectedPoint) {
         // We need to re-send the active queries.
         for (query_id, (query, _, _)) in self.active_queries.iter() {
             if query.is_waiting(&peer_id) {
@@ -331,6 +339,14 @@ where
                     peer_id: peer_id.clone(),
                     event: query.target().to_rpc_request(*query_id),
                 });
+            }
+        }
+
+        if let ConnectedPoint::Dialer { address } = new_endpoint {
+            if let Some(list) = self.kbuckets.entry_mut(&peer_id) {
+                if list.iter().all(|a| *a != address) {
+                    list.push(address);
+                }
             }
         }
     }

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -319,6 +319,8 @@ where
         for (query, _, _) in self.active_queries.values_mut() {
             query.inject_rpc_error(id);
         }
+
+        self.kbuckets.set_disconnected(&id);
     }
 
     fn inject_replaced(&mut self, peer_id: PeerId, _: ConnectedPoint, _: ConnectedPoint) {

--- a/protocols/kad/src/query.rs
+++ b/protocols/kad/src/query.rs
@@ -216,6 +216,33 @@ impl QueryState {
         }
     }
 
+    /// Returns true if we are waiting for a query answer from that peer.
+    ///
+    /// After `poll()` returned `SendRpc`, this function will return `true`.
+    pub fn is_waiting(&self, id: &PeerId) -> bool {
+        let state = self
+            .closest_peers
+            .iter()
+            .filter_map(
+                |(peer_id, state)| {
+                    if peer_id == id {
+                        Some(state)
+                    } else {
+                        None
+                    }
+                },
+            )
+            .next();
+
+        match state {
+            Some(&QueryPeerState::InProgress(_)) => true,
+            Some(&QueryPeerState::NotContacted) => false,
+            Some(&QueryPeerState::Succeeded) => false,
+            Some(&QueryPeerState::Failed) => false,
+            None => false,
+        }
+    }
+
     /// After `poll()` returned `SendRpc`, this function should be called if we were unable to
     /// reach the peer, or if an error of some sort happened.
     ///


### PR DESCRIPTION
Instead of calling "disconnected" followed with "connected", allows implementers to override an `inject_replaced` method.

The Kademlia behaviour needs this so that it can re-send the RPC query without marking the node as unreachable.