### PR TITLE
Fix CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,7 @@ jobs:
       - run:
           name: Build for wasm32
           # TODO: also run tests but with --no-run; important to detect linking errors
-          # TODO: secp doesn't compile for wasm yet
-          command: cargo web build --no-default-features --features "libp2p-websocket"
+          command: cargo web build
       - save_cache:
           key: test-wasm-cache
           paths:


### PR DESCRIPTION
Apparently a new version of `cargo web` doesn't allow at the same time `--no-default-features` and `--features`.

At the same time, I'm also trying to make secp2561 compile now that we have clang 8 in the image.