### PR TITLE
Move facade re-exports around

### DIFF
--- a/examples/ipfs-kad.rs
+++ b/examples/ipfs-kad.rs
@@ -30,8 +30,8 @@ use libp2p::{
     identity,
     build_development_transport
 };
-use libp2p::kad::{Kademlia, KademliaConfig, KademliaEvent, GetClosestPeersError};
-use libp2p::kad::record::store::MemoryStore;
+use libp2p::protocols::kad::{Kademlia, KademliaConfig, KademliaEvent, GetClosestPeersError};
+use libp2p::protocols::kad::record::store::MemoryStore;
 use std::env;
 use std::time::Duration;
 

--- a/examples/mdns-passive-discovery.rs
+++ b/examples/mdns-passive-discovery.rs
@@ -19,7 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use futures::prelude::*;
-use libp2p::mdns::service::{MdnsPacket, MdnsService};
+use libp2p::protocols::mdns::service::{MdnsPacket, MdnsService};
 use std::io;
 
 fn main() {

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -39,7 +39,7 @@
 //! and begin pinging each other.
 
 use futures::{prelude::*, future};
-use libp2p::{ identity, PeerId, ping::{Ping, PingConfig}, Swarm };
+use libp2p::{identity, PeerId, protocols::ping::{Ping, PingConfig}, Swarm};
 use std::env;
 
 fn main() {

--- a/misc/core-derive/src/lib.rs
+++ b/misc/core-derive/src/lib.rs
@@ -46,16 +46,16 @@ fn build(ast: &DeriveInput) -> TokenStream {
 fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
     let name = &ast.ident;
     let (_, ty_generics, where_clause) = ast.generics.split_for_impl();
-    let multiaddr = quote!{::libp2p::core::Multiaddr};
+    let multiaddr = quote!{::libp2p::Multiaddr};
     let trait_to_impl = quote!{::libp2p::swarm::NetworkBehaviour};
     let net_behv_event_proc = quote!{::libp2p::swarm::NetworkBehaviourEventProcess};
-    let either_ident = quote!{::libp2p::core::either::EitherOutput};
+    let either_ident = quote!{::libp2p::libp2p_core::either::EitherOutput};
     let network_behaviour_action = quote!{::libp2p::swarm::NetworkBehaviourAction};
     let into_protocols_handler = quote!{::libp2p::swarm::IntoProtocolsHandler};
     let protocols_handler = quote!{::libp2p::swarm::ProtocolsHandler};
     let into_proto_select_ident = quote!{::libp2p::swarm::IntoProtocolsHandlerSelect};
-    let peer_id = quote!{::libp2p::core::PeerId};
-    let connected_point = quote!{::libp2p::core::ConnectedPoint};
+    let peer_id = quote!{::libp2p::PeerId};
+    let connected_point = quote!{::libp2p::libp2p_core::ConnectedPoint};
 
     // Name of the type parameter that represents the substream.
     let substream_generic = {
@@ -89,8 +89,8 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
                     quote!{Self: #net_behv_event_proc<<#ty as #trait_to_impl>::OutEvent>},
                     quote!{<<#ty as #trait_to_impl>::ProtocolsHandler as #into_protocols_handler>::Handler: #protocols_handler<Substream = #substream_generic>},
                     // Note: this bound is required because of https://github.com/rust-lang/rust/issues/55697
-                    quote!{<<<#ty as #trait_to_impl>::ProtocolsHandler as #into_protocols_handler>::Handler as #protocols_handler>::InboundProtocol: ::libp2p::core::InboundUpgrade<#substream_generic>},
-                    quote!{<<<#ty as #trait_to_impl>::ProtocolsHandler as #into_protocols_handler>::Handler as #protocols_handler>::OutboundProtocol: ::libp2p::core::OutboundUpgrade<#substream_generic>},
+                    quote!{<<<#ty as #trait_to_impl>::ProtocolsHandler as #into_protocols_handler>::Handler as #protocols_handler>::InboundProtocol: ::libp2p::protocols::upgrade::InboundUpgrade<#substream_generic>},
+                    quote!{<<<#ty as #trait_to_impl>::ProtocolsHandler as #into_protocols_handler>::Handler as #protocols_handler>::OutboundProtocol: ::libp2p::protocols::upgrade::OutboundUpgrade<#substream_generic>},
                 ]
             })
             .collect::<Vec<_>>();

--- a/misc/core-derive/tests/test.rs
+++ b/misc/core-derive/tests/test.rs
@@ -37,11 +37,11 @@ fn one_field() {
     #[allow(dead_code)]
     #[derive(NetworkBehaviour)]
     struct Foo<TSubstream> {
-        ping: libp2p::ping::Ping<TSubstream>,
+        ping: libp2p::protocols::ping::Ping<TSubstream>,
     }
 
-    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::ping::PingEvent> for Foo<TSubstream> {
-        fn inject_event(&mut self, _: libp2p::ping::PingEvent) {
+    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::protocols::ping::PingEvent> for Foo<TSubstream> {
+        fn inject_event(&mut self, _: libp2p::protocols::ping::PingEvent) {
         }
     }
 
@@ -56,17 +56,17 @@ fn two_fields() {
     #[allow(dead_code)]
     #[derive(NetworkBehaviour)]
     struct Foo<TSubstream> {
-        ping: libp2p::ping::Ping<TSubstream>,
-        identify: libp2p::identify::Identify<TSubstream>,
+        ping: libp2p::protocols::ping::Ping<TSubstream>,
+        identify: libp2p::protocols::identify::Identify<TSubstream>,
     }
 
-    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::identify::IdentifyEvent> for Foo<TSubstream> {
-        fn inject_event(&mut self, _: libp2p::identify::IdentifyEvent) {
+    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::protocols::identify::IdentifyEvent> for Foo<TSubstream> {
+        fn inject_event(&mut self, _: libp2p::protocols::identify::IdentifyEvent) {
         }
     }
 
-    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::ping::PingEvent> for Foo<TSubstream> {
-        fn inject_event(&mut self, _: libp2p::ping::PingEvent) {
+    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::protocols::ping::PingEvent> for Foo<TSubstream> {
+        fn inject_event(&mut self, _: libp2p::protocols::ping::PingEvent) {
         }
     }
 
@@ -81,25 +81,25 @@ fn three_fields() {
     #[allow(dead_code)]
     #[derive(NetworkBehaviour)]
     struct Foo<TSubstream> {
-        ping: libp2p::ping::Ping<TSubstream>,
-        identify: libp2p::identify::Identify<TSubstream>,
-        kad: libp2p::kad::Kademlia<TSubstream, libp2p::kad::record::store::MemoryStore>,
+        ping: libp2p::protocols::ping::Ping<TSubstream>,
+        identify: libp2p::protocols::identify::Identify<TSubstream>,
+        kad: libp2p::protocols::kad::Kademlia<TSubstream, libp2p::protocols::kad::record::store::MemoryStore>,
         #[behaviour(ignore)]
         foo: String,
     }
 
-    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::ping::PingEvent> for Foo<TSubstream> {
-        fn inject_event(&mut self, _: libp2p::ping::PingEvent) {
+    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::protocols::ping::PingEvent> for Foo<TSubstream> {
+        fn inject_event(&mut self, _: libp2p::protocols::ping::PingEvent) {
         }
     }
 
-    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::identify::IdentifyEvent> for Foo<TSubstream> {
-        fn inject_event(&mut self, _: libp2p::identify::IdentifyEvent) {
+    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::protocols::identify::IdentifyEvent> for Foo<TSubstream> {
+        fn inject_event(&mut self, _: libp2p::protocols::identify::IdentifyEvent) {
         }
     }
 
-    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::kad::KademliaEvent> for Foo<TSubstream> {
-        fn inject_event(&mut self, _: libp2p::kad::KademliaEvent) {
+    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::protocols::kad::KademliaEvent> for Foo<TSubstream> {
+        fn inject_event(&mut self, _: libp2p::protocols::kad::KademliaEvent) {
         }
     }
 
@@ -115,17 +115,17 @@ fn custom_polling() {
     #[derive(NetworkBehaviour)]
     #[behaviour(poll_method = "foo")]
     struct Foo<TSubstream> {
-        ping: libp2p::ping::Ping<TSubstream>,
-        identify: libp2p::identify::Identify<TSubstream>,
+        ping: libp2p::protocols::ping::Ping<TSubstream>,
+        identify: libp2p::protocols::identify::Identify<TSubstream>,
     }
 
-    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::ping::PingEvent> for Foo<TSubstream> {
-        fn inject_event(&mut self, _: libp2p::ping::PingEvent) {
+    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::protocols::ping::PingEvent> for Foo<TSubstream> {
+        fn inject_event(&mut self, _: libp2p::protocols::ping::PingEvent) {
         }
     }
 
-    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::identify::IdentifyEvent> for Foo<TSubstream> {
-        fn inject_event(&mut self, _: libp2p::identify::IdentifyEvent) {
+    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::protocols::identify::IdentifyEvent> for Foo<TSubstream> {
+        fn inject_event(&mut self, _: libp2p::protocols::identify::IdentifyEvent) {
         }
     }
 
@@ -145,17 +145,17 @@ fn custom_event_no_polling() {
     #[derive(NetworkBehaviour)]
     #[behaviour(out_event = "Vec<String>")]
     struct Foo<TSubstream> {
-        ping: libp2p::ping::Ping<TSubstream>,
-        identify: libp2p::identify::Identify<TSubstream>,
+        ping: libp2p::protocols::ping::Ping<TSubstream>,
+        identify: libp2p::protocols::identify::Identify<TSubstream>,
     }
 
-    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::ping::PingEvent> for Foo<TSubstream> {
-        fn inject_event(&mut self, _: libp2p::ping::PingEvent) {
+    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::protocols::ping::PingEvent> for Foo<TSubstream> {
+        fn inject_event(&mut self, _: libp2p::protocols::ping::PingEvent) {
         }
     }
 
-    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::identify::IdentifyEvent> for Foo<TSubstream> {
-        fn inject_event(&mut self, _: libp2p::identify::IdentifyEvent) {
+    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::protocols::identify::IdentifyEvent> for Foo<TSubstream> {
+        fn inject_event(&mut self, _: libp2p::protocols::identify::IdentifyEvent) {
         }
     }
 
@@ -171,17 +171,17 @@ fn custom_event_and_polling() {
     #[derive(NetworkBehaviour)]
     #[behaviour(poll_method = "foo", out_event = "String")]
     struct Foo<TSubstream> {
-        ping: libp2p::ping::Ping<TSubstream>,
-        identify: libp2p::identify::Identify<TSubstream>,
+        ping: libp2p::protocols::ping::Ping<TSubstream>,
+        identify: libp2p::protocols::identify::Identify<TSubstream>,
     }
 
-    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::ping::PingEvent> for Foo<TSubstream> {
-        fn inject_event(&mut self, _: libp2p::ping::PingEvent) {
+    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::protocols::ping::PingEvent> for Foo<TSubstream> {
+        fn inject_event(&mut self, _: libp2p::protocols::ping::PingEvent) {
         }
     }
 
-    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::identify::IdentifyEvent> for Foo<TSubstream> {
-        fn inject_event(&mut self, _: libp2p::identify::IdentifyEvent) {
+    impl<TSubstream> libp2p::swarm::NetworkBehaviourEventProcess<libp2p::protocols::identify::IdentifyEvent> for Foo<TSubstream> {
+        fn inject_event(&mut self, _: libp2p::protocols::identify::IdentifyEvent) {
         }
     }
 
@@ -200,24 +200,24 @@ fn where_clause() {
     #[allow(dead_code)]
     #[derive(NetworkBehaviour)]
     struct Foo<TSubstream> where TSubstream: std::fmt::Debug {
-        ping: libp2p::ping::Ping<TSubstream>,
+        ping: libp2p::protocols::ping::Ping<TSubstream>,
     }
 
     #[allow(dead_code)]
     #[derive(NetworkBehaviour)]
     struct Bar<TSubstream: std::fmt::Debug> {
-        ping: libp2p::ping::Ping<TSubstream>,
+        ping: libp2p::protocols::ping::Ping<TSubstream>,
     }
 
     #[allow(dead_code)]
     #[derive(NetworkBehaviour)]
     struct Baz<TSubstream> where TSubstream: std::fmt::Debug + Clone, {
-        ping: libp2p::ping::Ping<TSubstream>,
+        ping: libp2p::protocols::ping::Ping<TSubstream>,
     }
 
     #[allow(dead_code)]
     #[derive(NetworkBehaviour)]
     struct Qux<TSubstream: std::fmt::Debug> where TSubstream: Clone {
-        ping: libp2p::ping::Ping<TSubstream>,
+        ping: libp2p::protocols::ping::Ping<TSubstream>,
     }
 }

--- a/src/bandwidth.rs
+++ b/src/bandwidth.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::{Multiaddr, core::{Transport, transport::{ListenerEvent, TransportError}}};
+use crate::{Multiaddr, transport::{Transport, ListenerEvent, TransportError}};
 use futures::{prelude::*, try_ready};
 use lazy_static::lazy_static;
 use parking_lot::Mutex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 //! Example (Dialing a TCP/IP multi-address):
 //!
 //! ```rust
-//! use libp2p::{Multiaddr, Transport, tcp::TcpConfig};
+//! use libp2p::{Multiaddr, Transport, transport::tcp::TcpConfig};
 //! let tcp = TcpConfig::new();
 //! let addr: Multiaddr = "/ip4/98.97.96.95/tcp/20500".parse().expect("invalid multiaddr");
 //! let _conn = tcp.dial(addr);
@@ -86,7 +86,7 @@
 //!
 //! ```rust
 //! # #[cfg(all(not(any(target_os = "emscripten", target_os = "unknown")), feature = "libp2p-secio"))] {
-//! use libp2p::{Transport, tcp::TcpConfig, secio::SecioConfig, identity::Keypair};
+//! use libp2p::{Transport, transport::tcp::TcpConfig, encryption::secio::SecioConfig, identity::Keypair};
 //! let tcp = TcpConfig::new();
 //! let secio_upgrade = SecioConfig::new(Keypair::generate_ed25519());
 //! let tcp_secio = tcp.with_upgrade(secio_upgrade);
@@ -161,70 +161,120 @@ pub use multihash;
 pub use tokio_io;
 pub use tokio_codec;
 
-#[doc(inline)]
-pub use libp2p_core as core;
-#[cfg(not(any(target_os = "emscripten", target_os = "unknown")))]
-#[doc(inline)]
-pub use libp2p_deflate as deflate;
-#[cfg(not(any(target_os = "emscripten", target_os = "unknown")))]
-#[doc(inline)]
-pub use libp2p_dns as dns;
-#[doc(inline)]
-pub use libp2p_identify as identify;
-#[doc(inline)]
-pub use libp2p_kad as kad;
-#[doc(inline)]
-pub use libp2p_floodsub as floodsub;
-#[doc(inline)]
-pub use libp2p_mplex as mplex;
-#[cfg(not(any(target_os = "emscripten", target_os = "unknown")))]
-#[doc(inline)]
-pub use libp2p_mdns as mdns;
-#[cfg(not(any(target_os = "emscripten", target_os = "unknown")))]
-#[doc(inline)]
-pub use libp2p_noise as noise;
-#[doc(inline)]
-pub use libp2p_ping as ping;
-#[doc(inline)]
-pub use libp2p_plaintext as plaintext;
-#[doc(inline)]
-pub use libp2p_ratelimit as ratelimit;
-#[doc(inline)]
-pub use libp2p_secio as secio;
+/// We re-export libp2p-core for the `NetworkBehaviour` macro.
+#[doc(hidden)]
+pub use libp2p_core;
+
 #[doc(inline)]
 pub use libp2p_swarm as swarm;
-#[cfg(not(any(target_os = "emscripten", target_os = "unknown")))]
-#[doc(inline)]
-pub use libp2p_tcp as tcp;
-#[doc(inline)]
-pub use libp2p_uds as uds;
-#[doc(inline)]
-pub use libp2p_wasm_ext as wasm_ext;
-#[cfg(all(feature = "libp2p-websocket", not(any(target_os = "emscripten", target_os = "unknown"))))]
-#[doc(inline)]
-pub use libp2p_websocket as websocket;
-#[doc(inline)]
-pub use libp2p_yamux as yamux;
 
+pub mod prelude {
+    //! A "prelude" containing common imports from libp2p.
+    //!
+    //! Just like the standard library's prelude, this module contains items commonly-imported when
+    //! using libp2p. Contrary to the standard library's prelude, however, you have to import it
+    //! manually:
+    //!
+    //! ```
+    //! use libp2p::prelude::*;
+    //! ```
+    //!
+    pub use crate::{PeerId, Multiaddr};
+    pub use crate::transport::{Transport as _, TransportExt as _};
+    pub use crate::protocols::upgrade::{InboundUpgradeExt as _, OutboundUpgradeExt as _};
+}
+
+pub mod encryption {
+    #[cfg(not(any(target_os = "emscripten", target_os = "unknown")))]
+    #[doc(inline)]
+    pub use libp2p_noise as noise;
+    #[doc(inline)]
+    pub use libp2p_plaintext as plaintext;
+    #[doc(inline)]
+    pub use libp2p_secio as secio;
+}
+
+pub mod protocols {
+    //! List of common protocols, and how to implement protocols.
+
+    #[doc(inline)]
+    pub use libp2p_core::upgrade;
+    #[cfg(not(any(target_os = "emscripten", target_os = "unknown")))]
+    #[doc(inline)]
+    pub use libp2p_deflate as deflate;
+    #[doc(inline)]
+    pub use libp2p_identify as identify;
+    #[doc(inline)]
+    pub use libp2p_kad as kad;
+    #[doc(inline)]
+    pub use libp2p_floodsub as floodsub;
+    #[cfg(not(any(target_os = "emscripten", target_os = "unknown")))]
+    #[doc(inline)]
+    pub use libp2p_mdns as mdns;
+    #[doc(inline)]
+    pub use libp2p_ping as ping;
+
+    pub use libp2p_swarm::{NetworkBehaviour, NetworkBehaviourAction, NetworkBehaviourEventProcess};
+    pub use libp2p_swarm::{KeepAlive, SwarmPollParameters};
+    pub use libp2p_core::upgrade::{InboundUpgrade, InboundUpgradeExt, OutboundUpgrade, OutboundUpgradeExt};
+    pub use crate::simple::SimpleProtocol;
+}
+
+pub mod muxing {
+    #[doc(inline)]
+    pub use libp2p_core::muxing as core;
+    #[doc(inline)]
+    pub use libp2p_mplex as mplex;
+    #[doc(inline)]
+    pub use libp2p_yamux as yamux;
+
+    pub use libp2p_core::muxing::StreamMuxer;
+    pub use libp2p_core::muxing::StreamMuxerBox;
+}
+
+pub mod transport {
+    #[doc(inline)]
+    pub use libp2p_core::transport as core;
+    #[cfg(not(any(target_os = "emscripten", target_os = "unknown")))]
+    #[doc(inline)]
+    pub use libp2p_dns as dns;
+    #[doc(inline)]
+    pub use libp2p_ratelimit as ratelimit;
+    #[cfg(not(any(target_os = "emscripten", target_os = "unknown")))]
+    #[doc(inline)]
+    pub use libp2p_tcp as tcp;
+    #[doc(inline)]
+    pub use libp2p_uds as uds;
+    #[doc(inline)]
+    pub use libp2p_wasm_ext as wasm_ext;
+    #[cfg(all(feature = "libp2p-websocket", not(any(target_os = "emscripten", target_os = "unknown"))))]
+    #[doc(inline)]
+    pub use libp2p_websocket as websocket;
+
+    #[doc(inline)]
+    pub mod bandwidth {
+        pub use crate::bandwidth::*;
+    }
+
+    pub use libp2p_core::transport::Transport;
+    pub use libp2p_core::transport::TransportError;
+    pub use libp2p_core::transport::ListenerEvent;
+    pub use libp2p_core::transport::OptionalTransport;
+    pub use libp2p_core::transport::boxed::Boxed;
+    pub use crate::transport_ext::TransportExt;
+}
+
+mod bandwidth;
+mod simple;
 mod transport_ext;
 
-pub mod bandwidth;
-pub mod simple;
-
-pub use self::core::{
-    identity,
-    PeerId,
-    Transport,
-    transport::TransportError,
-    upgrade::{InboundUpgrade, InboundUpgradeExt, OutboundUpgrade, OutboundUpgradeExt}
-};
+pub use libp2p_core::{identity, PeerId, Transport};
 pub use libp2p_core_derive::NetworkBehaviour;
 pub use self::multiaddr::{Multiaddr, multiaddr as build_multiaddr};
-pub use self::simple::SimpleProtocol;
-pub use self::swarm::Swarm;
-pub use self::transport_ext::TransportExt;
+pub use self::swarm::{Swarm, SwarmBuilder};
 
 use futures::prelude::*;
+use libp2p_core::upgrade::{InboundUpgradeExt as _, OutboundUpgradeExt as _};
 use std::{error, io, time::Duration};
 
 /// Builds a `Transport` that supports the most commonly-used protocols that libp2p supports.
@@ -232,7 +282,7 @@ use std::{error, io, time::Duration};
 /// > **Note**: This `Transport` is not suitable for production usage, as its implementation
 /// >           reserves the right to support additional protocols or remove deprecated protocols.
 pub fn build_development_transport(keypair: identity::Keypair)
-    -> impl Transport<Output = (PeerId, impl core::muxing::StreamMuxer<OutboundSubstream = impl Send, Substream = impl Send, Error = impl Into<io::Error>> + Send + Sync), Error = impl error::Error + Send, Listener = impl Send, Dial = impl Send, ListenerUpgrade = impl Send> + Clone
+    -> impl Transport<Output = (PeerId, impl muxing::StreamMuxer<OutboundSubstream = impl Send, Substream = impl Send, Error = impl Into<io::Error>> + Send + Sync), Error = impl error::Error + Send, Listener = impl Send, Dial = impl Send, ListenerUpgrade = impl Send> + Clone
 {
      build_tcp_ws_secio_mplex_yamux(keypair)
 }
@@ -244,19 +294,19 @@ pub fn build_development_transport(keypair: identity::Keypair)
 ///
 /// > **Note**: If you ever need to express the type of this `Transport`.
 pub fn build_tcp_ws_secio_mplex_yamux(keypair: identity::Keypair)
-    -> impl Transport<Output = (PeerId, impl core::muxing::StreamMuxer<OutboundSubstream = impl Send, Substream = impl Send, Error = impl Into<io::Error>> + Send + Sync), Error = impl error::Error + Send, Listener = impl Send, Dial = impl Send, ListenerUpgrade = impl Send> + Clone
+    -> impl Transport<Output = (PeerId, impl muxing::StreamMuxer<OutboundSubstream = impl Send, Substream = impl Send, Error = impl Into<io::Error>> + Send + Sync), Error = impl error::Error + Send, Listener = impl Send, Dial = impl Send, ListenerUpgrade = impl Send> + Clone
 {
     CommonTransport::new()
-        .with_upgrade(secio::SecioConfig::new(keypair))
+        .with_upgrade(encryption::secio::SecioConfig::new(keypair))
         .and_then(move |output, endpoint| {
             let peer_id = output.remote_key.into_peer_id();
             let peer_id2 = peer_id.clone();
-            let upgrade = core::upgrade::SelectUpgrade::new(yamux::Config::default(), mplex::MplexConfig::new())
+            let upgrade = protocols::upgrade::SelectUpgrade::new(muxing::yamux::Config::default(), muxing::mplex::MplexConfig::new())
                 // TODO: use a single `.map` instead of two maps
                 .map_inbound(move |muxer| (peer_id, muxer))
                 .map_outbound(move |muxer| (peer_id2, muxer));
-            core::upgrade::apply(output.stream, upgrade, endpoint)
-                .map(|(id, muxer)| (id, core::muxing::StreamMuxerBox::new(muxer)))
+            protocols::upgrade::apply(output.stream, upgrade, endpoint)
+                .map(|(id, muxer)| (id, muxing::StreamMuxerBox::new(muxer)))
         })
         .with_timeout(Duration::from_secs(20))
 }
@@ -272,11 +322,11 @@ struct CommonTransport {
 }
 
 #[cfg(all(not(any(target_os = "emscripten", target_os = "unknown")), feature = "libp2p-websocket"))]
-type InnerImplementation = core::transport::OrTransport<dns::DnsConfig<tcp::TcpConfig>, websocket::WsConfig<dns::DnsConfig<tcp::TcpConfig>>>;
+type InnerImplementation = transport::core::OrTransport<transport::dns::DnsConfig<transport::tcp::TcpConfig>, transport::websocket::WsConfig<transport::dns::DnsConfig<transport::tcp::TcpConfig>>>;
 #[cfg(all(not(any(target_os = "emscripten", target_os = "unknown")), not(feature = "libp2p-websocket")))]
 type InnerImplementation = dns::DnsConfig<tcp::TcpConfig>;
 #[cfg(any(target_os = "emscripten", target_os = "unknown"))]
-type InnerImplementation = core::transport::dummy::DummyTransport;
+type InnerImplementation = transport::core::dummy::DummyTransport;
 
 #[derive(Debug, Clone)]
 struct CommonTransportInner {
@@ -287,12 +337,12 @@ impl CommonTransport {
     /// Initializes the `CommonTransport`.
     #[cfg(not(any(target_os = "emscripten", target_os = "unknown")))]
     pub fn new() -> CommonTransport {
-        let tcp = tcp::TcpConfig::new().nodelay(true);
-        let transport = dns::DnsConfig::new(tcp);
+        let tcp = transport::tcp::TcpConfig::new().nodelay(true);
+        let transport = transport::dns::DnsConfig::new(tcp);
         #[cfg(feature = "libp2p-websocket")]
         let transport = {
             let trans_clone = transport.clone();
-            transport.or_transport(websocket::WsConfig::new(trans_clone))
+            transport.or_transport(transport::websocket::WsConfig::new(trans_clone))
         };
 
         CommonTransport {
@@ -303,7 +353,7 @@ impl CommonTransport {
     /// Initializes the `CommonTransport`.
     #[cfg(any(target_os = "emscripten", target_os = "unknown"))]
     pub fn new() -> CommonTransport {
-        let inner = core::transport::dummy::DummyTransport::new();
+        let inner = transport::core::dummy::DummyTransport::new();
         CommonTransport {
             inner: CommonTransportInner { inner }
         }
@@ -317,11 +367,11 @@ impl Transport for CommonTransport {
     type ListenerUpgrade = <InnerImplementation as Transport>::ListenerUpgrade;
     type Dial = <InnerImplementation as Transport>::Dial;
 
-    fn listen_on(self, addr: Multiaddr) -> Result<Self::Listener, TransportError<Self::Error>> {
+    fn listen_on(self, addr: Multiaddr) -> Result<Self::Listener, transport::TransportError<Self::Error>> {
         self.inner.inner.listen_on(addr)
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, transport::TransportError<Self::Error>> {
         self.inner.inner.dial(addr)
     }
 }

--- a/src/simple.rs
+++ b/src/simple.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::core::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo, Negotiated};
+use crate::protocols::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo, Negotiated};
 use bytes::Bytes;
 use futures::{future::FromErr, prelude::*};
 use std::{iter, io::Error as IoError, sync::Arc};

--- a/src/transport_ext.rs
+++ b/src/transport_ext.rs
@@ -20,7 +20,7 @@
 
 //! Provides the `TransportExt` trait.
 
-use crate::{bandwidth::BandwidthLogging, bandwidth::BandwidthSinks, ratelimit::RateLimited, Transport};
+use crate::{bandwidth::BandwidthLogging, bandwidth::BandwidthSinks, transport::ratelimit::RateLimited, transport::Transport};
 use std::{io, sync::Arc, time::Duration};
 use tokio_executor::DefaultExecutor;
 
@@ -30,8 +30,7 @@ use tokio_executor::DefaultExecutor;
 /// # Example
 ///
 /// ```
-/// use libp2p::TransportExt;
-/// use libp2p::tcp::TcpConfig;
+/// use libp2p::transport::{TransportExt, tcp::TcpConfig};
 /// use std::time::Duration;
 ///
 /// let _transport = TcpConfig::new()


### PR DESCRIPTION
Refactors the `libp2p` facade crate to have re-exports that make more sense.

Instead of just dumping everything, this PR puts up some organization in place.
