### PR TITLE
Fix possible arithmetic overflow in libp2p-kad.

### DIFF
--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -1313,7 +1313,7 @@ where
         let now = Instant::now();
 
         // Calculate the available capacity for queries triggered by background jobs.
-        let mut jobs_query_capacity = JOBS_MAX_QUERIES - self.queries.size();
+        let mut jobs_query_capacity = JOBS_MAX_QUERIES.saturating_sub(self.queries.size());
 
         // Run the periodic provider announcement job.
         if let Some(mut job) = self.add_provider_job.take() {


### PR DESCRIPTION
Fixes https://github.com/libp2p/rust-libp2p/issues/1290. When the number of active queries exceeds the (internal) JOBS_MAX_QUERIES limit, which is only supposed to bound the number of concurrent queries relating to background jobs, an arithmetic overflow occurs. This is fixed by using saturating subtraction.