### PR TITLE
Pass the ConnectedPoint to into_handler()

### DIFF
--- a/core/src/protocols_handler/mod.rs
+++ b/core/src/protocols_handler/mod.rs
@@ -37,6 +37,7 @@
 //! >           connection with a remote. In order to handle a protocol that requires knowledge of
 //! >           the network as a whole, see the `NetworkBehaviour` trait.
 
+use crate::nodes::raw_swarm::ConnectedPoint;
 use crate::PeerId;
 use crate::upgrade::{
     InboundUpgrade,
@@ -427,7 +428,7 @@ pub trait IntoProtocolsHandler {
     /// Builds the protocols handler.
     ///
     /// The `PeerId` is the id of the node the handler is going to handle.
-    fn into_handler(self, remote_peer_id: &PeerId) -> Self::Handler;
+    fn into_handler(self, remote_peer_id: &PeerId, connected_point: &ConnectedPoint) -> Self::Handler;
 
     /// Return the handler's inbound protocol.
     fn inbound_protocol(&self) -> <Self::Handler as ProtocolsHandler>::InboundProtocol;
@@ -456,7 +457,7 @@ where T: ProtocolsHandler
 {
     type Handler = Self;
 
-    fn into_handler(self, _: &PeerId) -> Self {
+    fn into_handler(self, _: &PeerId, _: &ConnectedPoint) -> Self {
         self
     }
 

--- a/core/src/protocols_handler/node_handler.rs
+++ b/core/src/protocols_handler/node_handler.rs
@@ -22,6 +22,7 @@ use crate::{
     PeerId,
     nodes::handled_node::{NodeHandler, NodeHandlerEndpoint, NodeHandlerEvent},
     nodes::handled_node_tasks::IntoNodeHandler,
+    nodes::raw_swarm::ConnectedPoint,
     protocols_handler::{KeepAlive, ProtocolsHandler, IntoProtocolsHandler, ProtocolsHandlerEvent, ProtocolsHandlerUpgrErr},
     upgrade::{
         self,
@@ -69,7 +70,8 @@ where
     }
 }
 
-impl<TIntoProtoHandler, TProtoHandler> IntoNodeHandler for NodeHandlerWrapperBuilder<TIntoProtoHandler>
+impl<TIntoProtoHandler, TProtoHandler> IntoNodeHandler<(PeerId, ConnectedPoint)>
+    for NodeHandlerWrapperBuilder<TIntoProtoHandler>
 where
     TIntoProtoHandler: IntoProtocolsHandler<Handler = TProtoHandler>,
     TProtoHandler: ProtocolsHandler,
@@ -78,9 +80,9 @@ where
 {
     type Handler = NodeHandlerWrapper<TIntoProtoHandler::Handler>;
 
-    fn into_handler(self, remote_peer_id: &PeerId) -> Self::Handler {
+    fn into_handler(self, remote_info: &(PeerId, ConnectedPoint)) -> Self::Handler {
         NodeHandlerWrapper {
-            handler: self.handler.into_handler(remote_peer_id),
+            handler: self.handler.into_handler(&remote_info.0, &remote_info.1),
             negotiating_in: Vec::new(),
             negotiating_out: Vec::new(),
             queued_dial_upgrades: Vec::new(),

--- a/core/src/protocols_handler/select.rs
+++ b/core/src/protocols_handler/select.rs
@@ -30,6 +30,7 @@ use crate::{
         ProtocolsHandlerEvent,
         ProtocolsHandlerUpgrErr,
     },
+    nodes::raw_swarm::ConnectedPoint,
     upgrade::{
         InboundUpgrade,
         OutboundUpgrade,
@@ -76,10 +77,10 @@ where
 {
     type Handler = ProtocolsHandlerSelect<TProto1::Handler, TProto2::Handler>;
 
-    fn into_handler(self, remote_peer_id: &PeerId) -> Self::Handler {
+    fn into_handler(self, remote_peer_id: &PeerId, connected_point: &ConnectedPoint) -> Self::Handler {
         ProtocolsHandlerSelect {
-            proto1: self.proto1.into_handler(remote_peer_id),
-            proto2: self.proto2.into_handler(remote_peer_id),
+            proto1: self.proto1.into_handler(remote_peer_id, connected_point),
+            proto2: self.proto2.into_handler(remote_peer_id, connected_point),
         }
     }
 

--- a/core/src/swarm/toggle.rs
+++ b/core/src/swarm/toggle.rs
@@ -156,9 +156,9 @@ where
 {
     type Handler = ToggleProtoHandler<TInner::Handler>;
 
-    fn into_handler(self, remote_peer_id: &PeerId) -> Self::Handler {
+    fn into_handler(self, remote_peer_id: &PeerId, connected_point: &ConnectedPoint) -> Self::Handler {
         ToggleProtoHandler {
-            inner: self.inner.map(|h| h.into_handler(remote_peer_id))
+            inner: self.inner.map(|h| h.into_handler(remote_peer_id, connected_point))
         }
     }
 


### PR DESCRIPTION
Fix #1054 

This works by having the `RawSwarm` pass `(TConnInfo, ConnectedPoint)` instead of `TConnInfo` to the lower layers, so that lower layers don't know who we are connected to (as should be the case).

There's one design issue remaining: we create a dummy protocols handler in `Swarm` in order to determine which protocols we support. In this PR, I pass a dummy `ConnectedPoint` when doing so. This is obviously a bad solution that should be fixed by not creating a dummy protocols handler.
