### PR TITLE
Add lighthouse to list of projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ libp2p = "0.2.2"
 
 - https://github.com/paritytech/polkadot
 - https://github.com/paritytech/substrate
+- https://github.com/sigp/lighthouse


### PR DESCRIPTION
Adds [Lighthouse](https://github.com/sigp/lighthouse) to the list of projects using rust-libp2p :). 