### PR TITLE
Add back simple, optional keep-alive to libp2p-ping.

### DIFF
--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -39,7 +39,7 @@
 //! and begin pinging each other.
 
 use futures::{prelude::*, future};
-use libp2p::{ identity, PeerId, ping::Ping, Swarm };
+use libp2p::{ identity, PeerId, ping::{Ping, PingConfig}, Swarm };
 use std::env;
 
 fn main() {
@@ -54,7 +54,11 @@ fn main() {
     let transport = libp2p::build_development_transport(id_keys);
 
     // Create a ping network behaviour.
-    let behaviour = Ping::default();
+    //
+    // For illustrative purposes, the ping protocol is configured to
+    // keep the connection alive, so a continuous sequence of pings
+    // can be observed.
+    let behaviour = Ping::new(PingConfig::new().with_keep_alive(true));
 
     // Create a Swarm that establishes connections through the given transport
     // and applies the ping behaviour on each connection.

--- a/protocols/ping/tests/ping.rs
+++ b/protocols/ping/tests/ping.rs
@@ -39,11 +39,13 @@ use tokio::runtime::Runtime;
 
 #[test]
 fn ping() {
+    let cfg = PingConfig::new().with_keep_alive(true);
+
     let (peer1_id, trans) = mk_transport();
-    let mut swarm1 = Swarm::new(trans, Ping::default(), peer1_id.clone());
+    let mut swarm1 = Swarm::new(trans, Ping::new(cfg.clone()), peer1_id.clone());
 
     let (peer2_id, trans) = mk_transport();
-    let mut swarm2 = Swarm::new(trans, Ping::default(), peer2_id.clone());
+    let mut swarm2 = Swarm::new(trans, Ping::new(cfg), peer2_id.clone());
 
     let (tx, rx) = sync_channel::<Multiaddr>(1);
 


### PR DESCRIPTION
Admittedly a bit of a back-and-forth, but this is now a very simple option serving multiple purposes:

  * It allows for stable (integration) tests involving a Swarm, which
    are otherwise subject to race conditions due to the connection being
    allowed to terminate at any time with `KeepAlive::No`
    (which remains the default).

  * It makes for a more entertaining ping example which continuously
    sends pings.

  * Maybe someone wants to use the ping protocol for application-layer
    connection keep-alive after all.

See also the discussion in https://github.com/libp2p/rust-libp2p/pull/1086.