### PR TITLE
[libp2p-kad] Replace usage of deprecated bigint crate.

### DIFF
--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -11,7 +11,6 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 arrayvec = "0.4.7"
-bigint = "4.2"
 bytes = "0.4"
 either = "1.5"
 fnv = "1.0"
@@ -28,6 +27,7 @@ smallvec = "0.6"
 tokio-codec = "0.1"
 tokio-io = "0.1"
 wasm-timer = "0.1"
+uint = "0.8"
 unsigned-varint = { version = "0.2.1", features = ["codec"] }
 void = "1.0"
 

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -128,7 +128,7 @@ impl BucketIndex {
         let lower = usize::pow(2, rem);
         let upper = usize::pow(2, rem + 1);
         bytes[31 - quot] = rng.gen_range(lower, upper) as u8;
-        Distance(bigint::U256::from(bytes))
+        Distance(U256::from(bytes))
     }
 }
 
@@ -477,7 +477,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use bigint::U256;
     use super::*;
     use libp2p_core::PeerId;
     use quickcheck::*;

--- a/protocols/kad/src/kbucket/key.rs
+++ b/protocols/kad/src/kbucket/key.rs
@@ -18,12 +18,17 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use bigint::U256;
+use uint::*;
 use libp2p_core::PeerId;
 use multihash::Multihash;
 use sha2::{Digest, Sha256};
 use sha2::digest::generic_array::{GenericArray, typenum::U32};
 use std::hash::{Hash, Hasher};
+
+construct_uint! {
+    /// 256-bit unsigned integer.
+    pub(super) struct U256(4);
+}
 
 /// A `Key` in the DHT keyspace with preserved preimage.
 ///
@@ -161,7 +166,7 @@ impl AsRef<KeyBytes> for KeyBytes {
 
 /// A distance between two keys in the DHT keyspace.
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Debug)]
-pub struct Distance(pub(super) bigint::U256);
+pub struct Distance(pub(super) U256);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
The `bigint` crate is deprecated and has been superseded by the `uint` crate for a while. It is only used by `libp2p-kad`.