### PR TITLE
[multistream-select] Fix Display impl for NegotiationError.

### DIFF
--- a/misc/multistream-select/src/negotiated.rs
+++ b/misc/multistream-select/src/negotiated.rs
@@ -334,7 +334,12 @@ impl Error for NegotiationError {
 
 impl fmt::Display for NegotiationError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", Error::description(self))
+        match self {
+            NegotiationError::ProtocolError(p) =>
+                fmt.write_fmt(format_args!("Protocol error: {}", p)),
+            NegotiationError::Failed =>
+                fmt.write_str("Protocol negotiation failed.")
+        }
     }
 }
 


### PR DESCRIPTION
The current `Display` impl for `NegotiationError` is pointless, since it uses `Error::description` which is both deprecated and not overridden for `NegotiationError`, thus the the `Display` impl produces  the unhelpful message: "description() is deprecated; use Display". This is corrected in this PR.