### PR TITLE
Reexport ConnectedPoint at the root

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -81,6 +81,7 @@ pub mod upgrade;
 
 pub use multiaddr::Multiaddr;
 pub use muxing::StreamMuxer;
+pub use nodes::raw_swarm::ConnectedPoint;
 pub use peer_id::PeerId;
 pub use protocols_handler::{ProtocolsHandler, ProtocolsHandlerEvent};
 pub use identity::PublicKey;


### PR DESCRIPTION
This type is used extremely often, and it's nested deep in `nodes::raw_swarm`. Let's re-export it at a more convenient location.