### PR TITLE
protocols/noise: Adapt to breaking changes in snow 0.16 and proto generation

### DIFF
--- a/protocols/noise/src/io.rs
+++ b/protocols/noise/src/io.rs
@@ -62,14 +62,14 @@ pub(crate) enum SnowState {
 }
 
 impl SnowState {
-    pub fn read_message(&mut self, message: &[u8], payload: &mut [u8]) -> Result<usize, SnowError> {
+    pub fn read_message(&mut self, message: &[u8], payload: &mut [u8]) -> Result<usize, snow::Error> {
         match self {
             SnowState::Handshake(session) => session.read_message(message, payload),
             SnowState::Transport(session) => session.read_message(message, payload),
         }
     }
 
-    pub fn write_message(&mut self, message: &[u8], payload: &mut [u8]) -> Result<usize, SnowError> {
+    pub fn write_message(&mut self, message: &[u8], payload: &mut [u8]) -> Result<usize, snow::Error> {
         match self {
             SnowState::Handshake(session) => session.write_message(message, payload),
             SnowState::Transport(session) => session.write_message(message, payload),
@@ -83,10 +83,10 @@ impl SnowState {
         }
     }
 
-    pub fn into_transport_mode(self) -> Result<snow::TransportState, SnowError> {
+    pub fn into_transport_mode(self) -> Result<snow::TransportState, snow::Error> {
         match self {
             SnowState::Handshake(session) => session.into_transport_mode(),
-            SnowState::Transport(_) => Err(SnowError::State(StateProblem::HandshakeAlreadyFinished)),
+            SnowState::Transport(_) => Err(snow::Error::State(snow::error::StateProblem::HandshakeAlreadyFinished)),
         }
     }
 }

--- a/protocols/noise/src/io/handshake.rs
+++ b/protocols/noise/src/io/handshake.rs
@@ -122,7 +122,7 @@ impl<T, C> Future for Handshake<T, C> {
 /// ```
 pub fn rt1_initiator<T, C>(
     io: T,
-    session: Result<snow::Session, NoiseError>,
+    session: Result<snow::HandshakeState, NoiseError>,
     identity: KeypairIdentity,
     identity_x: IdentityExchange
 ) -> Handshake<T, C>
@@ -156,7 +156,7 @@ where
 /// ```
 pub fn rt1_responder<T, C>(
     io: T,
-    session: Result<snow::Session, NoiseError>,
+    session: Result<snow::HandshakeState, NoiseError>,
     identity: KeypairIdentity,
     identity_x: IdentityExchange,
 ) -> Handshake<T, C>
@@ -192,7 +192,7 @@ where
 /// ```
 pub fn rt15_initiator<T, C>(
     io: T,
-    session: Result<snow::Session, NoiseError>,
+    session: Result<snow::HandshakeState, NoiseError>,
     identity: KeypairIdentity,
     identity_x: IdentityExchange
 ) -> Handshake<T, C>
@@ -229,7 +229,7 @@ where
 /// ```
 pub fn rt15_responder<T, C>(
     io: T,
-    session: Result<snow::Session, NoiseError>,
+    session: Result<snow::HandshakeState, NoiseError>,
     identity: KeypairIdentity,
     identity_x: IdentityExchange
 ) -> Handshake<T, C>
@@ -363,7 +363,7 @@ where
 
     let mut payload_buf = vec![0; len];
     state.io.read_exact(&mut payload_buf).await?;
-    let pb: payload::Identity = protobuf::parse_from_bytes(&payload_buf)?;
+    let pb: payload_proto::Identity = protobuf::parse_from_bytes(&payload_buf)?;
 
     if !pb.pubkey.is_empty() {
         let pk = identity::PublicKey::from_protobuf_encoding(pb.get_pubkey())
@@ -387,7 +387,7 @@ async fn send_identity<T>(state: &mut State<T>) -> Result<(), NoiseError>
 where
     T: AsyncWrite + Unpin,
 {
-    let mut pb = payload::Identity::new();
+    let mut pb = payload_proto::Identity::new();
     if state.send_identity {
         pb.set_pubkey(state.identity.public.clone().into_protobuf_encoding());
     }


### PR DESCRIPTION
Adapt libp2p's noise implementation to breaking changes of snow 0.16. Follow up to https://github.com/libp2p/rust-libp2p/pull/1265 for the *stable-futures* branch.

In addition fix wrong import path for protobuf structs introduced in https://github.com/libp2p/rust-libp2p/pull/1275.