### PR TITLE
[stable-futures] Switch MemoryTransport to Vec<u8> and fix tests

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -48,10 +48,8 @@ libp2p-mplex = { version = "0.12.0", path = "../muxers/mplex" }
 libp2p-secio = { version = "0.12.0", path = "../protocols/secio" }
 rand = "0.6"
 quickcheck = "0.8"
-tokio = "0.1"
-wasm-timer = "0.1"
+wasm-timer = "0.2"
 assert_matches = "1.3"
-tokio-mock-task = "0.1"
 
 [features]
 default = ["secp256k1"]

--- a/core/src/nodes/listeners.rs
+++ b/core/src/nodes/listeners.rs
@@ -51,32 +51,30 @@ use std::{collections::VecDeque, fmt, pin::Pin};
 /// listeners.listen_on("/ip4/0.0.0.0/tcp/0".parse().unwrap()).unwrap();
 ///
 /// // The `listeners` will now generate events when polled.
-/// let future = listeners.for_each(move |event| {
-///     match event {
-///         ListenersEvent::NewAddress { listener_id, listen_addr } => {
-///             println!("Listener {:?} is listening at address {}", listener_id, listen_addr);
-///         },
-///         ListenersEvent::AddressExpired { listener_id, listen_addr } => {
-///             println!("Listener {:?} is no longer listening at address {}", listener_id, listen_addr);
-///         },
-///         ListenersEvent::Closed { listener_id, .. } => {
-///             println!("Listener {:?} has been closed", listener_id);
-///         },
-///         ListenersEvent::Error { listener_id, error } => {
-///             println!("Listener {:?} has experienced an error: {}", listener_id, error);
-///         },
-///         ListenersEvent::Incoming { listener_id, upgrade, local_addr, .. } => {
-///             println!("Listener {:?} has a new connection on {}", listener_id, local_addr);
-///             // We don't do anything with the newly-opened connection, but in a real-life
-///             // program you probably want to use it!
-///             drop(upgrade);
-///         },
-///     };
-///
-///     Ok(())
-/// });
-///
-/// tokio::run(future.map_err(|_| ()));
+/// futures::executor::block_on(async move {
+///     while let Some(event) = listeners.next().await {
+///         match event {
+///             ListenersEvent::NewAddress { listener_id, listen_addr } => {
+///                 println!("Listener {:?} is listening at address {}", listener_id, listen_addr);
+///             },
+///             ListenersEvent::AddressExpired { listener_id, listen_addr } => {
+///                 println!("Listener {:?} is no longer listening at address {}", listener_id, listen_addr);
+///             },
+///             ListenersEvent::Closed { listener_id, .. } => {
+///                 println!("Listener {:?} has been closed", listener_id);
+///             },
+///             ListenersEvent::Error { listener_id, error } => {
+///                 println!("Listener {:?} has experienced an error: {}", listener_id, error);
+///             },
+///             ListenersEvent::Incoming { listener_id, upgrade, local_addr, .. } => {
+///                 println!("Listener {:?} has a new connection on {}", listener_id, local_addr);
+///                 // We don't do anything with the newly-opened connection, but in a real-life
+///                 // program you probably want to use it!
+///                 drop(upgrade);
+///             },
+///         }
+///     }
+/// })
 /// # }
 /// ```
 pub struct ListenersStream<TTrans>
@@ -358,7 +356,6 @@ mod tests {
     use super::*;
     use crate::transport::{self, ListenerEvent};
     use assert_matches::assert_matches;
-    use tokio::runtime::current_thread::Runtime;
     use std::{io, iter::FromIterator};
     use futures::{future::{self}, stream};
     use crate::PeerId;

--- a/core/tests/util.rs
+++ b/core/tests/util.rs
@@ -29,11 +29,11 @@ where
 {
     type Output = Result<M, M::Error>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         loop {
             match std::mem::replace(&mut self.state, CloseMuxerState::Done) {
                 CloseMuxerState::Close(muxer) => {
-                    if muxer.close()?.is_not_ready() {
+                    if !muxer.close(cx)?.is_ready() {
                         self.state = CloseMuxerState::Close(muxer);
                         return Poll::Pending
                     }
@@ -45,3 +45,5 @@ where
     }
 }
 
+impl<M> Unpin for CloseMuxer<M> {
+}


### PR DESCRIPTION
Fixes the tests in `libp2p-core`.

As a consequence, the `MemoryTransport` now uses `Vec<u8>` instead of `Bytes`, because it wouldn't be compatible with secio otherwise.