### PR TITLE
Update yamux to development version.

### DIFF
--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -10,8 +10,9 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-futures = "0.1"
+futures-preview = "0.3.0-alpha.19"
 libp2p-core = { version = "0.13.0", path = "../../core" }
-log = "0.4"
-tokio-io = "0.1"
-yamux = "0.2.1"
+log = "0.4.8"
+parking_lot = "0.9"
+thiserror = "1.0"
+yamux = { git = "https://github.com/paritytech/yamux.git", branch = "develop" }


### PR DESCRIPTION
This PR uses the Yamux development version which is based on futures-preview 0.3.0-alpha.19. Since we use a boxed version of the incoming `futures::stream::Stream` of substreams, we offer two sets of upgrades, one which requires a `Send` bound on the underlying I/O resource, and one which does not. If memory serves me well, we have some upgrades such as secio whose output is `!Send`. If we do not plan to support `!Send`, we can of course remove half of this PR.