### PR TITLE
Update soketto and enable deflate extension.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ libp2p-kad = { version = "0.9.0", path = "./protocols/kad" }
 libp2p-floodsub = { version = "0.9.0", path = "./protocols/floodsub" }
 libp2p-ping = { version = "0.9.0", path = "./protocols/ping" }
 libp2p-plaintext = { version = "0.9.0", path = "./protocols/plaintext" }
-libp2p-deflate = { version = "0.1.0", path = "./protocols/deflate" }
 libp2p-ratelimit = { version = "0.9.0", path = "./transports/ratelimit" }
 libp2p-core = { version = "0.9.1", path = "./core" }
 libp2p-core-derive = { version = "0.9.0", path = "./misc/core-derive" }
@@ -41,6 +40,7 @@ tokio-io = "0.1"
 wasm-timer = "0.1"
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "unknown")))'.dependencies]
+libp2p-deflate = { version = "0.1.0", path = "./protocols/deflate" }
 libp2p-dns = { version = "0.9.0", path = "./transports/dns" }
 libp2p-mdns = { version = "0.9.0", path = "./misc/mdns" }
 libp2p-noise = { version = "0.7.0", path = "./protocols/noise" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,7 @@ pub use tokio_codec;
 
 #[doc(inline)]
 pub use libp2p_core as core;
+#[cfg(not(any(target_os = "emscripten", target_os = "unknown")))]
 #[doc(inline)]
 pub use libp2p_deflate as deflate;
 #[cfg(not(any(target_os = "emscripten", target_os = "unknown")))]

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -18,7 +18,7 @@ rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
 tokio-codec = "0.1.1"
 tokio-io = "0.1.12"
 tokio-rustls = "0.10.0-alpha.3"
-soketto = "0.1.0"
+soketto = { version = "0.2.0", features = ["deflate"] }
 url = "1.7.2"
 webpki-roots = "0.16.0"
 

--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -75,6 +75,12 @@ impl<T> WsConfig<T> {
         self.transport.set_tls_config(c);
         self
     }
+
+    /// Should the deflate extension (RFC 7692) be used if supported?
+    pub fn use_deflate(&mut self, flag: bool) -> &mut Self {
+        self.transport.use_deflate(flag);
+        self
+    }
 }
 
 impl<T> From<framed::WsConfig<T>> for WsConfig<T> {


### PR DESCRIPTION
Due to the way feature resolution works in cargo today, the `deflate` feature of `soketto` will include `flate2` with feature `zlib` which is then also active for the `flate2` that `libp2p-deflate` depends on. This leads to compilation failures for WASM targets. This PR therefore moves `libp2p-deflate` to the crates which are not available on WASM.