### PR TITLE
Fix `multiaddr::util::BytesWriter`.

### DIFF
--- a/misc/multiaddr/src/util.rs
+++ b/misc/multiaddr/src/util.rs
@@ -1,4 +1,4 @@
-use bytes::{BufMut, BytesMut};
+use bytes::BytesMut;
 
 /// An [`io::Write`] impl for [`BytesMut`].
 ///
@@ -9,25 +9,8 @@ pub(crate) struct BytesWriter(pub(crate) BytesMut);
 
 impl std::io::Write for BytesWriter {
     fn write(&mut self, src: &[u8]) -> std::io::Result<usize> {
-        let n = std::cmp::min(self.0.remaining_mut(), src.len());
-        self.0.put(&src[.. n]);
-        Ok(n)
-    }
-
-    fn write_all(&mut self, mut buf: &[u8]) -> std::io::Result<()> {
-        if self.0.remaining_mut() < buf.len() {
-            self.0.reserve(buf.len() - self.0.remaining_mut());
-        }
-        while !buf.is_empty() {
-            match self.write(buf) {
-                Ok(0) => return Err(std::io::ErrorKind::WriteZero.into()),
-                Ok(n) => buf = &buf[n ..],
-                Err(e) => if e.kind() != std::io::ErrorKind::Interrupted {
-                    return Err(e)
-                }
-            }
-        }
-        Ok(())
+        self.0.extend_from_slice(src);
+        Ok(src.len())
     }
 
     fn flush(&mut self) -> std::io::Result<()> {

--- a/misc/multiaddr/tests/lib.rs
+++ b/misc/multiaddr/tests/lib.rs
@@ -34,10 +34,14 @@ fn to_from_str_identity() {
 
 #[test]
 fn byteswriter() {
-    fn prop(a: Ma, p: Proto) -> bool {
-        a.0.with(p.clone().0).pop() == Some(p.0)
+    fn prop(a: Ma, b: Ma) -> bool {
+        let mut x = a.0.clone();
+        for p in b.0.iter() {
+            x = x.with(p)
+        }
+        x.iter().zip(a.0.iter().chain(b.0.iter())).all(|(x, y)| x == y)
     }
-    QuickCheck::new().quickcheck(prop as fn(Ma, Proto) -> bool)
+    QuickCheck::new().quickcheck(prop as fn(Ma, Ma) -> bool)
 }
 
 #[test]


### PR DESCRIPTION
The current implementation does not properly reserve enough space for `Write::write_all` to succeed. The property test has been improved to trigger that issue.