### PR TITLE
Remove using void to bypass ICE

### DIFF
--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -22,7 +22,6 @@ tokio-codec = "0.1"
 tokio-io = "0.1.0"
 wasm-timer = "0.1"
 unsigned-varint = { version = "0.2.1", features = ["codec"] }
-void = "1.0"
 
 [dev-dependencies]
 libp2p-mplex = { version = "0.12.0", path = "../../muxers/mplex" }

--- a/protocols/identify/src/handler.rs
+++ b/protocols/identify/src/handler.rs
@@ -36,7 +36,6 @@ use smallvec::SmallVec;
 use std::{io, marker::PhantomData, time::Duration};
 use tokio_io::{AsyncRead, AsyncWrite};
 use wasm_timer::{Delay, Instant};
-use void::Void;
 
 /// Delay between the moment we connect and the first time we identify.
 const DELAY_TO_FIRST_ID: Duration = Duration::from_millis(500);
@@ -95,7 +94,7 @@ impl<TSubstream> ProtocolsHandler for IdentifyHandler<TSubstream>
 where
     TSubstream: AsyncRead + AsyncWrite,
 {
-    type InEvent = Void;
+    type InEvent = ();
     type OutEvent = IdentifyHandlerEvent<TSubstream>;
     type Error = wasm_timer::Error;
     type Substream = TSubstream;

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -37,7 +37,6 @@ use libp2p_swarm::{
 };
 use std::{collections::HashMap, collections::VecDeque, io};
 use tokio_io::{AsyncRead, AsyncWrite};
-use void::Void;
 
 /// Network behaviour that automatically identifies nodes periodically, returns information
 /// about them, and answers identify queries from other nodes.
@@ -53,7 +52,7 @@ pub struct Identify<TSubstream> {
     /// Pending replies to send.
     pending_replies: VecDeque<Reply<TSubstream>>,
     /// Pending events to be emitted when polled.
-    events: VecDeque<NetworkBehaviourAction<Void, IdentifyEvent>>,
+    events: VecDeque<NetworkBehaviourAction<(), IdentifyEvent>>,
 }
 
 /// A pending reply to an inbound identification request.


### PR DESCRIPTION
It turns out that nightly Rust ICEs when using enum with zero variants.
See https://github.com/rust-lang/rust/issues/65462

We were hoping that this ICE would eventually be fixed, but it's about to hit stable and it still isn't fix.

The solution now is unfortunately to remove using empty enums from our API.

Should be merged before #1294 