### PR TITLE
Configurable multistream-select protocol. `V1Lazy` variant.

### DIFF
--- a/core/src/transport/mod.rs
+++ b/core/src/transport/mod.rs
@@ -209,12 +209,12 @@ pub trait Transport {
     }
 
     /// Begins a series of protocol upgrades via an [`upgrade::Builder`].
-    fn upgrade(self) -> upgrade::Builder<Self>
+    fn upgrade(self, version: upgrade::Version) -> upgrade::Builder<Self>
     where
         Self: Sized,
         Self::Error: 'static
     {
-        upgrade::Builder::new(self)
+        upgrade::Builder::new(self, version)
     }
 }
 

--- a/core/src/upgrade/mod.rs
+++ b/core/src/upgrade/mod.rs
@@ -68,7 +68,7 @@ mod transfer;
 
 use futures::future::Future;
 
-pub use multistream_select::{Negotiated, NegotiatedComplete, NegotiationError, ProtocolError};
+pub use multistream_select::{Version, Negotiated, NegotiatedComplete, NegotiationError, ProtocolError};
 pub use self::{
     apply::{apply, apply_inbound, apply_outbound, InboundUpgradeApply, OutboundUpgradeApply},
     denied::DeniedUpgrade,

--- a/core/tests/network_dial_error.rs
+++ b/core/tests/network_dial_error.rs
@@ -95,7 +95,7 @@ fn deny_incoming_connec() {
         let local_key = identity::Keypair::generate_ed25519();
         let local_public_key = local_key.public();
         let transport = libp2p_tcp::TcpConfig::new()
-            .upgrade()
+            .upgrade(upgrade::Version::V1)
             .authenticate(libp2p_secio::SecioConfig::new(local_key))
             .multiplex(libp2p_mplex::MplexConfig::new());
         Network::new(transport, local_public_key.into())
@@ -105,7 +105,7 @@ fn deny_incoming_connec() {
         let local_key = identity::Keypair::generate_ed25519();
         let local_public_key = local_key.public();
         let transport = libp2p_tcp::TcpConfig::new()
-            .upgrade()
+            .upgrade(upgrade::Version::V1)
             .authenticate(libp2p_secio::SecioConfig::new(local_key))
             .multiplex(libp2p_mplex::MplexConfig::new());
         Network::new(transport, local_public_key.into())
@@ -170,7 +170,7 @@ fn dial_self() {
         let local_key = identity::Keypair::generate_ed25519();
         let local_public_key = local_key.public();
         let transport = libp2p_tcp::TcpConfig::new()
-            .upgrade()
+            .upgrade(upgrade::Version::V1)
             .authenticate(libp2p_secio::SecioConfig::new(local_key))
             .multiplex(libp2p_mplex::MplexConfig::new())
             .and_then(|(peer, mplex), _| {
@@ -249,7 +249,7 @@ fn dial_self_by_id() {
         let local_key = identity::Keypair::generate_ed25519();
         let local_public_key = local_key.public();
         let transport = libp2p_tcp::TcpConfig::new()
-            .upgrade()
+            .upgrade(upgrade::Version::V1)
             .authenticate(libp2p_secio::SecioConfig::new(local_key))
             .multiplex(libp2p_mplex::MplexConfig::new());
         Network::new(transport, local_public_key.into())
@@ -267,7 +267,7 @@ fn multiple_addresses_err() {
         let local_key = identity::Keypair::generate_ed25519();
         let local_public_key = local_key.public();
         let transport = libp2p_tcp::TcpConfig::new()
-            .upgrade()
+            .upgrade(upgrade::Version::V1)
             .authenticate(libp2p_secio::SecioConfig::new(local_key))
             .multiplex(libp2p_mplex::MplexConfig::new());
         Network::new(transport, local_public_key.into())

--- a/core/tests/network_simult.rs
+++ b/core/tests/network_simult.rs
@@ -110,7 +110,7 @@ fn raw_swarm_simultaneous_connect() {
             let local_key = identity::Keypair::generate_ed25519();
             let local_public_key = local_key.public();
             let transport = libp2p_tcp::TcpConfig::new()
-                .upgrade()
+                .upgrade(upgrade::Version::V1Lazy)
                 .authenticate(libp2p_secio::SecioConfig::new(local_key))
                 .multiplex(libp2p_mplex::MplexConfig::new())
                 .and_then(|(peer, mplex), _| {
@@ -125,7 +125,7 @@ fn raw_swarm_simultaneous_connect() {
             let local_key = identity::Keypair::generate_ed25519();
             let local_public_key = local_key.public();
             let transport = libp2p_tcp::TcpConfig::new()
-                .upgrade()
+                .upgrade(upgrade::Version::V1Lazy)
                 .authenticate(libp2p_secio::SecioConfig::new(local_key))
                 .multiplex(libp2p_mplex::MplexConfig::new())
                 .and_then(|(peer, mplex), _| {

--- a/core/tests/transport_upgrade.rs
+++ b/core/tests/transport_upgrade.rs
@@ -24,7 +24,7 @@ use futures::future::Future;
 use futures::stream::Stream;
 use libp2p_core::identity;
 use libp2p_core::transport::{Transport, MemoryTransport, ListenerEvent};
-use libp2p_core::upgrade::{UpgradeInfo, Negotiated, InboundUpgrade, OutboundUpgrade};
+use libp2p_core::upgrade::{self, UpgradeInfo, Negotiated, InboundUpgrade, OutboundUpgrade};
 use libp2p_mplex::MplexConfig;
 use libp2p_secio::SecioConfig;
 use multiaddr::Multiaddr;
@@ -78,7 +78,7 @@ fn upgrade_pipeline() {
     let listener_keys = identity::Keypair::generate_ed25519();
     let listener_id = listener_keys.public().into_peer_id();
     let listener_transport = MemoryTransport::default()
-        .upgrade()
+        .upgrade(upgrade::Version::V1)
         .authenticate(SecioConfig::new(listener_keys))
         .apply(HelloUpgrade {})
         .apply(HelloUpgrade {})
@@ -93,7 +93,7 @@ fn upgrade_pipeline() {
     let dialer_keys = identity::Keypair::generate_ed25519();
     let dialer_id = dialer_keys.public().into_peer_id();
     let dialer_transport = MemoryTransport::default()
-        .upgrade()
+        .upgrade(upgrade::Version::V1)
         .authenticate(SecioConfig::new(dialer_keys))
         .apply(HelloUpgrade {})
         .apply(HelloUpgrade {})

--- a/misc/multistream-select/src/lib.rs
+++ b/misc/multistream-select/src/lib.rs
@@ -62,7 +62,6 @@
 //! yet have sent the last negotiation message despite having settled on a protocol
 //! proposed by the dialer that it supports.
 //!
-//!
 //! This behaviour allows both the dialer and the listener to send data
 //! relating to the negotiated protocol together with the last negotiation
 //! message(s), which, in the case of the dialer only supporting a single
@@ -79,7 +78,7 @@
 //! ```no_run
 //! # fn main() {
 //! use bytes::Bytes;
-//! use multistream_select::dialer_select_proto;
+//! use multistream_select::{dialer_select_proto, Version};
 //! use futures::{Future, Sink, Stream};
 //! use tokio_tcp::TcpStream;
 //! use tokio::runtime::current_thread::Runtime;
@@ -91,7 +90,7 @@
 //!     .from_err()
 //!     .and_then(move |io| {
 //!         let protos = vec![b"/echo/1.0.0", b"/echo/2.5.0"];
-//!         dialer_select_proto(io, protos) // .map(|r| r.0)
+//!         dialer_select_proto(io, protos, Version::V1)
 //!     })
 //!     .map(|(protocol, _io)| protocol);
 //!
@@ -110,7 +109,7 @@ mod protocol;
 mod tests;
 
 pub use self::negotiated::{Negotiated, NegotiatedComplete, NegotiationError};
-pub use self::protocol::ProtocolError;
+pub use self::protocol::{ProtocolError, Version};
 pub use self::dialer_select::{dialer_select_proto, DialerSelectFuture};
 pub use self::listener_select::{listener_select_proto, ListenerSelectFuture};
 

--- a/misc/multistream-select/src/tests.rs
+++ b/misc/multistream-select/src/tests.rs
@@ -22,7 +22,7 @@
 
 #![cfg(test)]
 
-use crate::NegotiationError;
+use crate::{Version, NegotiationError};
 use crate::dialer_select::{dialer_select_proto_parallel, dialer_select_proto_serial};
 use crate::{dialer_select_proto, listener_select_proto};
 use futures::prelude::*;
@@ -32,137 +32,157 @@ use tokio_io::io as nio;
 
 #[test]
 fn select_proto_basic() {
-    let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
-    let listener_addr = listener.local_addr().unwrap();
+    fn run(version: Version) {
+        let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+        let listener_addr = listener.local_addr().unwrap();
 
-    let server = listener
-        .incoming()
-        .into_future()
-        .map(|s| s.0.unwrap())
-        .map_err(|(e, _)| e.into())
-        .and_then(move |connec| {
-            let protos = vec![b"/proto1", b"/proto2"];
-            listener_select_proto(connec, protos)
-        })
-        .and_then(|(proto, io)| {
-            nio::write_all(io, b"pong").from_err().map(move |_| proto)
-        });
-
-    let client = TcpStream::connect(&listener_addr)
-        .from_err()
-        .and_then(move |connec| {
-            let protos = vec![b"/proto3", b"/proto2"];
-            dialer_select_proto(connec, protos)
-        })
-        .and_then(|(proto, io)| {
-            nio::write_all(io, b"ping").from_err().map(move |(io, _)| (proto, io))
-        })
-        .and_then(|(proto, io)| {
-            nio::read_exact(io, [0; 4]).from_err().map(move |(_, msg)| {
-                assert_eq!(&msg, b"pong");
-                proto
+        let server = listener
+            .incoming()
+            .into_future()
+            .map(|s| s.0.unwrap())
+            .map_err(|(e, _)| e.into())
+            .and_then(move |connec| {
+                let protos = vec![b"/proto1", b"/proto2"];
+                listener_select_proto(connec, protos)
             })
-        });
+            .and_then(|(proto, io)| {
+                nio::write_all(io, b"pong").from_err().map(move |_| proto)
+            });
 
-    let mut rt = Runtime::new().unwrap();
-    let (dialer_chosen, listener_chosen) =
-        rt.block_on(client.join(server)).unwrap();
+        let client = TcpStream::connect(&listener_addr)
+            .from_err()
+            .and_then(move |connec| {
+                let protos = vec![b"/proto3", b"/proto2"];
+                dialer_select_proto(connec, protos, version)
+            })
+            .and_then(|(proto, io)| {
+                nio::write_all(io, b"ping").from_err().map(move |(io, _)| (proto, io))
+            })
+            .and_then(|(proto, io)| {
+                nio::read_exact(io, [0; 4]).from_err().map(move |(_, msg)| {
+                    assert_eq!(&msg, b"pong");
+                    proto
+                })
+            });
 
-    assert_eq!(dialer_chosen, b"/proto2");
-    assert_eq!(listener_chosen, b"/proto2");
+        let mut rt = Runtime::new().unwrap();
+        let (dialer_chosen, listener_chosen) =
+            rt.block_on(client.join(server)).unwrap();
+
+        assert_eq!(dialer_chosen, b"/proto2");
+        assert_eq!(listener_chosen, b"/proto2");
+    }
+
+    run(Version::V1);
+    run(Version::V1Lazy);
 }
 
 #[test]
 fn no_protocol_found() {
-    let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
-    let listener_addr = listener.local_addr().unwrap();
+    fn run(version: Version) {
+        let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+        let listener_addr = listener.local_addr().unwrap();
 
-    let server = listener
-        .incoming()
-        .into_future()
-        .map(|s| s.0.unwrap())
-        .map_err(|(e, _)| e.into())
-        .and_then(move |connec| {
-            let protos = vec![b"/proto1", b"/proto2"];
-            listener_select_proto(connec, protos)
-        })
-        .and_then(|(proto, io)| io.complete().map(move |_| proto));
+        let server = listener
+            .incoming()
+            .into_future()
+            .map(|s| s.0.unwrap())
+            .map_err(|(e, _)| e.into())
+            .and_then(move |connec| {
+                let protos = vec![b"/proto1", b"/proto2"];
+                listener_select_proto(connec, protos)
+            })
+            .and_then(|(proto, io)| io.complete().map(move |_| proto));
 
-    let client = TcpStream::connect(&listener_addr)
-        .from_err()
-        .and_then(move |connec| {
-            let protos = vec![b"/proto3", b"/proto4"];
-            dialer_select_proto(connec, protos)
-        })
-        .and_then(|(proto, io)| io.complete().map(move |_| proto));
+        let client = TcpStream::connect(&listener_addr)
+            .from_err()
+            .and_then(move |connec| {
+                let protos = vec![b"/proto3", b"/proto4"];
+                dialer_select_proto(connec, protos, version)
+            })
+            .and_then(|(proto, io)| io.complete().map(move |_| proto));
 
-    let mut rt = Runtime::new().unwrap();
-    match rt.block_on(client.join(server)) {
-        Err(NegotiationError::Failed) => (),
-        e => panic!("{:?}", e),
+        let mut rt = Runtime::new().unwrap();
+        match rt.block_on(client.join(server)) {
+            Err(NegotiationError::Failed) => (),
+            e => panic!("{:?}", e),
+        }
     }
+
+    run(Version::V1);
+    run(Version::V1Lazy);
 }
 
 #[test]
 fn select_proto_parallel() {
-    let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
-    let listener_addr = listener.local_addr().unwrap();
+    fn run(version: Version) {
+        let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+        let listener_addr = listener.local_addr().unwrap();
 
-    let server = listener
-        .incoming()
-        .into_future()
-        .map(|s| s.0.unwrap())
-        .map_err(|(e, _)| e.into())
-        .and_then(move |connec| {
-            let protos = vec![b"/proto1", b"/proto2"];
-            listener_select_proto(connec, protos)
-        })
-        .and_then(|(proto, io)| io.complete().map(move |_| proto));
+        let server = listener
+            .incoming()
+            .into_future()
+            .map(|s| s.0.unwrap())
+            .map_err(|(e, _)| e.into())
+            .and_then(move |connec| {
+                let protos = vec![b"/proto1", b"/proto2"];
+                listener_select_proto(connec, protos)
+            })
+            .and_then(|(proto, io)| io.complete().map(move |_| proto));
 
-    let client = TcpStream::connect(&listener_addr)
-        .from_err()
-        .and_then(move |connec| {
-            let protos = vec![b"/proto3", b"/proto2"];
-            dialer_select_proto_parallel(connec, protos.into_iter())
-        })
-        .and_then(|(proto, io)| io.complete().map(move |_| proto));
+        let client = TcpStream::connect(&listener_addr)
+            .from_err()
+            .and_then(move |connec| {
+                let protos = vec![b"/proto3", b"/proto2"];
+                dialer_select_proto_parallel(connec, protos.into_iter(), version)
+            })
+            .and_then(|(proto, io)| io.complete().map(move |_| proto));
 
-    let mut rt = Runtime::new().unwrap();
-    let (dialer_chosen, listener_chosen) =
-        rt.block_on(client.join(server)).unwrap();
+        let mut rt = Runtime::new().unwrap();
+        let (dialer_chosen, listener_chosen) =
+            rt.block_on(client.join(server)).unwrap();
 
-    assert_eq!(dialer_chosen, b"/proto2");
-    assert_eq!(listener_chosen, b"/proto2");
+        assert_eq!(dialer_chosen, b"/proto2");
+        assert_eq!(listener_chosen, b"/proto2");
+    }
+
+    run(Version::V1);
+    run(Version::V1Lazy);
 }
 
 #[test]
 fn select_proto_serial() {
-    let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
-    let listener_addr = listener.local_addr().unwrap();
+    fn run(version: Version) {
+        let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+        let listener_addr = listener.local_addr().unwrap();
 
-    let server = listener
-        .incoming()
-        .into_future()
-        .map(|s| s.0.unwrap())
-        .map_err(|(e, _)| e.into())
-        .and_then(move |connec| {
-            let protos = vec![b"/proto1", b"/proto2"];
-            listener_select_proto(connec, protos)
-        })
-        .and_then(|(proto, io)| io.complete().map(move |_| proto));
+        let server = listener
+            .incoming()
+            .into_future()
+            .map(|s| s.0.unwrap())
+            .map_err(|(e, _)| e.into())
+            .and_then(move |connec| {
+                let protos = vec![b"/proto1", b"/proto2"];
+                listener_select_proto(connec, protos)
+            })
+            .and_then(|(proto, io)| io.complete().map(move |_| proto));
 
-    let client = TcpStream::connect(&listener_addr)
-        .from_err()
-        .and_then(move |connec| {
-            let protos = vec![b"/proto3", b"/proto2"];
-            dialer_select_proto_serial(connec, protos.into_iter())
-        })
-        .and_then(|(proto, io)| io.complete().map(move |_| proto));
+        let client = TcpStream::connect(&listener_addr)
+            .from_err()
+            .and_then(move |connec| {
+                let protos = vec![b"/proto3", b"/proto2"];
+                dialer_select_proto_serial(connec, protos.into_iter(), version)
+            })
+            .and_then(|(proto, io)| io.complete().map(move |_| proto));
 
-    let mut rt = Runtime::new().unwrap();
-    let (dialer_chosen, listener_chosen) =
-        rt.block_on(client.join(server)).unwrap();
+        let mut rt = Runtime::new().unwrap();
+        let (dialer_chosen, listener_chosen) =
+            rt.block_on(client.join(server)).unwrap();
 
-    assert_eq!(dialer_chosen, b"/proto2");
-    assert_eq!(listener_chosen, b"/proto2");
+        assert_eq!(dialer_chosen, b"/proto2");
+        assert_eq!(listener_chosen, b"/proto2");
+    }
+
+    run(Version::V1);
+    run(Version::V1Lazy);
 }

--- a/muxers/mplex/tests/async_write.rs
+++ b/muxers/mplex/tests/async_write.rs
@@ -34,7 +34,8 @@ fn async_write() {
     let bg_thread = thread::spawn(move || {
         let mplex = libp2p_mplex::MplexConfig::new();
 
-        let transport = TcpConfig::new().and_then(move |c, e| upgrade::apply(c, mplex, e));
+        let transport = TcpConfig::new().and_then(move |c, e|
+            upgrade::apply(c, mplex, e, upgrade::Version::V1));
 
         let mut listener = transport
             .listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap())
@@ -69,7 +70,8 @@ fn async_write() {
     });
 
     let mplex = libp2p_mplex::MplexConfig::new();
-    let transport = TcpConfig::new().and_then(move |c, e| upgrade::apply(c, mplex, e));
+    let transport = TcpConfig::new().and_then(move |c, e|
+        upgrade::apply(c, mplex, e, upgrade::Version::V1));
 
     let future = transport
         .dial(rx.recv().unwrap())

--- a/muxers/mplex/tests/two_peers.rs
+++ b/muxers/mplex/tests/two_peers.rs
@@ -37,7 +37,8 @@ fn client_to_server_outbound() {
     let bg_thread = thread::spawn(move || {
         let mplex = libp2p_mplex::MplexConfig::new();
 
-        let transport = TcpConfig::new().and_then(move |c, e| upgrade::apply(c, mplex, e));
+        let transport = TcpConfig::new().and_then(move |c, e|
+            upgrade::apply(c, mplex, e, upgrade::Version::V1));
 
         let mut listener = transport
             .listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap())
@@ -77,7 +78,8 @@ fn client_to_server_outbound() {
     });
 
     let mplex = libp2p_mplex::MplexConfig::new();
-    let transport = TcpConfig::new().and_then(move |c, e| upgrade::apply(c, mplex, e));
+    let transport = TcpConfig::new().and_then(move |c, e|
+        upgrade::apply(c, mplex, e, upgrade::Version::V1));
 
     let future = transport
         .dial(rx.recv().unwrap())
@@ -101,7 +103,8 @@ fn client_to_server_inbound() {
 
     let bg_thread = thread::spawn(move || {
         let mplex = libp2p_mplex::MplexConfig::new();
-        let transport = TcpConfig::new().and_then(move |c, e| upgrade::apply(c, mplex, e));
+        let transport = TcpConfig::new().and_then(move |c, e|
+            upgrade::apply(c, mplex, e, upgrade::Version::V1));
 
         let mut listener = transport
             .listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap())
@@ -142,7 +145,8 @@ fn client_to_server_inbound() {
     });
 
     let mplex = libp2p_mplex::MplexConfig::new();
-    let transport = TcpConfig::new().and_then(move |c, e| upgrade::apply(c, mplex, e));
+    let transport = TcpConfig::new().and_then(move |c, e|
+        upgrade::apply(c, mplex, e, upgrade::Version::V1));
 
     let future = transport
         .dial(rx.recv().unwrap())

--- a/protocols/deflate/tests/test.rs
+++ b/protocols/deflate/tests/test.rs
@@ -32,7 +32,8 @@ fn deflate() {
     let _ = env_logger::try_init();
 
     fn prop(message: Vec<u8>) -> bool {
-        let client = TcpConfig::new().and_then(|c, e| upgrade::apply(c, DeflateConfig {}, e));
+        let client = TcpConfig::new().and_then(|c, e|
+            upgrade::apply(c, DeflateConfig {}, e, upgrade::Version::V1));
         let server = client.clone();
         run(server, client, message);
         true

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -262,6 +262,7 @@ mod tests {
         muxing::StreamMuxer,
         Multiaddr,
         Transport,
+        upgrade
     };
     use libp2p_tcp::TcpConfig;
     use libp2p_secio::SecioConfig;
@@ -282,7 +283,7 @@ mod tests {
         let pubkey = id_keys.public();
         let transport = TcpConfig::new()
             .nodelay(true)
-            .upgrade()
+            .upgrade(upgrade::Version::V1)
             .authenticate(SecioConfig::new(id_keys))
             .multiplex(MplexConfig::new());
         (pubkey, transport)

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -288,7 +288,7 @@ mod tests {
         identity,
         Transport,
         transport::ListenerEvent,
-        upgrade::{apply_outbound, apply_inbound}
+        upgrade::{self, apply_outbound, apply_inbound}
     };
     use std::{io, sync::mpsc, thread};
 
@@ -351,7 +351,7 @@ mod tests {
         let future = transport.dial(rx.recv().unwrap())
             .unwrap()
             .and_then(|socket| {
-                apply_outbound(socket, IdentifyProtocolConfig)
+                apply_outbound(socket, IdentifyProtocolConfig, upgrade::Version::V1)
                     .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
             })
             .and_then(|RemoteInfo { info, observed_addr, .. }| {

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -34,6 +34,7 @@ use libp2p_core::{
     nodes::Substream,
     multiaddr::{Protocol, multiaddr},
     muxing::StreamMuxerBox,
+    upgrade
 };
 use libp2p_secio::SecioConfig;
 use libp2p_swarm::Swarm;
@@ -63,7 +64,7 @@ fn build_nodes_with_config(num: usize, cfg: KademliaConfig) -> (u64, Vec<TestSwa
         let local_key = identity::Keypair::generate_ed25519();
         let local_public_key = local_key.public();
         let transport = MemoryTransport::default()
-            .upgrade()
+            .upgrade(upgrade::Version::V1)
             .authenticate(SecioConfig::new(local_key))
             .multiplex(yamux::Config::default())
             .map(|(p, m), _| (p, StreamMuxerBox::new(m)))

--- a/protocols/noise/src/lib.rs
+++ b/protocols/noise/src/lib.rs
@@ -36,7 +36,7 @@
 //! Example:
 //!
 //! ```
-//! use libp2p_core::{identity, Transport};
+//! use libp2p_core::{identity, Transport, upgrade};
 //! use libp2p_tcp::TcpConfig;
 //! use libp2p_noise::{Keypair, X25519, NoiseConfig};
 //!
@@ -44,7 +44,7 @@
 //! let id_keys = identity::Keypair::generate_ed25519();
 //! let dh_keys = Keypair::<X25519>::new().into_authentic(&id_keys).unwrap();
 //! let noise = NoiseConfig::xx(dh_keys).into_authenticated();
-//! let builder = TcpConfig::new().upgrade().authenticate(noise);
+//! let builder = TcpConfig::new().upgrade(upgrade::Version::V1).authenticate(noise);
 //! // let transport = builder.multiplex(...);
 //! # }
 //! ```

--- a/protocols/ping/src/protocol.rs
+++ b/protocols/ping/src/protocol.rs
@@ -217,7 +217,7 @@ mod tests {
 
         let client = MemoryTransport.dial(listener_addr).unwrap()
             .and_then(|c| {
-                upgrade::apply_outbound(c, Ping::default())
+                upgrade::apply_outbound(c, Ping::default(), upgrade::Version::V1)
                     .map_err(|e| panic!(e))
             });
 

--- a/protocols/ping/tests/ping.rs
+++ b/protocols/ping/tests/ping.rs
@@ -25,10 +25,9 @@ use libp2p_core::{
     PeerId,
     Negotiated,
     identity,
-    muxing::StreamMuxer,
     transport::{Transport, boxed::Boxed},
     either::EitherError,
-    upgrade::UpgradeError
+    upgrade::{self, UpgradeError}
 };
 use libp2p_ping::*;
 use libp2p_yamux::{self as yamux, Yamux};
@@ -36,7 +35,7 @@ use libp2p_secio::{SecioConfig, SecioOutput, SecioError};
 use libp2p_swarm::Swarm;
 use libp2p_tcp::{TcpConfig, TcpTransStream};
 use futures::{future, prelude::*};
-use std::{fmt, io, time::Duration, sync::mpsc::sync_channel};
+use std::{io, time::Duration, sync::mpsc::sync_channel};
 use tokio::runtime::Runtime;
 
 #[test]
@@ -114,7 +113,7 @@ fn mk_transport() -> (
     let peer_id = id_keys.public().into_peer_id();
     let transport = TcpConfig::new()
         .nodelay(true)
-        .upgrade()
+        .upgrade(upgrade::Version::V1)
         .authenticate(SecioConfig::new(id_keys))
         .multiplex(yamux::Config::default())
         .boxed();

--- a/protocols/secio/src/algo_support.rs
+++ b/protocols/secio/src/algo_support.rs
@@ -42,7 +42,7 @@ const SHA_256: &str = "SHA256";
 const SHA_512: &str = "SHA512";
 
 pub(crate) const DEFAULT_AGREEMENTS_PROPOSITION: &str = "P-256,P-384";
-pub(crate) const DEFAULT_CIPHERS_PROPOSITION: &str = "AES-128,AES-256,TwofishCTR";
+pub(crate) const DEFAULT_CIPHERS_PROPOSITION: &str = "NULL"; // "AES-128,AES-256,TwofishCTR";
 pub(crate) const DEFAULT_DIGESTS_PROPOSITION: &str = "SHA256,SHA512";
 
 /// Return a proposition string from the given sequence of `KeyAgreement` values.

--- a/protocols/secio/src/lib.rs
+++ b/protocols/secio/src/lib.rs
@@ -31,7 +31,7 @@
 //! # fn main() {
 //! use futures::Future;
 //! use libp2p_secio::{SecioConfig, SecioOutput};
-//! use libp2p_core::{PeerId, Multiaddr, identity};
+//! use libp2p_core::{PeerId, Multiaddr, identity, upgrade};
 //! use libp2p_core::transport::Transport;
 //! use libp2p_mplex::MplexConfig;
 //! use libp2p_tcp::TcpConfig;
@@ -41,7 +41,7 @@
 //!
 //! // Create a `Transport`.
 //! let transport = TcpConfig::new()
-//!     .upgrade()
+//!     .upgrade(upgrade::Version::V1)
 //!     .authenticate(SecioConfig::new(local_keys.clone()))
 //!     .multiplex(MplexConfig::default());
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,7 @@ pub fn build_tcp_ws_secio_mplex_yamux(keypair: identity::Keypair)
     -> impl Transport<Output = (PeerId, impl core::muxing::StreamMuxer<OutboundSubstream = impl Send, Substream = impl Send, Error = impl Into<io::Error>> + Send + Sync), Error = impl error::Error + Send, Listener = impl Send, Dial = impl Send, ListenerUpgrade = impl Send> + Clone
 {
     CommonTransport::new()
-        .upgrade()
+        .upgrade(core::upgrade::Version::V1)
         .authenticate(secio::SecioConfig::new(keypair))
         .multiplex(core::upgrade::SelectUpgrade::new(yamux::Config::default(), mplex::MplexConfig::new()))
         .map(|(peer, muxer), _| (peer, core::muxing::StreamMuxerBox::new(muxer)))

--- a/swarm/src/protocols_handler/select.rs
+++ b/swarm/src/protocols_handler/select.rs
@@ -126,8 +126,8 @@ where
         let proto1 = self.proto1.listen_protocol();
         let proto2 = self.proto2.listen_protocol();
         let timeout = std::cmp::max(proto1.timeout(), proto2.timeout()).clone();
-        SubstreamProtocol::new(SelectUpgrade::new(proto1.into_upgrade(), proto2.into_upgrade()))
-            .with_timeout(timeout)
+        let choice = SelectUpgrade::new(proto1.into_upgrade().1, proto2.into_upgrade().1);
+        SubstreamProtocol::new(choice).with_timeout(timeout)
     }
 
     fn inject_fully_negotiated_outbound(&mut self, protocol: <Self::OutboundProtocol as OutboundUpgrade<TSubstream>>::Output, endpoint: Self::OutboundOpenInfo) {


### PR DESCRIPTION
This is a proposal for making the multistream-select protocol (version) configurable both on transport upgrades as well as for individual substreams. It adds a new "lazy" version of multistream-select 1.0 that is identical on the wire but delays sending of negotiation protocol frames as much as possible, which is only safe to use under additional assumptions that go beyond what is required by the multistream-select v1 specification (see the inline doc-comment on `Version::V1Lazy` and the discussion in https://github.com/libp2p/rust-libp2p/pull/1212).

There are a couple of motivations behind this:

  1. It will arguably be necessary eventually to be able to specify the multistream-select protocol version to use, at least as a dialer, to ever support 0-RTT negotiation in the presence of multiple protocol versions to choose from.

  2. By defaulting to the standard `V1` version, the optimisations provided by lazy negotiation are still provided as an opt-in per transport and per substream protocol, without losing full compatibility by default (i.e. addressing https://github.com/libp2p/rust-libp2p/issues/1241 in a different way than https://github.com/libp2p/rust-libp2p/pull/1244). It may thus offer an opt-in fast-path for specific projects or protocols, especially ones that want to make heavy use of the substream-per-request pattern, such as in https://github.com/paritytech/substrate/pull/3520.

  3. The differences between the versions is constrained to the `multistream-select` library, not requiring outside workarounds for completely safe `V1` compatibility like there is currently in `libp2p-core` with the additional [`AwaitNegotiated`](https://github.com/libp2p/rust-libp2p/blob/master/core/src/upgrade/apply.rs#L158-L162) step for dialer upgrades. I.e. the distinction between fully conformant / interoperable `V1` and the `V1Lazy` variant are fully inside `multistream-select`, with the choice exposed through the choice of `Version` for the dialer (the listener can always safely support all protocol versions, which also provides a general upgrade path from older to newer versions).

An example for configuring transport upgrades to use lazy negotiation:

```rust
            let transport = libp2p_tcp::TcpConfig::new()
                .upgrade(upgrade::Version::V1Lazy)
                .authenticate(libp2p_secio::SecioConfig::new(local_key))
                .multiplex(libp2p_mplex::MplexConfig::new())
```

An example for configuring outbound substreams on a handler to use lazy negotiation:

```rust
let proto = SubstreamProtocol::new(p).with_upgrade_protocol(upgrade::Version::V1Lazy);
OneShotHandler::new(proto, self.config.inactivity_timeout)
```

The only thing that would still be nice to have is to default the multistream protocol version used for substreams to the one used for the transport upgrades, but I didn't see an easy way to do that kind of propagation at the moment.