### PR TITLE
Disconnect only after the identify answer

### DIFF
--- a/protocols/identify/src/periodic_id_handler.rs
+++ b/protocols/identify/src/periodic_id_handler.rs
@@ -105,7 +105,8 @@ where
         protocol: <Self::OutboundProtocol as OutboundUpgrade<TSubstream>>::Output,
         _info: Self::OutboundOpenInfo,
     ) {
-        self.pending_result = Some(PeriodicIdHandlerEvent::Identified(protocol))
+        self.pending_result = Some(PeriodicIdHandlerEvent::Identified(protocol));
+        self.first_id_happened = true;
     }
 
     #[inline]
@@ -117,6 +118,7 @@ where
     #[inline]
     fn inject_dial_upgrade_error(&mut self, _: Self::OutboundOpenInfo, err: ProtocolsHandlerUpgrErr<<Self::OutboundProtocol as OutboundUpgrade<Self::Substream>>::Error>) {
         self.pending_result = Some(PeriodicIdHandlerEvent::IdentificationError(err));
+        self.first_id_happened = true;
         if let Some(ref mut next_id) = self.next_id {
             next_id.reset(Instant::now() + TRY_AGAIN_ON_ERR);
         }
@@ -164,7 +166,6 @@ where
                 next_id.reset(Instant::now() + DELAY_TO_NEXT_ID);
                 let upgrade = self.config.clone();
                 let ev = ProtocolsHandlerEvent::OutboundSubstreamRequest { upgrade, info: () };
-                self.first_id_happened = true;
                 Ok(Async::Ready(ev))
             }
         }


### PR DESCRIPTION
Right now we report that the connection is useless right after we send the identify request.
Instead, we should wait for the answer.