### PR TITLE
Add Kademlia::kbuckets_entries()

### DIFF
--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -269,9 +269,12 @@ impl<TSubstream> Kademlia<TSubstream> {
 
         behaviour
     }
-}
 
-impl<TSubstream> Kademlia<TSubstream> {
+    /// Returns an iterator to all the peer IDs in the bucket, without the pending nodes.
+    pub fn kbuckets_entries(&self) -> impl Iterator<Item = &PeerId> {
+        self.kbuckets.entries_not_pending().map(|(id, _)| id)
+    }
+
     /// Performs the Kademlia initialization process.
     ///
     /// If you called `new` to create the `Kademlia`, then this has been started. Calling this


### PR DESCRIPTION
Based on top of #1012 

Adds a method for querying the list of known peers.