### PR TITLE
Update parking_lot to v0.9

### DIFF
--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -15,7 +15,7 @@ fnv = "1.0"
 futures = "0.1"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4"
-parking_lot = "0.8"
+parking_lot = "0.9"
 tokio-codec = "0.1"
 tokio-io = "0.1"
 unsigned-varint = { version = "0.2.1", features = ["codec"] }


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

Seems to forget to upgrade the `parking_lot` dep of the `mplex` to v0.9