### PR TITLE
Kademlia: Send all pending RPCs for a peer on established connection.

### DIFF
--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -493,7 +493,7 @@ where
     }
 
     fn inject_connected(&mut self, id: PeerId, endpoint: ConnectedPoint) {
-        if let Some(pos) = self.pending_rpcs.iter().position(|(p, _)| p == &id) {
+        while let Some(pos) = self.pending_rpcs.iter().position(|(p, _)| p == &id) {
             let (_, rpc) = self.pending_rpcs.remove(pos);
             self.queued_events.push(NetworkBehaviourAction::SendEvent {
                 peer_id: id.clone(),


### PR DESCRIPTION
This is a minimal patch extracted from https://github.com/libp2p/rust-libp2p/pull/1154 that may be worthwhile incorporating on its own. Currently, when a connection to a peer is established, only the first pending RPC found for that peer is sent, although there may be multiple (from concurrent queries). I chose the simplest possible fix (`if let` -> `while let`) as the list of pending RPCs is assumed to be small, if not empty. An alternative may be to partition the list into two new `SmallVec`s, keeping one and iterating over the other to send the RPC events, but I really can't say if that is worthwhile doing as I haven't benchmarked.