### PR TITLE
Return a sequence of `Multiaddr`s in `listen_on`.

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -64,6 +64,7 @@ pub use multiaddr;
 pub use multistream_select::Negotiated;
 
 mod keys_proto;
+mod multiaddrs;
 mod peer_id;
 
 #[cfg(test)]
@@ -79,6 +80,7 @@ pub mod transport;
 pub mod upgrade;
 
 pub use self::multiaddr::Multiaddr;
+pub use self::multiaddrs::{MultiaddrSeq, MultiAddrIter, MultiAddrIterMut, IntoMultiAddrIter};
 pub use self::muxing::StreamMuxer;
 pub use self::peer_id::PeerId;
 pub use self::protocols_handler::{ProtocolsHandler, ProtocolsHandlerEvent};

--- a/core/src/multiaddrs.rs
+++ b/core/src/multiaddrs.rs
@@ -1,0 +1,158 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use multiaddr::Multiaddr;
+use smallvec::SmallVec;
+use std::{fmt, iter, slice};
+
+/// A non-empty sequence of [`Multiaddr`]s.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MultiaddrSeq {
+    head: Multiaddr,
+    tail: SmallVec<[Multiaddr; 4]>
+}
+
+impl fmt::Display for MultiaddrSeq {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
+impl MultiaddrSeq {
+    /// Create a one-element multi-address sequence.
+    pub fn singleton(a: Multiaddr) -> Self {
+        MultiaddrSeq { head: a, tail: SmallVec::new() }
+    }
+
+    /// Get the number of addresses in this sequence.
+    pub fn len(&self) -> usize {
+        1 + self.tail.len()
+    }
+
+    /// Get a reference to the first [`Multiaddr`] of this sequence.
+    pub fn head(&self) -> &Multiaddr {
+        &self.head
+    }
+
+    /// Get a reference to a [`Multiaddr`] by index.
+    pub fn get(&self, pos: usize) -> Option<&Multiaddr> {
+        if pos == 0 {
+            return Some(&self.head)
+        }
+        self.tail.get(pos)
+    }
+
+    /// Get a unique reference to a [`Multiaddr`] by index.
+    pub fn get_mut(&mut self, pos: usize) -> Option<&mut Multiaddr> {
+        if pos == 0 {
+            return Some(&mut self.head)
+        }
+        self.tail.get_mut(pos)
+    }
+
+    /// Add a [`Multiaddr`] to the end of this sequence.
+    pub fn push(&mut self, a: Multiaddr) {
+        self.tail.push(a)
+    }
+
+    /// Remove and return the last [`Multiaddr`] of this sequence.
+    ///
+    /// This removes all but the first [`Multiaddr`] from this sequence.
+    pub fn pop(&mut self) -> Option<Multiaddr> {
+        self.tail.pop()
+    }
+
+    /// Replace the first element with the given [`Multiaddr`].
+    pub fn replace_head(&mut self, a: Multiaddr) {
+        self.head = a
+    }
+
+    /// Create an [`Iterator`] over all [`Multiaddr`] of this sequence.
+    pub fn iter(&self) -> MultiAddrIter {
+        MultiAddrIter {
+            inner: std::iter::once(&self.head).chain(self.tail.iter())
+        }
+    }
+
+    /// Create a mutable [`Iterator`] over all [`Multiaddr`] of this sequence.
+    pub fn iter_mut(&mut self) -> MultiAddrIterMut {
+        MultiAddrIterMut {
+            inner: std::iter::once(&mut self.head).chain(self.tail.iter_mut())
+        }
+    }
+}
+
+impl IntoIterator for MultiaddrSeq {
+    type Item = Multiaddr;
+    type IntoIter = IntoMultiAddrIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoMultiAddrIter {
+            inner: std::iter::once(self.head).chain(self.tail.into_iter())
+        }
+    }
+}
+
+/// [`Iterator`] implementation returning references to each [`Multiaddr`] in order.
+pub struct MultiAddrIter<'a> {
+    inner: iter::Chain<iter::Once<&'a Multiaddr>, slice::Iter<'a, Multiaddr>>
+}
+
+impl<'a> iter::Iterator for MultiAddrIter<'a> {
+    type Item = &'a Multiaddr;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+/// [`Iterator`] implementation returning unique references to each [`Multiaddr`] in order.
+pub struct MultiAddrIterMut<'a> {
+    inner: iter::Chain<iter::Once<&'a mut Multiaddr>, slice::IterMut<'a, Multiaddr>>
+}
+
+impl<'a> iter::Iterator for MultiAddrIterMut<'a> {
+    type Item = &'a mut Multiaddr;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+/// [`Iterator`] implementation returning [`Multiaddr`]eses in order.
+pub struct IntoMultiAddrIter {
+    inner: iter::Chain<iter::Once<Multiaddr>, smallvec::IntoIter<[Multiaddr; 4]>>
+}
+
+impl iter::Iterator for IntoMultiAddrIter {
+    type Item = Multiaddr;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+/// Convert from [`Multiaddr`] to [`MultiaddrSeq`].
+impl From<Multiaddr> for MultiaddrSeq {
+    fn from(x: Multiaddr) -> Self {
+        MultiaddrSeq::singleton(x)
+    }
+}
+

--- a/core/src/tests/dummy_transport.rs
+++ b/core/src/tests/dummy_transport.rs
@@ -28,7 +28,7 @@ use futures::{
     stream,
 };
 use std::io;
-use crate::{Multiaddr, PeerId, Transport, transport::TransportError};
+use crate::{Multiaddr, MultiaddrSeq, PeerId, Transport, transport::TransportError};
 use crate::tests::dummy_muxer::DummyMuxer;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -73,7 +73,7 @@ impl Transport for DummyTransport {
     type ListenerUpgrade = FutureResult<Self::Output, io::Error>;
     type Dial = Box<dyn Future<Item = Self::Output, Error = io::Error> + Send>;
 
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>>
+    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, MultiaddrSeq), TransportError<Self::Error>>
     where
         Self: Sized,
     {
@@ -84,15 +84,15 @@ impl Transport for DummyTransport {
                 Ok(match r#async {
                     Async::NotReady => {
                         let stream = stream::poll_fn(|| Ok(Async::NotReady)).map(tupelize);
-                        (Box::new(stream), addr2)
+                        (Box::new(stream), MultiaddrSeq::from(addr2))
                     }
                     Async::Ready(Some(tup)) => {
                         let stream = stream::poll_fn(move || Ok( Async::Ready(Some(tup.clone()) ))).map(tupelize);
-                        (Box::new(stream), addr2)
+                        (Box::new(stream), MultiaddrSeq::from(addr2))
                     }
                     Async::Ready(None) => {
                         let stream = stream::empty();
-                        (Box::new(stream), addr2)
+                        (Box::new(stream), MultiaddrSeq::from(addr2))
                     }
                 })
             }

--- a/core/src/transport/choice.rs
+++ b/core/src/transport/choice.rs
@@ -20,6 +20,7 @@
 
 use crate::either::{EitherListenStream, EitherOutput, EitherError, EitherFuture};
 use crate::transport::{Transport, TransportError};
+use crate::MultiaddrSeq;
 use multiaddr::Multiaddr;
 
 /// Struct returned by `or_transport()`.
@@ -43,7 +44,7 @@ where
     type ListenerUpgrade = EitherFuture<A::ListenerUpgrade, B::ListenerUpgrade>;
     type Dial = EitherFuture<A::Dial, B::Dial>;
 
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>> {
+    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, MultiaddrSeq), TransportError<Self::Error>> {
         let addr = match self.0.listen_on(addr) {
             Ok((connec, addr)) => return Ok((EitherListenStream::First(connec), addr)),
             Err(TransportError::MultiaddrNotSupported(addr)) => addr,

--- a/core/src/transport/dummy.rs
+++ b/core/src/transport/dummy.rs
@@ -19,7 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use crate::transport::{Transport, TransportError};
-use multiaddr::Multiaddr;
+use crate::{Multiaddr, MultiaddrSeq};
 use std::{fmt, io, marker::PhantomData};
 
 /// Implementation of `Transport` that doesn't support any multiaddr.
@@ -60,7 +60,7 @@ impl<TOut> Transport for DummyTransport<TOut> {
     type Dial = futures::future::Empty<Self::Output, io::Error>;
 
     #[inline]
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>> {
+    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, MultiaddrSeq), TransportError<Self::Error>> {
         Err(TransportError::MultiaddrNotSupported(addr))
     }
 

--- a/core/src/transport/map_err.rs
+++ b/core/src/transport/map_err.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::transport::{Transport, TransportError};
+use crate::{MultiaddrSeq, transport::{Transport, TransportError}};
 use futures::prelude::*;
 use multiaddr::Multiaddr;
 use std::error;
@@ -50,7 +50,7 @@ where
     type ListenerUpgrade = MapErrListenerUpgrade<T, F>;
     type Dial = MapErrDial<T, F>;
 
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>> {
+    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, MultiaddrSeq), TransportError<Self::Error>> {
         let map = self.map;
 
         match self.transport.listen_on(addr) {

--- a/core/src/transport/memory.rs
+++ b/core/src/transport/memory.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::{Transport, transport::TransportError};
+use crate::{MultiaddrSeq, Transport, transport::TransportError};
 use bytes::{Bytes, IntoBuf};
 use fnv::FnvHashMap;
 use futures::{future::{self, FutureResult}, prelude::*, sync::mpsc, try_ready};
@@ -43,7 +43,7 @@ impl Transport for MemoryTransport {
     type ListenerUpgrade = FutureResult<Self::Output, Self::Error>;
     type Dial = FutureResult<Self::Output, Self::Error>;
 
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>> {
+    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, MultiaddrSeq), TransportError<Self::Error>> {
         let port = if let Ok(port) = parse_memory_addr(&addr) {
             port
         } else {
@@ -66,7 +66,7 @@ impl Transport for MemoryTransport {
             }
         };
 
-        let actual_addr = Protocol::Memory(port.get()).into();
+        let actual_addr = MultiaddrSeq::singleton(Protocol::Memory(port.get()).into());
 
         let (tx, rx) = mpsc::unbounded();
         match hub.entry(port) {

--- a/core/src/transport/mod.rs
+++ b/core/src/transport/mod.rs
@@ -25,7 +25,7 @@
 //! any desired protocols. The rest of the module defines combinators for
 //! modifying a transport through composition with other transports or protocol upgrades.
 
-use crate::{InboundUpgrade, OutboundUpgrade, nodes::raw_swarm::ConnectedPoint};
+use crate::{MultiaddrSeq, InboundUpgrade, OutboundUpgrade, nodes::raw_swarm::ConnectedPoint};
 use futures::prelude::*;
 use multiaddr::Multiaddr;
 use std::{error, fmt};
@@ -115,7 +115,7 @@ pub trait Transport {
     /// > **Note**: The new [`Multiaddr`] that is returned alongside the connection stream
     /// > is the address that should be advertised to other nodes, as the given address
     /// > may be subject to changes such as an OS-assigned port number.
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>>
+    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, MultiaddrSeq), TransportError<Self::Error>>
     where
         Self: Sized;
 

--- a/core/src/transport/timeout.rs
+++ b/core/src/transport/timeout.rs
@@ -24,7 +24,7 @@
 //! underlying `Transport`.
 // TODO: add example
 
-use crate::{Multiaddr, Transport, transport::TransportError};
+use crate::{Multiaddr, MultiaddrSeq, Transport, transport::TransportError};
 use futures::{try_ready, Async, Future, Poll, Stream};
 use log::debug;
 use std::{error, fmt, time::Duration};
@@ -86,7 +86,7 @@ where
     type ListenerUpgrade = TokioTimerMapErr<Timeout<InnerTrans::ListenerUpgrade>>;
     type Dial = TokioTimerMapErr<Timeout<InnerTrans::Dial>>;
 
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>> {
+    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, MultiaddrSeq), TransportError<Self::Error>> {
         let (listener, addr) = self.inner.listen_on(addr)
             .map_err(|err| err.map(TransportTimeoutError::Other))?;
 

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -19,6 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use crate::{
+    MultiaddrSeq,
     transport::Transport,
     transport::TransportError,
     upgrade::{
@@ -69,7 +70,7 @@ where
         })
     }
 
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>> {
+    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, MultiaddrSeq), TransportError<Self::Error>> {
         let (inbound, addr) = self.inner.listen_on(addr)
             .map_err(|err| err.map(TransportUpgradeError::Transport))?;
         Ok((ListenerStream { stream: inbound, upgrade: self.upgrade }, addr))

--- a/core/tests/raw_swarm_simult.rs
+++ b/core/tests/raw_swarm_simult.rs
@@ -157,7 +157,7 @@ fn raw_swarm_simultaneous_connect() {
                             Async::Ready(_) => {
                                 let handler = TestHandler::default().into_node_handler_builder();
                                 swarm1.peer(swarm2.local_peer_id().clone()).into_not_connected().unwrap()
-                                    .connect(swarm2_listen.clone(), handler);
+                                    .connect(swarm2_listen.head().clone(), handler);
                                 swarm1_step = 1;
                                 swarm1_not_ready = false;
                             },
@@ -170,7 +170,7 @@ fn raw_swarm_simultaneous_connect() {
                             Async::Ready(_) => {
                                 let handler = TestHandler::default().into_node_handler_builder();
                                 swarm2.peer(swarm1.local_peer_id().clone()).into_not_connected().unwrap()
-                                    .connect(swarm1_listen.clone(), handler);
+                                    .connect(swarm1_listen.head().clone(), handler);
                                 swarm2_step = 1;
                                 swarm2_not_ready = false;
                             },

--- a/muxers/mplex/tests/two_peers.rs
+++ b/muxers/mplex/tests/two_peers.rs
@@ -69,7 +69,7 @@ fn client_to_server_outbound() {
     let transport = TcpConfig::new().with_upgrade(libp2p_mplex::MplexConfig::new());
 
     let future = transport
-        .dial(rx.recv().unwrap())
+        .dial(rx.recv().unwrap().head().clone())
         .unwrap()
         .map_err(|err| panic!("{:?}", err))
         .and_then(|client| muxing::inbound_from_ref_and_wrap(Arc::new(client)))
@@ -123,7 +123,7 @@ fn client_to_server_inbound() {
     let transport = TcpConfig::new().with_upgrade(libp2p_mplex::MplexConfig::new());
 
     let future = transport
-        .dial(rx.recv().unwrap())
+        .dial(rx.recv().unwrap().head().clone())
         .unwrap()
         .map_err(|err| panic!("{:?}", err))
         .and_then(|client| muxing::outbound_from_ref_and_wrap(Arc::new(client)))

--- a/protocols/identify/src/id_transport.rs
+++ b/protocols/identify/src/id_transport.rs
@@ -23,7 +23,7 @@
 use crate::protocol::{RemoteInfo, IdentifyProtocolConfig};
 use futures::{future, prelude::*, stream, AndThen, MapErr};
 use libp2p_core::{
-    Multiaddr, PeerId, PublicKey, muxing, Transport,
+    Multiaddr, MultiaddrSeq, PeerId, PublicKey, muxing, Transport,
     transport::{TransportError, upgrade::TransportUpgradeError},
     upgrade::{self, OutboundUpgradeApply, UpgradeError}
 };
@@ -75,7 +75,7 @@ where
     >;
 
     #[inline]
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>> {
+    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, MultiaddrSeq), TransportError<Self::Error>> {
         Err(TransportError::MultiaddrNotSupported(addr))
     }
 

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -271,7 +271,7 @@ mod tests {
         };
 
         let actual_addr = Swarm::listen_on(&mut swarm1, "/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
-        Swarm::dial_addr(&mut swarm2, actual_addr).unwrap();
+        Swarm::dial_addr(&mut swarm2, actual_addr.head().clone()).unwrap();
 
         let mut swarm1_good = false;
         let mut swarm2_good = false;

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -321,7 +321,7 @@ mod tests {
 
         let transport = TcpConfig::new();
 
-        let future = transport.dial(rx.recv().unwrap())
+        let future = transport.dial(rx.recv().unwrap().head().clone())
             .unwrap()
             .and_then(|socket| {
                 apply_outbound(socket, IdentifyProtocolConfig)

--- a/protocols/noise/tests/smoke.rs
+++ b/protocols/noise/tests/smoke.rs
@@ -106,7 +106,7 @@ where
 {
     let message2 = message1.clone();
 
-    let (server, server_address) = server_transport
+    let (server, server_addresses) = server_transport
         .listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap())
         .unwrap();
 
@@ -122,7 +122,7 @@ where
             Ok(())
         });
 
-    let client = client_transport.dial(server_address).unwrap()
+    let client = client_transport.dial(server_addresses.head().clone()).unwrap()
         .map_err(|e| panic!("client error: {}", e))
         .and_then(move |(_, server)| {
             io::write_all(server, message2).and_then(|(client, _)| io::flush(client))

--- a/src/bandwidth.rs
+++ b/src/bandwidth.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::{Multiaddr, core::Transport, core::transport::TransportError};
+use crate::{Multiaddr, MultiaddrSeq, core::Transport, core::transport::TransportError};
 use futures::{prelude::*, try_ready};
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
@@ -65,7 +65,7 @@ where
     type ListenerUpgrade = BandwidthFuture<TInner::ListenerUpgrade>;
     type Dial = BandwidthFuture<TInner::Dial>;
 
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>> {
+    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, MultiaddrSeq), TransportError<Self::Error>> {
         let sinks = self.sinks;
         self.inner
             .listen_on(addr)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,7 @@ pub mod simple;
 
 pub use self::core::{
     identity,
-    Transport, PeerId, Swarm,
+    Transport, PeerId, Swarm, MultiaddrSeq,
     transport::TransportError,
     upgrade::{InboundUpgrade, InboundUpgradeExt, OutboundUpgrade, OutboundUpgradeExt}
 };
@@ -325,7 +325,7 @@ impl Transport for CommonTransport {
     type Dial = <InnerImplementation as Transport>::Dial;
 
     #[inline]
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>> {
+    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, MultiaddrSeq), TransportError<Self::Error>> {
         self.inner.inner.listen_on(addr)
     }
 

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -33,13 +33,11 @@
 //! replaced with respectively an `/ip4/` or an `/ip6/` component.
 //!
 
-use libp2p_core as swarm;
-
 use futures::{future::{self, Either, FutureResult, JoinAll}, prelude::*, stream, try_ready};
+use libp2p_core::{MultiaddrSeq, Transport, transport::TransportError};
 use log::{debug, trace, log_enabled, Level};
 use multiaddr::{Protocol, Multiaddr};
 use std::{error, fmt, io, marker::PhantomData, net::IpAddr};
-use swarm::{Transport, transport::TransportError};
 use tokio_dns::{CpuPoolResolver, Resolver};
 
 /// Represents the configuration for a DNS transport capability of libp2p.
@@ -104,7 +102,7 @@ where
     >;
 
     #[inline]
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>> {
+    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, MultiaddrSeq), TransportError<Self::Error>> {
         let (listener, new_addr) = self.inner.listen_on(addr)
             .map_err(|err| err.map(DnsErr::Underlying))?;
         let listener = listener
@@ -318,7 +316,7 @@ where
 mod tests {
     use libp2p_tcp::TcpConfig;
     use futures::future;
-    use super::swarm::{Transport, transport::TransportError};
+    use libp2p_core::{MultiaddrSeq, Transport, transport::TransportError};
     use multiaddr::{Protocol, Multiaddr};
     use super::DnsConfig;
 
@@ -337,7 +335,7 @@ mod tests {
             fn listen_on(
                 self,
                 _addr: Multiaddr,
-            ) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>> {
+            ) -> Result<(Self::Listener, MultiaddrSeq), TransportError<Self::Error>> {
                 unreachable!()
             }
 

--- a/transports/ratelimit/src/lib.rs
+++ b/transports/ratelimit/src/lib.rs
@@ -21,7 +21,7 @@
 use aio_limited::{Limited, Limiter};
 use futures::prelude::*;
 use futures::try_ready;
-use libp2p_core::{Multiaddr, Transport, transport::TransportError};
+use libp2p_core::{Multiaddr, MultiaddrSeq, Transport, transport::TransportError};
 use log::error;
 use std::{error, fmt, io};
 use tokio_executor::Executor;
@@ -190,7 +190,7 @@ where
     type ListenerUpgrade = ListenerUpgrade<T>;
     type Dial = DialFuture<T::Dial>;
 
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>> {
+    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, MultiaddrSeq), TransportError<Self::Error>> {
         let r = self.rlimiter;
         let w = self.wlimiter;
         self.value

--- a/transports/uds/src/lib.rs
+++ b/transports/uds/src/lib.rs
@@ -51,7 +51,7 @@ use futures::stream::Stream;
 use log::debug;
 use multiaddr::{Protocol, Multiaddr};
 use std::{io, path::PathBuf};
-use libp2p_core::{Transport, transport::TransportError};
+use libp2p_core::{MultiaddrSeq, Transport, transport::TransportError};
 use tokio_uds::{UnixListener, UnixStream};
 
 /// Represents the configuration for a Unix domain sockets transport capability for libp2p.
@@ -77,7 +77,7 @@ impl Transport for UdsConfig {
     type ListenerUpgrade = FutureResult<Self::Output, io::Error>;
     type Dial = tokio_uds::ConnectFuture;
 
-    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>> {
+    fn listen_on(self, addr: Multiaddr) -> Result<(Self::Listener, MultiaddrSeq), TransportError<Self::Error>> {
         if let Ok(path) = multiaddr_to_path(&addr) {
             let listener = UnixListener::bind(&path);
             // We need to build the `Multiaddr` to return from this function. If an error happened,
@@ -89,7 +89,7 @@ impl Transport for UdsConfig {
                         stream: listener.incoming(),
                         addr: addr.clone()
                     };
-                    Ok((future, addr))
+                    Ok((future, MultiaddrSeq::from(addr)))
                 }
                 Err(_) => return Err(TransportError::MultiaddrNotSupported(addr)),
             }

--- a/transports/websocket/src/browser.rs
+++ b/transports/websocket/src/browser.rs
@@ -18,7 +18,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use libp2p_core as swarm;
 use log::debug;
 use futures::{future, stream};
 use futures::stream::Then as StreamThen;
@@ -31,7 +30,7 @@ use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
 use stdweb::web::TypedArray;
 use stdweb::{self, Reference};
-use swarm::{Transport, transport::TransportError};
+use libp2p_core::{MultiaddrSeq, Transport, transport::TransportError};
 use tokio_io::{AsyncRead, AsyncWrite};
 
 /// Represents the configuration for a websocket transport capability for libp2p.
@@ -61,7 +60,7 @@ impl Transport for BrowserWsConfig {
     type Dial = Box<Future<Item = Self::Output, Error = IoError> + Send>;
 
     #[inline]
-    fn listen_on(self, a: Multiaddr) -> Result<(Self::Listener, Multiaddr), TransportError<Self::Error>> {
+    fn listen_on(self, a: Multiaddr) -> Result<(Self::Listener, MultiaddrSeq), TransportError<Self::Error>> {
         // Listening is never supported.
         Err(TransportError::MultiaddrNotSupported(a))
     }


### PR DESCRIPTION
This is part of the proposed changes to the `Transport` trait as outlined in [[1]].

To allow transport implementations to listen on multiple addresses we now report all those addresses as a sequence of multi-addresses instead of supporting only a single one.

Instead of making `Transport::listen_on` return a generic iterator a concrete type `MultiaddrSeq` is introduced to support non-emptiness.

[1]: https://github.com/libp2p/rust-libp2p/issues/794#issuecomment-475950601