### PR TITLE
[libp2p-kad] Generalise record keys.

### DIFF
--- a/protocols/kad/src/jobs.rs
+++ b/protocols/kad/src/jobs.rs
@@ -61,11 +61,9 @@
 //! > to the size of all stored records. As a job runs, the records are moved
 //! > out of the job to the consumer, where they can be dropped after being sent.
 
-use crate::record::{Record, ProviderRecord, store::RecordStore};
-
+use crate::record::{self, Record, ProviderRecord, store::RecordStore};
 use libp2p_core::PeerId;
 use futures::prelude::*;
-use multihash::Multihash;
 use std::collections::HashSet;
 use std::time::Duration;
 use std::vec;
@@ -131,7 +129,7 @@ pub struct PutRecordJob {
     next_publish: Option<Instant>,
     publish_interval: Option<Duration>,
     record_ttl: Option<Duration>,
-    skipped: HashSet<Multihash>,
+    skipped: HashSet<record::Key>,
     inner: PeriodicJob<vec::IntoIter<Record>>,
 }
 
@@ -162,7 +160,7 @@ impl PutRecordJob {
 
     /// Adds the key of a record that is ignored on the current or
     /// next run of the job.
-    pub fn skip(&mut self, key: Multihash) {
+    pub fn skip(&mut self, key: record::Key) {
         self.skipped.insert(key);
     }
 

--- a/protocols/kad/src/record/store.rs
+++ b/protocols/kad/src/record/store.rs
@@ -64,13 +64,13 @@ pub trait RecordStore<'a> {
     type ProvidedIter: Iterator<Item = Cow<'a, ProviderRecord>>;
 
     /// Gets a record from the store, given its key.
-    fn get(&'a self, k: &Multihash) -> Option<Cow<Record>>;
+    fn get(&'a self, k: &Key) -> Option<Cow<Record>>;
 
     /// Puts a record into the store.
     fn put(&'a mut self, r: Record) -> Result<()>;
 
     /// Removes the record with the given key from the store.
-    fn remove(&'a mut self, k: &Multihash);
+    fn remove(&'a mut self, k: &Key);
 
     /// Gets an iterator over all (value-) records currently stored.
     fn records(&'a self) -> Self::RecordsIter;
@@ -83,13 +83,13 @@ pub trait RecordStore<'a> {
     fn add_provider(&'a mut self, record: ProviderRecord) -> Result<()>;
 
     /// Gets a copy of the stored provider records for the given key.
-    fn providers(&'a self, key: &Multihash) -> Vec<ProviderRecord>;
+    fn providers(&'a self, key: &Key) -> Vec<ProviderRecord>;
 
     /// Gets an iterator over all stored provider records for which the
     /// node owning the store is itself the provider.
     fn provided(&'a self) -> Self::ProvidedIter;
 
     /// Removes a provider record from the store.
-    fn remove_provider(&'a mut self, k: &Multihash, p: &PeerId);
+    fn remove_provider(&'a mut self, k: &Key, p: &PeerId);
 }
 


### PR DESCRIPTION
This PR proposes a generalization of record keys from `Multihash` to a new opaque `record::Key` type, as previously mentioned and discussed in [the context of PR #1189](https://github.com/libp2p/rust-libp2p/pull/1189/files#r299686846).