### PR TITLE
Upgrade url and percent-encoding deps to 2.1.0

### DIFF
--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -18,7 +18,7 @@ multihash = { package = "parity-multihash", version = "0.1.0", path = "../multih
 percent-encoding = "2.1.0"
 serde = "1.0.70"
 unsigned-varint = "0.2"
-url = { version = "1.7.2", default-features = false }
+url = { version = "2.1.0", default-features = false }
 
 [dev-dependencies]
 bincode = "1"

--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -15,7 +15,7 @@ byteorder = "1.3.1"
 bytes = "0.4.12"
 data-encoding = "2.1"
 multihash = { package = "parity-multihash", version = "0.1.0", path = "../multihash" }
-percent-encoding = "1.0.1"
+percent-encoding = "2.1.0"
 serde = "1.0.70"
 unsigned-varint = "0.2"
 url = { version = "1.7.2", default-features = false }

--- a/misc/multiaddr/src/protocol.rs
+++ b/misc/multiaddr/src/protocol.rs
@@ -41,6 +41,19 @@ const WS_WITH_PATH: u32 = 4770;         // Note: not standard
 const WSS: u32 = 478;
 const WSS_WITH_PATH: u32 = 4780;        // Note: not standard
 
+const PATH_SEGMENT_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
+    .add(b'%')
+    .add(b'/')
+    .add(b'`')
+    .add(b'?')
+    .add(b'{')
+    .add(b'}')
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'<')
+    .add(b'>');
+
 /// `Protocol` describes all possible multiaddress protocols.
 ///
 /// For `Unix`, `Ws` and `Wss` we use `&str` instead of `Path` to allow
@@ -429,12 +442,12 @@ impl<'a> fmt::Display for Protocol<'a> {
             Utp => f.write_str("/utp"),
             Ws(ref s) if s == "/" => f.write_str("/ws"),
             Ws(s) => {
-                let encoded = percent_encoding::percent_encode(s.as_bytes(), percent_encoding::PATH_SEGMENT_ENCODE_SET);
+                let encoded = percent_encoding::percent_encode(s.as_bytes(), PATH_SEGMENT_ENCODE_SET);
                 write!(f, "/x-parity-ws/{}", encoded)
             },
             Wss(ref s) if s == "/" => f.write_str("/wss"),
             Wss(s) => {
-                let encoded = percent_encoding::percent_encode(s.as_bytes(), percent_encoding::PATH_SEGMENT_ENCODE_SET);
+                let encoded = percent_encoding::percent_encode(s.as_bytes(), PATH_SEGMENT_ENCODE_SET);
                 write!(f, "/x-parity-wss/{}", encoded)
             },
         }

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -19,7 +19,7 @@ tokio-codec = "0.1.1"
 tokio-io = "0.1.12"
 tokio-rustls = "0.10.0-alpha.3"
 soketto = { version = "0.2.3", features = ["deflate"] }
-url = "1.7.2"
+url = "2.1.0"
 webpki-roots = "0.16.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This brings `url` and `percent-encoding` up to latest.

For `percent-encoding` I followed the [upgrading guide](https://github.com/servo/rust-url/blob/master/UPGRADING.md#upgrading-from-percent-encoding-1x-to-2x) to address the resulting API breakage.