### PR TITLE
Change score calculation.

### DIFF
--- a/core/src/swarm/registry.rs
+++ b/core/src/swarm/registry.rs
@@ -64,16 +64,17 @@ impl Addresses {
     pub fn add(&mut self, a: Multiaddr) {
         for r in &mut self.registry {
             if &r.addr == &a {
-                r.score = r.score.saturating_add(1);
-                isort(&mut self.registry);
-                return ()
+                r.score = r.score.saturating_add(1)
+            } else {
+                r.score = r.score.saturating_sub(1)
             }
         }
         if self.registry.len() == self.limit.get() {
             self.registry.pop();
         }
-        let r = Record { score: 0, addr: a };
-        self.registry.push(r)
+        let r = Record { score: 1, addr: a };
+        self.registry.push(r);
+        isort(&mut self.registry)
     }
 
     /// Return an iterator over all [`Multiaddr`] values.


### PR DESCRIPTION
When adding an address it now has an initial score of 1 instead of 0. Adding an existing address causes their score to be increased as before but we also decrement the score of every other address. This approach still favours most often reported addresses but helps with certain
cases, such as periodic address changes since expired addresses will reach 0 and a fresh address will immediately move to second position before eventually claiming the first spot.

Fixes #1135.