### PR TITLE
Kademlia: Fix premature query termination.

### DIFF
--- a/protocols/kad/src/query.rs
+++ b/protocols/kad/src/query.rs
@@ -319,10 +319,12 @@ where
             }
 
             if let QueryPeerState::Succeeded = state {
-                succeeded_counter.as_mut().map(|c| *c += 1);
-                // If we have enough results; the query is done.
-                if succeeded_counter.unwrap_or(0) >= num_results {
-                    return Async::Ready(QueryStatePollOut::Finished)
+                if let Some(ref mut cnt) = succeeded_counter {
+                    *cnt += 1;
+                    // If we have enough results; the query is done.
+                    if *cnt >= num_results {
+                        return Async::Ready(QueryStatePollOut::Finished)
+                    }
                 }
             }
 

--- a/protocols/kad/src/query.rs
+++ b/protocols/kad/src/query.rs
@@ -338,6 +338,11 @@ where
                         peer_id: peer_id.preimage(),
                         query_target: &self.target,
                     });
+                } else {
+                    // The peer is among the `num_results` closest and still
+                    // needs to be contacted, but the query is currently at
+                    // capacity w.r.t. the allowed parallelism.
+                    return Async::NotReady
                 }
             }
         }


### PR DESCRIPTION
This is a minimal fix for https://github.com/libp2p/rust-libp2p/issues/1105 extracted from https://github.com/libp2p/rust-libp2p/pull/1154 that may be worthwhile incorporating on its own and potentially useful for https://github.com/libp2p/rust-libp2p/pull/1144 (context https://github.com/montekki/rust-libp2p/pull/1#issuecomment-497923800).