### PR TITLE
Limit Kademlia messages to 4kiB

### DIFF
--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-kad"
 edition = "2018"
 description = "Kademlia protocol for libp2p"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -159,8 +159,11 @@ where
 
     #[inline]
     fn upgrade_inbound(self, incoming: C, _: Self::Info) -> Self::Future {
+        let mut codec = codec::UviBytes::default();
+        codec.set_max_len(4096);
+
         future::ok(
-            Framed::new(incoming, codec::UviBytes::default())
+            Framed::new(incoming, codec)
                 .from_err::<IoError>()
                 .with::<_, fn(_) -> _, _>(|response| -> Result<_, IoError> {
                     let proto_struct = resp_msg_to_proto(response);
@@ -185,8 +188,11 @@ where
 
     #[inline]
     fn upgrade_outbound(self, incoming: C, _: Self::Info) -> Self::Future {
+        let mut codec = codec::UviBytes::default();
+        codec.set_max_len(4096);
+
         future::ok(
-            Framed::new(incoming, codec::UviBytes::default())
+            Framed::new(incoming, codec)
                 .from_err::<IoError>()
                 .with::<_, fn(_) -> _, _>(|request| -> Result<_, IoError> {
                     let proto_struct = req_msg_to_proto(request);


### PR DESCRIPTION
cc https://github.com/paritytech/substrate/issues/1645

The number of results is 20.
A message of 4kiB is enough to transfer 20 nodes with around 15 addresses each. Nodes typically don't have 15 addresses.