### PR TITLE
Split address reach error and node reach error

### DIFF
--- a/core/src/swarm.rs
+++ b/core/src/swarm.rs
@@ -182,7 +182,9 @@ where TBehaviour: NetworkBehaviour,
         match me.raw_swarm.peer(peer_id.clone()) {
             raw_swarm::Peer::NotConnected(peer) => {
                 let handler = me.behaviour.new_handler().into_node_handler_builder();
-                let _ = peer.connect_iter(addrs, handler);
+                if peer.connect_iter(addrs, handler).is_err() {
+                    me.behaviour.inject_dial_failure(&peer_id);
+                }
             },
             raw_swarm::Peer::PendingConnect(mut peer) => {
                 peer.append_multiaddr_attempts(addrs)
@@ -272,11 +274,14 @@ where TBehaviour: NetworkBehaviour,
                 },
                 Async::Ready(RawSwarmEvent::ListenerClosed { .. }) => {},
                 Async::Ready(RawSwarmEvent::IncomingConnectionError { .. }) => {},
-                Async::Ready(RawSwarmEvent::DialError { peer_id, multiaddr, error, .. }) => {
-                    self.behaviour.inject_dial_failure(Some(&peer_id), &multiaddr, &error);
+                Async::Ready(RawSwarmEvent::DialError { peer_id, multiaddr, error, new_state }) => {
+                    self.behaviour.inject_addr_reach_failure(Some(&peer_id), &multiaddr, &error);
+                    if let raw_swarm::PeerState::NotConnected = new_state {
+                        self.behaviour.inject_dial_failure(&peer_id);
+                    }
                 },
                 Async::Ready(RawSwarmEvent::UnknownPeerDialError { multiaddr, error, .. }) => {
-                    self.behaviour.inject_dial_failure(None, &multiaddr, &error);
+                    self.behaviour.inject_addr_reach_failure(None, &multiaddr, &error);
                 },
             }
 
@@ -362,8 +367,15 @@ pub trait NetworkBehaviour {
         event: <<Self::ProtocolsHandler as IntoProtocolsHandler>::Handler as ProtocolsHandler>::OutEvent
     );
 
-    /// Indicates to the behaviour that we tried to reach a node, but failed.
-    fn inject_dial_failure(&mut self, _peer_id: Option<&PeerId>, _addr: &Multiaddr, _error: &dyn error::Error) {
+    /// Indicates to the behaviour that we tried to reach an address, but failed.
+    ///
+    /// If we were trying to reach a specific node, its ID is passed as parameter.
+    fn inject_addr_reach_failure(&mut self, _peer_id: Option<&PeerId>, _addr: &Multiaddr, _error: &dyn error::Error) {
+    }
+
+    /// Indicates to the behaviour that we tried to dial all the addresses known for a node, but
+    /// failed.
+    fn inject_dial_failure(&mut self, _peer_id: &PeerId) {
     }
 
     /// Polls for things that swarm should do.

--- a/core/src/swarm.rs
+++ b/core/src/swarm.rs
@@ -369,7 +369,9 @@ pub trait NetworkBehaviour {
 
     /// Indicates to the behaviour that we tried to reach an address, but failed.
     ///
-    /// If we were trying to reach a specific node, its ID is passed as parameter.
+    /// If we were trying to reach a specific node, its ID is passed as parameter. If this is the
+    /// last address to attempt for the given node, then `inject_dial_failure` must be called
+    /// afterwards.
     fn inject_addr_reach_failure(&mut self, _peer_id: Option<&PeerId>, _addr: &Multiaddr, _error: &dyn error::Error) {
     }
 
@@ -455,6 +457,9 @@ pub enum NetworkBehaviourAction<TInEvent, TOutEvent> {
     },
 
     /// Instructs the swarm to try reach the given peer.
+    ///
+    /// In the future, a corresponding `inject_dial_failure` or `inject_connected` function call
+    /// must be performed.
     DialPeer {
         /// The peer to try reach.
         peer_id: PeerId,

--- a/core/src/swarm.rs
+++ b/core/src/swarm.rs
@@ -370,8 +370,7 @@ pub trait NetworkBehaviour {
     /// Indicates to the behaviour that we tried to reach an address, but failed.
     ///
     /// If we were trying to reach a specific node, its ID is passed as parameter. If this is the
-    /// last address to attempt for the given node, then `inject_dial_failure` must be called
-    /// afterwards.
+    /// last address to attempt for the given node, then `inject_dial_failure` is called afterwards.
     fn inject_addr_reach_failure(&mut self, _peer_id: Option<&PeerId>, _addr: &Multiaddr, _error: &dyn error::Error) {
     }
 

--- a/misc/core-derive/src/lib.rs
+++ b/misc/core-derive/src/lib.rs
@@ -214,6 +214,20 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
         })
     };
 
+    // Build the list of statements to put in the body of `inject_addr_reach_failure()`.
+    let inject_addr_reach_failure_stmts = {
+        data_struct.fields.iter().enumerate().filter_map(move |(field_n, field)| {
+            if is_ignored(&field) {
+                return None;
+            }
+
+            Some(match field.ident {
+                Some(ref i) => quote!{ self.#i.inject_addr_reach_failure(peer_id, addr, error); },
+                None => quote!{ self.#field_n.inject_addr_reach_failure(peer_id, addr, error); },
+            })
+        })
+    };
+
     // Build the list of statements to put in the body of `inject_dial_failure()`.
     let inject_dial_failure_stmts = {
         data_struct.fields.iter().enumerate().filter_map(move |(field_n, field)| {
@@ -222,8 +236,8 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
             }
 
             Some(match field.ident {
-                Some(ref i) => quote!{ self.#i.inject_dial_failure(peer_id, addr, error); },
-                None => quote!{ self.#field_n.inject_dial_failure(peer_id, addr, error); },
+                Some(ref i) => quote!{ self.#i.inject_dial_failure(peer_id); },
+                None => quote!{ self.#field_n.inject_dial_failure(peer_id); },
             })
         })
     };
@@ -396,7 +410,12 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
             }
 
             #[inline]
-            fn inject_dial_failure(&mut self, peer_id: Option<&#peer_id>, addr: &#multiaddr, error: &dyn std::error::Error) {
+            fn inject_addr_reach_failure(&mut self, peer_id: Option<&#peer_id>, addr: &#multiaddr, error: &dyn std::error::Error) {
+                #(#inject_addr_reach_failure_stmts);*
+            }
+
+            #[inline]
+            fn inject_dial_failure(&mut self, peer_id: &#peer_id) {
                 #(#inject_dial_failure_stmts);*
             }
 

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -393,13 +393,25 @@ where
         self.connected_peers.insert(id);
     }
 
-    fn inject_dial_failure(&mut self, peer_id: Option<&PeerId>, addr: &Multiaddr, _: &dyn error::Error) {
+    fn inject_addr_reach_failure(&mut self, peer_id: Option<&PeerId>, addr: &Multiaddr, _: &dyn error::Error) {
         if let Some(peer_id) = peer_id {
             if let Some(list) = self.kbuckets.get_mut(peer_id) {
                 // TODO: don't remove the address if the error is that we are already connected
                 //       to this peer
                 list.remove_addr(addr);
             }
+
+            for query in self.active_queries.values_mut() {
+                if let Some(addrs) = query.target_mut().untrusted_addresses.get_mut(peer_id) {
+                    addrs.retain(|a| a != addr);
+                }
+            }
+        }
+    }
+
+    fn inject_dial_failure(&mut self, peer_id: &PeerId) {
+        for query in self.active_queries.values_mut() {
+            query.inject_rpc_error(peer_id);
         }
     }
 


### PR DESCRIPTION
The current API of `NetworkBehaviour` has some pretty big flaws:
- If we try to dial a node but we don't know any address for it, we ignore the problem and nothing happens (nothing is reported back).
- On dial failure, there's no way to know if the swarm is still trying to connect to a node through a different address or if it's no longer trying.
- Similarly, a dial failure kind of implies that we're not connected to the node, while it is possible, in the case of simulatenous dialing, that we report a dial failure *after* the connection.

This PR fixes that by splitting `inject_dial_failure` in two: `inject_dial_failure` only takes a `PeerId` and is called when we are no longer trying to dial, while `inject_addr_reach_failure` is called when we fail to reach a specific address. If this was the last address of a node that we failed to reach, then both methods are called.
