### PR TITLE
Call `Connection::close` in `StreamMuxer::shutdown`.

### DIFF
--- a/muxers/yamux/src/lib.rs
+++ b/muxers/yamux/src/lib.rs
@@ -113,7 +113,7 @@ where
 
     #[inline]
     fn shutdown(&self, _: Shutdown) -> Poll<(), IoError> {
-        self.0.shutdown()
+        self.0.close()
     }
 
     #[inline]


### PR DESCRIPTION
Related: https://github.com/paritytech/yamux/pull/44