### PR TITLE
CircleCI Test Fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ jobs:
   test:
     machine:
       enabled: true
-      docker_layer_caching: true
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
 version: 2
 
-
 workflows:
   version: 2
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2
 
+
 workflows:
   version: 2
   build:


### PR DESCRIPTION
PR tests were failing on CircleCI due to an account limitation (no support for Docker Layer Caching).

Fix: Removed the DLC flag.

Side effects: Tests take longer to run (~15 minutes for the `test` workflow, ~2 minutes for the `integration-test` workflow, ~3 minutes for `test-wasm`).

Better slow than never? 😅 