### PR TITLE
Fix version of noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.4.1 (2019-02-20)
+
+- Fixed wrong version of libp2p-noise.
+
 # Version 0.4.0 (2019-02-20)
 
 - Modified the functions in `upgrade::transfer` to be more convenient to use.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p"
 edition = "2018"
 description = "Peer-to-peer networking library"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -41,7 +41,7 @@ tokio-io = "0.1"
 [target.'cfg(not(any(target_os = "emscripten", target_os = "unknown")))'.dependencies]
 libp2p-dns = { version = "0.4.0", path = "./transports/dns" }
 libp2p-mdns = { version = "0.4.0", path = "./misc/mdns" }
-libp2p-noise = { version = "0.1.0", path = "./protocols/noise" }
+libp2p-noise = { version = "0.2.0", path = "./protocols/noise" }
 libp2p-tcp = { version = "0.4.0", path = "./transports/tcp" }
 
 [target.'cfg(any(target_os = "emscripten", target_os = "unknown"))'.dependencies]

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-noise"
 description = "Cryptographic handshake protocol using the noise framework."
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
I forgot to bump the version of libp2p-noise.
Very stupid mistake, but since I've already tagged and released v0.4.0, we should do a v0.4.1 for that.