### PR TITLE
Implement Debug for (ed25519/secp256k1)::(Keypair|SecretKey)

### DIFF
--- a/core/src/identity/ed25519.rs
+++ b/core/src/identity/ed25519.rs
@@ -24,6 +24,7 @@ use ed25519_dalek as ed25519;
 use failure::Fail;
 use super::error::DecodingError;
 use zeroize::Zeroize;
+use core::fmt;
 
 /// An Ed25519 keypair.
 pub struct Keypair(ed25519::Keypair);
@@ -63,6 +64,12 @@ impl Keypair {
     pub fn secret(&self) -> SecretKey {
         SecretKey::from_bytes(&mut self.0.secret.to_bytes())
             .expect("ed25519::SecretKey::from_bytes(to_bytes(k)) != k")
+    }
+}
+
+impl fmt::Debug for Keypair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Keypair").field("public", &self.0.public).finish()
     }
 }
 
@@ -132,6 +139,12 @@ impl Clone for SecretKey {
         let mut sk_bytes = self.0.to_bytes();
         Self::from_bytes(&mut sk_bytes)
             .expect("ed25519::SecretKey::from_bytes(to_bytes(k)) != k")
+    }
+}
+
+impl fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SecretKey")
     }
 }
 

--- a/core/src/identity/secp256k1.rs
+++ b/core/src/identity/secp256k1.rs
@@ -26,6 +26,7 @@ use sha2::{Digest as ShaDigestTrait, Sha256};
 use secp256k1::{Message, Signature};
 use super::error::{DecodingError, SigningError};
 use zeroize::Zeroize;
+use core::fmt;
 
 /// A Secp256k1 keypair.
 #[derive(Clone)]
@@ -51,6 +52,12 @@ impl Keypair {
     }
 }
 
+impl fmt::Debug for Keypair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Keypair").field("public", &self.public).finish()
+    }
+}
+
 /// Promote a Secp256k1 secret key into a keypair.
 impl From<SecretKey> for Keypair {
     fn from(secret: SecretKey) -> Keypair {
@@ -69,6 +76,12 @@ impl From<Keypair> for SecretKey {
 /// A Secp256k1 secret key.
 #[derive(Clone)]
 pub struct SecretKey(secp256k1::SecretKey);
+
+impl fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SecretKey")
+    }
+}
 
 impl SecretKey {
     /// Generate a new Secp256k1 secret key.


### PR DESCRIPTION
Sidenote: I see a bunch of deprecated functions, Rust 2015 stuff and `std::mem::uninitialized`. Is anyone going to update this project?