### PR TITLE
Rename `KeepAlive::Now` and `KeepAlive::Forever`.

### DIFF
--- a/core/src/protocols_handler/dummy.rs
+++ b/core/src/protocols_handler/dummy.rs
@@ -90,7 +90,7 @@ where
     fn inject_dial_upgrade_error(&mut self, _: Self::OutboundOpenInfo, _: ProtocolsHandlerUpgrErr<<Self::OutboundProtocol as OutboundUpgrade<Self::Substream>>::Error>) {}
 
     #[inline]
-    fn connection_keep_alive(&self) -> KeepAlive { KeepAlive::Now }
+    fn connection_keep_alive(&self) -> KeepAlive { KeepAlive::No }
 
     #[inline]
     fn poll(

--- a/core/src/protocols_handler/mod.rs
+++ b/core/src/protocols_handler/mod.rs
@@ -153,13 +153,13 @@ pub trait ProtocolsHandler {
     /// `ProtocolsHandler`s should be kept alive as far as this handler is concerned
     /// and if so, for how long.
     ///
-    /// Returning [`KeepAlive::Now`] indicates that the connection should be
+    /// Returning [`KeepAlive::No`] indicates that the connection should be
     /// closed and this handler destroyed immediately.
     ///
     /// Returning [`KeepAlive::Until`] indicates that the connection may be closed
     /// and this handler destroyed after the specified `Instant`.
     ///
-    /// Returning [`KeepAlive::Forever`] indicates that the connection should
+    /// Returning [`KeepAlive::Yes`] indicates that the connection should
     /// be kept alive until the next call to this method.
     ///
     /// > **Note**: The connection is always closed and the handler destroyed
@@ -466,16 +466,16 @@ pub enum KeepAlive {
     /// If nothing new happens, the connection should be closed at the given `Instant`.
     Until(Instant),
     /// Keep the connection alive.
-    Forever,
+    Yes,
     /// Close the connection as soon as possible.
-    Now,
+    No,
 }
 
 impl KeepAlive {
-    /// Returns true for `Forever`, false otherwise.
-    pub fn is_forever(&self) -> bool {
+    /// Returns true for `Yes`, false otherwise.
+    pub fn is_yes(&self) -> bool {
         match *self {
-            KeepAlive::Forever => true,
+            KeepAlive::Yes => true,
             _ => false,
         }
     }
@@ -492,10 +492,10 @@ impl Ord for KeepAlive {
         use self::KeepAlive::*;
 
         match (self, other) {
-            (Now, Now) | (Forever, Forever) => Ordering::Equal,
-            (Now, _) | (_, Forever) => Ordering::Less,
-            (_, Now) | (Forever, _) => Ordering::Greater,
-            (Until(expiration), Until(other_expiration)) => expiration.cmp(other_expiration),
+            (No, No) | (Yes, Yes)  => Ordering::Equal,
+            (No,  _) | (_,   Yes)  => Ordering::Less,
+            (_,  No) | (Yes,   _)  => Ordering::Greater,
+            (Until(t1), Until(t2)) => t1.cmp(t2),
         }
     }
 }

--- a/core/src/protocols_handler/node_handler.rs
+++ b/core/src/protocols_handler/node_handler.rs
@@ -282,8 +282,8 @@ where
                     d.reset(t)
                 },
             (_, KeepAlive::Until(t)) => self.shutdown = Shutdown::Later(Delay::new(t)),
-            (_, KeepAlive::Now) => self.shutdown = Shutdown::Asap,
-            (_, KeepAlive::Forever) => self.shutdown = Shutdown::None
+            (_, KeepAlive::No) => self.shutdown = Shutdown::Asap,
+            (_, KeepAlive::Yes) => self.shutdown = Shutdown::None
         };
 
         match poll_result {

--- a/core/src/protocols_handler/one_shot.rs
+++ b/core/src/protocols_handler/one_shot.rs
@@ -75,7 +75,7 @@ where
             dial_queue: SmallVec::new(),
             dial_negotiated: 0,
             max_dial_negotiated: 8,
-            keep_alive: KeepAlive::Forever,
+            keep_alive: KeepAlive::Yes,
             inactive_timeout,
             marker: PhantomData,
         }
@@ -108,7 +108,7 @@ where
     /// Opens an outbound substream with `upgrade`.
     #[inline]
     pub fn send_request(&mut self, upgrade: TOutProto) {
-        self.keep_alive = KeepAlive::Forever;
+        self.keep_alive = KeepAlive::Yes;
         self.dial_queue.push(upgrade);
     }
 }
@@ -157,7 +157,7 @@ where
         out: <Self::InboundProtocol as InboundUpgrade<Self::Substream>>::Output,
     ) {
         // If we're shutting down the connection for inactivity, reset the timeout.
-        if !self.keep_alive.is_forever() {
+        if !self.keep_alive.is_yes() {
             self.keep_alive = KeepAlive::Until(Instant::now() + self.inactive_timeout);
         }
 

--- a/core/src/swarm/toggle.rs
+++ b/core/src/swarm/toggle.rs
@@ -222,7 +222,7 @@ where
 
     fn connection_keep_alive(&self) -> KeepAlive {
         self.inner.as_ref().map(|h| h.connection_keep_alive())
-            .unwrap_or(KeepAlive::Now)
+            .unwrap_or(KeepAlive::No)
     }
 
     fn poll(

--- a/core/tests/raw_swarm_dial_error.rs
+++ b/core/tests/raw_swarm_dial_error.rs
@@ -78,7 +78,7 @@ where
 
     }
 
-    fn connection_keep_alive(&self) -> KeepAlive { KeepAlive::Now }
+    fn connection_keep_alive(&self) -> KeepAlive { KeepAlive::No }
 
     fn poll(&mut self) -> Poll<ProtocolsHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Self::OutEvent>, Self::Error> {
         Ok(Async::NotReady)

--- a/core/tests/raw_swarm_simult.rs
+++ b/core/tests/raw_swarm_simult.rs
@@ -76,7 +76,7 @@ where
 
     }
 
-    fn connection_keep_alive(&self) -> KeepAlive { KeepAlive::Forever }
+    fn connection_keep_alive(&self) -> KeepAlive { KeepAlive::Yes }
 
     fn poll(&mut self) -> Poll<ProtocolsHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Self::OutEvent>, Self::Error> {
         Ok(Async::NotReady)

--- a/protocols/identify/src/listen_handler.rs
+++ b/protocols/identify/src/listen_handler.rs
@@ -90,7 +90,7 @@ where
 
     #[inline]
     fn connection_keep_alive(&self) -> KeepAlive {
-        KeepAlive::Now
+        KeepAlive::No
     }
 
     fn poll(

--- a/protocols/identify/src/periodic_id_handler.rs
+++ b/protocols/identify/src/periodic_id_handler.rs
@@ -127,9 +127,9 @@ where
     #[inline]
     fn connection_keep_alive(&self) -> KeepAlive {
         if self.first_id_happened {
-            KeepAlive::Now
+            KeepAlive::No
         } else {
-            KeepAlive::Forever
+            KeepAlive::Yes
         }
     }
 

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -326,7 +326,7 @@ where
             allow_listening,
             next_connec_unique_id: UniqueConnecId(0),
             substreams: Vec::new(),
-            keep_alive: KeepAlive::Forever,
+            keep_alive: KeepAlive::Yes,
         }
     }
 }
@@ -525,7 +525,7 @@ where
         if self.substreams.is_empty() {
             self.keep_alive = KeepAlive::Until(Instant::now() + Duration::from_secs(10));
         } else {
-            self.keep_alive = KeepAlive::Forever;
+            self.keep_alive = KeepAlive::Yes;
         }
 
         Ok(Async::NotReady)

--- a/protocols/ping/src/handler.rs
+++ b/protocols/ping/src/handler.rs
@@ -202,7 +202,7 @@ where
         // the connection may be closed. I.e. the ping handler does not keep
         // the connection alive, it merely adds another condition (failed pings)
         // for terminating it.
-        KeepAlive::Now
+        KeepAlive::No
     }
 
     fn poll(&mut self) -> Poll<ProtocolsHandlerEvent<protocol::Ping, (), PingResult>, Self::Error> {


### PR DESCRIPTION
 Rename `KeepAlive` constructors as suggested in #1072:

  * `KeepAlive::Now` => `KeepAlive::No`
  * `KeepAlive::Forever` => `KeepAlive::Yes`

This branch sits on top of https://github.com/libp2p/rust-libp2p/pull/1077. The only new commit is  d5323ef .