### PR TITLE
Allow configuring the maximum message length

### DIFF
--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -109,8 +109,13 @@ fn main() {
 
     // Create a Swarm to manage peers and events
     let mut swarm = {
+        let config = libp2p::floodsub::FloodsubConfig {
+            max_message_size: 2048,
+            local_peer_id: local_peer_id.clone(),
+        };
+
         let mut behaviour = MyBehaviour {
-            floodsub: libp2p::floodsub::Floodsub::new(local_peer_id.clone()),
+            floodsub: libp2p::floodsub::Floodsub::new(config),
             mdns: libp2p::mdns::Mdns::new().expect("Failed to create mDNS service"),
         };
 

--- a/protocols/floodsub/src/lib.rs
+++ b/protocols/floodsub/src/lib.rs
@@ -27,6 +27,6 @@ mod layer;
 mod rpc_proto;
 mod topic;
 
-pub use self::layer::{Floodsub, FloodsubEvent};
+pub use self::layer::{Floodsub, FloodsubConfig, FloodsubEvent};
 pub use self::protocol::{FloodsubMessage, FloodsubRpc};
 pub use self::topic::{Topic, TopicBuilder, TopicHash};


### PR DESCRIPTION
Fix #991 

Instead of a `PeerId`, `Floodsub::new` now accepts a `FloodsubConfig` struct that contains the maximum allowed size for a message.

This fix is however not ideal, because libp2p will automatically combine multiple messages into one without accounting for that limit. In other words, if the limit is 2048 and you send two messages of 1025 bytes at once, you may get an error even though it would be feasible to dispatch them. After this PR is merged, an issue should be opened about this.
