### PR TITLE
Fix self-dialing in Kademlia.

### DIFF
--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -350,6 +350,7 @@ impl<TSubstream> Kademlia<TSubstream> {
         );
     }
 
+    /// Processes discovered peers from a query.
     fn discovered<'a, I>(&'a mut self, query_id: &QueryId, source: &PeerId, peers: I)
     where
         I: Iterator<Item=&'a KadPeer> + Clone

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -250,7 +250,7 @@ impl<TSubstream> Kademlia<TSubstream> {
         let parallelism = 3;
 
         Kademlia {
-            kbuckets: KBucketsTable::new(KadHash::from(local_peer_id), Duration::from_secs(60)),   // TODO: constant
+            kbuckets: KBucketsTable::new(local_peer_id.into(), Duration::from_secs(60)),   // TODO: constant
             queued_events: SmallVec::new(),
             active_queries: Default::default(),
             connected_peers: Default::default(),
@@ -348,6 +348,32 @@ impl<TSubstream> Kademlia<TSubstream> {
                 known_closest_peers,
             })
         );
+    }
+
+    fn discovered<'a, I>(&'a mut self, query_id: &QueryId, source: &PeerId, peers: I)
+    where
+        I: Iterator<Item=&'a KadPeer> + Clone
+    {
+        let local_id = self.kbuckets.my_id().peer_id().clone();
+        let others_iter = peers.filter(|p| p.node_id != local_id);
+
+        for peer in others_iter.clone() {
+            self.queued_events.push(NetworkBehaviourAction::GenerateEvent(
+                KademliaOut::Discovered {
+                    peer_id: peer.node_id.clone(),
+                    addresses: peer.multiaddrs.clone(),
+                    ty: peer.connection_ty,
+                }
+            ));
+        }
+
+        if let Some(query) = self.active_queries.get_mut(query_id) {
+            for peer in others_iter.clone() {
+                query.target_mut().untrusted_addresses
+                    .insert(peer.node_id.clone(), peer.multiaddrs.iter().cloned().collect());
+            }
+            query.inject_rpc_result(source, others_iter.cloned().map(|kp| kp.node_id))
+        }
     }
 }
 
@@ -551,22 +577,7 @@ where
                 closer_peers,
                 user_data,
             } => {
-                // It is possible that we obtain a response for a query that has finished, which is
-                // why we may not find an entry in `self.active_queries`.
-                for peer in closer_peers.iter() {
-                    self.queued_events.push(NetworkBehaviourAction::GenerateEvent(KademliaOut::Discovered {
-                        peer_id: peer.node_id.clone(),
-                        addresses: peer.multiaddrs.clone(),
-                        ty: peer.connection_ty,
-                    }));
-                }
-                if let Some(query) = self.active_queries.get_mut(&user_data) {
-                    for peer in closer_peers.iter() {
-                        query.target_mut().untrusted_addresses
-                            .insert(peer.node_id.clone(), peer.multiaddrs.iter().cloned().collect());
-                    }
-                    query.inject_rpc_result(&source, closer_peers.into_iter().map(|kp| kp.node_id))
-                }
+                self.discovered(&user_data, &source, closer_peers.iter());
             }
             KademliaHandlerEvent::GetProvidersReq { key, request_id } => {
                 let closer_peers = self.kbuckets
@@ -599,27 +610,16 @@ where
                 provider_peers,
                 user_data,
             } => {
-                for peer in closer_peers.iter().chain(provider_peers.iter()) {
-                    self.queued_events.push(NetworkBehaviourAction::GenerateEvent(KademliaOut::Discovered {
-                        peer_id: peer.node_id.clone(),
-                        addresses: peer.multiaddrs.clone(),
-                        ty: peer.connection_ty,
-                    }));
-                }
-
-                // It is possible that we obtain a response for a query that has finished, which is
-                // why we may not find an entry in `self.active_queries`.
+                let peers = closer_peers.iter().chain(provider_peers.iter());
+                self.discovered(&user_data, &source, peers);
                 if let Some(query) = self.active_queries.get_mut(&user_data) {
-                    if let QueryInfoInner::GetProviders { pending_results, .. } = &mut query.target_mut().inner {
+                    if let QueryInfoInner::GetProviders {
+                        pending_results, ..
+                    } = &mut query.target_mut().inner {
                         for peer in provider_peers {
                             pending_results.push(peer.node_id);
                         }
                     }
-                    for peer in closer_peers.iter() {
-                        query.target_mut().untrusted_addresses
-                            .insert(peer.node_id.clone(), peer.multiaddrs.iter().cloned().collect());
-                    }
-                    query.inject_rpc_result(&source, closer_peers.into_iter().map(|kp| kp.node_id))
                 }
             }
             KademliaHandlerEvent::QueryError { user_data, .. } => {
@@ -702,7 +702,7 @@ where
                                     peer_id: peer_id.clone(),
                                     event: rpc,
                                 });
-                            } else {
+                            } else if peer_id != self.kbuckets.my_id().peer_id() {
                                 self.pending_rpcs.push((peer_id.clone(), rpc));
                                 return Async::Ready(NetworkBehaviourAction::DialPeer {
                                     peer_id: peer_id.clone(),

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -764,9 +764,11 @@ fn process_kad_response<TUserData>(
                 user_data,
             }
         }
-        KadResponseMsg::FindNode { closer_peers } => KademliaHandlerEvent::FindNodeRes {
-            closer_peers,
-            user_data,
+        KadResponseMsg::FindNode { closer_peers } => {
+            KademliaHandlerEvent::FindNodeRes {
+                closer_peers,
+                user_data,
+            }
         },
         KadResponseMsg::GetProviders {
             closer_peers,


### PR DESCRIPTION
Addresses https://github.com/libp2p/rust-libp2p/issues/341 which is the cause for one of the observations made in https://github.com/libp2p/rust-libp2p/issues/1053. However, the latter is not considered to be fully addressed by these changes and needs further investigation.

Currently, whenever a search for a key yields a response containing the initiating peer as one of the closest peers known to the remote, the local node attempts to dial itself. That attempt is [ignored by the Swarm](https://github.com/libp2p/rust-libp2p/blob/master/core/src/swarm/swarm.rs#L185), but the Kademlia behaviour now believes it still has an RPC ongoing which will eventually time out. That timeout delays successful completion of the query. Hence, any query where a remote responds with the ID of the local node takes at least as long as the `rpc_timeout` (currently 8 seconds) to complete.

This problem is fixed here by ensuring that Kademlia never tries to dial the local node. Furthermore, `Discovered` events are no longer emitted for the local node and it is no longer inserted into the `untrusted_addresses` from discovery, as described in #341.

This commit also includes a change to the condition for freezing / terminating a Kademlia query upon receiving a response. Specifically, the condition is tightened such that it only applies if in addition to `parallelism` consecutive responses that failed to yield a peer closer to the target, the last response must also either not have reported any new peer or the number of collected peers has already reached the number of desired results. In effect, a Kademlia query now tries harder to actually return `k` closest peers, i.e. as long as `k == max_results` have not been reached and new nodes are discovered, they are queried even if the distance to the target seems to increase, since these are still considered to be among the `k` closest nodes to the target. If this change is undesirable, note that the tests can only run in a stable fashion with at most 4 nodes, since the node IDs are randomly distributed and thus it often occurs that the iterative lookups move further away from the target, hitting the `no_closer_in_a_row >= parallelism` condition and resulting in the query returning fewer results than the tests expect (this is how I ran into it while adding more variability to the tests).

The tests have been refactored for less duplication and a few additional expectations added.