### PR TITLE
Kademlia: Optimise iteration over closest keys / entries.

### DIFF
--- a/core/src/swarm/swarm.rs
+++ b/core/src/swarm/swarm.rs
@@ -377,7 +377,7 @@ impl<'a> PollParameters<'a> {
     }
 
     /// Returns the list of the addresses nodes can use to reach us.
-    pub fn external_addresses(&self) -> impl ExactSizeIterator<Item = &Multiaddr> {
+    pub fn external_addresses(&self) -> impl ExactSizeIterator<Item = &Multiaddr> + Clone {
         self.external_addrs.clone()
     }
 

--- a/core/src/swarm/swarm.rs
+++ b/core/src/swarm/swarm.rs
@@ -377,7 +377,7 @@ impl<'a> PollParameters<'a> {
     }
 
     /// Returns the list of the addresses nodes can use to reach us.
-    pub fn external_addresses(&self) -> impl ExactSizeIterator<Item = &Multiaddr> + Clone {
+    pub fn external_addresses(&self) -> impl ExactSizeIterator<Item = &Multiaddr> {
         self.external_addrs.clone()
     }
 

--- a/examples/ipfs-kad.rs
+++ b/examples/ipfs-kad.rs
@@ -44,16 +44,16 @@ fn main() {
         // to insert our local node in the DHT. However here we use `without_init` because this
         // example is very ephemeral and we don't want to pollute the DHT. In a real world
         // application, you want to use `new` instead.
-        let mut behaviour = libp2p::kad::Kademlia::without_init(local_peer_id.clone());
-        behaviour.add_connected_address(&"QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ".parse().unwrap(), "/ip4/104.131.131.82/tcp/4001".parse().unwrap());
-        behaviour.add_connected_address(&"QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM".parse().unwrap(), "/ip4/104.236.179.241/tcp/4001".parse().unwrap());
-        behaviour.add_connected_address(&"QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64".parse().unwrap(), "/ip4/104.236.76.40/tcp/4001".parse().unwrap());
-        behaviour.add_connected_address(&"QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu".parse().unwrap(), "/ip4/128.199.219.111/tcp/4001".parse().unwrap());
-        behaviour.add_connected_address(&"QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd".parse().unwrap(), "/ip4/178.62.158.247/tcp/4001".parse().unwrap());
-        behaviour.add_connected_address(&"QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu".parse().unwrap(), "/ip6/2400:6180:0:d0::151:6001/tcp/4001".parse().unwrap());
-        behaviour.add_connected_address(&"QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM".parse().unwrap(), "/ip6/2604:a880:1:20::203:d001/tcp/4001".parse().unwrap());
-        behaviour.add_connected_address(&"QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64".parse().unwrap(), "/ip6/2604:a880:800:10::4a:5001/tcp/4001".parse().unwrap());
-        behaviour.add_connected_address(&"QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd".parse().unwrap(), "/ip6/2a03:b0c0:0:1010::23:1001/tcp/4001".parse().unwrap());
+        let mut behaviour = libp2p::kad::Kademlia::new(local_peer_id.clone());
+        behaviour.add_address(&"QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ".parse().unwrap(), "/ip4/104.131.131.82/tcp/4001".parse().unwrap());
+        behaviour.add_address(&"QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM".parse().unwrap(), "/ip4/104.236.179.241/tcp/4001".parse().unwrap());
+        behaviour.add_address(&"QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64".parse().unwrap(), "/ip4/104.236.76.40/tcp/4001".parse().unwrap());
+        behaviour.add_address(&"QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu".parse().unwrap(), "/ip4/128.199.219.111/tcp/4001".parse().unwrap());
+        behaviour.add_address(&"QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd".parse().unwrap(), "/ip4/178.62.158.247/tcp/4001".parse().unwrap());
+        behaviour.add_address(&"QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu".parse().unwrap(), "/ip6/2400:6180:0:d0::151:6001/tcp/4001".parse().unwrap());
+        behaviour.add_address(&"QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM".parse().unwrap(), "/ip6/2604:a880:1:20::203:d001/tcp/4001".parse().unwrap());
+        behaviour.add_address(&"QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64".parse().unwrap(), "/ip6/2604:a880:800:10::4a:5001/tcp/4001".parse().unwrap());
+        behaviour.add_address(&"QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd".parse().unwrap(), "/ip6/2a03:b0c0:0:1010::23:1001/tcp/4001".parse().unwrap());
         libp2p::core::Swarm::new(transport, behaviour, local_peer_id)
     };
 

--- a/protocols/kad/src/addresses.rs
+++ b/protocols/kad/src/addresses.rs
@@ -36,9 +36,14 @@ impl Addresses {
         }
     }
 
-    /// Returns the list of addresses.
+    /// Returns an iterator over the list of addresses.
     pub fn iter(&self) -> impl Iterator<Item = &Multiaddr> {
         self.addrs.iter()
+    }
+
+    /// Converts the addresses into a `Vec`.
+    pub fn into_vec(self) -> Vec<Multiaddr> {
+        self.addrs.into_vec()
     }
 
     /// Returns true if the list of addresses is empty.

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -97,7 +97,7 @@ fn query_iter() {
 
         // Connect each swarm in the list to its predecessor in the list.
         for (i, (swarm, peer)) in &mut swarms.iter_mut().skip(1).zip(swarm_ids.clone()).enumerate() {
-            swarm.add_not_connected_address(&peer, Protocol::Memory(port_base + i as u64).into())
+            swarm.add_address(&peer, Protocol::Memory(port_base + i as u64).into())
         }
 
         // Ask the last peer in the list to search a random peer. The search should
@@ -150,7 +150,7 @@ fn unresponsive_not_returned_direct() {
 
     // Add fake addresses.
     for _ in 0 .. 10 {
-        swarms[0].add_not_connected_address(&PeerId::random(), Protocol::Udp(10u16).into());
+        swarms[0].add_address(&PeerId::random(), Protocol::Udp(10u16).into());
     }
 
     // Ask first to search a random value.
@@ -189,14 +189,14 @@ fn unresponsive_not_returned_indirect() {
     // Add fake addresses to first.
     let first_peer_id = Swarm::local_peer_id(&swarms[0]).clone();
     for _ in 0 .. 10 {
-        swarms[0].add_not_connected_address(
+        swarms[0].add_address(
             &PeerId::random(),
             multiaddr![Udp(10u16)]
         );
     }
 
     // Connect second to first.
-    swarms[1].add_not_connected_address(&first_peer_id, Protocol::Memory(port_base).into());
+    swarms[1].add_address(&first_peer_id, Protocol::Memory(port_base).into());
 
     // Ask second to search a random value.
     let search_target = PeerId::random();

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -18,35 +18,61 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! A k-buckets table allows one to store a value identified by keys, ordered by their distance
-//! to a reference key passed to the constructor.
-//!
-//! If the local ID has `N` bits, then the k-buckets table contains `N` *buckets* each containing
-//! a constant number of entries. Storing a key in the k-buckets table adds it to the bucket
-//! corresponding to its distance with the reference key.
+//! Implementation of a Kademlia routing table as used by a single peer
+//! participating in a Kademlia DHT.
 
-use arrayvec::ArrayVec;
+// [Implementation Notes]
+//
+// 1. Routing Table Layout
+//
+// The routing table is currently implemented as a fixed-size "array" of
+// buckets, ordered by increasing distance relative to a local key
+// that identifies the local peer. This is an often-used, simplified
+// implementation that approximates the properties of the b-tree (or prefix tree)
+// implementation described in the full paper [0], whereby buckets are split on-demand.
+// This should be treated as an implementation detail, however, so that the
+// implementation may change in the future without breaking the API.
+//
+// 2. Replacement Cache
+//
+// In this implementation, the "replacement cache" for unresponsive peers
+// consists of a single entry per bucket. Furthermore, this implementation is
+// currently tailored to connection-oriented transports, meaning that the
+// "LRU"-based ordering of entries in a bucket is actually based on the connection
+// status of the corresponding peers, from least-recently connected to
+// most-recently connected, and controlled through the `Entry` API. Entries in
+// the buckets are not reordered as a result of RPC activity, but only as a
+// result of entries being marked as connected or disconnected.
+//
+// [0]: https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf
+
+mod entry;
+
+pub use entry::*;
+
+use arrayvec::{self, ArrayVec};
 use bigint::U256;
 use libp2p_core::PeerId;
 use multihash::Multihash;
 use sha2::{Digest, Sha256, digest::generic_array::{GenericArray, typenum::U32}};
-use std::slice::IterMut as SliceIterMut;
+use std::slice;
 use std::time::{Duration, Instant};
-use std::vec::IntoIter as VecIntoIter;
 
 /// Maximum number of k-buckets.
 const NUM_BUCKETS: usize = 256;
-/// Maximum number of nodes in a bucket, i.e. `k`.
-const MAX_NODES_PER_BUCKET: usize = 20;
 
-/// A table of `KBucket`s, i.e. a Kademlia routing table.
+/// Maximum number of nodes in a bucket, i.e. the (currently fixed) `k` parameter.
+pub const MAX_NODES_PER_BUCKET: usize = 20;
+
+/// A `KBucketsTable` represents a Kademlia routing table.
 #[derive(Debug, Clone)]
 pub struct KBucketsTable<TPeerId, TVal> {
-    /// Peer ID of the local node.
+    /// The key identifying the local peer that owns the routing table.
     local_key: Key<TPeerId>,
-    /// The actual tables that store peers or values.
+    /// The buckets comprising the routing table.
     tables: Vec<KBucket<TPeerId, TVal>>,
-    /// The timeout when trying to reach the youngest node after which we consider it unresponsive.
+    /// The timeout when trying to reach the least-recently connected node after
+    /// which we consider it unresponsive.
     unresponsive_timeout: Duration,
 }
 
@@ -122,18 +148,59 @@ pub struct Distance(bigint::U256);
 /// A `KBucket` is a list of up to `MAX_NODES_PER_BUCKET` `Key`s and associated values,
 /// ordered from least recently used to most recently used.
 #[derive(Debug, Clone)]
-struct KBucket<TPeerId, TVal> {
-    /// Nodes are always ordered from oldest to newest. The nodes we are connected to are always
-    /// all on top (ie. have higher indices) of the nodes we are not connected to.
+pub struct KBucket<TPeerId, TVal> {
+    /// Nodes are always ordered from least-recently connected to most-recently connected.
     nodes: ArrayVec<[Node<TPeerId, TVal>; MAX_NODES_PER_BUCKET]>,
 
-    /// Index in `nodes` over which all nodes are connected. Must always be <= to the length
-    /// of `nodes`.
-    first_connected_pos: usize,
+    /// The position (index) in `nodes` that marks the first entry whose corresponding
+    /// peer is considered connected.
+    ///
+    /// Since the entries in `nodes` are ordered from least-recently connected to
+    /// most-recently connected, all entries above this index are also considered
+    /// connected, i.e. the range `[0, first_connected_pos)` marks entries
+    /// whose nodes are considered disconnected and the range
+    /// `[first_connected_pos, MAX_NODES_PER_BUCKET)` marks entries whose
+    /// nodes are considered connected.
+    ///
+    /// `None` indicates that there are no connected entries in the bucket, i.e.
+    /// the bucket is either empty, or contains only entries for peers that are
+    /// considered disconnected.
+    first_connected_pos: Option<usize>,
 
-    /// Node received when the bucket was full. Will be added to the list if the youngest node
-    /// doesn't respond in time to our reach attempt.
+    /// A node that is pending to be inserted into a full bucket, should the
+    /// least-recently connected (and currently disconnected) node not reconnect.
     pending_node: Option<PendingNode<TPeerId, TVal>>,
+}
+
+impl<TPeerId, TVal> KBucket<TPeerId, TVal> {
+    /// TODO
+    fn apply_pending(&mut self) {
+        if let Some(pending) = self.pending_node.take() {
+            if pending.replace <= Instant::now() {
+                // If there is a pending entry, then there must be at least one
+                // entry marked as disconnected and the bucket must be full.
+                debug_assert!(self.first_connected_pos.map_or(true, |p| p > 0));
+                debug_assert!(self.nodes.len() == MAX_NODES_PER_BUCKET);
+                // Remove the entry of the least-recently connected peer.
+                self.nodes.remove(0);
+                if pending.connected {
+                    self.first_connected_pos = self.first_connected_pos.or(Some(self.nodes.len()));
+                    self.nodes.push(pending.node);
+                }
+                // A disconnected pending node goes at the end of the entries
+                // for the disconnected peers.
+                else if let Some(p) = self.first_connected_pos {
+                    if p > 0 {
+                        self.nodes.insert(p - 1, pending.node);
+                    }
+                } else {
+                    self.nodes.push(pending.node);
+                }
+            } else {
+                self.pending_node = Some(pending)
+            }
+        }
+    }
 }
 
 /// State of the pending node.
@@ -145,7 +212,7 @@ struct PendingNode<TPeerId, TVal> {
     /// If true, we are connected to the pending node.
     connected: bool,
 
-    /// When the pending node will replace an existing node, provided that the youngest node
+    /// When the pending node will replace an existing node, provided that the oldest node
     /// doesn't become responsive before.
     replace: Instant,
 }
@@ -159,6 +226,35 @@ struct Node<TPeerId, TVal> {
     value: TVal,
 }
 
+/// A (safe) index into a `KBucketsTable`, i.e. a non-negative integer in the
+/// range `[0, NUM_BUCKETS)`.
+#[derive(Copy, Clone)]
+struct BucketIndex(usize);
+
+impl BucketIndex {
+    /// Creates a new `BucketIndex` for a `Distance` from the `local_key`.
+    ///
+    /// If the distance is zero, `None` is returned, in recognition of the fact that
+    /// the only key with distance `0` to the `local_key` is the `local_key` itself,
+    /// which does not belong in any bucket.
+    fn of(d: &Distance) -> Option<BucketIndex> { // TODO: new
+        (NUM_BUCKETS - d.0.leading_zeros() as usize)
+            .checked_sub(1)
+            .map(BucketIndex)
+    }
+
+    /// Gets the index value as an unsigned integer.
+    fn get(&self) -> usize {
+        self.0
+    }
+}
+
+impl<TPeerId> AsRef<Key<TPeerId>> for Key<TPeerId> { // Borrow?
+    fn as_ref(&self) -> &Key<TPeerId> {
+        self
+    }
+}
+
 impl<TPeerId, TVal> KBucketsTable<TPeerId, TVal>
 where
     TPeerId: Clone,
@@ -168,13 +264,12 @@ where
     pub fn new(local_key: Key<TPeerId>, unresponsive_timeout: Duration) -> Self {
         KBucketsTable {
             local_key,
-            tables: (0..NUM_BUCKETS)
-                .map(|_| KBucket {
-                    nodes: ArrayVec::new(),
-                    first_connected_pos: 0,
-                    pending_node: None,
-                })
-                .collect(),
+            tables: (0 .. NUM_BUCKETS).map(|_| KBucket {
+                nodes: ArrayVec::new(),
+                first_connected_pos: None,
+                pending_node: None,
+            })
+            .collect(),
             unresponsive_timeout,
         }
     }
@@ -184,80 +279,21 @@ where
         &self.local_key
     }
 
-    /// Returns the id of the bucket that should contain the peer with the given ID.
-    ///
-    /// Returns `None` if out of range, which happens if `id` is the same as the local peer id.
-    fn bucket_num(&self, key: &Key<TPeerId>) -> Option<usize> {
-        (NUM_BUCKETS - self.local_key.distance(key).0.leading_zeros() as usize).checked_sub(1)
+    fn bucket(&self, key: &Key<TPeerId>) -> Option<&KBucket<TPeerId, TVal>> {
+        BucketIndex::of(&self.local_key.distance(key)).map(|i| &self.tables[i.get()])
+    }
+
+    fn bucket_mut(&mut self, key: &Key<TPeerId>) -> Option<&mut KBucket<TPeerId, TVal>> {
+        BucketIndex::of(&self.local_key.distance(key)).map(move |i| &mut self.tables[i.get()])
     }
 
     /// Returns an object containing the state of the given entry.
     pub fn entry<'a>(&'a mut self, peer_id: &'a Key<TPeerId>) -> Entry<'a, TPeerId, TVal> {
-        let bucket_num = if let Some(num) = self.bucket_num(peer_id) {
-            num
-        } else {
-            return Entry::SelfEntry;
-        };
-
-        // Update the pending node state.
-        // TODO: must be reported to the user somehow, in a non-annoying API
-        if let Some(pending) = self.tables[bucket_num].pending_node.take() {
-            if pending.replace < Instant::now() {
-                let table = &mut self.tables[bucket_num];
-                let first_connected_pos = &mut table.first_connected_pos;
-                // If all the nodes in the bucket are connected, then there shouldn't be any
-                // pending node.
-                debug_assert!(*first_connected_pos >= 1);
-                table.nodes.remove(0);
-                if pending.connected {
-                    *first_connected_pos -= 1;
-                    table.nodes.insert(*first_connected_pos, pending.node);
-                } else {
-                    table.nodes.insert(*first_connected_pos - 1, pending.node);
-                }
-            } else {
-                self.tables[bucket_num].pending_node = Some(pending);
-            }
-        }
-
-        // Try to find the node in the bucket.
-        if let Some(pos) = self.tables[bucket_num].nodes.iter().position(|p| p.id == *peer_id) {
-            if pos >= self.tables[bucket_num].first_connected_pos {
-                Entry::InKbucketConnected(EntryInKbucketConn {
-                    parent: self,
-                    peer_id,
-                })
-
-            } else {
-                Entry::InKbucketDisconnected(EntryInKbucketDisc {
-                    parent: self,
-                    peer_id,
-                })
-            }
-
-        } else if self.tables[bucket_num].pending_node.as_ref().map(|p| p.node.id == *peer_id).unwrap_or(false) {
-            // Node is pending.
-            if self.tables[bucket_num].pending_node.as_ref().map(|p| p.connected).unwrap_or(false) {
-                Entry::InKbucketConnectedPending(EntryInKbucketConnPending {
-                    parent: self,
-                    peer_id,
-                })
-            } else {
-                Entry::InKbucketDisconnectedPending(EntryInKbucketDiscPending {
-                    parent: self,
-                    peer_id,
-                })
-            }
-
-        } else {
-            Entry::NotInKbucket(EntryNotInKbucket {
-                parent: self,
-                peer_id,
-            })
-        }
+        Entry::new(self, peer_id)
     }
 
-    /// Returns an iterator to all the peer IDs in the bucket, without the pending nodes.
+    /// Returns an iterator over all the entries in the bucket, excluding those that
+    /// are pending.
     pub fn entries_not_pending(&self) -> impl Iterator<Item = (&Key<TPeerId>, &TVal)> {
         self.tables
             .iter()
@@ -265,432 +301,205 @@ where
             .map(|node| (&node.id, &node.value))
     }
 
-    /// Returns an iterator to all the buckets of this table.
+    /// Returns an iterator over all buckets.
     ///
-    /// Ordered by proximity to the local node. Closest bucket (with max. one node in it) comes
-    /// first.
-    pub fn buckets(&mut self) -> BucketsIter<'_, TPeerId, TVal> {
-        BucketsIter(self.tables.iter_mut(), self.unresponsive_timeout)
+    /// The buckets are ordered by proximity to the `local_key`, i.e. the first
+    /// bucket is the closest bucket (containing at most one key).
+    pub fn buckets(&mut self) -> KBucketsIter<'_, TPeerId, TVal> {
+        KBucketsIter(self.tables.iter_mut(), self.unresponsive_timeout)
     }
 
-    /// Finds the keys closest to `key`, ordered by distance.
-    ///
-    /// Pending nodes are ignored.
-    pub fn find_closest<T>(&mut self, key: &Key<T>) -> VecIntoIter<Key<TPeerId>> {
-        // TODO: optimize
-        let mut out = Vec::new();
-        for table in self.tables.iter_mut() {
-            for node in table.nodes.iter() {
-                out.push(node.id.clone());
-            }
-
-            // TODO: this code that handles the pending_node should normally be shared with
-            //       the one in `entry()`; however right now there's no mechanism to notify the
-            //       user when a pending node has been inserted in the table, and thus we need to
-            //       rework this pending node handling code anyway; when that is being done, we
-            //       should rewrite this code properly
-            if let Some(ref pending) = table.pending_node {
-                if pending.replace <= Instant::now() && pending.connected {
-                    out.pop();
-                    out.push(pending.node.id.clone());
-                }
+    /// Creates an iterator over the keys closest to `target`, ordered by
+    /// increasing distance.
+    pub fn closest_keys<'a, T>(&'a mut self, target: &'a Key<T>)
+        -> impl Iterator<Item = Key<TPeerId>> + 'a
+    where
+        T: Clone
+    {
+        let distance = self.local_key.distance(target);
+        let buckets_iter = ClosestBucketsIter::new(distance);
+        ClosestIter {
+            target,
+            iter: None,
+            buckets: &mut self.tables,
+            buckets_iter,
+            fmap: |b: &KBucket<_, _>| -> ArrayVec<_> {
+                b.nodes.iter().map(|n| n.id.clone()).collect()
             }
         }
-        out.sort_by(|a, b| key.distance(a).cmp(&key.distance(b)));
-        out.into_iter()
     }
-}
 
-/// Represents an entry or a potential entry in the k-buckets.
-pub enum Entry<'a, TPeerId, TVal> {
-    /// Entry in a k-bucket that we're connected to.
-    InKbucketConnected(EntryInKbucketConn<'a, TPeerId, TVal>),
-    /// Entry pending waiting for a free slot to enter a k-bucket. We're connected to it.
-    InKbucketConnectedPending(EntryInKbucketConnPending<'a, TPeerId, TVal>),
-    /// Entry in a k-bucket but that we're not connected to.
-    InKbucketDisconnected(EntryInKbucketDisc<'a, TPeerId, TVal>),
-    /// Entry pending waiting for a free slot to enter a k-bucket. We're not connected to it.
-    InKbucketDisconnectedPending(EntryInKbucketDiscPending<'a, TPeerId, TVal>),
-    /// Entry is not present in any k-bucket.
-    NotInKbucket(EntryNotInKbucket<'a, TPeerId, TVal>),
-    /// Entry is the local peer ID.
-    SelfEntry,
-}
-
-impl<'a, TPeerId, TVal> Entry<'a, TPeerId, TVal>
-where
-    TPeerId: Clone,
-{
-    /// Returns the value associated to the entry in the bucket, including if the node is pending.
-    pub fn value(&mut self) -> Option<&mut TVal> {
-        match self {
-            Entry::InKbucketConnected(entry) => Some(entry.value()),
-            Entry::InKbucketConnectedPending(entry) => Some(entry.value()),
-            Entry::InKbucketDisconnected(entry) => Some(entry.value()),
-            Entry::InKbucketDisconnectedPending(entry) => Some(entry.value()),
-            Entry::NotInKbucket(_entry) => None,
-            Entry::SelfEntry => None,
+    /// Creates an iterator over the entries closest to `target`, ordered by
+    /// increasing distance.
+    pub fn closest<'a, T>(&'a mut self, target: &'a Key<T>)
+        -> impl Iterator<Item = EntryView<TPeerId, TVal>> + 'a
+    where
+        T: Clone,
+        TVal: Clone
+    {
+        let distance = self.local_key.distance(target);
+        let buckets_iter = ClosestBucketsIter::new(distance);
+        ClosestIter {
+            target,
+            iter: None,
+            buckets: &mut self.tables,
+            buckets_iter,
+            fmap: |b: &KBucket<_, TVal>| -> ArrayVec<_> {
+                b.nodes.iter().enumerate().map(|(i, n)| EntryView {
+                    key: n.id.clone(),
+                    value: n.value.clone(),
+                    connected: b.first_connected_pos.map_or(false, |j| i >= j)
+                }).collect()
+            }
         }
     }
 
-    /// Returns the value associated to the entry in the bucket.
-    pub fn value_not_pending(&mut self) -> Option<&mut TVal> {
-        match self {
-            Entry::InKbucketConnected(entry) => Some(entry.value()),
-            Entry::InKbucketConnectedPending(_entry) => None,
-            Entry::InKbucketDisconnected(entry) => Some(entry.value()),
-            Entry::InKbucketDisconnectedPending(_entry) => None,
-            Entry::NotInKbucket(_entry) => None,
-            Entry::SelfEntry => None,
-        }
-    }
 }
 
-/// Represents an entry in a k-bucket.
-pub struct EntryInKbucketConn<'a, TPeerId, TVal> {
-    parent: &'a mut KBucketsTable<TPeerId, TVal>,
-    peer_id: &'a Key<TPeerId>,
+/// TODO
+pub struct ClosestIter<'a, TTarget, TPeerId, TVal, TMap, TOut> {
+    target: &'a Key<TTarget>,
+    buckets: &'a mut Vec<KBucket<TPeerId, TVal>>,
+    buckets_iter: ClosestBucketsIter,
+    iter: Option<arrayvec::IntoIter<[TOut; MAX_NODES_PER_BUCKET]>>,
+    fmap: TMap
 }
 
-impl<'a, TPeerId, TVal> EntryInKbucketConn<'a, TPeerId, TVal>
-where
-    TPeerId: Clone,
-{
-    /// Returns the value associated to the entry in the bucket.
-    pub fn value(&mut self) -> &mut TVal {
-        let table = {
-            let num = self.parent.bucket_num(&self.peer_id)
-                .expect("we can only build a EntryInKbucketConn if we know of a bucket; QED");
-            &mut self.parent.tables[num]
-        };
+/// An iterator over all keys in a bucket, sorted by distance to a target key.
+type ClosestKeysIter<T> = arrayvec::IntoIter<[Key<T>; MAX_NODES_PER_BUCKET]>;
 
-        let peer_id = self.peer_id;
-        &mut table.nodes.iter_mut()
-            .find(move |p| p.id == *peer_id)
-            .expect("We can only build a EntryInKbucketConn if we know that the peer is in its \
-                     bucket; QED")
-            .value
+/// An iterator over the bucket indices, in the order determined the `Distance` of
+/// a target from the `local_key`, such that the nodes in the buckets are incrementally
+/// further away from the target, starting with the bucket covering the target.
+struct ClosestBucketsIter {
+    /// The distance to the `local_key`.
+    distance: Distance,
+    /// The current state of the iterator.
+    state: ClosestBucketsIterState
+}
+
+/// Operating states of a `ClosestBucketsIter`.
+enum ClosestBucketsIterState {
+    Start(BucketIndex),
+    /// Beginning with the bucket into which the `target` key falls, the
+    /// iterator "zooms in" to buckets cotaining nodes that are incrementally
+    /// closer to the local node but further from the `target`. These are
+    /// identified by a `1` in the corresponding bit position of the distance
+    /// bit string. When bucket `0` is reached, the iterator transitions to
+    /// state `ZoomOut`.
+    ZoomIn(BucketIndex),
+    /// Once bucket `0` has been reached, the iterator starts "zooming out"
+    /// to buckets containing nodes that are incrementally further away from
+    /// both the local node and the target. These are identified by a `0` in
+    /// the corresponding bit position of the distance bit string. When bucket
+    /// `255` is reached, the iterator transitions to state `Done`.
+    ZoomOut(BucketIndex),
+    /// The iterator is in this state once it has visited all buckets.
+    Done
+}
+
+impl ClosestBucketsIter {
+    fn new(distance: Distance) -> Self {
+        let state = match BucketIndex::of(&distance) {
+            Some(i) => ClosestBucketsIterState::Start(i),
+            None => ClosestBucketsIterState::Done
+        };
+        Self { distance, state }
     }
 
-    /// Reports that we are now disconnected from the given node.
-    ///
-    /// This moves the node down in its bucket. There are two possible outcomes:
-    ///
-    /// - Either we had a pending node which replaces the current node. `Replaced` is returned.
-    /// - Or we had no pending node, and the current node is kept. `Kept` is returned.
-    ///
-    pub fn set_disconnected(self) -> SetDisconnectedOutcome<'a, TPeerId, TVal> {
-        let table = {
-            let num = self.parent.bucket_num(&self.peer_id)
-                .expect("we can only build a EntryInKbucketConn if we know of a bucket; QED");
-            &mut self.parent.tables[num]
-        };
-
-        let peer_id = self.peer_id;
-        let pos = table.nodes.iter().position(move |elem| elem.id == *peer_id)
-            .expect("we can only build a EntryInKbucketConn if the node is in its bucket; QED");
-        debug_assert!(table.first_connected_pos <= pos);
-
-        // We replace it with the pending node, if any.
-        if let Some(pending) = table.pending_node.take() {
-            if pending.connected {
-                let removed = table.nodes.remove(pos);
-                let ret = SetDisconnectedOutcome::Replaced {
-                    replacement: pending.node.id.clone(),
-                    old_val: removed.value,
-                };
-                table.nodes.insert(table.first_connected_pos, pending.node);
-                return ret;
+    fn next_in(&self, i: BucketIndex) -> Option<BucketIndex> {
+        (0 .. i.get()).rev().find_map(|i|
+            if self.distance.0.bit(i) {
+                Some(BucketIndex(i))
             } else {
-                table.pending_node = Some(pending);
-            }
-        }
-
-        // Move the node in the bucket.
-        if pos != table.first_connected_pos {
-            let elem = table.nodes.remove(pos);
-            table.nodes.insert(table.first_connected_pos, elem);
-        }
-        table.first_connected_pos += 1;
-
-        // And return a EntryInKbucketDisc.
-        debug_assert!(table.nodes.iter()
-            .position(move |e| e.id == *peer_id)
-            .map(|p| p < table.first_connected_pos)
-            .unwrap_or(false));
-
-        SetDisconnectedOutcome::Kept(EntryInKbucketDisc {
-            parent: self.parent,
-            peer_id: self.peer_id,
-        })
-    }
-}
-
-/// Outcome of calling `set_disconnected`.
-#[must_use]
-pub enum SetDisconnectedOutcome<'a, TPeerId, TVal> {
-    /// Node is kept in the bucket.
-    Kept(EntryInKbucketDisc<'a, TPeerId, TVal>),
-    /// Node is pushed out of the bucket.
-    Replaced {
-        /// Node that replaced the node.
-        // TODO: could be a EntryInKbucketConn, but we have borrow issues with the new peer id
-        replacement: Key<TPeerId>,
-        /// Value os the node that has been pushed out.
-        old_val: TVal,
-    },
-}
-
-/// Represents an entry waiting for a slot to be available in its k-bucket.
-pub struct EntryInKbucketConnPending<'a, TPeerId, TVal> {
-    parent: &'a mut KBucketsTable<TPeerId, TVal>,
-    peer_id: &'a Key<TPeerId>,
-}
-
-impl<'a, TPeerId, TVal> EntryInKbucketConnPending<'a, TPeerId, TVal>
-where
-    TPeerId: Clone,
-{
-    /// Returns the value associated to the entry in the bucket.
-    pub fn value(&mut self) -> &mut TVal {
-        let table = {
-            let num = self.parent.bucket_num(&self.peer_id)
-                .expect("we can only build a EntryInKbucketConnPending if we know of a bucket; QED");
-            &mut self.parent.tables[num]
-        };
-
-        assert!(table.pending_node.as_ref().map(|n| &n.node.id) == Some(self.peer_id));
-        &mut table.pending_node
-            .as_mut()
-            .expect("we can only build a EntryInKbucketConnPending if the node is pending; QED")
-            .node.value
+                None
+            })
     }
 
-    /// Reports that we are now disconnected from the given node.
-    pub fn set_disconnected(self) -> EntryInKbucketDiscPending<'a, TPeerId, TVal> {
-        {
-            let table = {
-                let num = self.parent.bucket_num(&self.peer_id)
-                    .expect("we can only build a EntryInKbucketConnPending if we know of a bucket; QED");
-                &mut self.parent.tables[num]
-            };
-
-            let mut pending = table.pending_node.as_mut()
-                .expect("we can only build a EntryInKbucketConnPending if there's a pending node; QED");
-            debug_assert!(pending.connected);
-            pending.connected = false;
-        }
-
-        EntryInKbucketDiscPending {
-            parent: self.parent,
-            peer_id: self.peer_id,
-        }
-    }
-}
-
-/// Represents an entry waiting for a slot to be available in its k-bucket.
-pub struct EntryInKbucketDiscPending<'a, TPeerId, TVal> {
-    parent: &'a mut KBucketsTable<TPeerId, TVal>,
-    peer_id: &'a Key<TPeerId>,
-}
-
-impl<'a, TPeerId, TVal> EntryInKbucketDiscPending<'a, TPeerId, TVal>
-where
-    TPeerId: Clone,
-{
-    /// Returns the value associated to the entry in the bucket.
-    pub fn value(&mut self) -> &mut TVal {
-        let table = {
-            let num = self.parent.bucket_num(&self.peer_id)
-                .expect("we can only build a EntryInKbucketDiscPending if we know of a bucket; QED");
-            &mut self.parent.tables[num]
-        };
-
-        assert!(table.pending_node.as_ref().map(|n| &n.node.id) == Some(self.peer_id));
-        &mut table.pending_node
-            .as_mut()
-            .expect("we can only build a EntryInKbucketDiscPending if the node is pending; QED")
-            .node.value
-    }
-
-    /// Reports that we are now connected to the given node.
-    pub fn set_connected(self) -> EntryInKbucketConnPending<'a, TPeerId, TVal> {
-        {
-            let table = {
-                let num = self.parent.bucket_num(&self.peer_id)
-                    .expect("we can only build a EntryInKbucketDiscPending if we know of a bucket; QED");
-                &mut self.parent.tables[num]
-            };
-
-            let mut pending = table.pending_node.as_mut()
-                .expect("we can only build a EntryInKbucketDiscPending if there's a pending node; QED");
-            debug_assert!(!pending.connected);
-            pending.connected = true;
-        }
-
-        EntryInKbucketConnPending {
-            parent: self.parent,
-            peer_id: self.peer_id,
-        }
-    }
-}
-
-/// Represents an entry in a k-bucket.
-pub struct EntryInKbucketDisc<'a, TPeerId, TVal> {
-    parent: &'a mut KBucketsTable<TPeerId, TVal>,
-    peer_id: &'a Key<TPeerId>,
-}
-
-impl<'a, TPeerId, TVal> EntryInKbucketDisc<'a, TPeerId, TVal>
-where
-    TPeerId: Clone,
-{
-    /// Returns the value associated to the entry in the bucket.
-    pub fn value(&mut self) -> &mut TVal {
-        let table = {
-            let num = self.parent.bucket_num(&self.peer_id)
-                .expect("we can only build a EntryInKbucketDisc if we know of a bucket; QED");
-            &mut self.parent.tables[num]
-        };
-
-        let peer_id = self.peer_id;
-        &mut table.nodes.iter_mut()
-            .find(move |p| p.id == *peer_id)
-            .expect("We can only build a EntryInKbucketDisc if we know that the peer is in its \
-                     bucket; QED")
-            .value
-    }
-
-    /// Sets the node as connected. This moves the entry in the bucket.
-    pub fn set_connected(self) -> EntryInKbucketConn<'a, TPeerId, TVal> {
-        let table = {
-            let num = self.parent.bucket_num(&self.peer_id)
-                .expect("we can only build a EntryInKbucketDisc if we know of a bucket; QED");
-            &mut self.parent.tables[num]
-        };
-
-        let pos = {
-            let peer_id = self.peer_id;
-            table.nodes.iter().position(move |p| p.id == *peer_id)
-                .expect("We can only build a EntryInKbucketDisc if we know that the peer is in \
-                         its bucket; QED")
-        };
-
-        // If we are the youngest node, we are now connected, which means that we have to drop the
-        // pending node.
-        // Note that it is theoretically possible that the replacement should have occurred between
-        // the moment when we build the `EntryInKbucketConn` and the moment when we call
-        // `set_connected`, but we don't take that into account.
-        if pos == 0 {
-            table.pending_node = None;
-        }
-
-        debug_assert!(pos < table.first_connected_pos);
-        table.first_connected_pos -= 1;
-        if pos != table.first_connected_pos {
-            let entry = table.nodes.remove(pos);
-            table.nodes.insert(table.first_connected_pos, entry);
-        }
-
-        // There shouldn't be a pending node if all slots are full of connected nodes.
-        debug_assert!(!(table.first_connected_pos == 0 && table.pending_node.is_some()));
-
-        EntryInKbucketConn {
-            parent: self.parent,
-            peer_id: self.peer_id,
-        }
-    }
-}
-
-/// Represents an entry not in any k-bucket.
-pub struct EntryNotInKbucket<'a, TPeerId, TVal> {
-    parent: &'a mut KBucketsTable<TPeerId, TVal>,
-    peer_id: &'a Key<TPeerId>,
-}
-
-impl<'a, TPeerId, TVal> EntryNotInKbucket<'a, TPeerId, TVal>
-where
-    TPeerId: Clone,
-{
-    /// Inserts the node as connected, if possible.
-    pub fn insert_connected(self, value: TVal) -> InsertOutcome<TPeerId> {
-        let table = {
-            let num = self.parent.bucket_num(&self.peer_id)
-                .expect("we can only build a EntryNotInKbucket if we know of a bucket; QED");
-            &mut self.parent.tables[num]
-        };
-
-        if table.nodes.is_full() {
-            if table.first_connected_pos == 0 || table.pending_node.is_some() {
-                InsertOutcome::Full
+    fn next_out(&self, i: BucketIndex) -> Option<BucketIndex> {
+        (i.get() + 1 .. NUM_BUCKETS).find_map(|i|
+            if !self.distance.0.bit(i) {
+                Some(BucketIndex(i))
             } else {
-                table.pending_node = Some(PendingNode {
-                    node: Node { id: self.peer_id.clone(), value },
-                    replace: Instant::now() + self.parent.unresponsive_timeout,
-                    connected: true,
-                });
-                InsertOutcome::Pending {
-                    to_ping: table.nodes[0].id.clone()
-                }
-            }
-        } else {
-            table.nodes.insert(table.first_connected_pos, Node {
-                id: self.peer_id.clone(),
-                value,
-            });
-            InsertOutcome::Inserted
-        }
-    }
-
-    /// Inserts the node as disconnected, if possible.
-    ///
-    /// > **Note**: This function will never return `Pending`. If the bucket is full, we simply
-    /// >           do nothing.
-    pub fn insert_disconnected(self, value: TVal) -> InsertOutcome<TPeerId> {
-        let table = {
-            let num = self.parent.bucket_num(&self.peer_id)
-                .expect("we can only build a EntryNotInKbucket if we know of a bucket; QED");
-            &mut self.parent.tables[num]
-        };
-
-        if table.nodes.is_full() {
-            InsertOutcome::Full
-        } else {
-            table.nodes.insert(table.first_connected_pos, Node {
-                id: self.peer_id.clone(),
-                value,
-            });
-            table.first_connected_pos += 1;
-            InsertOutcome::Inserted
-        }
+                None
+            })
     }
 }
 
-/// Outcome of calling `insert`.
-#[must_use]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum InsertOutcome<TPeerId> {
-    /// The entry has been successfully inserted.
-    Inserted,
-    /// The entry has been inserted as a pending node.
-    Pending {
-        /// We have to try connect to the returned node.
-        to_ping: Key<TPeerId>,
-    },
-    /// The entry was not inserted because the bucket was full of connected nodes.
-    Full,
-}
-
-/// Iterator giving access to a bucket.
-pub struct BucketsIter<'a, TPeerId, TVal>(SliceIterMut<'a, KBucket<TPeerId, TVal>>, Duration);
-
-impl<'a, TPeerId, TVal> Iterator for BucketsIter<'a, TPeerId, TVal> {
-    type Item = Bucket<'a, TPeerId, TVal>;
+impl Iterator for ClosestBucketsIter {
+    type Item = BucketIndex;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|bucket| {
-            Bucket(bucket)
-        })
+        match self.state {
+            ClosestBucketsIterState::Start(i) => {
+                self.state = ClosestBucketsIterState::ZoomIn(i);
+                Some(i)
+            }
+            ClosestBucketsIterState::ZoomIn(i) =>
+                if let Some(i) = self.next_in(i) {
+                    self.state = ClosestBucketsIterState::ZoomIn(i);
+                    Some(i)
+                } else {
+                    let i = BucketIndex(0);
+                    self.state = ClosestBucketsIterState::ZoomOut(i);
+                    Some(i)
+                }
+            ClosestBucketsIterState::ZoomOut(i) =>
+                if let Some(i) = self.next_out(i) {
+                    self.state = ClosestBucketsIterState::ZoomOut(i);
+                    Some(i)
+                } else {
+                    self.state = ClosestBucketsIterState::Done;
+                    None
+                }
+            ClosestBucketsIterState::Done => None
+        }
+    }
+}
+
+impl<TTarget, TPeerId, TVal, TMap, TOut> Iterator
+for ClosestIter<'_, TTarget, TPeerId, TVal, TMap, TOut>
+where
+    TPeerId: Clone,
+    TMap: Fn(&KBucket<TPeerId, TVal>) -> ArrayVec<[TOut; MAX_NODES_PER_BUCKET]>,
+    TOut: AsRef<Key<TPeerId>>
+{
+    type Item = TOut;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match &mut self.iter {
+                Some(iter) => match iter.next() {
+                    Some(k) => return Some(k),
+                    None => self.iter = None
+                }
+                None => {
+                    if let Some(i) = self.buckets_iter.next() {
+                        let bucket = &mut self.buckets[i.get()];
+                        bucket.apply_pending();
+                        let mut v = (self.fmap)(bucket);
+                        v.sort_by(|a, b|
+                            self.target.distance(a.as_ref())
+                                .cmp(&self.target.distance(b.as_ref())));
+                        self.iter = Some(v.into_iter());
+                    } else {
+                        return None
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// By-reference iterator over `KBucket`s in the order of their increasing distance
+/// to the local key.
+pub struct KBucketsIter<'a, TPeerId, TVal>(slice::IterMut<'a, KBucket<TPeerId, TVal>>, Duration);
+
+impl<'a, TPeerId, TVal> Iterator for KBucketsIter<'a, TPeerId, TVal> {
+    type Item = KBucketRef<'a, TPeerId, TVal>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(KBucketRef)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -698,12 +507,12 @@ impl<'a, TPeerId, TVal> Iterator for BucketsIter<'a, TPeerId, TVal> {
     }
 }
 
-impl<'a, TPeerId, TVal> ExactSizeIterator for BucketsIter<'a, TPeerId, TVal> {}
+impl<'a, TPeerId, TVal> ExactSizeIterator for KBucketsIter<'a, TPeerId, TVal> {}
 
-/// Access to a bucket.
-pub struct Bucket<'a, TPeerId, TVal>(&'a mut KBucket<TPeerId, TVal>);
+/// A reference to a `KBucket`.
+pub struct KBucketRef<'a, TPeerId, TVal>(&'a mut KBucket<TPeerId, TVal>);
 
-impl<'a, TPeerId, TVal> Bucket<'a, TPeerId, TVal> {
+impl<'a, TPeerId, TVal> KBucketRef<'a, TPeerId, TVal> {
     /// Returns the number of entries in that bucket.
     ///
     /// > **Note**: Keep in mind that this operation can be racy. If `update()` is called on the
@@ -796,7 +605,7 @@ mod tests {
             panic!()
         }
 
-        let res = table.find_closest(&other_id).collect::<Vec<_>>();
+        let res = table.closest_keys(&other_id).collect::<Vec<_>>();
         assert_eq!(res.len(), 1);
         assert_eq!(res[0], other_id);
     }
@@ -836,6 +645,10 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
+        fn last_bucket(table: &mut KBucketsTable<PeerId, ()>) -> &mut KBucket<PeerId, ()> {
+            &mut table.tables[255]
+        }
+
         let first_node = fill_ids[0].clone();
         let second_node = fill_ids[1].clone();
 
@@ -849,19 +662,16 @@ mod tests {
             } else {
                 panic!()
             }
-            assert_eq!(table.buckets().nth(255).unwrap().num_entries(), num + 1);
+            assert_eq!(last_bucket(&mut table).nodes.len(), num + 1);
         }
-        assert_eq!(
-            table.buckets().nth(255).unwrap().num_entries(),
-            MAX_NODES_PER_BUCKET
-        );
-        assert!(!table.buckets().nth(255).unwrap().has_pending());
+        assert_eq!(last_bucket(&mut table).nodes.len(), MAX_NODES_PER_BUCKET);
+        assert!(last_bucket(&mut table).pending_node.is_none());
 
         // Step 2: Insert another key on the full bucket. It must be marked as
         // pending and the first (i.e. "least recently used") entry scheduled
         // for replacement.
-
-        if let Entry::NotInKbucket(entry) = table.entry(&fill_ids.remove(0)) {
+        let replacement = fill_ids.remove(0);
+        if let Entry::NotInKbucket(entry) = table.entry(&replacement) {
             match entry.insert_connected(()) {
                 InsertOutcome::Pending { ref to_ping } if *to_ping == first_node => (),
                 _ => panic!()
@@ -869,11 +679,9 @@ mod tests {
         } else {
             panic!()
         }
-        assert_eq!(
-            table.buckets().nth(255).unwrap().num_entries(),
-            MAX_NODES_PER_BUCKET
-        );
-        assert!(table.buckets().nth(255).unwrap().has_pending());
+        let pending = last_bucket(&mut table).pending_node.as_ref().map(|n| &n.node.id);
+        assert_eq!(pending, Some(&replacement));
+        assert_eq!(last_bucket(&mut table).nodes.len(), MAX_NODES_PER_BUCKET);
         // Trying to insert yet another key is rejected.
         if let Entry::NotInKbucket(entry) = table.entry(&Key::from(fill_ids.remove(0))) {
             match entry.insert_connected(()) {
@@ -886,18 +694,57 @@ mod tests {
 
         // Step 3: Make the pending nodes eligible for replacing existing nodes.
         // The pending node must be consumed and replace the first (i.e. "least
-        // recently used") node.
-
+        // recently connected") node.
         let elapsed = Instant::now() - Duration::from_secs(1);
-        table.tables[255].pending_node.as_mut().map(|n| n.replace = elapsed);
-        assert!(!table.buckets().nth(255).unwrap().has_pending());
-        if let Entry::NotInKbucket(entry) = table.entry(&fill_ids.remove(0)) {
+        last_bucket(&mut table).pending_node.as_mut().map(|n| n.replace = elapsed);
+        let replacement2 = fill_ids.remove(0);
+        if let Entry::NotInKbucket(entry) = table.entry(&replacement2) {
             match entry.insert_connected(()) {
                 InsertOutcome::Pending { ref to_ping } if *to_ping == second_node => (),
-                _ => panic!()
+                e => panic!("{:?}", e)
             }
         } else {
             panic!()
+        }
+
+        // The replacement must now be in the bucket and considered connected.
+        match table.entry(&replacement) {
+            Entry::InKbucketConnected(_) => {},
+            _ => panic!()
+        }
+        let pending = last_bucket(&mut table).pending_node.as_ref().map(|n| &n.node.id);
+        assert_eq!(pending, Some(&replacement2));
+    }
+
+    #[test]
+    fn closest() {
+        let local_key = Key::from(PeerId::random());
+        let mut table = KBucketsTable::<_, ()>::new(local_key, Duration::from_secs(5));
+        let mut count = 0;
+        loop {
+            if count == 100 { break; }
+            let key = Key::from(PeerId::random());
+            if let Entry::NotInKbucket(e) = table.entry(&key) {
+                match e.insert_connected(()) {
+                    InsertOutcome::Inserted => count += 1,
+                    _ => continue,
+                }
+            } else {
+                panic!("entry exists")
+            }
+        }
+
+        let mut expected_keys: Vec<_> = table.tables
+            .iter()
+            .flat_map(|t| t.nodes.iter().map(|n| n.id.clone()))
+            .collect();
+
+        for _ in 0 .. 10 {
+            let target_key = Key::from(PeerId::random());
+            let keys = table.closest_keys(&target_key).collect::<Vec<_>>();
+            // The list of keys is expected to match the result of a full-table scan.
+            expected_keys.sort_by_key(|k| k.distance(&target_key));
+            assert_eq!(keys, expected_keys);
         }
     }
 }

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -20,6 +20,24 @@
 
 //! Implementation of a Kademlia routing table as used by a single peer
 //! participating in a Kademlia DHT.
+//!
+//! The entry point for the API of this module is a [`KBucketsTable`].
+//!
+//! ## Pending Insertions
+//!
+//! When the bucket associated with the `Key` of an inserted entry is full
+//! but contains disconnected nodes, it accepts a [`PendingEntry`].
+//! Pending entries are inserted lazily when their timeout is found to be expired
+//! upon querying the `KBucketsTable`. When that happens, the `KBucketsTable` records
+//! an [`AppliedPending`] result which must be consumed by calling [`take_applied_pending`]
+//! regularly and / or after performing lookup operations like [`entry`] and [`closest`].
+//!
+//! [`entry`]: kbucket::KBucketsTable::entry
+//! [`closest`]: kbucket::KBucketsTable::closest
+//! [`AppliedPending`]: kbucket::AppliedPending
+//! [`KBucketsTable`]: kbucket::KBucketsTable
+//! [`take_applied_pending`]: kbucket::KBucketsTable::take_applied_pending
+//! [`PendingEntry`]: kbucket::PendingEntry
 
 // [Implementation Notes]
 //
@@ -38,31 +56,30 @@
 // In this implementation, the "replacement cache" for unresponsive peers
 // consists of a single entry per bucket. Furthermore, this implementation is
 // currently tailored to connection-oriented transports, meaning that the
-// "LRU"-based ordering of entries in a bucket is actually based on the connection
-// status of the corresponding peers, from least-recently connected to
-// most-recently connected, and controlled through the `Entry` API. Entries in
-// the buckets are not reordered as a result of RPC activity, but only as a
-// result of entries being marked as connected or disconnected.
+// "LRU"-based ordering of entries in a bucket is actually based on the last reported
+// connection status of the corresponding peers, from least-recently (dis)connected to
+// most-recently (dis)connected, and controlled through the `Entry` API. As a result,
+// the nodes in the buckets are not reordered as a result of RPC activity, but only as a
+// result of nodes being marked as connected or disconnected. In particular,
+// if a bucket is full and contains only entries for peers that are considered
+// connected, no pending entry is accepted. See the `bucket` submodule for
+// further details.
 //
 // [0]: https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf
 
+mod bucket;
 mod entry;
+mod key;
 
 pub use entry::*;
 
 use arrayvec::{self, ArrayVec};
-use bigint::U256;
-use libp2p_core::PeerId;
-use multihash::Multihash;
-use sha2::{Digest, Sha256, digest::generic_array::{GenericArray, typenum::U32}};
-use std::slice;
+use bucket::KBucket;
+use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
 /// Maximum number of k-buckets.
 const NUM_BUCKETS: usize = 256;
-
-/// Maximum number of nodes in a bucket, i.e. the (currently fixed) `k` parameter.
-pub const MAX_NODES_PER_BUCKET: usize = 20;
 
 /// A `KBucketsTable` represents a Kademlia routing table.
 #[derive(Debug, Clone)]
@@ -70,174 +87,26 @@ pub struct KBucketsTable<TPeerId, TVal> {
     /// The key identifying the local peer that owns the routing table.
     local_key: Key<TPeerId>,
     /// The buckets comprising the routing table.
-    tables: Vec<KBucket<TPeerId, TVal>>,
-    /// The timeout when trying to reach the least-recently connected node after
-    /// which we consider it unresponsive.
-    unresponsive_timeout: Duration,
+    buckets: Vec<KBucket<TPeerId, TVal>>,
+    /// The list of evicted entries that have been replaced with pending
+    /// entries since the last call to [`KBucketsTable::take_applied_pending`].
+    applied_pending: VecDeque<AppliedPending<TPeerId, TVal>>
 }
 
-/// A `Key` is a cryptographic hash, stored with an associated value in a `KBucket`
-/// of a `KBucketsTable`.
-///
-/// `Key`s have an XOR metric as defined in the Kademlia paper, i.e. the bitwise XOR of
-/// the hash digests, interpreted as an integer. See [`Key::distance`].
-///
-/// A `Key` preserves the preimage of type `T` of the hash function. See [`Key::preimage`].
-#[derive(Clone, Debug)]
-pub struct Key<T> {
-    preimage: T,
-    hash: GenericArray<u8, U32>,
-}
-
-impl<T> PartialEq for Key<T> {
-    fn eq(&self, other: &Key<T>) -> bool {
-        self.hash == other.hash
-    }
-}
-
-impl<T> Eq for Key<T> {}
-
-impl<T> Key<T> {
-    /// Construct a new `Key` by hashing the bytes of the given `preimage`.
-    ///
-    /// The preimage of type `T` is preserved. See [`Key::preimage`] and
-    /// [`Key::into_preimage`].
-    pub fn new(preimage: T) -> Key<T>
-    where
-        T: AsRef<[u8]>
-    {
-        let hash = Sha256::digest(preimage.as_ref());
-        Key { preimage, hash }
-    }
-
-    /// Borrows the preimage of the key.
-    pub fn preimage(&self) -> &T {
-        &self.preimage
-    }
-
-    /// Converts the key into its preimage.
-    pub fn into_preimage(self) -> T {
-        self.preimage
-    }
-
-    /// Computes the distance of the keys according to the XOR metric.
-    pub fn distance<U>(&self, other: &Key<U>) -> Distance {
-        let a = U256::from(self.hash.as_ref());
-        let b = U256::from(other.hash.as_ref());
-        Distance(a ^ b)
-    }
-}
-
-impl From<Multihash> for Key<Multihash> {
-    fn from(h: Multihash) -> Self {
-        let k = Key::new(h.clone().into_bytes());
-        Key { preimage: h, hash: k.hash }
-    }
-}
-
-impl From<PeerId> for Key<PeerId> {
-    fn from(peer_id: PeerId) -> Self {
-        Key::new(peer_id)
-    }
-}
-
-/// A distance between two `Key`s.
-#[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Debug)]
-pub struct Distance(bigint::U256);
-
-/// A `KBucket` is a list of up to `MAX_NODES_PER_BUCKET` `Key`s and associated values,
-/// ordered from least recently used to most recently used.
-#[derive(Debug, Clone)]
-pub struct KBucket<TPeerId, TVal> {
-    /// Nodes are always ordered from least-recently connected to most-recently connected.
-    nodes: ArrayVec<[Node<TPeerId, TVal>; MAX_NODES_PER_BUCKET]>,
-
-    /// The position (index) in `nodes` that marks the first entry whose corresponding
-    /// peer is considered connected.
-    ///
-    /// Since the entries in `nodes` are ordered from least-recently connected to
-    /// most-recently connected, all entries above this index are also considered
-    /// connected, i.e. the range `[0, first_connected_pos)` marks entries
-    /// whose nodes are considered disconnected and the range
-    /// `[first_connected_pos, MAX_NODES_PER_BUCKET)` marks entries whose
-    /// nodes are considered connected.
-    ///
-    /// `None` indicates that there are no connected entries in the bucket, i.e.
-    /// the bucket is either empty, or contains only entries for peers that are
-    /// considered disconnected.
-    first_connected_pos: Option<usize>,
-
-    /// A node that is pending to be inserted into a full bucket, should the
-    /// least-recently connected (and currently disconnected) node not reconnect.
-    pending_node: Option<PendingNode<TPeerId, TVal>>,
-}
-
-impl<TPeerId, TVal> KBucket<TPeerId, TVal> {
-    /// TODO
-    fn apply_pending(&mut self) {
-        if let Some(pending) = self.pending_node.take() {
-            if pending.replace <= Instant::now() {
-                // If there is a pending entry, then there must be at least one
-                // entry marked as disconnected and the bucket must be full.
-                debug_assert!(self.first_connected_pos.map_or(true, |p| p > 0));
-                debug_assert!(self.nodes.len() == MAX_NODES_PER_BUCKET);
-                // Remove the entry of the least-recently connected peer.
-                self.nodes.remove(0);
-                if pending.connected {
-                    self.first_connected_pos = self.first_connected_pos.or(Some(self.nodes.len()));
-                    self.nodes.push(pending.node);
-                }
-                // A disconnected pending node goes at the end of the entries
-                // for the disconnected peers.
-                else if let Some(p) = self.first_connected_pos {
-                    if p > 0 {
-                        self.nodes.insert(p - 1, pending.node);
-                    }
-                } else {
-                    self.nodes.push(pending.node);
-                }
-            } else {
-                self.pending_node = Some(pending)
-            }
-        }
-    }
-}
-
-/// State of the pending node.
-#[derive(Debug, Clone)]
-struct PendingNode<TPeerId, TVal> {
-    /// Node to insert.
-    node: Node<TPeerId, TVal>,
-
-    /// If true, we are connected to the pending node.
-    connected: bool,
-
-    /// When the pending node will replace an existing node, provided that the oldest node
-    /// doesn't become responsive before.
-    replace: Instant,
-}
-
-/// A single node in a `KBucket`.
-#[derive(Debug, Clone)]
-struct Node<TPeerId, TVal> {
-    /// Id of the node.
-    id: Key<TPeerId>,
-    /// Value associated to it.
-    value: TVal,
-}
-
-/// A (safe) index into a `KBucketsTable`, i.e. a non-negative integer in the
-/// range `[0, NUM_BUCKETS)`.
+/// A (type-safe) index into a `KBucketsTable`, i.e. a non-negative integer in the
+/// interval `[0, NUM_BUCKETS)`.
 #[derive(Copy, Clone)]
 struct BucketIndex(usize);
 
 impl BucketIndex {
-    /// Creates a new `BucketIndex` for a `Distance` from the `local_key`.
+    /// Creates a new `BucketIndex` for a `Distance`.
     ///
-    /// If the distance is zero, `None` is returned, in recognition of the fact that
-    /// the only key with distance `0` to the `local_key` is the `local_key` itself,
-    /// which does not belong in any bucket.
-    fn of(d: &Distance) -> Option<BucketIndex> { // TODO: new
+    /// The given distance is interpreted as the distance from a `local_key` of
+    /// a `KBucketsTable`. If the distance is zero, `None` is returned, in
+    /// recognition of the fact that the only key with distance `0` to a
+    /// `local_key` is the `local_key` itself, which does not belong in any
+    /// bucket.
+    fn new(d: &Distance) -> Option<BucketIndex> {
         (NUM_BUCKETS - d.0.leading_zeros() as usize)
             .checked_sub(1)
             .map(BucketIndex)
@@ -249,28 +118,21 @@ impl BucketIndex {
     }
 }
 
-impl<TPeerId> AsRef<Key<TPeerId>> for Key<TPeerId> { // Borrow?
-    fn as_ref(&self) -> &Key<TPeerId> {
-        self
-    }
-}
-
 impl<TPeerId, TVal> KBucketsTable<TPeerId, TVal>
 where
     TPeerId: Clone,
 {
-    /// Builds a new routing table whose keys are distributed over `KBucket`s as
-    /// per the relative distance to `local_key`.
-    pub fn new(local_key: Key<TPeerId>, unresponsive_timeout: Duration) -> Self {
+    /// Creates a new, empty Kademlia routing table with entries partitioned
+    /// into buckets as per the Kademlia protocol.
+    ///
+    /// The given `pending_timeout` specifies the duration after creation of
+    /// a [`PendingEntry`] after which it becomes eligible for insertion into
+    /// a full bucket, replacing the least-recently (dis)connected node.
+    pub fn new(local_key: Key<TPeerId>, pending_timeout: Duration) -> Self {
         KBucketsTable {
             local_key,
-            tables: (0 .. NUM_BUCKETS).map(|_| KBucket {
-                nodes: ArrayVec::new(),
-                first_connected_pos: None,
-                pending_node: None,
-            })
-            .collect(),
-            unresponsive_timeout,
+            buckets: (0 .. NUM_BUCKETS).map(|_| KBucket::new(pending_timeout)).collect(),
+            applied_pending: VecDeque::new()
         }
     }
 
@@ -279,37 +141,72 @@ where
         &self.local_key
     }
 
-    fn bucket(&self, key: &Key<TPeerId>) -> Option<&KBucket<TPeerId, TVal>> {
-        BucketIndex::of(&self.local_key.distance(key)).map(|i| &self.tables[i.get()])
+    /// Returns an `Entry` for the given key, representing the state of the entry
+    /// in the routing table.
+    pub fn entry<'a>(&'a mut self, key: &'a Key<TPeerId>) -> Entry<'a, TPeerId, TVal> {
+        let index = BucketIndex::new(&self.local_key.distance(key));
+        if let Some(i) = index {
+            let bucket = &mut self.buckets[i.get()];
+            if let Some(applied) = bucket.apply_pending() {
+                self.applied_pending.push_back(applied)
+            }
+            Entry::new(bucket, key)
+        } else {
+            Entry::SelfEntry
+        }
     }
 
-    fn bucket_mut(&mut self, key: &Key<TPeerId>) -> Option<&mut KBucket<TPeerId, TVal>> {
-        BucketIndex::of(&self.local_key.distance(key)).map(move |i| &mut self.tables[i.get()])
+    /// Returns an iterator over all the entries in the routing table.
+    pub fn iter<'a>(&'a mut self) -> impl Iterator<Item = EntryRefView<'a, TPeerId, TVal>> {
+        let applied_pending = &mut self.applied_pending;
+        self.buckets.iter_mut().flat_map(move |table| {
+            if let Some(applied) = table.apply_pending() {
+                applied_pending.push_back(applied)
+            }
+            let table = &*table;
+            table.iter().map(move |(n, status)| {
+                EntryRefView {
+                    node: NodeRefView {
+                        key: &n.key,
+                        value: &n.value
+                    },
+                    status
+                }
+            })
+        })
     }
 
-    /// Returns an object containing the state of the given entry.
-    pub fn entry<'a>(&'a mut self, peer_id: &'a Key<TPeerId>) -> Entry<'a, TPeerId, TVal> {
-        Entry::new(self, peer_id)
-    }
-
-    /// Returns an iterator over all the entries in the bucket, excluding those that
-    /// are pending.
-    pub fn entries_not_pending(&self) -> impl Iterator<Item = (&Key<TPeerId>, &TVal)> {
-        self.tables
-            .iter()
-            .flat_map(|table| table.nodes.iter())
-            .map(|node| (&node.id, &node.value))
-    }
-
-    /// Returns an iterator over all buckets.
+    /// Returns a by-reference iterator over all buckets.
     ///
     /// The buckets are ordered by proximity to the `local_key`, i.e. the first
     /// bucket is the closest bucket (containing at most one key).
-    pub fn buckets(&mut self) -> KBucketsIter<'_, TPeerId, TVal> {
-        KBucketsIter(self.tables.iter_mut(), self.unresponsive_timeout)
+    pub fn buckets<'a>(&'a mut self) -> impl Iterator<Item = KBucketRef<'a, TPeerId, TVal>> + 'a {
+        let applied_pending = &mut self.applied_pending;
+        self.buckets.iter_mut().map(move |b| {
+            if let Some(applied) = b.apply_pending() {
+                applied_pending.push_back(applied)
+            }
+            KBucketRef(b)
+        })
     }
 
-    /// Creates an iterator over the keys closest to `target`, ordered by
+    /// Consumes the next applied pending entry, if any.
+    ///
+    /// When an entry is attempted to be inserted and the respective bucket is full,
+    /// it may be recorded as pending insertion after a timeout, see [`InsertResult::Pending`].
+    ///
+    /// If the oldest currently disconnected entry in the respective bucket does not change
+    /// its status until the timeout of pending entry expires, it is evicted and
+    /// the pending entry inserted instead. These insertions of pending entries
+    /// happens lazily, whenever the `KBucketsTable` is accessed, and the corresponding
+    /// buckets are updated accordingly. The fact that a pending entry was applied is
+    /// recorded in the `KBucketsTable` in the form of `AppliedPending` results, which must be
+    /// consumed by calling this function.
+    pub fn take_applied_pending(&mut self) -> Option<AppliedPending<TPeerId, TVal>> {
+        self.applied_pending.pop_front()
+    }
+
+    /// Returns an iterator over the keys closest to `target`, ordered by
     /// increasing distance.
     pub fn closest_keys<'a, T>(&'a mut self, target: &'a Key<T>)
         -> impl Iterator<Item = Key<TPeerId>> + 'a
@@ -317,19 +214,18 @@ where
         T: Clone
     {
         let distance = self.local_key.distance(target);
-        let buckets_iter = ClosestBucketsIter::new(distance);
         ClosestIter {
             target,
             iter: None,
-            buckets: &mut self.tables,
-            buckets_iter,
+            table: self,
+            buckets_iter: ClosestBucketsIter::new(distance),
             fmap: |b: &KBucket<_, _>| -> ArrayVec<_> {
-                b.nodes.iter().map(|n| n.id.clone()).collect()
+                b.iter().map(|(n,_)| n.key.clone()).collect()
             }
         }
     }
 
-    /// Creates an iterator over the entries closest to `target`, ordered by
+    /// Returns an iterator over the nodes closest to the `target` key, ordered by
     /// increasing distance.
     pub fn closest<'a, T>(&'a mut self, target: &'a Key<T>)
         -> impl Iterator<Item = EntryView<TPeerId, TVal>> + 'a
@@ -338,38 +234,43 @@ where
         TVal: Clone
     {
         let distance = self.local_key.distance(target);
-        let buckets_iter = ClosestBucketsIter::new(distance);
         ClosestIter {
             target,
             iter: None,
-            buckets: &mut self.tables,
-            buckets_iter,
+            table: self,
+            buckets_iter: ClosestBucketsIter::new(distance),
             fmap: |b: &KBucket<_, TVal>| -> ArrayVec<_> {
-                b.nodes.iter().enumerate().map(|(i, n)| EntryView {
-                    key: n.id.clone(),
-                    value: n.value.clone(),
-                    connected: b.first_connected_pos.map_or(false, |j| i >= j)
+                b.iter().map(|(n, status)| EntryView {
+                    node: n.clone(),
+                    status
                 }).collect()
             }
         }
     }
-
 }
 
-/// TODO
-pub struct ClosestIter<'a, TTarget, TPeerId, TVal, TMap, TOut> {
+/// An iterator over (some projection of) the closest entries in a
+/// `KBucketsTable` w.r.t. some target `Key`.
+struct ClosestIter<'a, TTarget, TPeerId, TVal, TMap, TOut> {
+    /// A reference to the target key whose distance to the local key determines
+    /// the order in which the buckets are traversed. The resulting
+    /// array from projecting the entries of each bucket using `fmap` is
+    /// sorted according to the distance to the target.
     target: &'a Key<TTarget>,
-    buckets: &'a mut Vec<KBucket<TPeerId, TVal>>,
+    /// A reference to all buckets of the `KBucketsTable`.
+    table: &'a mut KBucketsTable<TPeerId, TVal>,
+    /// The iterator over the bucket indices in the order determined by the
+    /// distance of the local key to the target.
     buckets_iter: ClosestBucketsIter,
+    /// The iterator over the entries in the currently traversed bucket.
     iter: Option<arrayvec::IntoIter<[TOut; MAX_NODES_PER_BUCKET]>>,
+    /// The projection function / mapping applied on each bucket as
+    /// it is encountered, producing the next `iter`ator.
     fmap: TMap
 }
 
-/// An iterator over all keys in a bucket, sorted by distance to a target key.
-type ClosestKeysIter<T> = arrayvec::IntoIter<[Key<T>; MAX_NODES_PER_BUCKET]>;
-
-/// An iterator over the bucket indices, in the order determined the `Distance` of
-/// a target from the `local_key`, such that the nodes in the buckets are incrementally
+/// An iterator over the bucket indices, in the order determined by the `Distance` of
+/// a target from the `local_key`, such that the entries in the buckets are incrementally
 /// further away from the target, starting with the bucket covering the target.
 struct ClosestBucketsIter {
     /// The distance to the `local_key`.
@@ -380,17 +281,18 @@ struct ClosestBucketsIter {
 
 /// Operating states of a `ClosestBucketsIter`.
 enum ClosestBucketsIterState {
+    /// The starting state of the iterator yields the first bucket index and
+    /// then transitions to `ZoomIn`.
     Start(BucketIndex),
-    /// Beginning with the bucket into which the `target` key falls, the
-    /// iterator "zooms in" to buckets cotaining nodes that are incrementally
-    /// closer to the local node but further from the `target`. These are
-    /// identified by a `1` in the corresponding bit position of the distance
-    /// bit string. When bucket `0` is reached, the iterator transitions to
-    /// state `ZoomOut`.
+    /// The iterator "zooms in" to to yield the next bucket cotaining nodes that
+    /// are incrementally closer to the local node but further from the `target`.
+    /// These buckets are identified by a `1` in the corresponding bit position
+    /// of the distance bit string. When bucket `0` is reached, the iterator
+    /// transitions to `ZoomOut`.
     ZoomIn(BucketIndex),
     /// Once bucket `0` has been reached, the iterator starts "zooming out"
     /// to buckets containing nodes that are incrementally further away from
-    /// both the local node and the target. These are identified by a `0` in
+    /// both the local key and the target. These are identified by a `0` in
     /// the corresponding bit position of the distance bit string. When bucket
     /// `255` is reached, the iterator transitions to state `Done`.
     ZoomOut(BucketIndex),
@@ -400,7 +302,7 @@ enum ClosestBucketsIterState {
 
 impl ClosestBucketsIter {
     fn new(distance: Distance) -> Self {
-        let state = match BucketIndex::of(&distance) {
+        let state = match BucketIndex::new(&distance) {
             Some(i) => ClosestBucketsIterState::Start(i),
             None => ClosestBucketsIterState::Done
         };
@@ -475,8 +377,10 @@ where
                 }
                 None => {
                     if let Some(i) = self.buckets_iter.next() {
-                        let bucket = &mut self.buckets[i.get()];
-                        bucket.apply_pending();
+                        let bucket = &mut self.table.buckets[i.get()];
+                        if let Some(applied) = bucket.apply_pending() {
+                            self.table.applied_pending.push_back(applied)
+                        }
                         let mut v = (self.fmap)(bucket);
                         v.sort_by(|a, b|
                             self.target.distance(a.as_ref())
@@ -491,114 +395,38 @@ where
     }
 }
 
-/// By-reference iterator over `KBucket`s in the order of their increasing distance
-/// to the local key.
-pub struct KBucketsIter<'a, TPeerId, TVal>(slice::IterMut<'a, KBucket<TPeerId, TVal>>, Duration);
-
-impl<'a, TPeerId, TVal> Iterator for KBucketsIter<'a, TPeerId, TVal> {
-    type Item = KBucketRef<'a, TPeerId, TVal>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(KBucketRef)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.0.size_hint()
-    }
-}
-
-impl<'a, TPeerId, TVal> ExactSizeIterator for KBucketsIter<'a, TPeerId, TVal> {}
-
-/// A reference to a `KBucket`.
+/// A reference to a bucket in a `KBucketsTable`.
 pub struct KBucketRef<'a, TPeerId, TVal>(&'a mut KBucket<TPeerId, TVal>);
 
-impl<'a, TPeerId, TVal> KBucketRef<'a, TPeerId, TVal> {
-    /// Returns the number of entries in that bucket.
-    ///
-    /// > **Note**: Keep in mind that this operation can be racy. If `update()` is called on the
-    /// >           table while this function is running, the `update()` may or may not be taken
-    /// >           into account.
+impl<TPeerId, TVal> KBucketRef<'_, TPeerId, TVal>
+where
+    TPeerId: Clone
+{
+    /// Returns the number of entries in the bucket.
     pub fn num_entries(&self) -> usize {
-        self.0.nodes.len()
+        self.0.num_entries()
     }
 
-    /// Returns true if this bucket has a pending node.
+    /// Returns true if the bucket has a pending node.
     pub fn has_pending(&self) -> bool {
-        if let Some(ref node) = self.0.pending_node {
-            node.replace > Instant::now()
-        } else {
-            false
-        }
+        self.0.pending().map_or(false, |n| !n.is_ready())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quickcheck::*;
     use libp2p_core::PeerId;
-    use crate::kbucket::{Entry, InsertOutcome, KBucketsTable, MAX_NODES_PER_BUCKET};
-    use std::time::Duration;
-
-    impl Arbitrary for Key<PeerId> {
-        fn arbitrary<G: Gen>(_: &mut G) -> Key<PeerId> {
-            Key::from(PeerId::random())
-        }
-    }
-
-    #[test]
-    fn identity() {
-        fn prop(a: Key<PeerId>) -> bool {
-            a.distance(&a) == Distance::default()
-        }
-        quickcheck(prop as fn(_) -> _)
-    }
-
-    #[test]
-    fn symmetry() {
-        fn prop(a: Key<PeerId>, b: Key<PeerId>) -> bool {
-            a.distance(&b) == b.distance(&a)
-        }
-        quickcheck(prop as fn(_,_) -> _)
-    }
-
-    #[test]
-    fn triangle_inequality() {
-        fn prop(a: Key<PeerId>, b: Key<PeerId>, c: Key<PeerId>) -> TestResult {
-            let ab = a.distance(&b);
-            let bc = b.distance(&c);
-            let (ab_plus_bc, overflow) = ab.0.overflowing_add(bc.0);
-            if overflow {
-                TestResult::discard()
-            } else {
-                TestResult::from_bool(a.distance(&c) <= Distance(ab_plus_bc))
-            }
-        }
-        quickcheck(prop as fn(_,_,_) -> _)
-    }
-
-    #[test]
-    fn unidirectionality() {
-        fn prop(a: Key<PeerId>, b: Key<PeerId>) -> bool {
-            let d = a.distance(&b);
-            (0..100).all(|_| {
-                let c = Key::from(PeerId::random());
-                a.distance(&c) != d || b == c
-            })
-        }
-        quickcheck(prop as fn(_,_) -> _)
-    }
-
 
     #[test]
     fn basic_closest() {
-        let my_key = Key::from(PeerId::random());
+        let local_key = Key::from(PeerId::random());
         let other_id = Key::from(PeerId::random());
 
-        let mut table = KBucketsTable::<_, ()>::new(my_key, Duration::from_secs(5));
-        if let Entry::NotInKbucket(entry) = table.entry(&other_id) {
-            match entry.insert_connected(()) {
-                InsertOutcome::Inserted => (),
+        let mut table = KBucketsTable::<_, ()>::new(local_key, Duration::from_secs(5));
+        if let Entry::Absent(entry) = table.entry(&other_id) {
+            match entry.insert((), NodeStatus::Connected) {
+                InsertResult::Inserted => (),
                 _ => panic!()
             }
         } else {
@@ -612,108 +440,12 @@ mod tests {
 
     #[test]
     fn update_local_id_fails() {
-        let my_key = Key::from(PeerId::random());
-
-        let mut table = KBucketsTable::<_, ()>::new(my_key.clone(), Duration::from_secs(5));
-        match table.entry(&my_key) {
+        let local_key = Key::from(PeerId::random());
+        let mut table = KBucketsTable::<_, ()>::new(local_key.clone(), Duration::from_secs(5));
+        match table.entry(&local_key) {
             Entry::SelfEntry => (),
             _ => panic!(),
         }
-    }
-
-    #[test]
-    fn full_kbucket() {
-        let my_key = Key::from(PeerId::random());
-
-        let mut table = KBucketsTable::<_, ()>::new(my_key.clone(), Duration::from_secs(5));
-
-        // Step 1: Fill the most distant bucket, i.e. bucket index `NUM_BUCKETS - 1`,
-        // with "disconnected" peers.
-
-        // Prepare `MAX_NODES_PER_BUCKET` keys to fill the bucket, plus 2
-        // additional keys which will be used to test the behavior on a full
-        // bucket.
-        assert!(MAX_NODES_PER_BUCKET <= 251); // Test doesn't work otherwise.
-        let mut fill_ids = (0..MAX_NODES_PER_BUCKET + 3)
-            .map(|n| {
-                let mut id = my_key.clone();
-                // Flip the first bit so that we get in the most distant bucket.
-                id.hash[0] ^= 0x80;
-                // Each ID gets a unique low-order byte (i.e. counter).
-                id.hash[31] = id.hash[31].wrapping_add(n as u8);
-                id
-            })
-            .collect::<Vec<_>>();
-
-        fn last_bucket(table: &mut KBucketsTable<PeerId, ()>) -> &mut KBucket<PeerId, ()> {
-            &mut table.tables[255]
-        }
-
-        let first_node = fill_ids[0].clone();
-        let second_node = fill_ids[1].clone();
-
-        // Fill the bucket, consuming all but the last 3 test keys.
-        for (num, id) in fill_ids.drain(..MAX_NODES_PER_BUCKET).enumerate() {
-            if let Entry::NotInKbucket(entry) = table.entry(&id) {
-                match entry.insert_disconnected(()) {
-                    InsertOutcome::Inserted => (),
-                    _ => panic!()
-                }
-            } else {
-                panic!()
-            }
-            assert_eq!(last_bucket(&mut table).nodes.len(), num + 1);
-        }
-        assert_eq!(last_bucket(&mut table).nodes.len(), MAX_NODES_PER_BUCKET);
-        assert!(last_bucket(&mut table).pending_node.is_none());
-
-        // Step 2: Insert another key on the full bucket. It must be marked as
-        // pending and the first (i.e. "least recently used") entry scheduled
-        // for replacement.
-        let replacement = fill_ids.remove(0);
-        if let Entry::NotInKbucket(entry) = table.entry(&replacement) {
-            match entry.insert_connected(()) {
-                InsertOutcome::Pending { ref to_ping } if *to_ping == first_node => (),
-                _ => panic!()
-            }
-        } else {
-            panic!()
-        }
-        let pending = last_bucket(&mut table).pending_node.as_ref().map(|n| &n.node.id);
-        assert_eq!(pending, Some(&replacement));
-        assert_eq!(last_bucket(&mut table).nodes.len(), MAX_NODES_PER_BUCKET);
-        // Trying to insert yet another key is rejected.
-        if let Entry::NotInKbucket(entry) = table.entry(&Key::from(fill_ids.remove(0))) {
-            match entry.insert_connected(()) {
-                InsertOutcome::Full => (),
-                _ => panic!()
-            }
-        } else {
-            panic!()
-        }
-
-        // Step 3: Make the pending nodes eligible for replacing existing nodes.
-        // The pending node must be consumed and replace the first (i.e. "least
-        // recently connected") node.
-        let elapsed = Instant::now() - Duration::from_secs(1);
-        last_bucket(&mut table).pending_node.as_mut().map(|n| n.replace = elapsed);
-        let replacement2 = fill_ids.remove(0);
-        if let Entry::NotInKbucket(entry) = table.entry(&replacement2) {
-            match entry.insert_connected(()) {
-                InsertOutcome::Pending { ref to_ping } if *to_ping == second_node => (),
-                e => panic!("{:?}", e)
-            }
-        } else {
-            panic!()
-        }
-
-        // The replacement must now be in the bucket and considered connected.
-        match table.entry(&replacement) {
-            Entry::InKbucketConnected(_) => {},
-            _ => panic!()
-        }
-        let pending = last_bucket(&mut table).pending_node.as_ref().map(|n| &n.node.id);
-        assert_eq!(pending, Some(&replacement2));
     }
 
     #[test]
@@ -724,9 +456,9 @@ mod tests {
         loop {
             if count == 100 { break; }
             let key = Key::from(PeerId::random());
-            if let Entry::NotInKbucket(e) = table.entry(&key) {
-                match e.insert_connected(()) {
-                    InsertOutcome::Inserted => count += 1,
+            if let Entry::Absent(e) = table.entry(&key) {
+                match e.insert((), NodeStatus::Connected) {
+                    InsertResult::Inserted => count += 1,
                     _ => continue,
                 }
             } else {
@@ -734,9 +466,9 @@ mod tests {
             }
         }
 
-        let mut expected_keys: Vec<_> = table.tables
+        let mut expected_keys: Vec<_> = table.buckets
             .iter()
-            .flat_map(|t| t.nodes.iter().map(|n| n.id.clone()))
+            .flat_map(|t| t.iter().map(|(n,_)| n.key.clone()))
             .collect();
 
         for _ in 0 .. 10 {
@@ -746,5 +478,58 @@ mod tests {
             expected_keys.sort_by_key(|k| k.distance(&target_key));
             assert_eq!(keys, expected_keys);
         }
+    }
+
+    #[test]
+    fn applied_pending() {
+        let local_key = Key::from(PeerId::random());
+        let mut table = KBucketsTable::<_, ()>::new(local_key.clone(), Duration::from_millis(1));
+        let expected_applied;
+        let full_bucket_index;
+        loop {
+            let key = Key::from(PeerId::random());
+            if let Entry::Absent(e) = table.entry(&key) {
+                match e.insert((), NodeStatus::Disconnected) {
+                    InsertResult::Full => {
+                        if let Entry::Absent(e) = table.entry(&key) {
+                            match e.insert((), NodeStatus::Connected) {
+                                InsertResult::Pending { disconnected } => {
+                                    expected_applied = AppliedPending {
+                                        inserted: key.clone(),
+                                        evicted: Some(Node { key: disconnected, value: () })
+                                    };
+                                    full_bucket_index = BucketIndex::new(&key.distance(&local_key));
+                                    break
+                                },
+                                _ => panic!()
+                            }
+                        } else {
+                            panic!()
+                        }
+                    },
+                    _ => continue,
+                }
+            } else {
+                panic!("entry exists")
+            }
+        }
+
+        // Expire the timeout for the pending entry on the full bucket.`
+        let full_bucket = &mut table.buckets[full_bucket_index.unwrap().get()];
+        let elapsed = Instant::now() - Duration::from_secs(1);
+        full_bucket.pending_mut().unwrap().set_ready_at(elapsed);
+
+        match table.entry(&expected_applied.inserted) {
+            Entry::Present(_, NodeStatus::Connected) => {}
+            x => panic!("Unexpected entry: {:?}", x)
+        }
+
+        match table.entry(&expected_applied.evicted.as_ref().unwrap().key) {
+            Entry::Absent(_) => {}
+            x => panic!("Unexpected entry: {:?}", x)
+        }
+
+        assert_eq!(Some(expected_applied), table.take_applied_pending());
+        assert_eq!(None, table.take_applied_pending());
     }
 }

--- a/protocols/kad/src/kbucket/bucket.rs
+++ b/protocols/kad/src/kbucket/bucket.rs
@@ -1,0 +1,552 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! The internal API for a single `KBucket` in a `KBucketsTable`.
+//!
+//! > **Note**: Uniqueness of entries w.r.t. a `Key` in a `KBucket` is not
+//! > checked in this module. This is an invariant that must hold across all
+//! > buckets in a `KBucketsTable` and hence is enforced by the public API
+//! > of the `KBucketsTable` and in particular the public `Entry` API.
+
+use super::*;
+
+/// Maximum number of nodes in a bucket, i.e. the (fixed) `k` parameter.
+pub const MAX_NODES_PER_BUCKET: usize = 20;
+
+/// A `PendingNode` is a `Node` that is pending insertion into a `KBucket`.
+#[derive(Debug, Clone)]
+pub struct PendingNode<TPeerId, TVal> {
+    /// The pending node to insert.
+    node: Node<TPeerId, TVal>,
+
+    /// The status of the pending node.
+    status: NodeStatus,
+
+    /// The instant at which the pending node is eligible for insertion into a bucket.
+    replace: Instant,
+}
+
+/// The status of a node in a bucket.
+///
+/// The status of a node in a bucket together with the time of the
+/// last status change determines the position of the node in a
+/// bucket.
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+pub enum NodeStatus {
+    /// The node is considered connected.
+    Connected,
+    /// The node is considered disconnected.
+    Disconnected
+}
+
+impl<TPeerId, TVal> PendingNode<TPeerId, TVal> {
+    pub fn key(&self) -> &Key<TPeerId> {
+        &self.node.key
+    }
+
+    pub fn status(&self) -> NodeStatus {
+        self.status
+    }
+
+    pub fn value_mut(&mut self) -> &mut TVal {
+        &mut self.node.value
+    }
+
+    pub fn is_ready(&self) -> bool {
+        Instant::now() >= self.replace
+    }
+
+    pub fn set_ready_at(&mut self, t: Instant) {
+        self.replace = t;
+    }
+}
+
+/// A `Node` in a bucket, representing a peer participating
+/// in the Kademlia DHT together with an associated value (e.g. contact
+/// information).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Node<TPeerId, TVal> {
+    /// The key of the node, identifying the peer.
+    pub key: Key<TPeerId>,
+    /// The associated value.
+    pub value: TVal,
+}
+
+/// The position of a node in a `KBucket`, i.e. a non-negative integer
+/// in the range `[0, MAX_NODES_PER_BUCKET)`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Position(usize);
+
+/// A `KBucket` is a list of up to `MAX_NODES_PER_BUCKET` `Key`s and associated values,
+/// ordered from least-recently connected to most-recently connected.
+#[derive(Debug, Clone)]
+pub struct KBucket<TPeerId, TVal> {
+    /// The nodes contained in the bucket.
+    nodes: ArrayVec<[Node<TPeerId, TVal>; MAX_NODES_PER_BUCKET]>,
+
+    /// The position (index) in `nodes` that marks the first connected node.
+    ///
+    /// Since the entries in `nodes` are ordered from least-recently connected to
+    /// most-recently connected, all entries above this index are also considered
+    /// connected, i.e. the range `[0, first_connected_pos)` marks the sub-list of entries
+    /// that are considered disconnected and the range
+    /// `[first_connected_pos, MAX_NODES_PER_BUCKET)` marks sub-list of entries that are
+    /// considered connected.
+    ///
+    /// `None` indicates that there are no connected entries in the bucket, i.e.
+    /// the bucket is either empty, or contains only entries for peers that are
+    /// considered disconnected.
+    first_connected_pos: Option<usize>,
+
+    /// A node that is pending to be inserted into a full bucket, should the
+    /// least-recently connected (and currently disconnected) node not be
+    /// marked as connected within `unresponsive_timeout`.
+    pending: Option<PendingNode<TPeerId, TVal>>,
+
+    /// The timeout window before a new pending node is eligible for insertion,
+    /// if the least-recently connected node is not updated as being connected
+    /// in the meantime.
+    pending_timeout: Duration
+}
+
+/// The result of inserting an entry into a bucket.
+#[must_use]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InsertResult<TPeerId> {
+     /// The entry has been successfully inserted.
+     Inserted,
+     /// The entry is pending insertion because the relevant bucket is currently full.
+     /// The entry is inserted after a timeout elapsed, if the status of the
+     /// least-recently connected (and currently disconnected) node in the bucket
+     /// is not updated before the timeout expires.
+     Pending {
+         /// The key of the least-recently connected entry that is currently considered
+         /// disconnected and whose corresponding peer should be checked for connectivity
+         /// in order to prevent it from being evicted. If connectivity to the peer is
+         /// re-established, the corresponding entry should be updated with
+         /// [`NodeStatus::Connected`].
+         disconnected: Key<TPeerId>
+     },
+     /// The entry was not inserted because the relevant bucket is full.
+     Full
+}
+
+/// The result of applying a pending node to a bucket, possibly
+/// replacing an existing node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppliedPending<TPeerId, TVal> {
+    /// The key of the inserted pending node.
+    pub inserted: Key<TPeerId>,
+    /// The node that has been evicted from the bucket to make room for the
+    /// pending node, if any.
+    pub evicted: Option<Node<TPeerId, TVal>>
+}
+
+impl<TPeerId, TVal> KBucket<TPeerId, TVal>
+where
+    TPeerId: Clone
+{
+    /// Creates a new `KBucket` with the given timeout for pending entries.
+    pub fn new(pending_timeout: Duration) -> Self {
+        KBucket {
+            nodes: ArrayVec::new(),
+            first_connected_pos: None,
+            pending: None,
+            pending_timeout,
+        }
+    }
+
+    /// Returns a reference to the pending node of the bucket, if there is any.
+    pub fn pending(&self) -> Option<&PendingNode<TPeerId, TVal>> {
+        self.pending.as_ref()
+    }
+
+    /// Returns a mutable reference to the pending node of the bucket, if there is any.
+    pub fn pending_mut(&mut self) -> Option<&mut PendingNode<TPeerId, TVal>> {
+        self.pending.as_mut()
+    }
+
+    /// Returns a reference to the pending node of the bucket, if there is any
+    /// with a matching key.
+    pub fn as_pending(&self, key: &Key<TPeerId>) -> Option<&PendingNode<TPeerId, TVal>> {
+        self.pending().filter(|p| &p.node.key == key)
+    }
+
+    /// Returns a reference to a node in the bucket.
+    pub fn get(&self, key: &Key<TPeerId>) -> Option<&Node<TPeerId, TVal>> {
+        self.position(key).map(|p| &self.nodes[p.0])
+    }
+
+    /// Returns an iterator over the nodes in the bucket, together with their status.
+    pub fn iter(&self) -> impl Iterator<Item = (&Node<TPeerId, TVal>, NodeStatus)> {
+        self.nodes.iter().enumerate().map(move |(p, n)| (n, self.status(Position(p))))
+    }
+
+    /// Inserts the pending node into the bucket, if its timeout has elapsed,
+    /// replacing the least-recently connected node.
+    ///
+    /// If a pending node has been inserted, its key is returned together with
+    /// the node that was replaced. `None` indicates that the nodes in the
+    /// bucket remained unchanged.
+    pub fn apply_pending(&mut self) -> Option<AppliedPending<TPeerId, TVal>> {
+        if let Some(pending) = self.pending.take() {
+            if pending.replace <= Instant::now() {
+                if self.nodes.is_full() {
+                    if self.status(Position(0)) == NodeStatus::Connected {
+                        // The bucket is full with connected nodes. Drop the pending node.
+                        return None
+                    }
+                    // The pending node will be inserted.
+                    let inserted = pending.node.key.clone();
+                    // A connected pending node goes at the end of the list for
+                    // the connected peers, removing the least-recently connected.
+                    if pending.status == NodeStatus::Connected {
+                        let evicted = Some(self.nodes.remove(0));
+                        self.first_connected_pos = self.first_connected_pos
+                            .map_or_else(
+                                | | Some(self.nodes.len()),
+                                |p| p.checked_sub(1));
+                        self.nodes.push(pending.node);
+                        return Some(AppliedPending { inserted, evicted })
+                    }
+                    // A disconnected pending node goes at the end of the list
+                    // for the disconnected peers.
+                    else if let Some(p) = self.first_connected_pos {
+                        if let Some(insert_pos) = p.checked_sub(1) {
+                            let evicted = Some(self.nodes.remove(0));
+                            self.nodes.insert(insert_pos, pending.node);
+                            return Some(AppliedPending { inserted, evicted })
+                        }
+                    } else {
+                        // All nodes are disconnected. Insert the new node as the most
+                        // recently disconnected, removing the least-recently disconnected.
+                        let evicted = Some(self.nodes.remove(0));
+                        self.nodes.push(pending.node);
+                        return Some(AppliedPending { inserted, evicted })
+                    }
+                } else {
+                    // There is room in the bucket, so just insert the pending node.
+                    let inserted = pending.node.key.clone();
+                    match self.insert(pending.node, pending.status) {
+                        InsertResult::Inserted =>
+                            return Some(AppliedPending { inserted, evicted: None }),
+                        _ => unreachable!("Bucket is not full.")
+                    }
+                }
+            } else {
+                self.pending = Some(pending);
+            }
+        }
+
+        return None
+    }
+
+    /// Updates the status of the pending node, if any.
+    pub fn update_pending(&mut self, status: NodeStatus) {
+        if let Some(pending) = &mut self.pending {
+            pending.status = status
+        }
+    }
+
+    /// Updates the status of the node referred to by the given key, if it is
+    /// in the bucket.
+    pub fn update(&mut self, key: &Key<TPeerId>, status: NodeStatus) {
+        if let Some(pos) = self.position(key) {
+            let node = self.nodes.remove(pos.0);
+            if pos == Position(0) && status == NodeStatus::Connected {
+                self.pending = None
+            }
+            match self.insert(node, status) {
+                InsertResult::Inserted => {},
+                _ => unreachable!("The node is removed before being (re)inserted.")
+            }
+        }
+    }
+
+    /// Inserts a new node into the bucket with the given status.
+    ///
+    /// The status of the node to insert determines the result as follows:
+    ///
+    ///   * `NodeStatus::Connected`: If the bucket is full and either all nodes are connected
+    ///     or there is already a pending node, insertion fails with `InsertResult::Full`.
+    ///     If the bucket is full but at least one node is disconnected and there is no pending
+    ///     node, the new node is inserted as pending, yielding `InsertResult::Pending`.
+    ///     Otherwise the bucket has free slots and the new node is added to the end of the
+    ///     bucket as the most-recently connected node.
+    ///
+    ///   * `NodeStatus::Disconnected`: If the bucket is full, insertion fails with
+    ///     `InsertResult::Full`. Otherwise the bucket has free slots and the new node
+    ///     is inserted at the position preceding the first connected node,
+    ///     i.e. as the most-recently disconnected node. If there are no connected nodes,
+    ///     the new node is added as the last element of the bucket.
+    ///
+    pub fn insert(&mut self, node: Node<TPeerId, TVal>, status: NodeStatus) -> InsertResult<TPeerId> {
+        match status {
+            NodeStatus::Connected => {
+                if self.nodes.is_full() {
+                    if self.first_connected_pos == Some(0) || self.pending.is_some() {
+                        return InsertResult::Full
+                    } else {
+                        self.pending = Some(PendingNode {
+                            node,
+                            status: NodeStatus::Connected,
+                            replace: Instant::now() + self.pending_timeout,
+                        });
+                        return InsertResult::Pending {
+                            disconnected: self.nodes[0].key.clone()
+                        }
+                    }
+                }
+                let pos = self.nodes.len();
+                self.first_connected_pos = self.first_connected_pos.or(Some(pos));
+                self.nodes.push(node);
+                InsertResult::Inserted
+            }
+            NodeStatus::Disconnected => {
+                if self.nodes.is_full() {
+                    return InsertResult::Full
+                }
+                if let Some(ref mut first_connected_pos) = self.first_connected_pos {
+                    self.nodes.insert(*first_connected_pos, node);
+                    *first_connected_pos += 1;
+                } else {
+                    self.nodes.push(node);
+                }
+                InsertResult::Inserted
+            }
+        }
+    }
+
+    /// Returns the status of the node at the given position.
+    pub fn status(&self, pos: Position) -> NodeStatus {
+        if self.first_connected_pos.map_or(false, |i| pos.0 >= i) {
+            NodeStatus::Connected
+        } else {
+            NodeStatus::Disconnected
+        }
+    }
+
+    /// Checks whether the given position refers to a connected node.
+    pub fn is_connected(&self, pos: Position) -> bool {
+        self.status(pos) == NodeStatus::Connected
+    }
+
+    /// Gets the number of entries currently in the bucket.
+    pub fn num_entries(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Gets the number of entries in the bucket that are considered connected.
+    pub fn num_connected(&self) -> usize {
+        self.first_connected_pos.map_or(0, |i| self.nodes.len() - i)
+    }
+
+    /// Gets the number of entries in the bucket that are considered disconnected.
+    pub fn num_disconnected(&self) -> usize {
+        self.nodes.len() - self.num_connected()
+    }
+
+    /// Gets the position of an node in the bucket.
+    pub fn position(&self, key: &Key<TPeerId>) -> Option<Position> {
+        self.nodes.iter().position(|p| &p.key == key).map(Position)
+    }
+
+    /// Gets a mutable reference to the node identified by the given key.
+    ///
+    /// Returns `None` if the given key does not refer to an node in the
+    /// bucket.
+    pub fn get_mut(&mut self, key: &Key<TPeerId>) -> Option<&mut Node<TPeerId, TVal>> {
+        self.nodes.iter_mut().find(move |p| &p.key == key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use libp2p_core::PeerId;
+    use rand::Rng;
+    use std::collections::VecDeque;
+    use super::*;
+    use quickcheck::*;
+
+    impl Arbitrary for NodeStatus {
+        fn arbitrary<G: Gen>(g: &mut G) -> NodeStatus {
+            if g.gen() {
+                NodeStatus::Connected
+            } else {
+                NodeStatus::Disconnected
+            }
+        }
+    }
+
+    fn fill_bucket(bucket: &mut KBucket<PeerId, ()>, status: NodeStatus) {
+        for i in 0 .. MAX_NODES_PER_BUCKET - bucket.num_entries() {
+            let key = Key::new(PeerId::random());
+            let node = Node { key, value: () };
+            assert_eq!(InsertResult::Inserted, bucket.insert(node, status));
+            assert_eq!(bucket.num_entries(), i + 1);
+        }
+        assert!(bucket.pending().is_none());
+    }
+
+    #[test]
+    fn ordering() {
+        fn prop(status: Vec<NodeStatus>) -> bool {
+            let mut bucket = KBucket::<PeerId, ()>::new(Duration::from_secs(1));
+
+            // The expected lists of connected and disconnected nodes.
+            let mut connected = VecDeque::new();
+            let mut disconnected = VecDeque::new();
+
+            // Fill the bucket, thereby populating the expected lists in insertion order.
+            for status in status {
+                let key = Key::new(PeerId::random());
+                let node = Node { key: key.clone(), value: () };
+                let full = bucket.num_entries() == MAX_NODES_PER_BUCKET;
+                match bucket.insert(node, status) {
+                    InsertResult::Inserted => {
+                        let vec = match status {
+                            NodeStatus::Connected => &mut connected,
+                            NodeStatus::Disconnected => &mut disconnected
+                        };
+                        if full {
+                            vec.pop_front();
+                        }
+                        vec.push_back((status, key.clone()));
+                    }
+                    _ => {}
+                }
+            }
+
+            // Get all nodes from the bucket, together with their status.
+            let mut nodes = bucket.iter()
+                .map(|(n, s)| (s, n.key.clone()))
+                .collect::<Vec<_>>();
+
+            // Split the list of nodes at the first connected node.
+            let first_connected_pos = nodes.iter().position(|(s,_)| *s == NodeStatus::Connected);
+            assert_eq!(bucket.first_connected_pos, first_connected_pos);
+            let tail = first_connected_pos.map_or(Vec::new(), |p| nodes.split_off(p));
+
+            // All nodes before the first connected node must be disconnected and
+            // in insertion order. Similarly, all remaining nodes must be connected
+            // and in insertion order.
+            nodes == Vec::from(disconnected)
+                &&
+            tail == Vec::from(connected)
+        }
+
+        quickcheck(prop as fn(_) -> _);
+    }
+
+    #[test]
+    fn full_bucket() {
+        let mut bucket = KBucket::<PeerId, ()>::new(Duration::from_secs(1));
+
+        // Fill the bucket with disconnected nodes.
+        fill_bucket(&mut bucket, NodeStatus::Disconnected);
+
+        // Trying to insert another disconnected node fails.
+        let key = Key::new(PeerId::random());
+        let node = Node { key, value: () };
+        match bucket.insert(node, NodeStatus::Disconnected) {
+            InsertResult::Full => {},
+            x => panic!("{:?}", x)
+        }
+
+        // One-by-one fill the bucket with connected nodes, replacing the disconnected ones.
+        for i in 0 .. MAX_NODES_PER_BUCKET {
+            let (first, first_status) = bucket.iter().next().unwrap();
+            let first_disconnected = first.clone();
+            assert_eq!(first_status, NodeStatus::Disconnected);
+
+            // Add a connected node, which is expected to be pending, scheduled to
+            // replace the first (i.e. least-recently connected) node.
+            let key = Key::new(PeerId::random());
+            let node = Node { key: key.clone(), value: () };
+            match bucket.insert(node.clone(), NodeStatus::Connected) {
+                InsertResult::Pending { disconnected } =>
+                    assert_eq!(disconnected, first_disconnected.key),
+                x => panic!("{:?}", x)
+            }
+
+            // Trying to insert another connected node fails.
+            match bucket.insert(node.clone(), NodeStatus::Connected) {
+                InsertResult::Full => {},
+                x => panic!("{:?}", x)
+            }
+
+            assert!(bucket.pending().is_some());
+
+            // Apply the pending node.
+            let pending = bucket.pending_mut().expect("No pending node.");
+            pending.set_ready_at(Instant::now() - Duration::from_secs(1));
+            let result = bucket.apply_pending();
+            assert_eq!(result, Some(AppliedPending {
+                inserted: key.clone(),
+                evicted: Some(first_disconnected)
+            }));
+            assert_eq!(Some((&node, NodeStatus::Connected)), bucket.iter().last());
+            assert!(bucket.pending().is_none());
+            assert_eq!(Some(MAX_NODES_PER_BUCKET - (i + 1)), bucket.first_connected_pos);
+        }
+
+        assert!(bucket.pending().is_none());
+        assert_eq!(MAX_NODES_PER_BUCKET, bucket.num_entries());
+
+        // Trying to insert another connected node fails.
+        let key = Key::new(PeerId::random());
+        let node = Node { key, value: () };
+        match bucket.insert(node, NodeStatus::Connected) {
+            InsertResult::Full => {},
+            x => panic!("{:?}", x)
+        }
+    }
+
+    #[test]
+    fn full_bucket_discard_pending() {
+        let mut bucket = KBucket::<PeerId, ()>::new(Duration::from_secs(1));
+        fill_bucket(&mut bucket, NodeStatus::Disconnected);
+        let (first, _) = bucket.iter().next().unwrap();
+        let first_disconnected = first.clone();
+
+        // Add a connected pending node.
+        let key = Key::new(PeerId::random());
+        let node = Node { key: key.clone(), value: () };
+        if let InsertResult::Pending { disconnected } = bucket.insert(node, NodeStatus::Connected) {
+            assert_eq!(&disconnected, &first_disconnected.key);
+        } else {
+            panic!()
+        }
+        assert!(bucket.pending().is_some());
+
+        // Update the status of the first disconnected node to be connected.
+        bucket.update(&first_disconnected.key, NodeStatus::Connected);
+
+        // The pending node has been discarded.
+        assert!(bucket.pending().is_none());
+        assert!(bucket.iter().all(|(n,_)| &n.key != &key));
+
+        // The initially disconnected node is now the most-recently connected.
+        assert_eq!(Some((&first_disconnected, NodeStatus::Connected)), bucket.iter().last());
+        assert_eq!(bucket.position(&first_disconnected.key).map(|p| p.0), bucket.first_connected_pos);
+        assert_eq!(1, bucket.num_connected());
+        assert_eq!(MAX_NODES_PER_BUCKET - 1, bucket.num_disconnected());
+    }
+}

--- a/protocols/kad/src/kbucket/entry.rs
+++ b/protocols/kad/src/kbucket/entry.rs
@@ -1,0 +1,501 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Entry API for quering and modifying entries in a `KBucketsTable`.
+
+use super::*;
+
+/// A cloned, immutable view of an entry in a bucket.
+#[derive(Clone, Debug)]
+pub struct EntryView<TPeerId, TVal> {
+    /// The key of the entry.
+    pub key: Key<TPeerId>,
+    /// The value of the entry.
+    pub value: TVal,
+    /// Whether the peer identified by the key is currently considered connected.
+    pub connected: bool
+}
+
+impl<TPeerId, TVal> AsRef<Key<TPeerId>> for EntryView<TPeerId, TVal> {
+    fn as_ref(&self) -> &Key<TPeerId> {
+        &self.key
+    }
+}
+
+/// Represents an entry or a potential entry in the k-buckets.
+pub enum Entry<'a, TPeerId, TVal> {
+    /// Entry in a k-bucket that we're connected to.
+    InKbucketConnected(EntryInKbucketConn<'a, TPeerId, TVal>),
+    /// Entry pending waiting for a free slot to enter a k-bucket. We're connected to it.
+    InKbucketConnectedPending(EntryInKbucketConnPending<'a, TPeerId, TVal>),
+    /// Entry in a k-bucket but that we're not connected to.
+    InKbucketDisconnected(EntryInKbucketDisc<'a, TPeerId, TVal>),
+    /// Entry pending waiting for a free slot to enter a k-bucket. We're not connected to it.
+    InKbucketDisconnectedPending(EntryInKbucketDiscPending<'a, TPeerId, TVal>),
+    /// Entry is not present in any k-bucket.
+    NotInKbucket(EntryNotInKbucket<'a, TPeerId, TVal>),
+    /// Entry is the local peer ID.
+    SelfEntry,
+}
+
+impl<'a, TPeerId, TVal> Entry<'a, TPeerId, TVal>
+where
+    TPeerId: Clone,
+{
+    /// Returns an object containing the state of the given entry.
+    pub(super) fn new(parent: &'a mut KBucketsTable<TPeerId, TVal>, peer_id: &'a Key<TPeerId>)
+        -> Entry<'a, TPeerId, TVal>
+    {
+        let bucket = if let Some(bucket) = parent.bucket_mut(peer_id) {
+            bucket
+        } else {
+            return Entry::SelfEntry;
+        };
+
+        // Update the pending node state.
+        // TODO: must be reported to the user somehow, in a non-annoying API
+        bucket.apply_pending();
+
+        // Try to find the node in the bucket.
+        if let Some(pos) = bucket.nodes.iter().position(|p| p.id == *peer_id) {
+            if bucket.first_connected_pos.map_or(false, |i| pos >= i) {
+                Entry::InKbucketConnected(EntryInKbucketConn { parent, peer_id })
+            } else {
+                Entry::InKbucketDisconnected(EntryInKbucketDisc { parent, peer_id })
+            }
+        } else if bucket.pending_node.as_ref().map(|p| p.node.id == *peer_id).unwrap_or(false) {
+            // Node is pending.
+            if bucket.pending_node.as_ref().map(|p| p.connected).unwrap_or(false) {
+                Entry::InKbucketConnectedPending(EntryInKbucketConnPending { parent, peer_id })
+            } else {
+                Entry::InKbucketDisconnectedPending(EntryInKbucketDiscPending { parent, peer_id })
+            }
+        } else {
+            Entry::NotInKbucket(EntryNotInKbucket { parent, peer_id })
+        }
+    }
+
+
+    /// Creates a cloned, immutable view of the entry, if it is contained in a bucket.
+    ///
+    /// Returns `None` if the entry is not contained in any bucket.
+    pub fn view(&mut self) -> Option<EntryView<TPeerId, TVal>>
+    where
+        TVal: Clone
+    {
+        if let Some(key) = self.key().cloned() {
+            if let Some(value) = self.value().cloned() {
+                return Some(EntryView {
+                    key, value, connected: match self {
+                        Entry::InKbucketConnected(_) |
+                        Entry::InKbucketConnectedPending(_) => true,
+                        _ => false
+                    }
+                })
+            }
+        }
+        return None
+    }
+
+    /// Returns the key of the entry.
+    pub fn key(&self) -> Option<&Key<TPeerId>> {
+        match self {
+            Entry::InKbucketConnected(entry) => Some(entry.key()),
+            Entry::InKbucketConnectedPending(entry) => Some(entry.key()),
+            Entry::InKbucketDisconnected(entry) => Some(entry.key()),
+            Entry::InKbucketDisconnectedPending(entry) => Some(entry.key()),
+            Entry::NotInKbucket(_entry) => None,
+            Entry::SelfEntry => None,
+        }
+    }
+
+    /// Returns the value associated to the entry in the bucket, including if the node is pending.
+    pub fn value(&mut self) -> Option<&mut TVal> {
+        match self {
+            Entry::InKbucketConnected(entry) => Some(entry.value()),
+            Entry::InKbucketConnectedPending(entry) => Some(entry.value()),
+            Entry::InKbucketDisconnected(entry) => Some(entry.value()),
+            Entry::InKbucketDisconnectedPending(entry) => Some(entry.value()),
+            Entry::NotInKbucket(_entry) => None,
+            Entry::SelfEntry => None,
+        }
+    }
+
+    /// Returns the value associated to the entry in the bucket.
+    pub fn value_not_pending(&mut self) -> Option<&mut TVal> {
+        match self {
+            Entry::InKbucketConnected(entry) => Some(entry.value()),
+            Entry::InKbucketConnectedPending(_entry) => None,
+            Entry::InKbucketDisconnected(entry) => Some(entry.value()),
+            Entry::InKbucketDisconnectedPending(_entry) => None,
+            Entry::NotInKbucket(_entry) => None,
+            Entry::SelfEntry => None,
+        }
+    }
+}
+
+/// Represents an entry in a k-bucket.
+pub struct EntryInKbucketConn<'a, TPeerId, TVal> {
+    parent: &'a mut KBucketsTable<TPeerId, TVal>,
+    peer_id: &'a Key<TPeerId>,
+}
+
+impl<'a, TPeerId, TVal> EntryInKbucketConn<'a, TPeerId, TVal>
+where
+    TPeerId: Clone,
+{
+    pub fn key(&self) -> &Key<TPeerId> {
+        self.peer_id
+    }
+
+    /// Returns the value associated to the entry in the bucket.
+    pub fn value(&mut self) -> &mut TVal {
+        let table = self.parent.bucket_mut(&self.peer_id)
+            .expect("we can only build a EntryInKbucketConn if we know of a bucket; QED");
+
+        let peer_id = self.peer_id;
+        &mut table.nodes.iter_mut()
+            .find(move |p| p.id == *peer_id)
+            .expect("We can only build a EntryInKbucketConn if we know that the peer is in its \
+                     bucket; QED")
+            .value
+    }
+
+    /// Reports that we are now disconnected from the given node.
+    ///
+    /// This moves the node down in its bucket. There are two possible outcomes:
+    ///
+    /// - Either we had a pending node which replaces the current node. `Replaced` is returned.
+    /// - Or we had no pending node, and the current node is kept. `Kept` is returned.
+    ///
+    pub fn set_disconnected(self) -> SetDisconnectedOutcome<'a, TPeerId, TVal> {
+        let table = self.parent.bucket_mut(&self.peer_id)
+                .expect("we can only build a EntryInKbucketConn if we know of a bucket; QED");
+
+        let peer_id = self.peer_id;
+        let pos = table.nodes.iter().position(move |elem| elem.id == *peer_id)
+            .expect("we can only build a EntryInKbucketConn if the node is in its bucket; QED");
+        debug_assert!(table.first_connected_pos.map_or(false, |i| i <= pos));
+
+        // Replace the disconnected entry with the pending entry, if one exists
+        // and it is considered connected.
+        if let Some(pending) = table.pending_node.take() {
+            if pending.connected {
+                let removed = table.nodes.remove(pos);
+                let replacement = pending.node.id.clone();
+                // The pending entry is considered the most-recently connected, i.e.
+                // pushed to the end.
+                table.nodes.push(pending.node);
+                return SetDisconnectedOutcome::Replaced {
+                    replacement,
+                    old_val: removed.value,
+                }
+            } else {
+                table.pending_node = Some(pending);
+            }
+        }
+
+        // Otherwise, there is now one less connected entry. The entry for the most-recently
+        // disconnected peer precedes the entry of the first connected peer in the bucket.
+        if let Some(ref mut first_connected_pos) = table.first_connected_pos {
+            if pos != *first_connected_pos {
+                let elem = table.nodes.remove(pos);
+                table.nodes.insert(*first_connected_pos, elem);
+            }
+            if *first_connected_pos == table.nodes.len() - 1 {
+                table.first_connected_pos = None;
+            } else {
+                *first_connected_pos += 1;
+            }
+        } else {
+            let entry = table.nodes.remove(pos);
+            table.nodes.push(entry);
+        }
+
+        // And return a EntryInKbucketDisc.
+        debug_assert!(table.nodes.iter()
+            .position(move |e| e.id == *peer_id)
+            .map_or(false, |p| table.first_connected_pos.map_or(false, |i| p < i)));
+
+        SetDisconnectedOutcome::Kept(EntryInKbucketDisc {
+            parent: self.parent,
+            peer_id: self.peer_id,
+        })
+    }
+}
+
+/// Outcome of calling `set_disconnected`.
+#[must_use]
+pub enum SetDisconnectedOutcome<'a, TPeerId, TVal> {
+    /// Node is kept in the bucket.
+    Kept(EntryInKbucketDisc<'a, TPeerId, TVal>),
+    /// Node is pushed out of the bucket.
+    Replaced {
+        /// Node that replaced the node.
+        // TODO: could be a EntryInKbucketConn, but we have borrow issues with the new peer id
+        replacement: Key<TPeerId>,
+        /// Value os the node that has been pushed out.
+        old_val: TVal,
+    },
+}
+
+/// Represents an entry waiting for a slot to be available in its k-bucket.
+pub struct EntryInKbucketConnPending<'a, TPeerId, TVal> {
+    parent: &'a mut KBucketsTable<TPeerId, TVal>,
+    peer_id: &'a Key<TPeerId>,
+}
+
+impl<'a, TPeerId, TVal> EntryInKbucketConnPending<'a, TPeerId, TVal>
+where
+    TPeerId: Clone,
+{
+    pub fn key(&self) -> &Key<TPeerId> {
+        self.peer_id
+    }
+
+    /// Returns the value associated to the entry in the bucket.
+    pub fn value(&mut self) -> &mut TVal {
+        let table = self.parent.bucket_mut(&self.peer_id)
+                .expect("we can only build a EntryInKbucketConnPending if we know of a bucket; QED");
+
+        assert!(table.pending_node.as_ref().map(|n| &n.node.id) == Some(self.peer_id));
+        &mut table.pending_node
+            .as_mut()
+            .expect("we can only build a EntryInKbucketConnPending if the node is pending; QED")
+            .node.value
+    }
+
+    /// Reports that we are now disconnected from the given node.
+    pub fn set_disconnected(self) -> EntryInKbucketDiscPending<'a, TPeerId, TVal> {
+        let table = self.parent.bucket_mut(&self.peer_id)
+                .expect("we can only build a EntryInKbucketConnPending if we know of a bucket; QED");
+
+        let mut pending = table.pending_node.as_mut()
+            .expect("we can only build a EntryInKbucketConnPending if there's a pending node; QED");
+        debug_assert!(pending.connected);
+        pending.connected = false;
+
+        EntryInKbucketDiscPending {
+            parent: self.parent,
+            peer_id: self.peer_id,
+        }
+    }
+}
+
+/// Represents an entry waiting for a slot to be available in its k-bucket.
+pub struct EntryInKbucketDiscPending<'a, TPeerId, TVal> {
+    parent: &'a mut KBucketsTable<TPeerId, TVal>,
+    peer_id: &'a Key<TPeerId>,
+}
+
+impl<'a, TPeerId, TVal> EntryInKbucketDiscPending<'a, TPeerId, TVal>
+where
+    TPeerId: Clone,
+{
+    pub fn key(&self) -> &Key<TPeerId> {
+        self.peer_id
+    }
+
+    /// Returns the value associated to the entry in the bucket.
+    pub fn value(&mut self) -> &mut TVal {
+        let table = self.parent.bucket_mut(&self.peer_id)
+                .expect("we can only build a EntryInKbucketDiscPending if we know of a bucket; QED");
+
+        assert!(table.pending_node.as_ref().map(|n| &n.node.id) == Some(self.peer_id));
+        &mut table.pending_node
+            .as_mut()
+            .expect("we can only build a EntryInKbucketDiscPending if the node is pending; QED")
+            .node.value
+    }
+
+    /// Reports that we are now connected to the given node.
+    pub fn set_connected(self) -> EntryInKbucketConnPending<'a, TPeerId, TVal> {
+        let table = self.parent.bucket_mut(&self.peer_id)
+                .expect("we can only build a EntryInKbucketDiscPending if we know of a bucket; QED");
+
+        let mut pending = table.pending_node.as_mut()
+            .expect("we can only build a EntryInKbucketDiscPending if there's a pending node; QED");
+        debug_assert!(!pending.connected);
+        pending.connected = true;
+
+        EntryInKbucketConnPending {
+            parent: self.parent,
+            peer_id: self.peer_id,
+        }
+    }
+}
+
+/// Represents an entry in a k-bucket.
+pub struct EntryInKbucketDisc<'a, TPeerId, TVal> {
+    parent: &'a mut KBucketsTable<TPeerId, TVal>,
+    peer_id: &'a Key<TPeerId>,
+}
+
+impl<'a, TPeerId, TVal> EntryInKbucketDisc<'a, TPeerId, TVal>
+where
+    TPeerId: Clone,
+{
+    pub fn key(&self) -> &Key<TPeerId> {
+        self.peer_id
+    }
+
+    /// Returns the value associated to the entry in the bucket.
+    pub fn value(&mut self) -> &mut TVal {
+        let table = self.parent.bucket_mut(&self.peer_id)
+                .expect("we can only build a EntryInKbucketDisc if we know of a bucket; QED");
+
+        let peer_id = self.peer_id;
+        &mut table.nodes.iter_mut()
+            .find(move |p| p.id == *peer_id)
+            .expect("We can only build a EntryInKbucketDisc if we know that the peer is in its \
+                     bucket; QED")
+            .value
+    }
+
+    /// Sets the node as connected. This moves the entry in the bucket.
+    pub fn set_connected(self) -> EntryInKbucketConn<'a, TPeerId, TVal> {
+        let table = self.parent.bucket_mut(&self.peer_id)
+                .expect("we can only build a EntryInKbucketDisc if we know of a bucket; QED");
+
+        let pos = {
+            let peer_id = self.peer_id;
+            table.nodes.iter().position(|p| p.id == *peer_id)
+                .expect("We can only build a EntryInKbucketDisc if we know that the peer is in \
+                         its bucket; QED")
+        };
+
+        // If the position marks the least-recently connected peer, it is now re-connected,
+        // which means that the pending entry should be dropped, as preference is given to
+        // previously known peers.
+        //
+        // Note that it is theoretically possible that the replacement could have occurred between
+        // the moment when we build the `EntryInKbucketConn` and the moment when we call
+        // `set_connected`, but we don't take that into account.
+        if pos == 0 {
+            table.pending_node = None;
+        }
+
+        // The entry for the most-recently connected peer goes at the end of the bucket.
+        debug_assert!(table.first_connected_pos.map_or(true, |i| pos < i));
+        let last = table.nodes.len() - 1;
+        table.first_connected_pos = table.first_connected_pos.map(|p| p - 1).or(Some(last));
+        let entry = table.nodes.remove(pos);
+        table.nodes.push(entry);
+
+        // There shouldn't be a pending node if all slots are full of connected nodes.
+        debug_assert!(table.first_connected_pos != Some(0) || table.pending_node.is_none());
+
+        EntryInKbucketConn {
+            parent: self.parent,
+            peer_id: self.peer_id,
+        }
+    }
+}
+
+/// Represents an entry not in any k-bucket.
+pub struct EntryNotInKbucket<'a, TPeerId, TVal> {
+    parent: &'a mut KBucketsTable<TPeerId, TVal>,
+    peer_id: &'a Key<TPeerId>,
+}
+
+impl<TPeerId, TVal> EntryNotInKbucket<'_, TPeerId, TVal>
+where
+    TPeerId: Clone,
+{
+    /// Inserts the node as connected, if possible.
+    pub fn insert_connected(self, value: TVal) -> InsertOutcome<TPeerId> {
+        let unresponsive_timeout = self.parent.unresponsive_timeout;
+
+        let table = self.parent.bucket_mut(&self.peer_id)
+                .expect("we can only build a EntryNotInKbucket if we know of a bucket; QED");
+
+        if table.nodes.is_full() {
+            if table.first_connected_pos == Some(0) || table.pending_node.is_some() {
+                InsertOutcome::Full
+            } else {
+                table.pending_node = Some(PendingNode {
+                    node: Node { id: self.peer_id.clone(), value },
+                    replace: Instant::now() + unresponsive_timeout,
+                    connected: true,
+                });
+                InsertOutcome::Pending {
+                    to_ping: table.nodes[0].id.clone()
+                }
+            }
+        } else {
+            // The most-recently connected peer is the last entry in the bucket.
+            let pos = table.nodes.len();
+            table.nodes.push(Node {
+                id: self.peer_id.clone(),
+                value,
+            });
+            table.first_connected_pos = table.first_connected_pos.or(Some(pos));
+            InsertOutcome::Inserted
+        }
+    }
+
+    /// Inserts the node as disconnected, if possible.
+    ///
+    /// > **Note**: This function will never return `Pending`. If the bucket is full, we simply
+    /// >           do nothing.
+    pub fn insert_disconnected(self, value: TVal) -> InsertOutcome<TPeerId> {
+        let table = self.parent.bucket_mut(&self.peer_id)
+                .expect("we can only build a EntryNotInKbucket if we know of a bucket; QED");
+
+        if table.nodes.is_full() {
+            InsertOutcome::Full
+        } else {
+            // The most-recently disconnected peer is the entry preceding the first
+            // connected peer.
+            let node = Node { id: self.peer_id.clone(), value };
+            if let Some(ref mut first_connected_pos) = table.first_connected_pos {
+                table.nodes.insert(*first_connected_pos, node);
+                *first_connected_pos += 1;
+            } else {
+                table.nodes.push(node);
+            }
+            InsertOutcome::Inserted
+        }
+    }
+}
+
+/// The outcome of [`EntryNotInKbucket::insert_connected`] and
+/// [`EntryNotInKbucket::insert_disconnected`].
+#[must_use]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InsertOutcome<TPeerId> {
+    /// The entry has been successfully inserted into a bucket.
+    Inserted,
+    /// The entry is pending insertion into a bucket that is currently full. The pending
+    /// entry is inserted after a timeout elapsed, if the connection to the peer
+    /// corresponding to the least-recently connected entry is not re-established within
+    /// that timeout window.
+    Pending {
+        /// The identifier of the least-recently connected peer that is currently considered
+        /// disconnected and should be checked for connectivity in order to prevent it from being
+        /// replaced. If connectivity to the peer is re-established, the corresponding
+        /// entry should be updated via [`EntryInKbucketDisc::set_connected`].
+        to_ping: Key<TPeerId>,
+    },
+    /// The entry was not inserted because the bucket is filled with entries marked
+    /// as connected and there already exists a pending entry for that bucket.
+    Full,
+}
+

--- a/protocols/kad/src/kbucket/entry.rs
+++ b/protocols/kad/src/kbucket/entry.rs
@@ -18,484 +18,237 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! Entry API for quering and modifying entries in a `KBucketsTable`.
+//! The `Entry` API for quering and modifying the entries of a `KBucketsTable`
+//! representing the nodes participating in the Kademlia DHT.
+
+pub use super::bucket::{Node, NodeStatus, InsertResult, AppliedPending, MAX_NODES_PER_BUCKET};
+pub use super::key::*;
 
 use super::*;
 
-/// A cloned, immutable view of an entry in a bucket.
+/// An immutable by-reference view of a bucket entry.
+pub struct EntryRefView<'a, TPeerId, TVal> {
+    /// The node represented by the entry.
+    pub node: NodeRefView<'a, TPeerId, TVal>,
+    /// The status of the node identified by the key.
+    pub status: NodeStatus
+}
+
+/// An immutable by-reference view of a `Node`.
+pub struct NodeRefView<'a, TPeerId, TVal> {
+    pub key: &'a Key<TPeerId>,
+    pub value: &'a TVal
+}
+
+impl<TPeerId, TVal> EntryRefView<'_, TPeerId, TVal> {
+    pub fn to_owned(&self) -> EntryView<TPeerId, TVal>
+    where
+        TPeerId: Clone,
+        TVal: Clone
+    {
+        EntryView {
+            node: Node {
+                key: self.node.key.clone(),
+                value: self.node.value.clone()
+            },
+            status: self.status
+        }
+    }
+}
+
+/// A cloned, immutable view of an entry that is either present in a bucket
+/// or pending insertion.
 #[derive(Clone, Debug)]
 pub struct EntryView<TPeerId, TVal> {
-    /// The key of the entry.
-    pub key: Key<TPeerId>,
-    /// The value of the entry.
-    pub value: TVal,
-    /// Whether the peer identified by the key is currently considered connected.
-    pub connected: bool
+    /// The node represented by the entry.
+    pub node: Node<TPeerId, TVal>,
+    /// The status of the node.
+    pub status: NodeStatus
 }
 
 impl<TPeerId, TVal> AsRef<Key<TPeerId>> for EntryView<TPeerId, TVal> {
     fn as_ref(&self) -> &Key<TPeerId> {
-        &self.key
+        &self.node.key
     }
 }
 
-/// Represents an entry or a potential entry in the k-buckets.
+/// A reference into a single entry of a `KBucketsTable`.
+#[derive(Debug)]
 pub enum Entry<'a, TPeerId, TVal> {
-    /// Entry in a k-bucket that we're connected to.
-    InKbucketConnected(EntryInKbucketConn<'a, TPeerId, TVal>),
-    /// Entry pending waiting for a free slot to enter a k-bucket. We're connected to it.
-    InKbucketConnectedPending(EntryInKbucketConnPending<'a, TPeerId, TVal>),
-    /// Entry in a k-bucket but that we're not connected to.
-    InKbucketDisconnected(EntryInKbucketDisc<'a, TPeerId, TVal>),
-    /// Entry pending waiting for a free slot to enter a k-bucket. We're not connected to it.
-    InKbucketDisconnectedPending(EntryInKbucketDiscPending<'a, TPeerId, TVal>),
-    /// Entry is not present in any k-bucket.
-    NotInKbucket(EntryNotInKbucket<'a, TPeerId, TVal>),
-    /// Entry is the local peer ID.
+    /// The entry is present in a bucket.
+    Present(PresentEntry<'a, TPeerId, TVal>, NodeStatus),
+    /// The entry is pending insertion in a bucket.
+    Pending(PendingEntry<'a, TPeerId, TVal>, NodeStatus),
+    /// The entry is absent and may be inserted.
+    Absent(AbsentEntry<'a, TPeerId, TVal>),
+    /// The entry represents the local node.
     SelfEntry,
+}
+
+/// The internal representation of the different states of an `Entry`,
+/// referencing the associated key and bucket.
+#[derive(Debug)]
+struct EntryRef<'a, TPeerId, TVal> {
+    bucket: &'a mut KBucket<TPeerId, TVal>,
+    key: &'a Key<TPeerId>,
 }
 
 impl<'a, TPeerId, TVal> Entry<'a, TPeerId, TVal>
 where
     TPeerId: Clone,
 {
-    /// Returns an object containing the state of the given entry.
-    pub(super) fn new(parent: &'a mut KBucketsTable<TPeerId, TVal>, peer_id: &'a Key<TPeerId>)
-        -> Entry<'a, TPeerId, TVal>
-    {
-        let bucket = if let Some(bucket) = parent.bucket_mut(peer_id) {
-            bucket
+    /// Creates a new `Entry` for a `Key`, encapsulating access to a bucket.
+    pub(super) fn new(bucket: &'a mut KBucket<TPeerId, TVal>, key: &'a Key<TPeerId>) -> Self {
+        if let Some(pos) = bucket.position(key) {
+            let status = bucket.status(pos);
+            Entry::Present(PresentEntry::new(bucket, key), status)
+        } else if let Some(pending) = bucket.as_pending(key) {
+            let status = pending.status();
+            Entry::Pending(PendingEntry::new(bucket, key), status)
         } else {
-            return Entry::SelfEntry;
-        };
-
-        // Update the pending node state.
-        // TODO: must be reported to the user somehow, in a non-annoying API
-        bucket.apply_pending();
-
-        // Try to find the node in the bucket.
-        if let Some(pos) = bucket.nodes.iter().position(|p| p.id == *peer_id) {
-            if bucket.first_connected_pos.map_or(false, |i| pos >= i) {
-                Entry::InKbucketConnected(EntryInKbucketConn { parent, peer_id })
-            } else {
-                Entry::InKbucketDisconnected(EntryInKbucketDisc { parent, peer_id })
-            }
-        } else if bucket.pending_node.as_ref().map(|p| p.node.id == *peer_id).unwrap_or(false) {
-            // Node is pending.
-            if bucket.pending_node.as_ref().map(|p| p.connected).unwrap_or(false) {
-                Entry::InKbucketConnectedPending(EntryInKbucketConnPending { parent, peer_id })
-            } else {
-                Entry::InKbucketDisconnectedPending(EntryInKbucketDiscPending { parent, peer_id })
-            }
-        } else {
-            Entry::NotInKbucket(EntryNotInKbucket { parent, peer_id })
+            Entry::Absent(AbsentEntry::new(bucket, key))
         }
     }
 
-
-    /// Creates a cloned, immutable view of the entry, if it is contained in a bucket.
+    /// Creates an immutable by-reference view of the entry.
     ///
-    /// Returns `None` if the entry is not contained in any bucket.
-    pub fn view(&mut self) -> Option<EntryView<TPeerId, TVal>>
-    where
-        TVal: Clone
-    {
-        if let Some(key) = self.key().cloned() {
-            if let Some(value) = self.value().cloned() {
-                return Some(EntryView {
-                    key, value, connected: match self {
-                        Entry::InKbucketConnected(_) |
-                        Entry::InKbucketConnectedPending(_) => true,
-                        _ => false
-                    }
-                })
-            }
+    /// Returns `None` if the entry is neither present in a bucket nor
+    /// pending insertion into a bucket.
+    pub fn view(&'a mut self) -> Option<EntryRefView<'a, TPeerId, TVal>> {
+        match self {
+            Entry::Present(entry, status) => Some(EntryRefView {
+                node: NodeRefView {
+                    key: entry.0.key,
+                    value: entry.value()
+                },
+                status: *status
+            }),
+            Entry::Pending(entry, status) => Some(EntryRefView {
+                node: NodeRefView {
+                    key: entry.0.key,
+                    value: entry.value()
+                },
+                status: *status
+            }),
+            _ => None
         }
-        return None
     }
 
     /// Returns the key of the entry.
+    ///
+    /// Returns `None` if the `Key` used to construct this `Entry` is not a valid
+    /// key for an entry in a bucket, which is the case for the `local_key` of
+    /// the `KBucketsTable` referring to the local node.
     pub fn key(&self) -> Option<&Key<TPeerId>> {
         match self {
-            Entry::InKbucketConnected(entry) => Some(entry.key()),
-            Entry::InKbucketConnectedPending(entry) => Some(entry.key()),
-            Entry::InKbucketDisconnected(entry) => Some(entry.key()),
-            Entry::InKbucketDisconnectedPending(entry) => Some(entry.key()),
-            Entry::NotInKbucket(_entry) => None,
+            Entry::Present(entry, _) => Some(entry.key()),
+            Entry::Pending(entry, _) => Some(entry.key()),
+            Entry::Absent(entry) => Some(entry.key()),
             Entry::SelfEntry => None,
         }
     }
 
-    /// Returns the value associated to the entry in the bucket, including if the node is pending.
+    /// Returns the value associated with the entry.
+    ///
+    /// Returns `None` if the entry absent from any bucket or refers to the
+    /// local node.
     pub fn value(&mut self) -> Option<&mut TVal> {
         match self {
-            Entry::InKbucketConnected(entry) => Some(entry.value()),
-            Entry::InKbucketConnectedPending(entry) => Some(entry.value()),
-            Entry::InKbucketDisconnected(entry) => Some(entry.value()),
-            Entry::InKbucketDisconnectedPending(entry) => Some(entry.value()),
-            Entry::NotInKbucket(_entry) => None,
-            Entry::SelfEntry => None,
-        }
-    }
-
-    /// Returns the value associated to the entry in the bucket.
-    pub fn value_not_pending(&mut self) -> Option<&mut TVal> {
-        match self {
-            Entry::InKbucketConnected(entry) => Some(entry.value()),
-            Entry::InKbucketConnectedPending(_entry) => None,
-            Entry::InKbucketDisconnected(entry) => Some(entry.value()),
-            Entry::InKbucketDisconnectedPending(_entry) => None,
-            Entry::NotInKbucket(_entry) => None,
+            Entry::Present(entry, _) => Some(entry.value()),
+            Entry::Pending(entry, _) => Some(entry.value()),
+            Entry::Absent(_) => None,
             Entry::SelfEntry => None,
         }
     }
 }
 
-/// Represents an entry in a k-bucket.
-pub struct EntryInKbucketConn<'a, TPeerId, TVal> {
-    parent: &'a mut KBucketsTable<TPeerId, TVal>,
-    peer_id: &'a Key<TPeerId>,
-}
+/// An entry present in a bucket.
+#[derive(Debug)]
+pub struct PresentEntry<'a, TPeerId, TVal>(EntryRef<'a, TPeerId, TVal>);
 
-impl<'a, TPeerId, TVal> EntryInKbucketConn<'a, TPeerId, TVal>
+impl<'a, TPeerId, TVal> PresentEntry<'a, TPeerId, TVal>
 where
     TPeerId: Clone,
 {
-    pub fn key(&self) -> &Key<TPeerId> {
-        self.peer_id
+    fn new(bucket: &'a mut KBucket<TPeerId, TVal>, key: &'a Key<TPeerId>) -> Self {
+        PresentEntry(EntryRef { bucket, key })
     }
 
-    /// Returns the value associated to the entry in the bucket.
-    pub fn value(&mut self) -> &mut TVal {
-        let table = self.parent.bucket_mut(&self.peer_id)
-            .expect("we can only build a EntryInKbucketConn if we know of a bucket; QED");
+    /// Returns the key of the entry.
+    pub fn key(&self) -> &Key<TPeerId> {
+        self.0.key
+    }
 
-        let peer_id = self.peer_id;
-        &mut table.nodes.iter_mut()
-            .find(move |p| p.id == *peer_id)
-            .expect("We can only build a EntryInKbucketConn if we know that the peer is in its \
-                     bucket; QED")
+    /// Returns the value associated with the key.
+    pub fn value(&mut self) -> &mut TVal {
+        &mut self.0.bucket
+            .get_mut(self.0.key)
+            .expect("We can only build a ConnectedEntry if the entry is in the bucket; QED")
             .value
     }
 
-    /// Reports that we are now disconnected from the given node.
-    ///
-    /// This moves the node down in its bucket. There are two possible outcomes:
-    ///
-    /// - Either we had a pending node which replaces the current node. `Replaced` is returned.
-    /// - Or we had no pending node, and the current node is kept. `Kept` is returned.
-    ///
-    pub fn set_disconnected(self) -> SetDisconnectedOutcome<'a, TPeerId, TVal> {
-        let table = self.parent.bucket_mut(&self.peer_id)
-                .expect("we can only build a EntryInKbucketConn if we know of a bucket; QED");
-
-        let peer_id = self.peer_id;
-        let pos = table.nodes.iter().position(move |elem| elem.id == *peer_id)
-            .expect("we can only build a EntryInKbucketConn if the node is in its bucket; QED");
-        debug_assert!(table.first_connected_pos.map_or(false, |i| i <= pos));
-
-        // Replace the disconnected entry with the pending entry, if one exists
-        // and it is considered connected.
-        if let Some(pending) = table.pending_node.take() {
-            if pending.connected {
-                let removed = table.nodes.remove(pos);
-                let replacement = pending.node.id.clone();
-                // The pending entry is considered the most-recently connected, i.e.
-                // pushed to the end.
-                table.nodes.push(pending.node);
-                return SetDisconnectedOutcome::Replaced {
-                    replacement,
-                    old_val: removed.value,
-                }
-            } else {
-                table.pending_node = Some(pending);
-            }
-        }
-
-        // Otherwise, there is now one less connected entry. The entry for the most-recently
-        // disconnected peer precedes the entry of the first connected peer in the bucket.
-        if let Some(ref mut first_connected_pos) = table.first_connected_pos {
-            if pos != *first_connected_pos {
-                let elem = table.nodes.remove(pos);
-                table.nodes.insert(*first_connected_pos, elem);
-            }
-            if *first_connected_pos == table.nodes.len() - 1 {
-                table.first_connected_pos = None;
-            } else {
-                *first_connected_pos += 1;
-            }
-        } else {
-            let entry = table.nodes.remove(pos);
-            table.nodes.push(entry);
-        }
-
-        // And return a EntryInKbucketDisc.
-        debug_assert!(table.nodes.iter()
-            .position(move |e| e.id == *peer_id)
-            .map_or(false, |p| table.first_connected_pos.map_or(false, |i| p < i)));
-
-        SetDisconnectedOutcome::Kept(EntryInKbucketDisc {
-            parent: self.parent,
-            peer_id: self.peer_id,
-        })
+    /// Sets the status of the entry to `NodeStatus::Disconnected`.
+    pub fn update(self, status: NodeStatus) -> Self {
+        self.0.bucket.update(self.0.key, status);
+        Self::new(self.0.bucket, self.0.key)
     }
 }
 
-/// Outcome of calling `set_disconnected`.
-#[must_use]
-pub enum SetDisconnectedOutcome<'a, TPeerId, TVal> {
-    /// Node is kept in the bucket.
-    Kept(EntryInKbucketDisc<'a, TPeerId, TVal>),
-    /// Node is pushed out of the bucket.
-    Replaced {
-        /// Node that replaced the node.
-        // TODO: could be a EntryInKbucketConn, but we have borrow issues with the new peer id
-        replacement: Key<TPeerId>,
-        /// Value os the node that has been pushed out.
-        old_val: TVal,
-    },
-}
+/// An entry waiting for a slot to be available in a bucket.
+#[derive(Debug)]
+pub struct PendingEntry<'a, TPeerId, TVal>(EntryRef<'a, TPeerId, TVal>);
 
-/// Represents an entry waiting for a slot to be available in its k-bucket.
-pub struct EntryInKbucketConnPending<'a, TPeerId, TVal> {
-    parent: &'a mut KBucketsTable<TPeerId, TVal>,
-    peer_id: &'a Key<TPeerId>,
-}
-
-impl<'a, TPeerId, TVal> EntryInKbucketConnPending<'a, TPeerId, TVal>
+impl<'a, TPeerId, TVal> PendingEntry<'a, TPeerId, TVal>
 where
     TPeerId: Clone,
 {
+    fn new(bucket: &'a mut KBucket<TPeerId, TVal>, key: &'a Key<TPeerId>) -> Self {
+        PendingEntry(EntryRef { bucket, key })
+    }
+
+    /// Returns the key of the entry.
     pub fn key(&self) -> &Key<TPeerId> {
-        self.peer_id
+        self.0.key
     }
 
-    /// Returns the value associated to the entry in the bucket.
+    /// Returns the value associated with the key.
     pub fn value(&mut self) -> &mut TVal {
-        let table = self.parent.bucket_mut(&self.peer_id)
-                .expect("we can only build a EntryInKbucketConnPending if we know of a bucket; QED");
-
-        assert!(table.pending_node.as_ref().map(|n| &n.node.id) == Some(self.peer_id));
-        &mut table.pending_node
-            .as_mut()
-            .expect("we can only build a EntryInKbucketConnPending if the node is pending; QED")
-            .node.value
+        self.0.bucket
+            .pending_mut()
+            .expect("We can only build a ConnectedPendingEntry if the entry is pending; QED")
+            .value_mut()
     }
 
-    /// Reports that we are now disconnected from the given node.
-    pub fn set_disconnected(self) -> EntryInKbucketDiscPending<'a, TPeerId, TVal> {
-        let table = self.parent.bucket_mut(&self.peer_id)
-                .expect("we can only build a EntryInKbucketConnPending if we know of a bucket; QED");
-
-        let mut pending = table.pending_node.as_mut()
-            .expect("we can only build a EntryInKbucketConnPending if there's a pending node; QED");
-        debug_assert!(pending.connected);
-        pending.connected = false;
-
-        EntryInKbucketDiscPending {
-            parent: self.parent,
-            peer_id: self.peer_id,
-        }
+    /// Updates the status of the pending entry.
+    pub fn update(self, status: NodeStatus) -> PendingEntry<'a, TPeerId, TVal> {
+        self.0.bucket.update_pending(status);
+        PendingEntry::new(self.0.bucket, self.0.key)
     }
 }
 
-/// Represents an entry waiting for a slot to be available in its k-bucket.
-pub struct EntryInKbucketDiscPending<'a, TPeerId, TVal> {
-    parent: &'a mut KBucketsTable<TPeerId, TVal>,
-    peer_id: &'a Key<TPeerId>,
-}
+/// An entry that is not present in any bucket.
+#[derive(Debug)]
+pub struct AbsentEntry<'a, TPeerId, TVal>(EntryRef<'a, TPeerId, TVal>);
 
-impl<'a, TPeerId, TVal> EntryInKbucketDiscPending<'a, TPeerId, TVal>
+impl<'a, TPeerId, TVal> AbsentEntry<'a, TPeerId, TVal>
 where
     TPeerId: Clone,
 {
+    fn new(bucket: &'a mut KBucket<TPeerId, TVal>, key: &'a Key<TPeerId>) -> Self {
+        AbsentEntry(EntryRef { bucket, key })
+    }
+
+    /// Returns the key of the entry.
     pub fn key(&self) -> &Key<TPeerId> {
-        self.peer_id
+        self.0.key
     }
 
-    /// Returns the value associated to the entry in the bucket.
-    pub fn value(&mut self) -> &mut TVal {
-        let table = self.parent.bucket_mut(&self.peer_id)
-                .expect("we can only build a EntryInKbucketDiscPending if we know of a bucket; QED");
-
-        assert!(table.pending_node.as_ref().map(|n| &n.node.id) == Some(self.peer_id));
-        &mut table.pending_node
-            .as_mut()
-            .expect("we can only build a EntryInKbucketDiscPending if the node is pending; QED")
-            .node.value
+    /// Attempts to insert the entry into a bucket.
+    pub fn insert(self, value: TVal, status: NodeStatus) -> InsertResult<TPeerId> {
+        self.0.bucket.insert(Node {
+            key: self.0.key.clone(),
+            value
+        }, status)
     }
-
-    /// Reports that we are now connected to the given node.
-    pub fn set_connected(self) -> EntryInKbucketConnPending<'a, TPeerId, TVal> {
-        let table = self.parent.bucket_mut(&self.peer_id)
-                .expect("we can only build a EntryInKbucketDiscPending if we know of a bucket; QED");
-
-        let mut pending = table.pending_node.as_mut()
-            .expect("we can only build a EntryInKbucketDiscPending if there's a pending node; QED");
-        debug_assert!(!pending.connected);
-        pending.connected = true;
-
-        EntryInKbucketConnPending {
-            parent: self.parent,
-            peer_id: self.peer_id,
-        }
-    }
-}
-
-/// Represents an entry in a k-bucket.
-pub struct EntryInKbucketDisc<'a, TPeerId, TVal> {
-    parent: &'a mut KBucketsTable<TPeerId, TVal>,
-    peer_id: &'a Key<TPeerId>,
-}
-
-impl<'a, TPeerId, TVal> EntryInKbucketDisc<'a, TPeerId, TVal>
-where
-    TPeerId: Clone,
-{
-    pub fn key(&self) -> &Key<TPeerId> {
-        self.peer_id
-    }
-
-    /// Returns the value associated to the entry in the bucket.
-    pub fn value(&mut self) -> &mut TVal {
-        let table = self.parent.bucket_mut(&self.peer_id)
-                .expect("we can only build a EntryInKbucketDisc if we know of a bucket; QED");
-
-        let peer_id = self.peer_id;
-        &mut table.nodes.iter_mut()
-            .find(move |p| p.id == *peer_id)
-            .expect("We can only build a EntryInKbucketDisc if we know that the peer is in its \
-                     bucket; QED")
-            .value
-    }
-
-    /// Sets the node as connected. This moves the entry in the bucket.
-    pub fn set_connected(self) -> EntryInKbucketConn<'a, TPeerId, TVal> {
-        let table = self.parent.bucket_mut(&self.peer_id)
-                .expect("we can only build a EntryInKbucketDisc if we know of a bucket; QED");
-
-        let pos = {
-            let peer_id = self.peer_id;
-            table.nodes.iter().position(|p| p.id == *peer_id)
-                .expect("We can only build a EntryInKbucketDisc if we know that the peer is in \
-                         its bucket; QED")
-        };
-
-        // If the position marks the least-recently connected peer, it is now re-connected,
-        // which means that the pending entry should be dropped, as preference is given to
-        // previously known peers.
-        //
-        // Note that it is theoretically possible that the replacement could have occurred between
-        // the moment when we build the `EntryInKbucketConn` and the moment when we call
-        // `set_connected`, but we don't take that into account.
-        if pos == 0 {
-            table.pending_node = None;
-        }
-
-        // The entry for the most-recently connected peer goes at the end of the bucket.
-        debug_assert!(table.first_connected_pos.map_or(true, |i| pos < i));
-        let last = table.nodes.len() - 1;
-        table.first_connected_pos = table.first_connected_pos.map(|p| p - 1).or(Some(last));
-        let entry = table.nodes.remove(pos);
-        table.nodes.push(entry);
-
-        // There shouldn't be a pending node if all slots are full of connected nodes.
-        debug_assert!(table.first_connected_pos != Some(0) || table.pending_node.is_none());
-
-        EntryInKbucketConn {
-            parent: self.parent,
-            peer_id: self.peer_id,
-        }
-    }
-}
-
-/// Represents an entry not in any k-bucket.
-pub struct EntryNotInKbucket<'a, TPeerId, TVal> {
-    parent: &'a mut KBucketsTable<TPeerId, TVal>,
-    peer_id: &'a Key<TPeerId>,
-}
-
-impl<TPeerId, TVal> EntryNotInKbucket<'_, TPeerId, TVal>
-where
-    TPeerId: Clone,
-{
-    /// Inserts the node as connected, if possible.
-    pub fn insert_connected(self, value: TVal) -> InsertOutcome<TPeerId> {
-        let unresponsive_timeout = self.parent.unresponsive_timeout;
-
-        let table = self.parent.bucket_mut(&self.peer_id)
-                .expect("we can only build a EntryNotInKbucket if we know of a bucket; QED");
-
-        if table.nodes.is_full() {
-            if table.first_connected_pos == Some(0) || table.pending_node.is_some() {
-                InsertOutcome::Full
-            } else {
-                table.pending_node = Some(PendingNode {
-                    node: Node { id: self.peer_id.clone(), value },
-                    replace: Instant::now() + unresponsive_timeout,
-                    connected: true,
-                });
-                InsertOutcome::Pending {
-                    to_ping: table.nodes[0].id.clone()
-                }
-            }
-        } else {
-            // The most-recently connected peer is the last entry in the bucket.
-            let pos = table.nodes.len();
-            table.nodes.push(Node {
-                id: self.peer_id.clone(),
-                value,
-            });
-            table.first_connected_pos = table.first_connected_pos.or(Some(pos));
-            InsertOutcome::Inserted
-        }
-    }
-
-    /// Inserts the node as disconnected, if possible.
-    ///
-    /// > **Note**: This function will never return `Pending`. If the bucket is full, we simply
-    /// >           do nothing.
-    pub fn insert_disconnected(self, value: TVal) -> InsertOutcome<TPeerId> {
-        let table = self.parent.bucket_mut(&self.peer_id)
-                .expect("we can only build a EntryNotInKbucket if we know of a bucket; QED");
-
-        if table.nodes.is_full() {
-            InsertOutcome::Full
-        } else {
-            // The most-recently disconnected peer is the entry preceding the first
-            // connected peer.
-            let node = Node { id: self.peer_id.clone(), value };
-            if let Some(ref mut first_connected_pos) = table.first_connected_pos {
-                table.nodes.insert(*first_connected_pos, node);
-                *first_connected_pos += 1;
-            } else {
-                table.nodes.push(node);
-            }
-            InsertOutcome::Inserted
-        }
-    }
-}
-
-/// The outcome of [`EntryNotInKbucket::insert_connected`] and
-/// [`EntryNotInKbucket::insert_disconnected`].
-#[must_use]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum InsertOutcome<TPeerId> {
-    /// The entry has been successfully inserted into a bucket.
-    Inserted,
-    /// The entry is pending insertion into a bucket that is currently full. The pending
-    /// entry is inserted after a timeout elapsed, if the connection to the peer
-    /// corresponding to the least-recently connected entry is not re-established within
-    /// that timeout window.
-    Pending {
-        /// The identifier of the least-recently connected peer that is currently considered
-        /// disconnected and should be checked for connectivity in order to prevent it from being
-        /// replaced. If connectivity to the peer is re-established, the corresponding
-        /// entry should be updated via [`EntryInKbucketDisc::set_connected`].
-        to_ping: Key<TPeerId>,
-    },
-    /// The entry was not inserted because the bucket is filled with entries marked
-    /// as connected and there already exists a pending entry for that bucket.
-    Full,
 }
 

--- a/protocols/kad/src/kbucket/key.rs
+++ b/protocols/kad/src/kbucket/key.rs
@@ -1,0 +1,156 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use bigint::U256;
+use libp2p_core::PeerId;
+use multihash::Multihash;
+use sha2::{Digest, Sha256, digest::generic_array::{GenericArray, typenum::U32}};
+
+/// A `Key` is a cryptographic hash, identifying both the nodes participating in
+/// the Kademlia DHT, as well as records stored in the DHT.
+///
+/// The set of all `Key`s defines the Kademlia keyspace.
+///
+/// `Key`s have an XOR metric as defined in the Kademlia paper, i.e. the bitwise XOR of
+/// the hash digests, interpreted as an integer. See [`Key::distance`].
+///
+/// A `Key` preserves the preimage of type `T` of the hash function. See [`Key::preimage`].
+#[derive(Clone, Debug)]
+pub struct Key<T> {
+    preimage: T,
+    hash: GenericArray<u8, U32>,
+}
+
+impl<T> PartialEq for Key<T> {
+    fn eq(&self, other: &Key<T>) -> bool {
+        self.hash == other.hash
+    }
+}
+
+impl<T> Eq for Key<T> {}
+
+impl<TPeerId> AsRef<Key<TPeerId>> for Key<TPeerId> {
+    fn as_ref(&self) -> &Key<TPeerId> {
+        self
+    }
+}
+
+impl<T> Key<T> {
+    /// Construct a new `Key` by hashing the bytes of the given `preimage`.
+    ///
+    /// The preimage of type `T` is preserved. See [`Key::preimage`] and
+    /// [`Key::into_preimage`].
+    pub fn new(preimage: T) -> Key<T>
+    where
+        T: AsRef<[u8]>
+    {
+        let hash = Sha256::digest(preimage.as_ref());
+        Key { preimage, hash }
+    }
+
+    /// Borrows the preimage of the key.
+    pub fn preimage(&self) -> &T {
+        &self.preimage
+    }
+
+    /// Converts the key into its preimage.
+    pub fn into_preimage(self) -> T {
+        self.preimage
+    }
+
+    /// Computes the distance of the keys according to the XOR metric.
+    pub fn distance<U>(&self, other: &Key<U>) -> Distance {
+        let a = U256::from(self.hash.as_ref());
+        let b = U256::from(other.hash.as_ref());
+        Distance(a ^ b)
+    }
+}
+
+impl From<Multihash> for Key<Multihash> {
+    fn from(h: Multihash) -> Self {
+        let k = Key::new(h.clone().into_bytes());
+        Key { preimage: h, hash: k.hash }
+    }
+}
+
+impl From<PeerId> for Key<PeerId> {
+    fn from(peer_id: PeerId) -> Self {
+        Key::new(peer_id)
+    }
+}
+
+/// A distance between two `Key`s.
+#[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Debug)]
+pub struct Distance(pub(super) bigint::U256);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quickcheck::*;
+
+    impl Arbitrary for Key<PeerId> {
+        fn arbitrary<G: Gen>(_: &mut G) -> Key<PeerId> {
+            Key::from(PeerId::random())
+        }
+    }
+
+    #[test]
+    fn identity() {
+        fn prop(a: Key<PeerId>) -> bool {
+            a.distance(&a) == Distance::default()
+        }
+        quickcheck(prop as fn(_) -> _)
+    }
+
+    #[test]
+    fn symmetry() {
+        fn prop(a: Key<PeerId>, b: Key<PeerId>) -> bool {
+            a.distance(&b) == b.distance(&a)
+        }
+        quickcheck(prop as fn(_,_) -> _)
+    }
+
+    #[test]
+    fn triangle_inequality() {
+        fn prop(a: Key<PeerId>, b: Key<PeerId>, c: Key<PeerId>) -> TestResult {
+            let ab = a.distance(&b);
+            let bc = b.distance(&c);
+            let (ab_plus_bc, overflow) = ab.0.overflowing_add(bc.0);
+            if overflow {
+                TestResult::discard()
+            } else {
+                TestResult::from_bool(a.distance(&c) <= Distance(ab_plus_bc))
+            }
+        }
+        quickcheck(prop as fn(_,_,_) -> _)
+    }
+
+    #[test]
+    fn unidirectionality() {
+        fn prop(a: Key<PeerId>, b: Key<PeerId>) -> bool {
+            let d = a.distance(&b);
+            (0 .. 100).all(|_| {
+                let c = Key::from(PeerId::random());
+                a.distance(&c) != d || b == c
+            })
+        }
+        quickcheck(prop as fn(_,_) -> _)
+    }
+}

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! Kademlia protocol. Allows peer discovery, records store and records fetch.
+//! Implementation of the Kademlia protocol for libp2p.
 
 // TODO: we allow dead_code for now because this library contains a lot of unused code that will
 //       be useful later for record store

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -25,6 +25,10 @@
 //! The upgrade's output is a `Sink + Stream` of messages. The `Stream` component is used
 //! to poll the underlying transport for incoming messages, and the `Sink` component
 //! is used to send messages to remote peers.
+//!
+//! [`KademliaProtocolConfig`]: protocol::KademliaProtocolConfig
+//! [`KadRequestMsg`]: protocol::KadRequestMsg
+//! [`KadResponseMsg`]: protocol::KadResponseMsg
 
 use bytes::BytesMut;
 use codec::UviBytes;

--- a/protocols/kad/src/query.rs
+++ b/protocols/kad/src/query.rs
@@ -350,7 +350,7 @@ where
         }
     }
 
-    /// Consumes the query and returns the targe tand known closest peers.
+    /// Consumes the query and returns the target and known closest peers.
     ///
     /// > **Note**: This can be called at any time, but you normally only do that once the query
     /// >           is finished.


### PR DESCRIPTION
Based on https://github.com/libp2p/rust-libp2p/pull/1108.

The current implementation for finding the entries whose keys are closest to some target key in the Kademlia routing table involves copying the keys of all buckets into a new `Vec` which is then sorted based on the
distances of the entries to the target and turned into an iterator from which only a small number of elements (by default 20) are drawn.

This commit introduces an iterator for finding the closest keys (or entries) to a target that visits the buckets in the optimal order, based on the information contained in the distance bit-string representing the distance between the local key and the target (introduced in https://github.com/libp2p/rust-libp2p/pull/1108). I.e. the needed contents of the respectively next bucket are cloned and sorted only as more elements are drawn from the iterator.

Correctness is tested against full-table scans.

Because there was some overlap between the handling of pending nodes and the newly introduced iterator(s) in the sense that any access to a bucket should check for applicability of pending nodes to bring the bucket up-to-date, and there were a few TODOs left around the pending node handling, I refactored that part and added more tests. In particular, I did the following:

  * The (internal) bucket API for a single bucket was moved to `kbucket::bucket`, extracting large parts of code formerly directly embedded into the `Entry` API. That improves reuse and testability.
  * The (public) `Entry` API was moved to the `kbucket::entry` sub-module and simplified due to the first point. The `Entry` API now just mediates access to the internal bucket API.
  * The pending node handling reflects the following policy: `The nodes in a bucket are ordered from least-recently connected to most-recently connected`, i.e. a "connection-oriented" variant of what is described in the paper.

Due to refactorings the diffs are a bit large and I suggest the following (bottom-up) order for an effective review:

  1. The new `kbucket::bucket` module.
  2. The new `kbucket::entry` module.
  3. The new iterator(s) in the `kbucket` module and the new top-level functions `closest` and `closest_keys`, implementing the optimised bucket iteration. [Here is the relevant part in the `kbucket` module](https://github.com/libp2p/rust-libp2p/blob/7949879f73352b23a9e5e43c0f9fae1d312c2f46/protocols/kad/src/kbucket.rs#L209-L396).
  4. The remaining full diff of the `kbucket` and `behaviour` modules which adopt the rest of the code to the above changes. That should be quick after seeing all the previous changes.