### PR TITLE
Add the possibility to assume that multistream-select will succeed

### DIFF
--- a/misc/multistream-select/src/lib.rs
+++ b/misc/multistream-select/src/lib.rs
@@ -70,60 +70,11 @@ mod dialer_select;
 mod error;
 mod length_delimited;
 mod listener_select;
-mod tests;
-
+mod negotiated;
 mod protocol;
-
-use futures::prelude::*;
-use std::io;
+mod tests;
 
 pub use self::dialer_select::{dialer_select_proto, DialerSelectFuture};
 pub use self::error::ProtocolChoiceError;
 pub use self::listener_select::{listener_select_proto, ListenerSelectFuture};
-
-/// A stream after it has been negotiated.
-pub struct Negotiated<TInner>(pub(crate) TInner);
-
-impl<TInner> io::Read for Negotiated<TInner>
-where
-    TInner: io::Read
-{
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.0.read(buf)
-    }
-}
-
-impl<TInner> tokio_io::AsyncRead for Negotiated<TInner>
-where
-    TInner: tokio_io::AsyncRead
-{
-    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
-        self.0.prepare_uninitialized_buffer(buf)
-    }
-
-    fn read_buf<B: bytes::BufMut>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
-        self.0.read_buf(buf)
-    }
-}
-
-impl<TInner> io::Write for Negotiated<TInner>
-where
-    TInner: io::Write
-{
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.0.flush()
-    }
-}
-
-impl<TInner> tokio_io::AsyncWrite for Negotiated<TInner>
-where
-    TInner: tokio_io::AsyncWrite
-{
-    fn shutdown(&mut self) -> Poll<(), io::Error> {
-        self.0.shutdown()
-    }
-}
+pub use self::negotiated::Negotiated;

--- a/misc/multistream-select/src/listener_select.rs
+++ b/misc/multistream-select/src/listener_select.rs
@@ -171,7 +171,7 @@ where
                         }
                     };
                     if let Some(p) = outcome {
-                        return Ok(Async::Ready((p, Negotiated(listener.into_inner()), protocols)))
+                        return Ok(Async::Ready((p, Negotiated::finished(listener.into_inner()), protocols)))
                     } else {
                         let stream = listener.into_future();
                         self.inner = ListenerSelectState::Incoming { stream, protocols }

--- a/misc/multistream-select/src/negotiated.rs
+++ b/misc/multistream-select/src/negotiated.rs
@@ -1,0 +1,77 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use futures::prelude::*;
+use std::io;
+
+/// A stream after it has been negotiated.
+pub struct Negotiated<TInner>(TInner);
+
+impl<TInner> Negotiated<TInner> {
+    /// Builds a `Negotiated` containing a stream that's already been successfully negotiated to
+    /// a specific protocol.
+    pub(crate) fn finished(inner: TInner) -> Self {
+        Negotiated(inner)
+    }
+}
+
+impl<TInner> io::Read for Negotiated<TInner>
+where
+    TInner: io::Read
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl<TInner> tokio_io::AsyncRead for Negotiated<TInner>
+where
+    TInner: tokio_io::AsyncRead
+{
+    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
+        self.0.prepare_uninitialized_buffer(buf)
+    }
+
+    fn read_buf<B: bytes::BufMut>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
+        self.0.read_buf(buf)
+    }
+}
+
+impl<TInner> io::Write for Negotiated<TInner>
+where
+    TInner: io::Write
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
+impl<TInner> tokio_io::AsyncWrite for Negotiated<TInner>
+where
+    TInner: tokio_io::AsyncWrite
+{
+    fn shutdown(&mut self) -> Poll<(), io::Error> {
+        self.0.shutdown()
+    }
+}

--- a/protocols/floodsub/src/protocol.rs
+++ b/protocols/floodsub/src/protocol.rs
@@ -164,7 +164,7 @@ impl UpgradeInfo for FloodsubRpc {
 
 impl<TSocket> OutboundUpgrade<TSocket> for FloodsubRpc
 where
-    TSocket: AsyncWrite,
+    TSocket: AsyncRead + AsyncWrite,
 {
     type Output = ();
     type Error = io::Error;


### PR DESCRIPTION
Fix #659

Does unfortunately not work and is quite hacky.

One unfortunate consequence (which is not a hack), is that we require the AsyncRead trait on write-only substreams, because we need to read whether the remote sent a negotiation success message. This is a small breaking change.