### PR TITLE
Add secp256k1::SecretKey::to_bytes

### DIFF
--- a/core/src/identity/secp256k1.rs
+++ b/core/src/identity/secp256k1.rs
@@ -126,6 +126,11 @@ impl SecretKey {
             .map(|s| s.0.serialize_der().as_ref().into())
             .map_err(|_| SigningError::new("failed to create secp256k1 signature"))
     }
+
+    /// Returns the raw bytes of the secret key.
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.0.serialize()
+    }
 }
 
 /// A Secp256k1 public key.


### PR DESCRIPTION
Has been removed during the switch to `libsecp256k1` and there's no replacement.