### PR TITLE
Fix an infinite loop in ProtocolsHandlerSelect

### DIFF
--- a/core/src/protocols_handler/select.rs
+++ b/core/src/protocols_handler/select.rs
@@ -248,7 +248,7 @@ where
                     }));
                 },
                 Async::Ready(ProtocolsHandlerEvent::Shutdown) => {
-                    if !self.proto1.is_shutdown() {
+                    if !self.proto1.is_shutting_down_or_shutdown() {
                         self.proto1.shutdown();
                         continue;
                     }


### PR DESCRIPTION
When shutting down, we were looping infinitely as long as `self.proto1` is not shut down.
This is a mistake, it should loop infinitely as long as `self.proto1` is not in the process of shutting down (in practice, it should only ever loop once).