### PR TITLE
[question] protocols/plaintext: How to use plaintext1 with builder pattern

### DIFF
--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -18,3 +18,6 @@ void = "1"
 tokio-io = "0.1.12"
 protobuf = "2.3"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
+
+[dev-dependencies]
+libp2p-tcp = { version = "0.12.0", path = "../../transports/tcp" }


### PR DESCRIPTION
When calling `Transport::upgrade` one retrieves a
`core::transport::upgrade::Builder`. Calling `authenticate` on this `Builder`
requires the `InboundUpgrade::Output` and `OutboundUprade::Output`
implementation of the passed struct to be a tuple of 
`(ConnectionInfo, AsyncRead + AsyncWrite)`.

One can not use the above builder pattern upgrade with
`libp2p_plaintext::Plaintext1`, given that its `InboundUpgrade` and
`OutboundUpgrade` don't define a tuple as their `Output`, but just return the
plain `Negotiated<C>`. In addition, given that `Plaintext1` is just a simple
wrapper around `Negotiated<C>` it is not aware of the identity of the other
side, and can thus not fulfill the `ConnectionInfo` trait.

`Plaintext2` does a full handshake to retrieve the PeerId of the other side to
satisfy the `ConnectionInfo` trait.

This patch makes `Plaintext1` simply return a random PeerId. Whether this is a
valid solution is questionable. It rather serves the purpose of showcasing the
issue.

What is the correct way of upgrading a transport with `Plaintext1`?

Relates to https://github.com/libp2p/rust-libp2p/pull/1240.
