### PR TITLE
zeroize: Upgrade to v0.9

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,7 +35,7 @@ tokio-io = "0.1"
 wasm-timer = "0.1"
 unsigned-varint = "0.2"
 void = "1"
-zeroize = "0.5"
+zeroize = "0.9"
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "unknown")))'.dependencies]
 ring = { version = "0.14", features = ["use_heap"], default-features = false }

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -20,7 +20,7 @@ ring = { version = "0.14", features = ["use_heap"], default-features = false }
 snow = { version = "0.5.2", features = ["ring-resolver"], default-features = false }
 tokio-io = "0.1"
 x25519-dalek = "0.5"
-zeroize = "0.8"
+zeroize = "0.9"
 
 [dev-dependencies]
 env_logger = "0.6"


### PR DESCRIPTION
The `libp2p-noise` crate presently seems to be one of the biggest users of zeroize v0.8 by downloads.

I'm trying to phase out (and eventually yank) v0.8 for reasons it isn't impacted by: namely it included an implicit Drop impl in its custom derive support, and I'm trying to backtrack on that and ensure it's always explicit. But before that, I want to make sure nobody is expecting an explicit Drop impl when one won't be provided.

Before I yank it, I want to ensure existing users are up-to-date. This crate doesn't use `zeroize_derive`, but to phase out the old API I need to get everyone on v0.9.