### PR TITLE
Small addendum to #1072.

### DIFF
--- a/core/src/protocols_handler/mod.rs
+++ b/core/src/protocols_handler/mod.rs
@@ -150,10 +150,10 @@ pub trait ProtocolsHandler {
     ///
     /// This method is called by the `Swarm` after each invocation of
     /// [`ProtocolsHandler::poll`] to determine if the connection and the associated
-    /// `ProtocolsHandler`s should be kept alive as far as this handler is concernced
+    /// `ProtocolsHandler`s should be kept alive as far as this handler is concerned
     /// and if so, for how long.
     ///
-    /// Returning [`KeepAlive::Now`] indicates that the connection can be
+    /// Returning [`KeepAlive::Now`] indicates that the connection should be
     /// closed and this handler destroyed immediately.
     ///
     /// Returning [`KeepAlive::Until`] indicates that the connection may be closed

--- a/core/src/protocols_handler/node_handler.rs
+++ b/core/src/protocols_handler/node_handler.rs
@@ -276,10 +276,11 @@ where
 
         // Ask the handler whether it wants the connection (and the handler itself)
         // to be kept alive, which determines the planned shutdown, if any.
-        self.shutdown = match self.handler.connection_keep_alive() {
-            KeepAlive::Until(t) => Shutdown::Later(Delay::new(t)),
-            KeepAlive::Now => Shutdown::Asap,
-            KeepAlive::Forever => Shutdown::None
+        match (&self.shutdown, self.handler.connection_keep_alive()) {
+            (Shutdown::Later(d), KeepAlive::Until(t)) if d.deadline() == t => (),
+            (_, KeepAlive::Until(t)) => self.shutdown = Shutdown::Later(Delay::new(t)),
+            (_, KeepAlive::Now) => self.shutdown = Shutdown::Asap,
+            (_, KeepAlive::Forever) => self.shutdown = Shutdown::None
         };
 
         match poll_result {

--- a/core/src/protocols_handler/node_handler.rs
+++ b/core/src/protocols_handler/node_handler.rs
@@ -276,8 +276,11 @@ where
 
         // Ask the handler whether it wants the connection (and the handler itself)
         // to be kept alive, which determines the planned shutdown, if any.
-        match (&self.shutdown, self.handler.connection_keep_alive()) {
-            (Shutdown::Later(d), KeepAlive::Until(t)) if d.deadline() == t => (),
+        match (&mut self.shutdown, self.handler.connection_keep_alive()) {
+            (Shutdown::Later(d), KeepAlive::Until(t)) =>
+                if d.deadline() != t {
+                    d.reset(t)
+                },
             (_, KeepAlive::Until(t)) => self.shutdown = Shutdown::Later(Delay::new(t)),
             (_, KeepAlive::Now) => self.shutdown = Shutdown::Asap,
             (_, KeepAlive::Forever) => self.shutdown = Shutdown::None


### PR DESCRIPTION
Small addendum to #1072:

  * Missed two review comments related to documentation.
  * Avoid creating new `Delay`s when possible, e.g. when the deadline did not change or only changed to a different instant, since they're not exactly cheap (an `Arc`ed  [Entry](https://github.com/tokio-rs/tokio/blob/master/tokio-timer/src/timer/entry.rs#L110-L120)) and returning `KeepAlive::Until(t)` with the same or a different instant `t` over a prolonged period of time is common. If the instant is the same, this is now a no-op and if they're different it uses [Delay::reset()](https://docs.rs/tokio-timer/0.2.10/tokio_timer/struct.Delay.html#method.reset).