### PR TITLE
Fix generics in out_event type in derive

### DIFF
--- a/misc/core-derive/Cargo.toml
+++ b/misc/core-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-core-derive"
 edition = "2018"
 description = "Procedural macros of libp2p-core"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/misc/core-derive/src/lib.rs
+++ b/misc/core-derive/src/lib.rs
@@ -122,7 +122,7 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
                 match meta_item {
                     syn::NestedMeta::Meta(syn::Meta::NameValue(ref m)) if m.ident == "out_event" => {
                         if let syn::Lit::Str(ref s) = m.lit {
-                            let ident: Ident = syn::parse_str(&s.value()).unwrap();
+                            let ident: syn::Type = syn::parse_str(&s.value()).unwrap();
                             out = quote!{#ident};
                         }
                     }

--- a/misc/core-derive/tests/test.rs
+++ b/misc/core-derive/tests/test.rs
@@ -145,7 +145,7 @@ fn custom_polling() {
 fn custom_event_no_polling() {
     #[allow(dead_code)]
     #[derive(NetworkBehaviour)]
-    #[behaviour(out_event = "String")]
+    #[behaviour(out_event = "Vec<String>")]
     struct Foo<TSubstream> {
         ping: libp2p::ping::Ping<TSubstream>,
         identify: libp2p::identify::Identify<TSubstream>,


### PR DESCRIPTION
Right now, writing `#[behaviour(out_event = "Vec<String>")]` is refused because `Vec<String>` is parsed an `Ident` instead of a `Type`.