### PR TITLE
Add missing zeroize() call for secp256k1::SecretKey::from_bytes.

### DIFF
--- a/core/src/identity/secp256k1.rs
+++ b/core/src/identity/secp256k1.rs
@@ -96,6 +96,7 @@ impl SecretKey {
         let sk_bytes = sk.as_mut();
         let secret = secp::key::SecretKey::from_slice(&*sk_bytes)
             .map_err(|e| DecodingError::new("Secp256k1 secret key", e))?;
+        sk_bytes.zeroize();
         Ok(SecretKey(secret))
     }
 

--- a/core/src/identity/secp256k1.rs
+++ b/core/src/identity/secp256k1.rs
@@ -157,3 +157,18 @@ impl PublicKey {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn secp256k1_secret_from_bytes() {
+        let sk1 = SecretKey::generate();
+        let mut sk_bytes = [0; 32];
+        sk_bytes.copy_from_slice(sk1.as_ref());
+        let sk2 = SecretKey::from_bytes(&mut sk_bytes).unwrap();
+        assert_eq!(sk1.as_ref(), sk2.as_ref());
+        assert_eq!(sk_bytes, [0; 32]);
+    }
+}
+


### PR DESCRIPTION
A small oversight discovered while looking through https://github.com/libp2p/rust-libp2p/pull/1029. Now the function implementation actually does what was already written in its documentation.