### PR TITLE
Fix simultaneous dialing test

### DIFF
--- a/core/src/either.rs
+++ b/core/src/either.rs
@@ -243,6 +243,13 @@ where
         }
     }
 
+    fn is_remote_acknowledged(&self) -> bool {
+        match self {
+            EitherOutput::First(inner) => inner.is_remote_acknowledged(),
+            EitherOutput::Second(inner) => inner.is_remote_acknowledged()
+        }
+    }
+
     fn shutdown(&self, kind: Shutdown) -> Poll<(), IoError> {
         match self {
             EitherOutput::First(inner) => inner.shutdown(kind),

--- a/core/src/muxing.rs
+++ b/core/src/muxing.rs
@@ -143,6 +143,14 @@ pub trait StreamMuxer {
     /// Destroys a substream.
     fn destroy_substream(&self, s: Self::Substream);
 
+    /// Returns `true` if the remote has shown any sign of activity after the muxer has been open.
+    ///
+    /// For optimisation purposes, the connection handshake of libp2p can be very optimistic and is
+    /// allowed to assume that the handshake has succeeded when it didn't in fact succeed. This
+    /// method can be called in order to determine whether the remote has accepted our handshake or
+    /// has potentially not received it yet.
+    fn is_remote_acknowledged(&self) -> bool;
+
     /// Shutdown this `StreamMuxer`.
     ///
     /// If supported, sends a hint to the remote that we may no longer open any further outbound
@@ -478,6 +486,11 @@ impl StreamMuxer for StreamMuxerBox {
     }
 
     #[inline]
+    fn is_remote_acknowledged(&self) -> bool {
+        self.inner.is_remote_acknowledged()
+    }
+
+    #[inline]
     fn flush_all(&self) -> Poll<(), IoError> {
         self.inner.flush_all()
     }
@@ -570,6 +583,11 @@ impl<T> StreamMuxer for Wrap<T> where T: StreamMuxer {
     #[inline]
     fn shutdown(&self, kind: Shutdown) -> Poll<(), IoError> {
         self.inner.shutdown(kind)
+    }
+
+    #[inline]
+    fn is_remote_acknowledged(&self) -> bool {
+        self.inner.is_remote_acknowledged()
     }
 
     #[inline]

--- a/core/src/nodes/handled_node.rs
+++ b/core/src/nodes/handled_node.rs
@@ -215,6 +215,13 @@ where
         self.handler.inject_event(event);
     }
 
+    /// Returns `true` if the remote has shown any sign of activity after the muxer has been open.
+    ///
+    /// See `StreamMuxer::is_remote_acknowledged`.
+    pub fn is_remote_acknowledged(&self) -> bool {
+        self.node.get_ref().is_remote_acknowledged()
+    }
+
     /// Returns true if the inbound channel of the muxer is open.
     ///
     /// If `true` is returned, more inbound substream will be received.

--- a/core/src/nodes/node.rs
+++ b/core/src/nodes/node.rs
@@ -163,6 +163,13 @@ where
         self.outbound_state == StreamState::Open
     }
 
+    /// Returns `true` if the remote has shown any sign of activity after the muxer has been open.
+    ///
+    /// See `StreamMuxer::is_remote_acknowledged`.
+    pub fn is_remote_acknowledged(&self) -> bool {
+        self.muxer.is_remote_acknowledged()
+    }
+
     /// Destroys the node stream and returns all the pending outbound substreams.
     pub fn close(mut self) -> Vec<TUserData> {
         self.cancel_outgoing()

--- a/core/src/tests/dummy_muxer.rs
+++ b/core/src/tests/dummy_muxer.rs
@@ -114,6 +114,7 @@ impl StreamMuxer for DummyMuxer {
         unreachable!()
     }
     fn destroy_substream(&self, _: Self::Substream) {}
+    fn is_remote_acknowledged(&self) -> bool { true }
     fn shutdown(&self, _: Shutdown) -> Poll<(), IoError> {
         Ok(Async::Ready(()))
     }


### PR DESCRIPTION
It turns out that the `raw_swarm_simultaneous_connect` test had an issue: we were only applying the muxer as outbound. This was causing the test to erroneously succeed.

It turns out that fixing it was quite complicated. The underlying issue is that when we have two connections to the same remote, and one of them has a higher priority, immediately closing the one with the lower priority is a bad idea, because the remote might not know that the one with the higher priority has been open yet. There's no quick and easy fix to that, as the end of the handshake of the higher-prio connection might get lost or take a shorter path than the closing of the lower-prio connection. The only way to reliably do that is to wait for some data from the remote on the higher priority connection, which confirms that it has acknowledged it.

The changes are as follow:

- Closing a task or interrupting a reach attempt now returns respectively a `ClosedTask` or a `InterruptedReachAttempt`. These object represent a connection that's still open with the remote, but that is detached from the swarm. The swarm won't receive events from them.
- Although not required for this fix, the `TaskClosed` event now returns a `ClosedTask`, for consistency.
- You can now have a task or a connection to a peer take over respectively a `ClosedTask` or a `InterruptedReachAttempt`. "Taking over" means that the closed task or reach attempt will be closed only when we receive an acknowledgement on the task/connection that is taking over.
- Adds a `StreamMuxer::is_remote_acknowledged() -> bool` method. It should return true if the remote has sent some bytes on the network.
- Communication from the outside to the inside of a task is now done through a `ExtToInMessage` enum.
- The simultaneous dialing test now uses `tokio_timer::Delay` to start the dialing. Right now we're using randomness, but that doesn't make sense as we always wait for both nodes to start dialing in the first iteration of the loop.

I had to remote some tests because they were manually constructive private structs, which is a bad idea.
