### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ libp2p-uds = { version = "0.8.0", path = "./transports/uds" }
 libp2p-wasm-ext = { version = "0.1.0", path = "./transports/wasm-ext" }
 libp2p-websocket = { version = "0.8.0", path = "./transports/websocket", optional = true }
 libp2p-yamux = { version = "0.8.0", path = "./muxers/yamux" }
-parking_lot = "0.7"
+parking_lot = "0.8"
 smallvec = "0.6"
 tokio-codec = "0.1"
 tokio-executor = "0.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,7 +22,7 @@ multiaddr = { package = "parity-multiaddr", version = "0.4.0", path = "../misc/m
 multihash = { package = "parity-multihash", version = "0.1.0", path = "../misc/multihash" }
 multistream-select = { version = "0.4.0", path = "../misc/multistream-select" }
 futures = { version = "0.1", features = ["use_std"] }
-parking_lot = "0.7"
+parking_lot = "0.8"
 protobuf = "2.3"
 quick-error = "1.2"
 rand = "0.6"

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -15,7 +15,7 @@ fnv = "1.0"
 futures = "0.1"
 libp2p-core = { version = "0.8.0", path = "../../core" }
 log = "0.4"
-parking_lot = "0.7"
+parking_lot = "0.8"
 tokio-codec = "0.1"
 tokio-io = "0.1"
 unsigned-varint = { version = "0.2.1", features = ["codec"] }

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.1"
 libp2p-core = { version = "0.8.0", path = "../../core" }
 log = "0.4.1"
 multiaddr = { package = "parity-multiaddr", version = "0.4.0", path = "../../misc/multiaddr" }
-parking_lot = "0.7"
+parking_lot = "0.8"
 protobuf = "2.3"
 smallvec = "0.6"
 tokio-codec = "0.1"

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -21,7 +21,7 @@ libp2p-core = { version = "0.8.0", path = "../../core" }
 log = "0.4"
 multiaddr = { package = "parity-multiaddr", version = "0.4.0", path = "../../misc/multiaddr" }
 multihash = { package = "parity-multihash", version = "0.1.0", path = "../../misc/multihash" }
-parking_lot = "0.7"
+parking_lot = "0.8"
 protobuf = "2.3"
 rand = "0.6.0"
 sha2 = "0.8.0"

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -20,7 +20,7 @@ ring = { version = "0.14", features = ["use_heap"], default-features = false }
 snow = { version = "0.5.2", features = ["ring-resolver"], default-features = false }
 tokio-io = "0.1"
 x25519-dalek = "0.5"
-zeroize = "0.5"
+zeroize = "0.8"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -16,7 +16,7 @@ libp2p-core = { version = "0.8.0", path = "../../core" }
 log = "0.4.1"
 multiaddr = { package = "parity-multiaddr", version = "0.4.0", path = "../../misc/multiaddr" }
 futures = "0.1"
-parking_lot = "0.7"
+parking_lot = "0.8"
 rand = "0.6"
 tokio-codec = "0.1"
 tokio-io = "0.1"


### PR DESCRIPTION
Based on https://deps.rs/repo/github/libp2p/rust-libp2p

This is technically a breaking change, because we expose `zeroize::Zeroize` in the API, but we're already in breaking-change land with #1117.