### PR TITLE
[Kademlia] Rehash PeerId before inserting in a KBucketsTable

### DIFF
--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
+arrayref = "0.3"
 arrayvec = "0.4.7"
 bs58 = "0.2.0"
 bigint = "4.2"

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -249,7 +249,7 @@ impl<TSubstream> Kademlia<TSubstream> {
     fn new_inner(local_peer_id: PeerId) -> Self {
         let parallelism = 3;
 
-        let behaviour = Kademlia {
+        Kademlia {
             kbuckets: KBucketsTable::new(KadHash::from(&local_peer_id), Duration::from_secs(60)),   // TODO: constant
             queued_events: SmallVec::new(),
             active_queries: Default::default(),
@@ -264,9 +264,7 @@ impl<TSubstream> Kademlia<TSubstream> {
             rpc_timeout: Duration::from_secs(8),
             add_provider: SmallVec::new(),
             marker: PhantomData,
-        };
-
-        behaviour
+        }
     }
 
     /// Returns an iterator to all the peer IDs in the bucket, without the pending nodes.
@@ -296,10 +294,8 @@ impl<TSubstream> Kademlia<TSubstream> {
     /// The actual meaning of *providing* the value of a key is not defined, and is specific to
     /// the value whose key is the hash.
     pub fn add_providing(&mut self, key: PeerId) {
-        let kad_hash = KadHash::from(&key);
-
-        self.providing_keys.insert(kad_hash.hash().clone());
-        let providers = self.values_providers.entry(kad_hash.hash().clone()).or_insert_with(Default::default);
+        self.providing_keys.insert(key.clone().into());
+        let providers = self.values_providers.entry(key.into()).or_insert_with(Default::default);
         let my_id = self.kbuckets.my_id();
         if !providers.iter().any(|peer_id| peer_id == my_id.peer_id()) {
             providers.push(my_id.peer_id().clone());

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -20,6 +20,7 @@
 
 use crate::addresses::Addresses;
 use crate::handler::{KademliaHandler, KademliaHandlerEvent, KademliaHandlerIn};
+use crate::kad_hash::KadHash;
 use crate::kbucket::{self, KBucketsTable, KBucketsPeerId};
 use crate::protocol::{KadConnectionType, KadPeer};
 use crate::query::{QueryConfig, QueryState, QueryStatePollOut};
@@ -39,7 +40,7 @@ mod test;
 /// Network behaviour that handles Kademlia.
 pub struct Kademlia<TSubstream> {
     /// Storage for the nodes. Contains the known multiaddresses for this node.
-    kbuckets: KBucketsTable<PeerId, Addresses>,
+    kbuckets: KBucketsTable<KadHash, Addresses>,
 
     /// All the iterative queries we are currently performing, with their ID. The last parameter
     /// is the list of accumulated providers for `GET_PROVIDERS` queries.
@@ -59,7 +60,7 @@ pub struct Kademlia<TSubstream> {
     ///
     /// Our local peer ID can be in this container.
     // TODO: Note that in reality the value is a SHA-256 of the actual value (https://github.com/libp2p/rust-libp2p/issues/694)
-    values_providers: FnvHashMap<Multihash, SmallVec<[PeerId; 20]>>,
+    values_providers: FnvHashMap<Multihash, SmallVec<[KadHash; 20]>>,
 
     /// List of values that we are providing ourselves. Must be kept in sync with
     /// `values_providers`.
@@ -186,7 +187,7 @@ impl<TSubstream> Kademlia<TSubstream> {
     /// Creates a `Kademlia`.
     #[inline]
     pub fn new(local_peer_id: PeerId) -> Self {
-        Self::new_inner(local_peer_id, true)
+        Self::new_inner(local_peer_id)
     }
 
     /// Creates a `Kademlia`.
@@ -194,8 +195,9 @@ impl<TSubstream> Kademlia<TSubstream> {
     /// Contrary to `new`, doesn't perform the initialization queries that store our local ID into
     /// the DHT and fill our buckets.
     #[inline]
+    #[deprecated(note="this function is now equivalent to new() and will be removed in the future")]
     pub fn without_init(local_peer_id: PeerId) -> Self {
-        Self::new_inner(local_peer_id, false)
+        Self::new_inner(local_peer_id)
     }
 
     /// Adds a known address for the given `PeerId`. We are connected to this address.
@@ -213,7 +215,9 @@ impl<TSubstream> Kademlia<TSubstream> {
 
     /// Underlying implementation for `add_connected_address` and `add_not_connected_address`.
     fn add_address(&mut self, peer_id: &PeerId, address: Multiaddr, connected: bool) {
-        match self.kbuckets.entry(peer_id) {
+        let kad_hash = KadHash::from(peer_id);
+
+        match self.kbuckets.entry(&kad_hash) {
             kbucket::Entry::InKbucketConnected(mut entry) => entry.value().insert(address),
             kbucket::Entry::InKbucketConnectedPending(mut entry) => entry.value().insert(address),
             kbucket::Entry::InKbucketDisconnected(mut entry) => entry.value().insert(address),
@@ -232,7 +236,7 @@ impl<TSubstream> Kademlia<TSubstream> {
                     kbucket::InsertOutcome::Full => (),
                     kbucket::InsertOutcome::Pending { to_ping } => {
                         self.queued_events.push(NetworkBehaviourAction::DialPeer {
-                            peer_id: to_ping.clone(),
+                            peer_id: to_ping.peer_id().clone(),
                         })
                     },
                 }
@@ -243,11 +247,11 @@ impl<TSubstream> Kademlia<TSubstream> {
     }
 
     /// Inner implementation of the constructors.
-    fn new_inner(local_peer_id: PeerId, initialize: bool) -> Self {
+    fn new_inner(local_peer_id: PeerId) -> Self {
         let parallelism = 3;
 
-        let mut behaviour = Kademlia {
-            kbuckets: KBucketsTable::new(local_peer_id, Duration::from_secs(60)),   // TODO: constant
+        let behaviour = Kademlia {
+            kbuckets: KBucketsTable::new(KadHash::from(&local_peer_id), Duration::from_secs(60)),   // TODO: constant
             queued_events: SmallVec::new(),
             active_queries: Default::default(),
             connected_peers: Default::default(),
@@ -263,35 +267,12 @@ impl<TSubstream> Kademlia<TSubstream> {
             marker: PhantomData,
         };
 
-        if initialize {
-            behaviour.initialize();
-        }
-
         behaviour
     }
 
     /// Returns an iterator to all the peer IDs in the bucket, without the pending nodes.
     pub fn kbuckets_entries(&self) -> impl Iterator<Item = &PeerId> {
-        self.kbuckets.entries_not_pending().map(|(id, _)| id)
-    }
-
-    /// Performs the Kademlia initialization process.
-    ///
-    /// If you called `new` to create the `Kademlia`, then this has been started. Calling this
-    /// method manually is useful in order to re-perform the initialization later.
-    ///
-    /// Starts one query per bucket with the intention of connecting to nodes along the way and
-    /// fill our own buckets. This also adds the effect of adding our local node to other nodes'
-    /// buckets.
-    pub fn initialize(&mut self) {
-        for n in 0..256 {   // TODO: 256 should be grabbed from the kbuckets module
-            let target = match gen_random_id(self.kbuckets.my_id(), n) {
-                Ok(p) => p,
-                Err(()) => continue,
-            };
-
-            self.start_query(QueryInfoInner::Initialization { target });
-        }
+        self.kbuckets.entries_not_pending().map(|(kad_hash, _)| kad_hash.peer_id())
     }
 
     /// Starts an iterative `FIND_NODE` request.
@@ -316,8 +297,10 @@ impl<TSubstream> Kademlia<TSubstream> {
     /// The actual meaning of *providing* the value of a key is not defined, and is specific to
     /// the value whose key is the hash.
     pub fn add_providing(&mut self, key: PeerId) {
-        self.providing_keys.insert(key.clone().into());
-        let providers = self.values_providers.entry(key.into()).or_insert_with(Default::default);
+        let kad_hash = KadHash::from(&key);
+
+        self.providing_keys.insert(kad_hash.hash().clone());
+        let providers = self.values_providers.entry(kad_hash.hash().clone()).or_insert_with(Default::default);
         let my_id = self.kbuckets.my_id();
         if !providers.iter().any(|k| k == my_id) {
             providers.push(my_id.clone());
@@ -331,10 +314,10 @@ impl<TSubstream> Kademlia<TSubstream> {
     ///
     /// There doesn't exist any "remove provider" message to broadcast on the network, therefore we
     /// will still be registered as a provider in the DHT for as long as the timeout doesn't expire.
-    pub fn remove_providing(&mut self, key: &Multihash) {
-        self.providing_keys.remove(key);
+    pub fn remove_providing(&mut self, key: &KadHash) {
+        self.providing_keys.remove(key.hash());
 
-        let providers = match self.values_providers.get_mut(key) {
+        let providers = match self.values_providers.get_mut(key.hash()) {
             Some(p) => p,
             None => return,
         };
@@ -357,7 +340,8 @@ impl<TSubstream> Kademlia<TSubstream> {
 
         let known_closest_peers = self.kbuckets
             .find_closest(target.as_ref())
-            .take(self.num_results);
+            .take(self.num_results)
+            .map(|h| h.peer_id().clone());
 
         self.active_queries.insert(
             query_id,
@@ -387,7 +371,7 @@ where
         // We should order addresses from decreasing likelyhood of connectivity, so start with
         // the addresses of that peer in the k-buckets.
         let mut out_list = self.kbuckets
-            .entry(peer_id)
+            .entry(&KadHash::from(peer_id))
             .value_not_pending()
             .map(|l| l.iter().cloned().collect::<Vec<_>>())
             .unwrap_or_else(Vec::new);
@@ -418,7 +402,9 @@ where
             ConnectedPoint::Listener { .. } => None,
         };
 
-        match self.kbuckets.entry(&id) {
+        let id_kad_hash = KadHash::from(&id);
+
+        match self.kbuckets.entry(&id_kad_hash) {
             kbucket::Entry::InKbucketConnected(_) => {
                 unreachable!("Kbuckets are always kept in sync with the connection state; QED")
             },
@@ -456,7 +442,7 @@ where
                     kbucket::InsertOutcome::Full => (),
                     kbucket::InsertOutcome::Pending { to_ping } => {
                         self.queued_events.push(NetworkBehaviourAction::DialPeer {
-                            peer_id: to_ping.clone(),
+                            peer_id: to_ping.peer_id().clone(),
                         })
                     },
                 }
@@ -472,14 +458,16 @@ where
 
     fn inject_addr_reach_failure(&mut self, peer_id: Option<&PeerId>, addr: &Multiaddr, _: &dyn error::Error) {
         if let Some(peer_id) = peer_id {
-            if let Some(list) = self.kbuckets.entry(peer_id).value() {
+            let id_kad_hash = KadHash::from(peer_id);
+
+            if let Some(list) = self.kbuckets.entry(&id_kad_hash).value() {
                 // TODO: don't remove the address if the error is that we are already connected
                 //       to this peer
                 list.remove(addr);
             }
 
             for query in self.active_queries.values_mut() {
-                if let Some(addrs) = query.target_mut().untrusted_addresses.get_mut(peer_id) {
+                if let Some(addrs) = query.target_mut().untrusted_addresses.get_mut(id_kad_hash.peer_id()) {
                     addrs.retain(|a| a != addr);
                 }
             }
@@ -500,13 +488,13 @@ where
             query.inject_rpc_error(id);
         }
 
-        match self.kbuckets.entry(id) {
+        match self.kbuckets.entry(&KadHash::from(id)) {
             kbucket::Entry::InKbucketConnected(entry) => {
                 match entry.set_disconnected() {
                     kbucket::SetDisconnectedOutcome::Kept(_) => {},
                     kbucket::SetDisconnectedOutcome::Replaced { replacement, .. } => {
                         let event = KademliaOut::KBucketAdded {
-                            peer_id: replacement,
+                            peer_id: replacement.peer_id().clone(),
                             replaced: Some(id.clone()),
                         };
                         self.queued_events.push(NetworkBehaviourAction::GenerateEvent(event));
@@ -540,7 +528,7 @@ where
             }
         }
 
-        if let Some(list) = self.kbuckets.entry(&peer_id).value() {
+        if let Some(list) = self.kbuckets.entry(&KadHash::from(&peer_id)).value() {
             if let ConnectedPoint::Dialer { address } = new_endpoint {
                 list.insert(address);
             }
@@ -551,9 +539,9 @@ where
         match event {
             KademliaHandlerEvent::FindNodeReq { key, request_id } => {
                 let closer_peers = self.kbuckets
-                    .find_closest(&key)
+                    .find_closest(&KadHash::from(&key))
                     .take(self.num_results)
-                    .map(|peer_id| build_kad_peer(peer_id, &mut self.kbuckets))
+                    .map(|kad_hash| build_kad_peer(kad_hash.peer_id().clone(), &mut self.kbuckets))
                     .collect();
 
                 self.queued_events.push(NetworkBehaviourAction::SendEvent {
@@ -589,7 +577,7 @@ where
                 let closer_peers = self.kbuckets
                     .find_closest(&key)
                     .take(self.num_results)
-                    .map(|peer_id| build_kad_peer(peer_id, &mut self.kbuckets))
+                    .map(|kad_hash| build_kad_peer(kad_hash.peer_id().clone(), &mut self.kbuckets))
                     .collect();
 
                 let provider_peers = {
@@ -598,7 +586,7 @@ where
                         .get(&key)
                         .into_iter()
                         .flat_map(|peers| peers)
-                        .map(move |peer_id| build_kad_peer(peer_id.clone(), kbuckets))
+                        .map(move |kad_hash| build_kad_peer(kad_hash.peer_id().clone(), kbuckets))
                         .collect()
                 };
 
@@ -670,12 +658,12 @@ where
         // Flush the changes to the topology that we want to make.
         for (key, provider) in self.add_provider.drain() {
             // Don't add ourselves to the providers.
-            if provider == *self.kbuckets.my_id() {
+            if provider == *self.kbuckets.my_id().peer_id() {
                 continue;
             }
             let providers = self.values_providers.entry(key).or_insert_with(Default::default);
-            if !providers.iter().any(|k| k == &provider) {
-                providers.push(provider);
+            if !providers.iter().any(|k| k.peer_id() == &provider) {
+                providers.push(KadHash::from(&provider));
             }
         }
         self.add_provider.shrink_to_fit();
@@ -863,9 +851,9 @@ fn gen_random_id(my_id: &PeerId, bucket_num: usize) -> Result<PeerId, ()> {
 /// > **Note**: This is just a convenience function that doesn't do anything note-worthy.
 fn build_kad_peer(
     peer_id: PeerId,
-    kbuckets: &mut KBucketsTable<PeerId, Addresses>
+    kbuckets: &mut KBucketsTable<KadHash, Addresses>
 ) -> KadPeer {
-    let (multiaddrs, connection_ty) = match kbuckets.entry(&peer_id) {
+    let (multiaddrs, connection_ty) = match kbuckets.entry(&KadHash::from(&peer_id)) {
         kbucket::Entry::NotInKbucket(_) => (Vec::new(), KadConnectionType::NotConnected),       // TODO: pending connection?
         kbucket::Entry::InKbucketConnected(mut entry) => (entry.value().iter().cloned().collect(), KadConnectionType::Connected),
         kbucket::Entry::InKbucketDisconnected(mut entry) => (entry.value().iter().cloned().collect(), KadConnectionType::NotConnected),

--- a/protocols/kad/src/kad_hash.rs
+++ b/protocols/kad/src/kad_hash.rs
@@ -1,0 +1,74 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Docs
+
+use crate::kbucket::KBucketsPeerId;
+use libp2p_core::PeerId;
+use multihash::Multihash;
+use std::num::NonZeroUsize;
+
+///Hi
+#[derive(Clone, Debug, PartialEq)]
+pub struct KadHash {
+    peer_id: PeerId,
+    hash: Multihash,
+}
+
+impl KadHash {
+    pub fn peer_id(&self) -> &PeerId {
+        &self.peer_id
+    }
+
+    pub fn hash(&self) -> &Multihash {
+        &self.hash
+    }
+}
+
+impl From<&PeerId> for KadHash {
+    fn from(peer_id: &PeerId) -> Self {
+        KadHash{peer_id: peer_id.clone(), hash: multihash::encode(multihash::Hash::SHA2256, peer_id.as_bytes()).expect("sha2-256 is always supported")}
+    }
+}
+
+impl KBucketsPeerId for KadHash {
+    fn distance_with(&self, other: &Self) -> u32 {
+//        self.hash().distance_with(other.hash())
+        <Multihash as KBucketsPeerId<Multihash>>::distance_with(self.hash(), other.hash())
+    }
+
+    fn max_distance() -> NonZeroUsize {
+        <Multihash as KBucketsPeerId>::max_distance()
+    }
+}
+
+impl PartialEq<multihash::Multihash> for KadHash {
+    #[inline]
+    fn eq(&self, other: &multihash::Multihash) -> bool {
+        self.hash() == other
+    }
+}
+
+impl PartialEq<KadHash> for multihash::Multihash {
+    #[inline]
+    fn eq(&self, other: &KadHash) -> bool {
+        self == other.hash()
+    }
+}

--- a/protocols/kad/src/kad_hash.rs
+++ b/protocols/kad/src/kad_hash.rs
@@ -18,20 +18,24 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! Docs
+//! Inside a KBucketsTable we would like to store the hash of a PeerId
+//! even if a PeerId is itself already a hash. When querying the table
+//! we may be interested in getting the PeerId back. This module provides
+//! a struct, KadHash that stores together a PeerId and its hash for
+//! convenience.
 
-use crate::kbucket::KBucketsPeerId;
 use libp2p_core::PeerId;
 use multihash::Multihash;
-use std::num::NonZeroUsize;
 
-///Hi
+/// Used as key in a KBucketsTable for Kademlia. Stores the hash of a
+/// PeerId, and the PeerId itself because it may need to be queried.
 #[derive(Clone, Debug, PartialEq)]
 pub struct KadHash {
     peer_id: PeerId,
     hash: Multihash,
 }
 
+/// Provide convenience getters.
 impl KadHash {
     pub fn peer_id(&self) -> &PeerId {
         &self.peer_id
@@ -44,18 +48,10 @@ impl KadHash {
 
 impl From<&PeerId> for KadHash {
     fn from(peer_id: &PeerId) -> Self {
-        KadHash{peer_id: peer_id.clone(), hash: multihash::encode(multihash::Hash::SHA2256, peer_id.as_bytes()).expect("sha2-256 is always supported")}
-    }
-}
-
-impl KBucketsPeerId for KadHash {
-    fn distance_with(&self, other: &Self) -> u32 {
-//        self.hash().distance_with(other.hash())
-        <Multihash as KBucketsPeerId<Multihash>>::distance_with(self.hash(), other.hash())
-    }
-
-    fn max_distance() -> NonZeroUsize {
-        <Multihash as KBucketsPeerId>::max_distance()
+        KadHash{
+            peer_id: peer_id.clone(),
+            hash: multihash::encode(multihash::Hash::SHA2256, peer_id.as_bytes()).expect("sha2-256 is always supported")
+        }
     }
 }
 

--- a/protocols/kad/src/kad_hash.rs
+++ b/protocols/kad/src/kad_hash.rs
@@ -26,8 +26,6 @@
 
 use arrayref::array_ref;
 use libp2p_core::PeerId;
-use multihash::Multihash;
-
 
 /// Used as key in a KBucketsTable for Kademlia. Stores the hash of a
 /// PeerId, and the PeerId itself because it may need to be queried.
@@ -48,12 +46,12 @@ impl KadHash {
     }
 }
 
-impl From<&PeerId> for KadHash {
-    fn from(peer_id: &PeerId) -> Self {
+impl From<PeerId> for KadHash {
+    fn from(peer_id: PeerId) -> Self {
         let encoding = multihash::encode(multihash::Hash::SHA2256, peer_id.as_bytes()).expect("sha2-256 is always supported");
 
         KadHash{
-            peer_id: peer_id.clone(),
+            peer_id: peer_id,
             hash: array_ref!(encoding.digest(), 0, 32).clone(),
         }
     }

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -27,6 +27,7 @@
 
 use arrayvec::ArrayVec;
 use bigint::U512;
+use crate::kad_hash::KadHash;
 use libp2p_core::PeerId;
 use multihash::Multihash;
 use std::num::NonZeroUsize;
@@ -117,6 +118,16 @@ impl KBucketsPeerId<PeerId> for Multihash {
 
     fn max_distance() -> NonZeroUsize {
         <PeerId as KBucketsPeerId>::max_distance()
+    }
+}
+
+impl KBucketsPeerId<KadHash> for Multihash {
+    fn distance_with(&self, other: &KadHash) -> u32 {
+        <Multihash as KBucketsPeerId<Multihash>>::distance_with(self, other.hash())
+    }
+
+    fn max_distance() -> NonZeroUsize {
+        <Multihash as KBucketsPeerId>::max_distance()
     }
 }
 

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -121,6 +121,16 @@ impl KBucketsPeerId<PeerId> for Multihash {
     }
 }
 
+impl KBucketsPeerId for KadHash {
+    fn distance_with(&self, other: &Self) -> u32 {
+        <Multihash as KBucketsPeerId<Multihash>>::distance_with(self.hash(), other.hash())
+    }
+
+    fn max_distance() -> NonZeroUsize {
+        <Multihash as KBucketsPeerId>::max_distance()
+    }
+}
+
 impl KBucketsPeerId<KadHash> for Multihash {
     fn distance_with(&self, other: &KadHash) -> u32 {
         <Multihash as KBucketsPeerId<Multihash>>::distance_with(self, other.hash())

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -66,5 +66,6 @@ pub mod protocol;
 
 mod addresses;
 mod behaviour;
+mod kad_hash;
 mod protobuf_structs;
 mod query;


### PR DESCRIPTION
We currently use `PeerId` directly as a key into a Kademlia table because it happens to be a hash of the address of a peer. However, the reference implementation uses a hash of the hash. This PR introduces a new struct, `KadHash` that is to be used instead as key.

There are actually two use cases for `PeerId`: as key into the Kademlia table and as an actual identifier of a peer. `KadHash` supports both by storing the `PeerId` and the new hash together.

Function `Kademlia::initialize()` has become obsolete and has been removed.
Function `Kademlia::without_init()` has been marked deprecated.

This PR includes minor fixes for warnings.

Addresses: #694 