### PR TITLE
zeroize: Upgrade to v1.0

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,7 +35,7 @@ tokio-io = "0.1"
 wasm-timer = "0.1"
 unsigned-varint = "0.2"
 void = "1"
-zeroize = "0.9"
+zeroize = "1"
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "unknown")))'.dependencies]
 ring = { version = "^0.16", features = ["alloc"], default-features = false }

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -20,7 +20,7 @@ ring = { version = "^0.16", features = ["alloc"], default-features = false }
 snow = { version = "0.6.1", features = ["ring-resolver"], default-features = false }
 tokio-io = "0.1"
 x25519-dalek = "0.5"
-zeroize = "0.9"
+zeroize = "1"
 
 [dev-dependencies]
 env_logger = "0.6"


### PR DESCRIPTION
v1.0 final release is out. Release notes:

https://github.com/iqlusioninc/crates/pull/279