### PR TITLE
Address edition-2018 idioms.

### DIFF
--- a/core/src/either.rs
+++ b/core/src/either.rs
@@ -34,7 +34,7 @@ where
     A: fmt::Display,
     B: fmt::Display
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             EitherError::A(a) => a.fmt(f),
             EitherError::B(b) => b.fmt(f)

--- a/core/src/keys_proto.rs
+++ b/core/src/keys_proto.rs
@@ -103,7 +103,7 @@ impl ::protobuf::Message for PublicKey {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -136,7 +136,7 @@ impl ::protobuf::Message for PublicKey {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.Type {
             os.write_enum(1, v.value())?;
         }
@@ -159,13 +159,13 @@ impl ::protobuf::Message for PublicKey {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -224,13 +224,13 @@ impl ::protobuf::Clear for PublicKey {
 }
 
 impl ::std::fmt::Debug for PublicKey {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for PublicKey {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -317,7 +317,7 @@ impl ::protobuf::Message for PrivateKey {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -350,7 +350,7 @@ impl ::protobuf::Message for PrivateKey {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.Type {
             os.write_enum(1, v.value())?;
         }
@@ -373,13 +373,13 @@ impl ::protobuf::Message for PrivateKey {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -438,13 +438,13 @@ impl ::protobuf::Clear for PrivateKey {
 }
 
 impl ::std::fmt::Debug for PrivateKey {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for PrivateKey {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -502,7 +502,7 @@ impl ::std::default::Default for KeyType {
 }
 
 impl ::protobuf::reflect::ProtobufValue for KeyType {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -63,7 +63,7 @@
 
 
 /// Multi-address re-export.
-pub extern crate multiaddr;
+pub use multiaddr;
 
 mod keys_proto;
 mod peer_id;

--- a/core/src/muxing.rs
+++ b/core/src/muxing.rs
@@ -303,7 +303,7 @@ where
     P::Target: StreamMuxer,
     <P::Target as StreamMuxer>::Substream: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "Substream({:?})", self.substream)
     }
 }
@@ -398,7 +398,7 @@ where
 
 /// Abstract `StreamMuxer`.
 pub struct StreamMuxerBox {
-    inner: Box<StreamMuxer<Substream = usize, OutboundSubstream = usize> + Send + Sync>,
+    inner: Box<dyn StreamMuxer<Substream = usize, OutboundSubstream = usize> + Send + Sync>,
 }
 
 impl StreamMuxerBox {

--- a/core/src/nodes/handled_node.rs
+++ b/core/src/nodes/handled_node.rs
@@ -173,7 +173,7 @@ where
     TMuxer: StreamMuxer,
     THandler: NodeHandler<Substream = Substream<TMuxer>> + fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("HandledNode")
             .field("node", &self.node)
             .field("handler", &self.handler)
@@ -338,7 +338,7 @@ pub enum HandledNodeError<THandlerErr> {
 impl<THandlerErr> fmt::Display for HandledNodeError<THandlerErr>
 where THandlerErr: fmt::Display
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             HandledNodeError::Node(err) => write!(f, "{}", err),
             HandledNodeError::Handler(err) => write!(f, "{}", err),

--- a/core/src/nodes/listeners.rs
+++ b/core/src/nodes/listeners.rs
@@ -40,10 +40,6 @@ use void::Void;
 /// # Example
 ///
 /// ```no_run
-/// # extern crate futures;
-/// # extern crate libp2p_core;
-/// # extern crate libp2p_tcp;
-/// # extern crate tokio;
 /// # fn main() {
 /// use futures::prelude::*;
 /// use libp2p_core::nodes::listeners::{ListenersEvent, ListenersStream};
@@ -238,7 +234,7 @@ impl<TTrans> fmt::Debug for ListenersStream<TTrans>
 where
     TTrans: Transport + fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         f.debug_struct("ListenersStream")
             .field("transport", &self.transport)
             .field("listeners", &self.listeners().collect::<Vec<_>>())
@@ -251,7 +247,7 @@ where
     TTrans: Transport,
     <TTrans::Listener as Stream>::Error: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             ListenersEvent::Incoming {
                 ref listen_addr, ..
@@ -274,8 +270,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    extern crate libp2p_tcp;
-
     use super::*;
     use crate::transport;
     use assert_matches::assert_matches;

--- a/core/src/nodes/node.rs
+++ b/core/src/nodes/node.rs
@@ -322,7 +322,7 @@ impl<TMuxer, TUserData> fmt::Debug for NodeStream<TMuxer, TUserData>
 where
     TMuxer: muxing::StreamMuxer,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         f.debug_struct("NodeStream")
             .field("inbound_state", &self.inbound_state)
             .field("outbound_state", &self.outbound_state)
@@ -351,7 +351,7 @@ where
     TMuxer::Substream: fmt::Debug,
     TUserData: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             NodeEvent::InboundSubstream { substream } => {
                 f.debug_struct("NodeEvent::OutboundClosed")

--- a/core/src/peer_id.rs
+++ b/core/src/peer_id.rs
@@ -34,7 +34,7 @@ pub struct PeerId {
 }
 
 impl fmt::Debug for PeerId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "PeerId({})", self.to_base58())
     }
 }

--- a/core/src/protocols_handler/mod.rs
+++ b/core/src/protocols_handler/mod.rs
@@ -342,7 +342,7 @@ impl<TUpgrErr> fmt::Display for ProtocolsHandlerUpgrErr<TUpgrErr>
 where
     TUpgrErr: fmt::Display,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ProtocolsHandlerUpgrErr::Timeout => {
                 write!(f, "Timeout error while opening a substream")

--- a/core/src/swarm.rs
+++ b/core/src/swarm.rs
@@ -373,7 +373,7 @@ pub trait NetworkBehaviour {
     /// Polls for things that swarm should do.
     ///
     /// This API mimics the API of the `Stream` trait.
-    fn poll(&mut self, topology: &mut PollParameters) -> Async<NetworkBehaviourAction<<<Self::ProtocolsHandler as IntoProtocolsHandler>::Handler as ProtocolsHandler>::InEvent, Self::OutEvent>>;
+    fn poll(&mut self, topology: &mut PollParameters<'_>) -> Async<NetworkBehaviourAction<<<Self::ProtocolsHandler as IntoProtocolsHandler>::Handler as ProtocolsHandler>::InEvent, Self::OutEvent>>;
 }
 
 /// Used when deriving `NetworkBehaviour`. When deriving `NetworkBehaviour`, must be implemented
@@ -591,7 +591,7 @@ mod tests {
         fn inject_node_event(&mut self, _: PeerId,
             _: <Self::ProtocolsHandler as ProtocolsHandler>::OutEvent) {}
 
-        fn poll(&mut self, _: &mut PollParameters) ->
+        fn poll(&mut self, _: &mut PollParameters<'_>) ->
             Async<NetworkBehaviourAction<<Self::ProtocolsHandler as
             ProtocolsHandler>::InEvent, Self::OutEvent>>
         {

--- a/core/src/tests/dummy_transport.rs
+++ b/core/src/tests/dummy_transport.rs
@@ -69,9 +69,9 @@ impl DummyTransport {
 impl Transport for DummyTransport {
     type Output = (PeerId, DummyMuxer);
     type Error = io::Error;
-    type Listener = Box<Stream<Item=(Self::ListenerUpgrade, Multiaddr), Error=io::Error> + Send>;
+    type Listener = Box<dyn Stream<Item=(Self::ListenerUpgrade, Multiaddr), Error=io::Error> + Send>;
     type ListenerUpgrade = FutureResult<Self::Output, io::Error>;
-    type Dial = Box<Future<Item = Self::Output, Error = io::Error> + Send>;
+    type Dial = Box<dyn Future<Item = Self::Output, Error = io::Error> + Send>;
 
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>>
     where

--- a/core/src/transport/boxed.rs
+++ b/core/src/transport/boxed.rs
@@ -37,9 +37,9 @@ where
     }
 }
 
-pub type Dial<O, E> = Box<Future<Item = O, Error = E> + Send>;
-pub type Listener<O, E> = Box<Stream<Item = (ListenerUpgrade<O, E>, Multiaddr), Error = E> + Send>;
-pub type ListenerUpgrade<O, E> = Box<Future<Item = O, Error = E> + Send>;
+pub type Dial<O, E> = Box<dyn Future<Item = O, Error = E> + Send>;
+pub type Listener<O, E> = Box<dyn Stream<Item = (ListenerUpgrade<O, E>, Multiaddr), Error = E> + Send>;
+pub type ListenerUpgrade<O, E> = Box<dyn Future<Item = O, Error = E> + Send>;
 
 trait Abstract<O, E> {
     fn listen_on(&self, addr: Multiaddr) -> Result<(Listener<O, E>, Multiaddr), TransportError<E>>;
@@ -76,11 +76,11 @@ where
 
 /// See the `Transport::boxed` method.
 pub struct Boxed<O, E> {
-    inner: Arc<Abstract<O, E> + Send + Sync>,
+    inner: Arc<dyn Abstract<O, E> + Send + Sync>,
 }
 
 impl<O, E> fmt::Debug for Boxed<O, E> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "BoxedTransport")
     }
 }

--- a/core/src/transport/memory.rs
+++ b/core/src/transport/memory.rs
@@ -53,9 +53,9 @@ impl<T> Clone for Dialer<T> {
 impl<T: IntoBuf + Send + 'static> Transport for Dialer<T> {
     type Output = Channel<T>;
     type Error = MemoryTransportError;
-    type Listener = Box<Stream<Item=(Self::ListenerUpgrade, Multiaddr), Error=MemoryTransportError> + Send>;
+    type Listener = Box<dyn Stream<Item=(Self::ListenerUpgrade, Multiaddr), Error=MemoryTransportError> + Send>;
     type ListenerUpgrade = FutureResult<Self::Output, MemoryTransportError>;
-    type Dial = Box<Future<Item=Self::Output, Error=MemoryTransportError> + Send>;
+    type Dial = Box<dyn Future<Item=Self::Output, Error=MemoryTransportError> + Send>;
 
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>> {
         Err(TransportError::MultiaddrNotSupported(addr))
@@ -92,7 +92,7 @@ pub enum MemoryTransportError {
 }
 
 impl fmt::Display for MemoryTransportError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             MemoryTransportError::RemoteClosed => 
                 write!(f, "The other side of the memory transport has been closed."),
@@ -114,9 +114,9 @@ impl<T> Clone for Listener<T> {
 impl<T: IntoBuf + Send + 'static> Transport for Listener<T> {
     type Output = Channel<T>;
     type Error = MemoryTransportError;
-    type Listener = Box<Stream<Item=(Self::ListenerUpgrade, Multiaddr), Error=MemoryTransportError> + Send>;
+    type Listener = Box<dyn Stream<Item=(Self::ListenerUpgrade, Multiaddr), Error=MemoryTransportError> + Send>;
     type ListenerUpgrade = FutureResult<Self::Output, MemoryTransportError>;
-    type Dial = Box<Future<Item=Self::Output, Error=MemoryTransportError> + Send>;
+    type Dial = Box<dyn Future<Item=Self::Output, Error=MemoryTransportError> + Send>;
 
     fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>> {
         if !is_memory_addr(&addr) {

--- a/core/src/transport/mod.rs
+++ b/core/src/transport/mod.rs
@@ -246,7 +246,7 @@ impl<TErr> TransportError<TErr> {
 impl<TErr> fmt::Display for TransportError<TErr>
 where TErr: fmt::Display,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TransportError::MultiaddrNotSupported(addr) => write!(f, "Multiaddr is not supported: {}", addr),
             TransportError::Other(err) => write!(f, "{}", err),

--- a/core/src/transport/timeout.rs
+++ b/core/src/transport/timeout.rs
@@ -183,7 +183,7 @@ pub enum TransportTimeoutError<TErr> {
 impl<TErr> fmt::Display for TransportTimeoutError<TErr>
 where TErr: fmt::Display,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TransportTimeoutError::Timeout => write!(f, "Timeout has been reached"),
             TransportTimeoutError::TimerError => write!(f, "Error in the timer"),

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -94,7 +94,7 @@ where
     TTransErr: fmt::Display,
     TUpgrErr: fmt::Display,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TransportUpgradeError::Transport(e) => write!(f, "Transport error: {}", e),
             TransportUpgradeError::Upgrade(e) => write!(f, "Upgrade error: {}", e),

--- a/core/src/upgrade/error.rs
+++ b/core/src/upgrade/error.rs
@@ -53,7 +53,7 @@ impl<E> fmt::Display for UpgradeError<E>
 where
     E: fmt::Display
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             UpgradeError::Select(e) => write!(f, "select error: {}", e),
             UpgradeError::Apply(e) => write!(f, "upgrade apply error: {}", e),

--- a/core/src/upgrade/transfer.rs
+++ b/core/src/upgrade/transfer.rs
@@ -260,7 +260,7 @@ impl From<std::io::Error> for ReadOneError {
 }
 
 impl fmt::Display for ReadOneError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ReadOneError::Io(ref err) => write!(f, "{}", err),
             ReadOneError::TooLarge { .. } => write!(f, "Received data size over maximum"),

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -49,12 +49,6 @@
 //!
 //! The two nodes then connect.
 
-extern crate env_logger;
-extern crate futures;
-extern crate libp2p;
-extern crate tokio;
-extern crate void;
-
 use futures::prelude::*;
 use libp2p::{
     NetworkBehaviour,

--- a/examples/ipfs-kad.rs
+++ b/examples/ipfs-kad.rs
@@ -23,11 +23,6 @@
 //! You can pass as parameter a base58 peer ID to search for. If you don't pass any parameter, a
 //! peer ID will be generated randomly.
 
-extern crate futures;
-extern crate libp2p;
-extern crate rand;
-extern crate tokio;
-
 use futures::prelude::*;
 use libp2p::{
     core::PublicKey,

--- a/examples/mdns-passive-discovery.rs
+++ b/examples/mdns-passive-discovery.rs
@@ -18,11 +18,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-extern crate futures;
-extern crate libp2p;
-extern crate rand;
-extern crate tokio;
-
 use futures::prelude::*;
 use libp2p::mdns::service::{MdnsPacket, MdnsService};
 use std::io;

--- a/misc/core-derive/src/lib.rs
+++ b/misc/core-derive/src/lib.rs
@@ -21,13 +21,10 @@
 #![recursion_limit = "256"]
 
 extern crate proc_macro;
-#[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate quote;
 
-use self::proc_macro::TokenStream;
-use syn::{DeriveInput, Data, DataStruct, Ident};
+use quote::quote;
+use proc_macro::TokenStream;
+use syn::{parse_macro_input, DeriveInput, Data, DataStruct, Ident};
 
 /// The interface that satisfies Rust.
 #[proc_macro_derive(NetworkBehaviour, attributes(behaviour))]

--- a/misc/core-derive/tests/test.rs
+++ b/misc/core-derive/tests/test.rs
@@ -18,9 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-#[macro_use]
-extern crate libp2p;
-extern crate void;
+use libp2p_core_derive::*;
 
 /// Small utility to check that a type implements `NetworkBehaviour`.
 #[allow(dead_code)]

--- a/misc/mdns/src/behaviour.rs
+++ b/misc/mdns/src/behaviour.rs
@@ -103,7 +103,7 @@ impl ExactSizeIterator for DiscoveredAddrsIter {
 }
 
 impl fmt::Debug for DiscoveredAddrsIter {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("DiscoveredAddrsIter")
             .finish()
     }
@@ -132,7 +132,7 @@ impl ExactSizeIterator for ExpiredAddrsIter {
 }
 
 impl fmt::Debug for ExpiredAddrsIter {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("ExpiredAddrsIter")
             .finish()
     }
@@ -172,7 +172,7 @@ where
 
     fn poll(
         &mut self,
-        params: &mut PollParameters,
+        params: &mut PollParameters<'_>,
     ) -> Async<
         NetworkBehaviourAction<
             <Self::ProtocolsHandler as ProtocolsHandler>::InEvent,
@@ -277,7 +277,7 @@ where
 }
 
 impl<TSubstream> fmt::Debug for Mdns<TSubstream> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Mdns")
             .field("service", &self.service)
             .finish()

--- a/misc/mdns/src/dns.rs
+++ b/misc/mdns/src/dns.rs
@@ -29,7 +29,7 @@ use std::{borrow::Cow, cmp, error, fmt, str, time::Duration};
 
 /// Decodes a `<character-string>` (as defined by RFC1035) into a `Vec` of ASCII characters.
 // TODO: better error type?
-pub fn decode_character_string(mut from: &[u8]) -> Result<Cow<[u8]>, ()> {
+pub fn decode_character_string(mut from: &[u8]) -> Result<Cow<'_, [u8]>, ()> {
     if from.is_empty() {
         return Ok(Cow::Owned(Vec::new()));
     }
@@ -317,7 +317,7 @@ pub enum MdnsResponseError {
 }
 
 impl fmt::Display for MdnsResponseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             MdnsResponseError::TxtRecordTooLong => {
                 write!(f, "TXT record invalid because it is too long")

--- a/misc/mdns/src/lib.rs
+++ b/misc/mdns/src/lib.rs
@@ -30,23 +30,6 @@
 //! struct will automatically discover other libp2p nodes on the local network.
 //!
 
-extern crate data_encoding;
-extern crate dns_parser;
-extern crate futures;
-extern crate libp2p_core;
-extern crate multiaddr;
-extern crate net2;
-extern crate rand;
-extern crate smallvec;
-extern crate tokio_io;
-extern crate tokio_reactor;
-extern crate tokio_timer;
-extern crate tokio_udp;
-extern crate void;
-
-#[cfg(test)]
-extern crate tokio;
-
 /// Hardcoded name of the mDNS service. Part of the mDNS libp2p specifications.
 const SERVICE_NAME: &[u8] = b"_p2p._udp.local";
 /// Hardcoded name of the service used for DNS-SD.

--- a/misc/mdns/src/service.rs
+++ b/misc/mdns/src/service.rs
@@ -18,20 +18,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-extern crate data_encoding;
-extern crate dns_parser;
-extern crate futures;
-extern crate libp2p_core;
-extern crate multiaddr;
-extern crate net2;
-extern crate rand;
-extern crate tokio_reactor;
-extern crate tokio_timer;
-extern crate tokio_udp;
-
-#[cfg(test)]
-extern crate tokio;
-
 use crate::{SERVICE_NAME, META_QUERY_SERVICE, dns};
 use dns_parser::{Packet, RData};
 use futures::{prelude::*, task};
@@ -66,9 +52,6 @@ pub use dns::MdnsResponseError;
 /// # Example
 ///
 /// ```rust
-/// # extern crate futures;
-/// # extern crate libp2p_core;
-/// # extern crate libp2p_mdns;
 /// # use futures::prelude::*;
 /// # use libp2p_mdns::service::{MdnsService, MdnsPacket};
 /// # use std::{io, time::Duration};
@@ -173,7 +156,7 @@ impl MdnsService {
     }
 
     /// Polls the service for packets.
-    pub fn poll(&mut self) -> Async<MdnsPacket> {
+    pub fn poll(&mut self) -> Async<MdnsPacket<'_>> {
         // Send a query every time `query_interval` fires.
         // Note that we don't use a loop here—it is pretty unlikely that we need it, and there is
         // no point in sending multiple requests in a row.
@@ -302,7 +285,7 @@ impl MdnsService {
 }
 
 impl fmt::Debug for MdnsService {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("MdnsService")
             .field("silent", &self.silent)
             .finish()
@@ -363,7 +346,7 @@ impl<'a> MdnsQuery<'a> {
 }
 
 impl<'a> fmt::Debug for MdnsQuery<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MdnsQuery")
             .field("from", self.remote_addr())
             .field("query_id", &self.query_id)
@@ -397,7 +380,7 @@ impl<'a> MdnsServiceDiscovery<'a> {
 }
 
 impl<'a> fmt::Debug for MdnsServiceDiscovery<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MdnsServiceDiscovery")
             .field("from", self.remote_addr())
             .field("query_id", &self.query_id)
@@ -464,7 +447,7 @@ impl<'a> MdnsResponse<'a> {
 }
 
 impl<'a> fmt::Debug for MdnsResponse<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MdnsResponse")
             .field("from", self.remote_addr())
             .finish()
@@ -544,7 +527,7 @@ impl<'a> MdnsPeer<'a> {
 }
 
 impl<'a> fmt::Debug for MdnsPeer<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MdnsPeer")
             .field("peer_id", &self.peer_id)
             .finish()

--- a/misc/multiaddr/src/errors.rs
+++ b/misc/multiaddr/src/errors.rs
@@ -20,7 +20,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::DataLessThanLen => f.write_str("we have less data than indicated by length"),
             Error::InvalidMultiaddr => f.write_str("invalid multiaddr"),

--- a/misc/multiaddr/src/lib.rs
+++ b/misc/multiaddr/src/lib.rs
@@ -3,14 +3,7 @@
 ///! Implementation of [multiaddr](https://github.com/jbenet/multiaddr)
 ///! in Rust.
 
-#[macro_use]
-extern crate arrayref;
-extern crate bs58;
-extern crate byteorder;
-extern crate data_encoding;
-extern crate serde;
-extern crate unsigned_varint;
-pub extern crate multihash;
+pub use multihash;
 
 mod protocol;
 mod errors;
@@ -60,7 +53,7 @@ impl<'de> Deserialize<'de> for Multiaddr {
         impl<'de> de::Visitor<'de> for Visitor {
             type Value = Multiaddr;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("multiaddress")
             }
             fn visit_str<E: de::Error>(self, v: &str) -> StdResult<Self::Value, E> {
@@ -93,7 +86,7 @@ impl<'de> Deserialize<'de> for Multiaddr {
 
 impl fmt::Debug for Multiaddr {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.to_string().fmt(f)
     }
 }
@@ -111,7 +104,7 @@ impl fmt::Display for Multiaddr {
     /// ```
     ///
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for s in self.iter() {
             s.to_string().fmt(f)?;
         }
@@ -185,7 +178,7 @@ impl Multiaddr {
     /// ```
     ///
     #[inline]
-    pub fn append(&mut self, p: Protocol) {
+    pub fn append(&mut self, p: Protocol<'_>) {
         let n = self.bytes.len();
         let mut w = io::Cursor::new(&mut self.bytes);
         w.set_position(n as u64);
@@ -267,7 +260,7 @@ impl Multiaddr {
     /// ```
     ///
     #[inline]
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         Iter(&self.bytes)
     }
 

--- a/misc/multiaddr/src/protocol.rs
+++ b/misc/multiaddr/src/protocol.rs
@@ -1,3 +1,5 @@
+
+use arrayref::array_ref;
 use bs58;
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt, WriteBytesExt};
 use crate::{Result, Error};
@@ -350,7 +352,7 @@ impl<'a> Protocol<'a> {
 }
 
 impl<'a> fmt::Display for Protocol<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::Protocol::*;
         match self {
             Dccp(port) => write!(f, "/dccp/{}", port),

--- a/misc/multiaddr/tests/lib.rs
+++ b/misc/multiaddr/tests/lib.rs
@@ -1,11 +1,3 @@
-extern crate bs58;
-extern crate bincode;
-extern crate data_encoding;
-extern crate parity_multiaddr;
-extern crate multihash;
-extern crate quickcheck;
-extern crate rand;
-extern crate serde_json;
 
 use data_encoding::HEXUPPER;
 use multihash::Multihash;
@@ -108,7 +100,7 @@ impl Arbitrary for SubString {
 // other unit tests
 
 
-fn ma_valid(source: &str, target: &str, protocols: Vec<Protocol>) {
+fn ma_valid(source: &str, target: &str, protocols: Vec<Protocol<'_>>) {
     let parsed = source.parse::<Multiaddr>().unwrap();
     assert_eq!(HEXUPPER.encode(&parsed.to_bytes()[..]), target);
     assert_eq!(parsed.iter().collect::<Vec<_>>(), protocols);

--- a/misc/multihash/src/errors.rs
+++ b/misc/multihash/src/errors.rs
@@ -9,7 +9,7 @@ pub enum EncodeError {
 
 impl fmt::Display for EncodeError {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             EncodeError::UnsupportedType => write!(f, "This type is not supported yet"),
         }
@@ -29,7 +29,7 @@ pub enum DecodeError {
 
 impl fmt::Display for DecodeError {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             DecodeError::BadInputLength => write!(f, "Not matching input length"),
             DecodeError::UnknownCode => write!(f, "Found unknown code"),
@@ -52,7 +52,7 @@ pub struct DecodeOwnedError {
 
 impl fmt::Display for DecodeOwnedError {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.error)
     }
 }

--- a/misc/multihash/src/lib.rs
+++ b/misc/multihash/src/lib.rs
@@ -5,19 +5,11 @@
 //! A `Multihash` is a structure that contains a hashing algorithm, plus some hashed data.
 //! A `MultihashRef` is the same as a `Multihash`, except that it doesn't own its data.
 
-extern crate blake2;
-extern crate rand;
-extern crate sha1;
-extern crate sha2;
-extern crate tiny_keccak;
-extern crate unsigned_varint;
-
 mod errors;
 mod hashes;
 
-use std::fmt::Write;
-
 use sha2::Digest;
+use std::fmt::Write;
 use tiny_keccak::Keccak;
 use unsigned_varint::{decode, encode};
 
@@ -169,7 +161,7 @@ impl Multihash {
 
     /// Builds a `MultihashRef` corresponding to this `Multihash`.
     #[inline]
-    pub fn as_ref(&self) -> MultihashRef {
+    pub fn as_ref(&self) -> MultihashRef<'_> {
         MultihashRef { bytes: &self.bytes }
     }
 

--- a/misc/multihash/tests/lib.rs
+++ b/misc/multihash/tests/lib.rs
@@ -1,4 +1,4 @@
-extern crate parity_multihash;
+
 
 use parity_multihash::*;
 

--- a/misc/multistream-select/src/error.rs
+++ b/misc/multistream-select/src/error.rs
@@ -66,7 +66,7 @@ impl error::Error for ProtocolChoiceError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             ProtocolChoiceError::MultistreamSelectError(ref err) => Some(err),
             _ => None,
@@ -76,7 +76,7 @@ impl error::Error for ProtocolChoiceError {
 
 impl fmt::Display for ProtocolChoiceError {
     #[inline]
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(fmt, "{}", error::Error::description(self))
     }
 }

--- a/misc/multistream-select/src/protocol/error.rs
+++ b/misc/multistream-select/src/protocol/error.rs
@@ -77,7 +77,7 @@ impl error::Error for MultistreamSelectError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             MultistreamSelectError::IoError(ref err) => Some(err),
             _ => None,
@@ -87,7 +87,7 @@ impl error::Error for MultistreamSelectError {
 
 impl fmt::Display for MultistreamSelectError {
     #[inline]
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(fmt, "{}", error::Error::description(self))
     }
 }

--- a/misc/peer-id-generator/src/main.rs
+++ b/misc/peer-id-generator/src/main.rs
@@ -18,11 +18,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-extern crate libp2p_core;
-extern crate libp2p_secio;
-extern crate num_cpus;
-extern crate rand;
-
 use libp2p_core::PeerId;
 use libp2p_secio::SecioKeyPair;
 use std::{env, str, thread, time::Duration};

--- a/misc/rw-stream-sink/src/lib.rs
+++ b/misc/rw-stream-sink/src/lib.rs
@@ -27,10 +27,6 @@
 //! > **Note**: Although this crate is hosted in the libp2p repo, it is purely a utility crate and
 //! >           not at all specific to libp2p.
 
-extern crate bytes;
-extern crate futures;
-extern crate tokio_io;
-
 use bytes::{Buf, IntoBuf};
 use futures::{Async, AsyncSink, Poll, Sink, Stream};
 use std::cmp;

--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -337,7 +337,7 @@ where
 
     fn poll(
         &mut self,
-        _: &mut PollParameters,
+        _: &mut PollParameters<'_>,
     ) -> Async<
         NetworkBehaviourAction<
             <Self::ProtocolsHandler as ProtocolsHandler>::InEvent,

--- a/protocols/floodsub/src/lib.rs
+++ b/protocols/floodsub/src/lib.rs
@@ -21,19 +21,6 @@
 //! Implements the floodsub protocol, see also the:
 //! [spec](https://github.com/libp2p/specs/tree/master/pubsub).
 
-extern crate bs58;
-extern crate bytes;
-extern crate cuckoofilter;
-extern crate fnv;
-extern crate futures;
-extern crate libp2p_core;
-extern crate protobuf;
-extern crate rand;
-extern crate smallvec;
-extern crate tokio_codec;
-extern crate tokio_io;
-extern crate unsigned_varint;
-
 pub mod protocol;
 
 mod layer;

--- a/protocols/floodsub/src/protocol.rs
+++ b/protocols/floodsub/src/protocol.rs
@@ -121,7 +121,7 @@ impl From<ProtobufError> for FloodsubDecodeError {
 }
 
 impl fmt::Display for FloodsubDecodeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             FloodsubDecodeError::ReadError(ref err) =>
                 write!(f, "Error while reading from socket: {}", err),

--- a/protocols/floodsub/src/rpc_proto.rs
+++ b/protocols/floodsub/src/rpc_proto.rs
@@ -102,7 +102,7 @@ impl ::protobuf::Message for RPC {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -137,7 +137,7 @@ impl ::protobuf::Message for RPC {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         for v in &self.subscriptions {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -164,13 +164,13 @@ impl ::protobuf::Message for RPC {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -229,13 +229,13 @@ impl ::protobuf::Clear for RPC {
 }
 
 impl ::std::fmt::Debug for RPC {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for RPC {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -316,7 +316,7 @@ impl ::protobuf::Message for RPC_SubOpts {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -353,7 +353,7 @@ impl ::protobuf::Message for RPC_SubOpts {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.subscribe {
             os.write_bool(1, v)?;
         }
@@ -376,13 +376,13 @@ impl ::protobuf::Message for RPC_SubOpts {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -441,13 +441,13 @@ impl ::protobuf::Clear for RPC_SubOpts {
 }
 
 impl ::std::fmt::Debug for RPC_SubOpts {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for RPC_SubOpts {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -608,7 +608,7 @@ impl ::protobuf::Message for Message {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -653,7 +653,7 @@ impl ::protobuf::Message for Message {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.from.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -682,13 +682,13 @@ impl ::protobuf::Message for Message {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -759,13 +759,13 @@ impl ::protobuf::Clear for Message {
 }
 
 impl ::std::fmt::Debug for Message {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Message {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -904,7 +904,7 @@ impl ::protobuf::Message for TopicDescriptor {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -945,7 +945,7 @@ impl ::protobuf::Message for TopicDescriptor {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.name.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -975,13 +975,13 @@ impl ::protobuf::Message for TopicDescriptor {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -1046,13 +1046,13 @@ impl ::protobuf::Clear for TopicDescriptor {
 }
 
 impl ::std::fmt::Debug for TopicDescriptor {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for TopicDescriptor {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -1122,7 +1122,7 @@ impl ::protobuf::Message for TopicDescriptor_AuthOpts {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -1155,7 +1155,7 @@ impl ::protobuf::Message for TopicDescriptor_AuthOpts {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.mode {
             os.write_enum(1, v.value())?;
         }
@@ -1178,13 +1178,13 @@ impl ::protobuf::Message for TopicDescriptor_AuthOpts {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -1243,13 +1243,13 @@ impl ::protobuf::Clear for TopicDescriptor_AuthOpts {
 }
 
 impl ::std::fmt::Debug for TopicDescriptor_AuthOpts {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for TopicDescriptor_AuthOpts {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -1307,7 +1307,7 @@ impl ::std::default::Default for TopicDescriptor_AuthOpts_AuthMode {
 }
 
 impl ::protobuf::reflect::ProtobufValue for TopicDescriptor_AuthOpts_AuthMode {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())
     }
 }
@@ -1377,7 +1377,7 @@ impl ::protobuf::Message for TopicDescriptor_EncOpts {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -1410,7 +1410,7 @@ impl ::protobuf::Message for TopicDescriptor_EncOpts {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.mode {
             os.write_enum(1, v.value())?;
         }
@@ -1433,13 +1433,13 @@ impl ::protobuf::Message for TopicDescriptor_EncOpts {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -1498,13 +1498,13 @@ impl ::protobuf::Clear for TopicDescriptor_EncOpts {
 }
 
 impl ::std::fmt::Debug for TopicDescriptor_EncOpts {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for TopicDescriptor_EncOpts {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -1562,7 +1562,7 @@ impl ::std::default::Default for TopicDescriptor_EncOpts_EncMode {
 }
 
 impl ::protobuf::reflect::ProtobufValue for TopicDescriptor_EncOpts_EncMode {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())
     }
 }

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -129,7 +129,7 @@ where
 
     fn poll(
         &mut self,
-        params: &mut PollParameters,
+        params: &mut PollParameters<'_>,
     ) -> Async<
         NetworkBehaviourAction<
             <Self::ProtocolsHandler as ProtocolsHandler>::InEvent,

--- a/protocols/identify/src/lib.rs
+++ b/protocols/identify/src/lib.rs
@@ -65,22 +65,6 @@
 //! a `IdentifySender` struct that can be used to transmit back to the remote the information about
 //! it.
 
-extern crate bytes;
-extern crate fnv;
-#[macro_use]
-extern crate futures;
-extern crate libp2p_core;
-extern crate log;
-extern crate multiaddr;
-extern crate parking_lot;
-extern crate protobuf;
-extern crate smallvec;
-extern crate tokio_codec;
-extern crate tokio_io;
-extern crate tokio_timer;
-extern crate unsigned_varint;
-extern crate void;
-
 pub use self::identify::{Identify, IdentifyEvent};
 pub use self::id_transport::IdentifyTransport;
 pub use self::protocol::IdentifyInfo;

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -21,6 +21,7 @@
 use bytes::BytesMut;
 use crate::structs_proto;
 use futures::{future::{self, FutureResult}, Async, AsyncSink, Future, Poll, Sink, Stream};
+use futures::try_ready;
 use libp2p_core::{
     Multiaddr, PublicKey,
     upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo}
@@ -261,12 +262,9 @@ fn parse_proto_msg(msg: BytesMut) -> Result<(IdentifyInfo, Multiaddr), IoError> 
 
 #[cfg(test)]
 mod tests {
-    extern crate libp2p_tcp;
-    extern crate tokio;
-
     use crate::protocol::{IdentifyInfo, RemoteInfo, IdentifyProtocolConfig};
-    use self::tokio::runtime::current_thread::Runtime;
-    use self::libp2p_tcp::TcpConfig;
+    use tokio::runtime::current_thread::Runtime;
+    use libp2p_tcp::TcpConfig;
     use futures::{Future, Stream};
     use libp2p_core::{PublicKey, Transport, upgrade::{apply_outbound, apply_inbound}};
     use std::{io, sync::mpsc, thread};

--- a/protocols/identify/src/structs_proto.rs
+++ b/protocols/identify/src/structs_proto.rs
@@ -240,7 +240,7 @@ impl ::protobuf::Message for Identify {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -297,7 +297,7 @@ impl ::protobuf::Message for Identify {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.protocolVersion.as_ref() {
             os.write_string(5, &v)?;
         }
@@ -332,13 +332,13 @@ impl ::protobuf::Message for Identify {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -421,13 +421,13 @@ impl ::protobuf::Clear for Identify {
 }
 
 impl ::std::fmt::Debug for Identify {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Identify {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -171,7 +171,7 @@ impl<TSubstream> Kademlia<TSubstream> {
     }
 
     /// Builds the answer to a request.
-    fn build_result<TUserData>(&mut self, query: QueryTarget, request_id: KademliaRequestId, parameters: &mut PollParameters)
+    fn build_result<TUserData>(&mut self, query: QueryTarget, request_id: KademliaRequestId, parameters: &mut PollParameters<'_>)
         -> KademliaHandlerIn<TUserData>
     {
         match query {
@@ -444,7 +444,7 @@ where
 
     fn poll(
         &mut self,
-        parameters: &mut PollParameters,
+        parameters: &mut PollParameters<'_>,
     ) -> Async<
         NetworkBehaviourAction<
             <Self::ProtocolsHandler as ProtocolsHandler>::InEvent,
@@ -674,7 +674,7 @@ fn gen_random_id(my_id: &PeerId, bucket_num: usize) -> Result<PeerId, ()> {
 /// > **Note**: This is just a convenience function that doesn't do anything note-worthy.
 fn build_kad_peer(
     peer_id: PeerId,
-    parameters: &mut PollParameters,
+    parameters: &mut PollParameters<'_>,
     kbuckets: &KBucketsTable<PeerId, SmallVec<[Multiaddr; 4]>>,
     connected_peers: &FnvHashSet<PeerId>
 ) -> KadPeer {

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -197,7 +197,7 @@ pub enum KademliaHandlerQueryErr {
 }
 
 impl fmt::Display for KademliaHandlerQueryErr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             KademliaHandlerQueryErr::Upgrade(err) => {
                 write!(f, "Error while performing Kademlia query: {}", err)

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -181,7 +181,7 @@ where
     /// Ordered by proximity to the local node. Closest bucket (with max. one node in it) comes
     /// first.
     #[inline]
-    pub fn buckets(&mut self) -> BucketsIter<TPeerId, TVal> {
+    pub fn buckets(&mut self) -> BucketsIter<'_, TPeerId, TVal> {
         BucketsIter(self.tables.iter_mut(), self.unresponsive_timeout)
     }
 
@@ -279,7 +279,7 @@ where
     /// This inserts the node in the k-buckets, if possible. If it is already in a k-bucket, puts
     /// it above the disconnected nodes. If it is not already in a k-bucket, then the value will
     /// be built with the `Default` trait.
-    pub fn set_connected(&mut self, id: &TPeerId) -> Update<TPeerId>
+    pub fn set_connected(&mut self, id: &TPeerId) -> Update<'_, TPeerId>
     where
         TVal: Default,
     {
@@ -412,9 +412,9 @@ pub enum Update<'a, TPeerId> {
 }
 
 /// Iterator giving access to a bucket.
-pub struct BucketsIter<'a, TPeerId: 'a, TVal: 'a>(SliceIterMut<'a, KBucket<TPeerId, TVal>>, Duration);
+pub struct BucketsIter<'a, TPeerId, TVal>(SliceIterMut<'a, KBucket<TPeerId, TVal>>, Duration);
 
-impl<'a, TPeerId: 'a, TVal: 'a> Iterator for BucketsIter<'a, TPeerId, TVal> {
+impl<'a, TPeerId, TVal> Iterator for BucketsIter<'a, TPeerId, TVal> {
     type Item = Bucket<'a, TPeerId, TVal>;
 
     #[inline]
@@ -431,12 +431,12 @@ impl<'a, TPeerId: 'a, TVal: 'a> Iterator for BucketsIter<'a, TPeerId, TVal> {
     }
 }
 
-impl<'a, TPeerId: 'a, TVal: 'a> ExactSizeIterator for BucketsIter<'a, TPeerId, TVal> {}
+impl<'a, TPeerId, TVal> ExactSizeIterator for BucketsIter<'a, TPeerId, TVal> {}
 
 /// Access to a bucket.
-pub struct Bucket<'a, TPeerId: 'a, TVal: 'a>(&'a mut KBucket<TPeerId, TVal>);
+pub struct Bucket<'a, TPeerId, TVal>(&'a mut KBucket<TPeerId, TVal>);
 
-impl<'a, TPeerId: 'a, TVal: 'a> Bucket<'a, TPeerId, TVal> {
+impl<'a, TPeerId, TVal> Bucket<'a, TPeerId, TVal> {
     /// Returns the number of entries in that bucket.
     ///
     /// > **Note**: Keep in mind that this operation can be racy. If `update()` is called on the
@@ -464,8 +464,7 @@ impl<'a, TPeerId: 'a, TVal: 'a> Bucket<'a, TPeerId, TVal> {
 
 #[cfg(test)]
 mod tests {
-    extern crate rand;
-    use self::rand::random;
+    use rand::random;
     use crate::kbucket::{KBucketsPeerId, KBucketsTable, Update, MAX_NODES_PER_BUCKET};
     use multihash::{Multihash, Hash};
     use std::thread;

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -56,32 +56,6 @@
 //   `KademliaSystem`.
 //
 
-extern crate arrayvec;
-extern crate bigint;
-extern crate bs58;
-extern crate bytes;
-extern crate fnv;
-#[cfg_attr(test, macro_use)]
-extern crate futures;
-extern crate libp2p_core;
-extern crate libp2p_identify;
-extern crate libp2p_ping;
-extern crate log;
-extern crate multiaddr;
-extern crate multihash;
-extern crate parking_lot;
-extern crate protobuf;
-extern crate rand;
-extern crate smallvec;
-extern crate tokio_codec;
-extern crate tokio_io;
-extern crate tokio_timer;
-extern crate unsigned_varint;
-extern crate void;
-
-#[cfg(test)]
-extern crate tokio;
-
 pub use self::behaviour::{Kademlia, KademliaOut};
 pub use self::kbucket::KBucketsPeerId;
 pub use self::protocol::KadConnectionType;

--- a/protocols/kad/src/protobuf_structs/dht.rs
+++ b/protocols/kad/src/protobuf_structs/dht.rs
@@ -218,7 +218,7 @@ impl ::protobuf::Message for Message {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -282,7 +282,7 @@ impl ::protobuf::Message for Message {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.field_type {
             os.write_enum(1, v.value())?;
         }
@@ -323,13 +323,13 @@ impl ::protobuf::Message for Message {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -412,13 +412,13 @@ impl ::protobuf::Clear for Message {
 }
 
 impl ::std::fmt::Debug for Message {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Message {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -525,7 +525,7 @@ impl ::protobuf::Message for Message_Peer {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -564,7 +564,7 @@ impl ::protobuf::Message for Message_Peer {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.id.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -590,13 +590,13 @@ impl ::protobuf::Message for Message_Peer {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -661,13 +661,13 @@ impl ::protobuf::Clear for Message_Peer {
 }
 
 impl ::std::fmt::Debug for Message_Peer {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Message_Peer {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -734,7 +734,7 @@ impl ::std::default::Default for Message_MessageType {
 }
 
 impl ::protobuf::reflect::ProtobufValue for Message_MessageType {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())
     }
 }
@@ -795,7 +795,7 @@ impl ::std::default::Default for Message_ConnectionType {
 }
 
 impl ::protobuf::reflect::ProtobufValue for Message_ConnectionType {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())
     }
 }

--- a/protocols/kad/src/protobuf_structs/record.rs
+++ b/protocols/kad/src/protobuf_structs/record.rs
@@ -225,7 +225,7 @@ impl ::protobuf::Message for Record {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -276,7 +276,7 @@ impl ::protobuf::Message for Record {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.key.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -308,13 +308,13 @@ impl ::protobuf::Message for Record {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -391,13 +391,13 @@ impl ::protobuf::Clear for Record {
 }
 
 impl ::std::fmt::Debug for Record {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Record {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -463,8 +463,6 @@ fn proto_to_resp_msg(
 
 #[cfg(test)]
 mod tests {
-    extern crate libp2p_tcp;
-    extern crate tokio;
 
     /*// TODO: restore
     use self::libp2p_tcp::TcpConfig;

--- a/protocols/kad/src/query.rs
+++ b/protocols/kad/src/query.rs
@@ -275,7 +275,7 @@ impl QueryState {
     }
 
     /// Polls this individual query.
-    pub fn poll(&mut self) -> Async<QueryStatePollOut> {
+    pub fn poll(&mut self) -> Async<QueryStatePollOut<'_>> {
         // While iterating over peers, count the number of queries currently being processed.
         // This is used to not go over the limit of parallel requests.
         // If this is still 0 at the end of the function, that means the query is finished.
@@ -468,7 +468,7 @@ enum QueryPeerState {
 #[cfg(test)]
 mod tests {
     use super::{QueryConfig, QueryState, QueryStatePollOut, QueryTarget};
-    use futures::{self, prelude::*};
+    use futures::{self, try_ready, prelude::*};
     use libp2p_core::PeerId;
     use std::{iter, time::Duration, sync::Arc, sync::Mutex, thread};
     use tokio;

--- a/protocols/noise/src/error.rs
+++ b/protocols/noise/src/error.rs
@@ -35,7 +35,7 @@ pub enum NoiseError {
 }
 
 impl fmt::Display for NoiseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             NoiseError::Io(e) => write!(f, "{}", e),
             NoiseError::Noise(e) => write!(f, "{}", e),

--- a/protocols/noise/src/io.rs
+++ b/protocols/noise/src/io.rs
@@ -44,7 +44,7 @@ struct BufferBorrow<'a> {
 
 impl Buffer {
     /// Create a mutable borrow by splitting the buffer slice.
-    fn borrow_mut(&mut self) -> BufferBorrow {
+    fn borrow_mut(&mut self) -> BufferBorrow<'_> {
         let (r, w) = self.inner.split_at_mut(2 * MAX_NOISE_PKG_LEN);
         let (read, read_crypto) = r.split_at_mut(MAX_NOISE_PKG_LEN);
         let (write, write_crypto) = w.split_at_mut(MAX_WRITE_BUF_LEN);
@@ -101,7 +101,7 @@ pub struct NoiseOutput<T> {
 }
 
 impl<T> fmt::Debug for NoiseOutput<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("NoiseOutput")
             .field("read_state", &self.read_state)
             .field("write_state", &self.write_state)

--- a/protocols/noise/src/util.rs
+++ b/protocols/noise/src/util.rs
@@ -108,7 +108,7 @@ impl snow::types::Dh for X25519 {
         self.keypair = Keypair::new(secret, public)
     }
 
-    fn generate(&mut self, rng: &mut snow::types::Random) {
+    fn generate(&mut self, rng: &mut dyn snow::types::Random) {
         let mut s = [0; 32];
         rng.fill_bytes(&mut s);
         let secret = SecretKey::new(s);

--- a/protocols/observed/src/lib.rs
+++ b/protocols/observed/src/lib.rs
@@ -21,13 +21,6 @@
 //! Connection upgrade to allow retrieving the externally visible address (as dialer) or
 //! to report the externally visible address (as listener).
 
-extern crate bytes;
-extern crate futures;
-extern crate libp2p_core;
-extern crate tokio_codec;
-extern crate tokio_io;
-extern crate unsigned_varint;
-
 use bytes::Bytes;
 use futures::{future, prelude::*};
 use libp2p_core::{Multiaddr, upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo}};
@@ -107,11 +100,9 @@ impl<C: AsyncWrite> Sender<C> {
 
 #[cfg(test)]
 mod tests {
-    extern crate tokio;
-
     use libp2p_core::{Multiaddr, upgrade::{InboundUpgrade, OutboundUpgrade}};
-    use self::tokio::runtime::current_thread;
-    use self::tokio::net::{TcpListener, TcpStream};
+    use tokio::runtime::current_thread;
+    use tokio::net::{TcpListener, TcpStream};
     use super::*;
 
     #[test]

--- a/protocols/ping/src/lib.rs
+++ b/protocols/ping/src/lib.rs
@@ -113,7 +113,7 @@ where
 
     fn poll(
         &mut self,
-        _: &mut PollParameters,
+        _: &mut PollParameters<'_>,
     ) -> Async<
         NetworkBehaviourAction<
             <Self::ProtocolsHandler as ProtocolsHandler>::InEvent,

--- a/protocols/plaintext/src/lib.rs
+++ b/protocols/plaintext/src/lib.rs
@@ -18,10 +18,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-extern crate futures;
-extern crate libp2p_core;
-extern crate void;
-
 use futures::future::{self, FutureResult};
 use libp2p_core::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use std::iter;

--- a/protocols/secio/src/error.rs
+++ b/protocols/secio/src/error.rs
@@ -76,7 +76,7 @@ pub enum SecioError {
 }
 
 impl error::Error for SecioError {
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             SecioError::IoError(ref err) => Some(err),
             SecioError::Protobuf(ref err) => Some(err),
@@ -91,7 +91,7 @@ impl error::Error for SecioError {
 
 impl fmt::Display for SecioError {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             SecioError::IoError(e) =>
                 write!(f, "I/O error: {}", e),

--- a/protocols/secio/src/lib.rs
+++ b/protocols/secio/src/lib.rs
@@ -221,7 +221,7 @@ impl SecioKeyPair {
     pub fn rsa_from_pkcs8<P>(
         private: &[u8],
         public: P,
-    ) -> Result<SecioKeyPair, Box<Error + Send + Sync>>
+    ) -> Result<SecioKeyPair, Box<dyn Error + Send + Sync>>
     where
         P: Into<Vec<u8>>,
     {
@@ -236,7 +236,7 @@ impl SecioKeyPair {
     }
 
     /// Generates a new Ed25519 key pair and uses it.
-    pub fn ed25519_generated() -> Result<SecioKeyPair, Box<Error + Send + Sync>> {
+    pub fn ed25519_generated() -> Result<SecioKeyPair, Box<dyn Error + Send + Sync>> {
         let mut csprng = rand::thread_rng();
         let keypair: Ed25519KeyPair = Ed25519KeyPair::generate::<_>(&mut csprng);
         Ok(SecioKeyPair {
@@ -249,7 +249,7 @@ impl SecioKeyPair {
     /// Builds a `SecioKeyPair` from a raw ed25519 32 bytes private key.
     ///
     /// Returns an error if the slice doesn't have the correct length.
-    pub fn ed25519_raw_key(key: impl AsRef<[u8]>) -> Result<SecioKeyPair, Box<Error + Send + Sync>> {
+    pub fn ed25519_raw_key(key: impl AsRef<[u8]>) -> Result<SecioKeyPair, Box<dyn Error + Send + Sync>> {
         let secret = ed25519_dalek::SecretKey::from_bytes(key.as_ref())
             .map_err(|err| err.to_string())?;
         let public = ed25519_dalek::PublicKey::from(&secret);
@@ -266,7 +266,7 @@ impl SecioKeyPair {
 
     /// Generates a new random sec256k1 key pair.
     #[cfg(feature = "secp256k1")]
-    pub fn secp256k1_generated() -> Result<SecioKeyPair, Box<Error + Send + Sync>> {
+    pub fn secp256k1_generated() -> Result<SecioKeyPair, Box<dyn Error + Send + Sync>> {
         let private = secp256k1::key::SecretKey::new(&mut secp256k1::rand::thread_rng());
         Ok(SecioKeyPair {
             inner: SecioKeyPairInner::Secp256k1 { private },
@@ -275,7 +275,7 @@ impl SecioKeyPair {
 
     /// Builds a `SecioKeyPair` from a raw secp256k1 32 bytes private key.
     #[cfg(feature = "secp256k1")]
-    pub fn secp256k1_raw_key<K>(key: K) -> Result<SecioKeyPair, Box<Error + Send + Sync>>
+    pub fn secp256k1_raw_key<K>(key: K) -> Result<SecioKeyPair, Box<dyn Error + Send + Sync>>
     where
         K: AsRef<[u8]>,
     {
@@ -288,7 +288,7 @@ impl SecioKeyPair {
 
     /// Builds a `SecioKeyPair` from a secp256k1 private key in DER format.
     #[cfg(feature = "secp256k1")]
-    pub fn secp256k1_from_der<K>(key: K) -> Result<SecioKeyPair, Box<Error + Send + Sync>>
+    pub fn secp256k1_from_der<K>(key: K) -> Result<SecioKeyPair, Box<dyn Error + Send + Sync>>
     where
         K: AsRef<[u8]>,
     {

--- a/protocols/secio/src/structs_proto.rs
+++ b/protocols/secio/src/structs_proto.rs
@@ -225,7 +225,7 @@ impl ::protobuf::Message for Propose {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -276,7 +276,7 @@ impl ::protobuf::Message for Propose {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.rand.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -308,13 +308,13 @@ impl ::protobuf::Message for Propose {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -391,13 +391,13 @@ impl ::protobuf::Clear for Propose {
 }
 
 impl ::std::fmt::Debug for Propose {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Propose {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -495,7 +495,7 @@ impl ::protobuf::Message for Exchange {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -528,7 +528,7 @@ impl ::protobuf::Message for Exchange {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.epubkey.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -551,13 +551,13 @@ impl ::protobuf::Message for Exchange {
         &mut self.unknown_fields
     }
 
-    fn as_any(&self) -> &::std::any::Any {
-        self as &::std::any::Any
+    fn as_any(&self) -> &dyn (::std::any::Any) {
+        self as &dyn (::std::any::Any)
     }
-    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
-        self as &mut ::std::any::Any
+    fn as_any_mut(&mut self) -> &mut dyn (::std::any::Any) {
+        self as &mut dyn (::std::any::Any)
     }
-    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<dyn (::std::any::Any)> {
         self
     }
 
@@ -616,13 +616,13 @@ impl ::protobuf::Clear for Exchange {
 }
 
 impl ::std::fmt::Debug for Exchange {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Exchange {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,15 +132,12 @@
 #![doc(html_logo_url = "https://libp2p.io/img/logo_small.png")]
 #![doc(html_favicon_url = "https://libp2p.io/img/favicon.png")]
 
-pub extern crate bytes;
-pub extern crate futures;
-pub extern crate multiaddr;
-pub extern crate multihash;
-pub extern crate tokio_io;
-pub extern crate tokio_codec;
-
-extern crate libp2p_core_derive;
-extern crate tokio_executor;
+pub use bytes;
+pub use futures;
+pub use multiaddr::{self};
+pub use multihash;
+pub use tokio_io;
+pub use tokio_codec;
 
 #[doc(inline)]
 pub use libp2p_core as core;

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -33,16 +33,10 @@
 //! replaced with respectively an `/ip4/` or an `/ip6/` component.
 //!
 
-extern crate futures;
-extern crate libp2p_core as swarm;
-#[macro_use]
-extern crate log;
-extern crate multiaddr;
-extern crate tokio_dns;
-extern crate tokio_io;
+use libp2p_core as swarm;
 
 use futures::{future::{self, Either, FutureResult, JoinAll}, prelude::*, stream, try_ready};
-use log::Level;
+use log::{debug, trace, log_enabled, Level};
 use multiaddr::{Protocol, Multiaddr};
 use std::{error, fmt, io, marker::PhantomData, net::IpAddr};
 use swarm::{Transport, transport::TransportError};
@@ -85,7 +79,7 @@ where
     T: fmt::Debug,
 {
     #[inline]
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_tuple("DnsConfig").field(&self.inner).finish()
     }
 }
@@ -195,7 +189,7 @@ pub enum DnsErr<TErr> {
 impl<TErr> fmt::Display for DnsErr<TErr>
 where TErr: fmt::Display
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             DnsErr::Underlying(err) => write!(f, "{}", err),
             DnsErr::ResolveFail(addr) => write!(f, "Failed to resolve DNS address: {:?}", addr),
@@ -322,10 +316,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    extern crate libp2p_tcp;
-    use self::libp2p_tcp::TcpConfig;
+    use libp2p_tcp::TcpConfig;
     use futures::future;
-    use swarm::{Transport, transport::TransportError};
+    use super::swarm::{Transport, transport::TransportError};
     use multiaddr::{Protocol, Multiaddr};
     use super::DnsConfig;
 

--- a/transports/ratelimit/src/lib.rs
+++ b/transports/ratelimit/src/lib.rs
@@ -18,18 +18,11 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-extern crate aio_limited;
-#[macro_use]
-extern crate futures;
-extern crate libp2p_core;
-#[macro_use]
-extern crate log;
-extern crate tokio_executor;
-extern crate tokio_io;
-
 use aio_limited::{Limited, Limiter};
 use futures::prelude::*;
+use futures::try_ready;
 use libp2p_core::{Multiaddr, Transport, transport::TransportError};
+use log::error;
 use std::{error, fmt, io};
 use tokio_executor::Executor;
 use tokio_io::{AsyncRead, AsyncWrite, io::{ReadHalf, WriteHalf}};
@@ -82,7 +75,7 @@ pub enum RateLimitedErr<TErr> {
 impl<TErr> fmt::Display for RateLimitedErr<TErr>
 where TErr: fmt::Display
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             RateLimitedErr::LimiterError(err) => write!(f, "Limiter initialization error: {}", err),
             RateLimitedErr::Underlying(err) => write!(f, "{}", err),

--- a/transports/tcp/src/lib.rs
+++ b/transports/tcp/src/lib.rs
@@ -38,16 +38,9 @@
 //! The `TcpConfig` structs implements the `Transport` trait of the `swarm` library. See the
 //! documentation of `swarm` and of libp2p in general to learn how to use the `Transport` trait.
 
-extern crate futures;
-extern crate libp2p_core as swarm;
-#[macro_use]
-extern crate log;
-extern crate multiaddr;
-extern crate tk_listen;
-extern crate tokio_io;
-extern crate tokio_tcp;
-
 use futures::{future, future::FutureResult, prelude::*, Async, Poll};
+use libp2p_core as swarm;
+use log::{debug, error};
 use multiaddr::{Protocol, Multiaddr, ToMultiaddr};
 use std::fmt;
 use std::io::{self, Read, Write};
@@ -338,7 +331,7 @@ impl Stream for TcpListenStream {
 }
 
 impl fmt::Debug for TcpListenStream {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.inner {
             Ok(_) => write!(f, "TcpListenStream"),
             Err(None) => write!(f, "TcpListenStream(Errored)"),
@@ -394,15 +387,14 @@ impl Drop for TcpTransStream {
 
 #[cfg(test)]
 mod tests {
-    extern crate tokio;
-    use self::tokio::runtime::current_thread::Runtime;
+    use tokio::runtime::current_thread::Runtime;
     use super::{multiaddr_to_socketaddr, TcpConfig};
     use futures::stream::Stream;
     use futures::Future;
     use multiaddr::Multiaddr;
     use std;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-    use swarm::Transport;
+    use super::swarm::Transport;
     use tokio_io;
 
     #[test]

--- a/transports/uds/src/lib.rs
+++ b/transports/uds/src/lib.rs
@@ -46,22 +46,9 @@
 
 #![cfg(all(unix, not(any(target_os = "emscripten", target_os = "unknown"))))]
 
-extern crate futures;
-extern crate libp2p_core;
-#[macro_use]
-extern crate log;
-extern crate multiaddr;
-extern crate tokio_uds;
-
-#[cfg(test)]
-extern crate tempfile;
-#[cfg(test)]
-extern crate tokio_io;
-#[cfg(test)]
-extern crate tokio;
-
 use futures::{future::{self, FutureResult}, prelude::*, try_ready};
 use futures::stream::Stream;
+use log::debug;
 use multiaddr::{Protocol, Multiaddr};
 use std::{io, path::PathBuf};
 use libp2p_core::{Transport, transport::TransportError};

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "libp2p-websocket"
+edition = "2018"
 description = "WebSocket transport for libp2p"
 version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/transports/websocket/src/browser.rs
+++ b/transports/websocket/src/browser.rs
@@ -18,6 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use libp2p_core as swarm;
+use log::debug;
 use futures::{future, stream};
 use futures::stream::Then as StreamThen;
 use futures::sync::{mpsc, oneshot};

--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -68,19 +68,9 @@
 //! ```
 //!
 
-extern crate futures;
-extern crate libp2p_core as swarm;
-#[macro_use]
-extern crate log;
-extern crate multiaddr;
-extern crate rw_stream_sink;
-extern crate tokio_io;
-
 #[cfg(any(target_os = "emscripten", target_os = "unknown"))]
 #[macro_use]
 extern crate stdweb;
-#[cfg(not(any(target_os = "emscripten", target_os = "unknown")))]
-extern crate websocket;
 
 #[cfg(any(target_os = "emscripten", target_os = "unknown"))]
 mod browser;


### PR DESCRIPTION
Completes https://github.com/libp2p/rust-libp2p/issues/866. This is basically a walk-through with `cargo fix --edition-idioms` augmented by some manual labour. The remaining uses of `extern crate` are as follows:

```
src/lib.rs|313| /// # extern crate libp2p;
transports/tcp/src/lib.rs|30| //! extern crate libp2p_tcp;
transports/websocket/src/lib.rs|55| //! extern crate libp2p_core;
transports/websocket/src/lib.rs|56| //! extern crate libp2p_tcp;
transports/websocket/src/lib.rs|57| //! extern crate libp2p_websocket;
transports/websocket/src/lib.rs|73| extern crate stdweb;
transports/uds/src/lib.rs|36| //! extern crate libp2p_uds;
misc/core-derive/src/lib.rs|23| extern crate proc_macro;
protocols/secio/src/lib.rs|83| extern crate stdweb;
```

That is, it is still used in the public API documentation, for `proc_macro` where it is required and for the `stdweb` macros, due to dependencies on other macros (e.g. `_js_impl`) which would otherwise have to be explicitly imported as well.

Is it desirable to remove the usage of `extern crate` in the public API docs as well already? If so, it could be added to this PR.