### PR TITLE
Filter requesting peer from results.

### DIFF
--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -562,6 +562,7 @@ where
             KademliaHandlerEvent::FindNodeReq { key, request_id } => {
                 let closer_peers = self.kbuckets
                     .find_closest(&KadHash::from(key.clone()))
+                    .filter(|p| p.peer_id() != &source)
                     .take(self.num_results)
                     .map(|kad_hash| build_kad_peer(&kad_hash, &mut self.kbuckets))
                     .collect();
@@ -583,6 +584,7 @@ where
             KademliaHandlerEvent::GetProvidersReq { key, request_id } => {
                 let closer_peers = self.kbuckets
                     .find_closest(&key)
+                    .filter(|p| p.peer_id() != &source)
                     .take(self.num_results)
                     .map(|kad_hash| build_kad_peer(&kad_hash, &mut self.kbuckets))
                     .collect();
@@ -593,6 +595,7 @@ where
                         .get(&key)
                         .into_iter()
                         .flat_map(|peers| peers)
+                        .filter(|p| *p != &source)
                         .map(move |peer_id| build_kad_peer(&KadHash::from(peer_id.clone()), kbuckets))
                         .collect()
                 };


### PR DESCRIPTION
Although not explicitly mentioned in the paper, it seems clear that including an entry for the requesting peer in a `FIND_NODE` response never gives useful information and just occupies a result slot that may have been better filled with another peer that the requestor may not know about.

There is one explicit mention that this is the desired behavior in a somewhat dated design document of another p2p framework [1]:

"The recipient of a FIND_NODE should never return a triple containing the nodeID of the requestor."

The same reasoning supposedly applies to the libp2p-specific `GET_PROVIDERS` request.

I haven't checked whether the js or go implementations do this but am interested to learn whether they do this or not and for what reasons.

[1] http://xlattice.sourceforge.net/components/protocol/kademlia/specs.html#FIND_NODE