### PR TITLE
[multistream-select] Fix restoring remaining buffer on write error in Negotiated I/O streams.

### DIFF
--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "multistream-select"
 description = "Multistream-select negotiation protocol for libp2p"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/misc/multistream-select/src/negotiated.rs
+++ b/misc/multistream-select/src/negotiated.rs
@@ -224,8 +224,7 @@ where
                     remaining.extend_from_slice(buf);
                     match io.write(&remaining) {
                         Err(e) => {
-                            remaining.split_off(buf.len());
-                            debug_assert_eq!(remaining.len(), remaining_len);
+                            remaining.split_off(remaining_len);
                             Err(e)
                         }
                         Ok(n) => {
@@ -333,6 +332,77 @@ impl Error for NegotiationError {
 impl fmt::Display for NegotiationError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         write!(fmt, "{}", Error::description(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quickcheck::*;
+    use std::io::Write;
+
+    /// An I/O resource with a fixed write capacity (total and per write op).
+    struct Capped { buf: Vec<u8>, step: usize }
+
+    impl io::Write for Capped {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            if self.buf.len() + buf.len() > self.buf.capacity() {
+                return Err(io::ErrorKind::WriteZero.into())
+            }
+            self.buf.write(&buf[.. usize::min(self.step, buf.len())])
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl AsyncWrite for Capped {
+        fn shutdown(&mut self) -> Poll<(), io::Error> {
+            Ok(().into())
+        }
+    }
+
+    #[test]
+    fn write_remaining() {
+        fn prop(rem: Vec<u8>, new: Vec<u8>, free: u8) -> TestResult {
+            let cap = rem.len() + free as usize;
+            let buf = Capped { buf: Vec::with_capacity(cap), step: free as usize };
+            let mut rem = BytesMut::from(rem);
+            let mut io = Negotiated::completed(buf, rem.clone());
+            let mut written = 0;
+            loop {
+                // Write until `new` has been fully written or the capped buffer is
+                // full (in which case the buffer should remain unchanged from the
+                // last successful write).
+                match io.write(&new[written..]) {
+                    Ok(n) =>
+                        if let State::Completed { remaining, .. } = &io.state {
+                            if n == rem.len() + new[written..].len() {
+                                assert!(remaining.is_empty())
+                            } else {
+                                assert!(remaining.len() <= rem.len());
+                            }
+                            written += n;
+                            if written == new.len() {
+                                return TestResult::passed()
+                            }
+                            rem = remaining.clone();
+                        } else {
+                            return TestResult::failed()
+                        }
+                    Err(_) =>
+                        if let State::Completed { remaining, .. } = &io.state {
+                            assert!(rem.len() + new[written..].len() > cap);
+                            assert_eq!(remaining, &rem);
+                            return TestResult::passed()
+                        } else {
+                            return TestResult::failed()
+                        }
+                }
+            }
+        }
+        quickcheck(prop as fn(_,_,_) -> _)
     }
 }
 


### PR DESCRIPTION
This addresses https://github.com/libp2p/rust-libp2p/issues/1227. The wrong argument was being passed to `BytesMut::split_off`. The properties of the `remaining` buffer, in particular that it never increases, are now checked.