### PR TITLE
secio: fix deprecated length_delimited warnings

### DIFF
--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -25,6 +25,7 @@ ctr = "0.3"
 lazy_static = "1.2.0"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
 tokio-io = "0.1.0"
+tokio = "0.1.1"
 sha2 = "0.8.0"
 hmac = "0.7.0"
 


### PR DESCRIPTION
the current  `secio` code uses the `tokio_io::codec::length_delimited::Framed` that is being deprecated due to a move to `tokio::codec`, hence a ton of build warnings. However, the `Encoder` implementation for new `LengthDelmitedCodec` now has `Item = Bytes` instead of `Item = BytesMut` as in the older version which changes things a bit for fullcodec so `EncoderMiddleware`'s underlying `Sink: Item` now changes to `Bytes`.

This change probably has to be done at some point anyway, however I am not sure about bringing the whole `tokio` dependency in. That's needed because `LengthDelimitedCodec` lives there and not in `tokio-codec`.