### PR TITLE
Implement Encode/Decode from parity-codec

### DIFF
--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -19,6 +19,7 @@ percent-encoding = "1.0.1"
 serde = "1.0.70"
 unsigned-varint = "0.2"
 url = { version = "1.7.2", default-features = false }
+parity-codec = { version = "4.1.2", features = ["derive"] }
 
 [dev-dependencies]
 bincode = "1"

--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -6,7 +6,7 @@ description = "Implementation of the multiaddr format"
 homepage = "https://github.com/libp2p/rust-libp2p"
 keywords = ["multiaddr", "ipfs"]
 license = "MIT"
-version = "0.5.0"
+version = "0.5.1"
 
 [dependencies]
 arrayref = "0.3"

--- a/misc/multiaddr/src/lib.rs
+++ b/misc/multiaddr/src/lib.rs
@@ -23,7 +23,7 @@ use std::{
     result::Result as StdResult,
     str::FromStr
 };
-use parity_codec::{Compact, Encode, Decode, Input, Output};
+use parity_codec::{Encode, Decode, Input, Output};
 pub use self::errors::{Result, Error};
 pub use self::from_url::{FromUrlErr, from_url, from_url_lossy};
 pub use self::protocol::Protocol;
@@ -51,6 +51,11 @@ impl Multiaddr {
     /// Return a copy of this [`Multiaddr`]'s byte representation.
     pub fn to_vec(&self) -> Vec<u8> {
         Vec::from(&self.bytes[..])
+    }
+
+    /// Builds a [`Multiaddr`] from a byte representation.
+    pub fn from_vec(vec: Vec<u8>) -> Self {
+		Self { bytes: Bytes::from(vec) }
     }
 
     /// Adds an already-parsed address component to the end of this multiaddr.
@@ -401,32 +406,15 @@ impl<'de> Deserialize<'de> for Multiaddr {
 
 impl Encode for Multiaddr {
     fn encode_to<T: Output>(&self, output: &mut T) {
-        let len: usize = self.bytes.len();
-        assert!(len <= u32::max_value() as usize, "Attempted to serialize a Multiaddr which is too long.");
-        output.push(&Compact(len as u32));
-
-        &self.bytes
-			.as_ref()
-			.iter()
-			.for_each(|&b| {
-				output.push_byte(b);
-			});
+        let vec = self.to_vec();
+        vec.encode_to(output);
     }
 }
 
 impl Decode for Multiaddr {
     fn decode<I: Input>(input: &mut I) -> Option<Self> {
-		<Compact<u32>>::decode(input).and_then(move |Compact(len)| {
-			let len = len as usize;
-			let mut buffer = vec![0; len];
-			let len_read = input.read(&mut buffer[..len]);
-
-			if len_read == 0 {
-				return None;
-			}
-
-			Some(Multiaddr::from_vec(buffer))
-		})
+        Decode::decode(input)
+            .map(|v| Multiaddr::from_vec(v))
     }
 }
 

--- a/misc/multiaddr/tests/lib.rs
+++ b/misc/multiaddr/tests/lib.rs
@@ -2,6 +2,7 @@
 use data_encoding::HEXUPPER;
 use multihash::Multihash;
 use parity_multiaddr::*;
+use parity_codec::{Encode, Decode};
 use quickcheck::{Arbitrary, Gen, QuickCheck};
 use rand::Rng;
 use std::{
@@ -328,3 +329,18 @@ fn replace_ip4_with_ip6() {
     assert_eq!(result.unwrap(), "/ip6/2001:db8::1/tcp/10000".parse::<Multiaddr>().unwrap())
 }
 
+#[test]
+fn encode_decode_ipv4() {
+    let server = multiaddr!(Ip4(Ipv4Addr::LOCALHOST), Tcp(10000u16));
+	let enc = Encode::encode(&server);
+    let dec = Decode::decode(&mut &enc[..]).unwrap();
+    assert_eq!(server, dec);
+}
+
+#[test]
+fn encode_decode_ipv6() {
+    let server = multiaddr!(Ip6(Ipv6Addr::LOCALHOST), Tcp(10000u16));
+    let enc = Encode::encode(&server);
+    let dec = Decode::decode(&mut &enc[..]).unwrap();
+    assert_eq!(server, dec);
+}


### PR DESCRIPTION
The PR contains two commits. The first one should be cheaper, but requires an assertion, which I think we want to avoid. Hence the second one, using a `Vec`.
