### PR TITLE
protocols/plaintext: Move to stable futures and use unsigned varints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next Version
+
+- Use varints instead of fixed sized (4 byte) integers to delimit plaintext 2.0 messages to align implementation with the specification.
+
 # Version 0.13.0 (2019-11-05)
 
 - Reworked the transport upgrade API. See https://github.com/libp2p/rust-libp2p/pull/1240 for more information.

--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -10,11 +10,12 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-futures-preview = "0.3.0-alpha.18"
-libp2p-core = { version = "0.13.0", path = "../../core" }
 bytes = "0.4.12"
+futures = "0.3.1"
+futures_codec = "0.3.1"
+libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4.8"
-void = "1.0.2"
-tokio-io = "0.1.12"
 protobuf = "2.8.1"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
+unsigned-varint = { version = "0.2.3", features = ["futures-codec"] }
+void = "1.0.2"

--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -19,3 +19,9 @@ protobuf = "2.8.1"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
 unsigned-varint = { version = "0.2.3", features = ["futures-codec"] }
 void = "1.0.2"
+
+[dev-dependencies]
+env_logger = "0.7.1"
+quickcheck = "0.9.0"
+rand = "0.7"
+futures-timer = "2.0"

--- a/protocols/plaintext/src/lib.rs
+++ b/protocols/plaintext/src/lib.rs
@@ -24,7 +24,7 @@ use crate::handshake::Remote;
 use bytes::BytesMut;
 use futures::future::{self, Ready};
 use futures::prelude::*;
-use futures::{Sink, Stream};
+use futures::{future::BoxFuture, Sink, Stream};
 use futures_codec::Framed;
 use libp2p_core::{
     identity,
@@ -125,7 +125,7 @@ where
 {
     type Output = (PeerId, PlainTextOutput<Negotiated<C>>);
     type Error = PlainTextError;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
+    type Future = BoxFuture<'static, Result<Self::Output, Self::Error>>;
 
     fn upgrade_inbound(self, socket: Negotiated<C>, _: Self::Info) -> Self::Future {
         Box::pin(self.handshake(socket))
@@ -138,7 +138,7 @@ where
 {
     type Output = (PeerId, PlainTextOutput<Negotiated<C>>);
     type Error = PlainTextError;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
+    type Future = BoxFuture<'static, Result<Self::Output, Self::Error>>;
 
     fn upgrade_outbound(self, socket: Negotiated<C>, _: Self::Info) -> Self::Future {
         Box::pin(self.handshake(socket))

--- a/protocols/plaintext/src/lib.rs
+++ b/protocols/plaintext/src/lib.rs
@@ -18,15 +18,18 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures::future::{self, Ready};
-use libp2p_core::{InboundUpgrade, OutboundUpgrade, UpgradeInfo, upgrade::Negotiated};
-use std::iter;
-use tokio_io::{AsyncRead, AsyncWrite};
-use tokio_io::codec::length_delimited::Framed;
 use crate::error::PlainTextError;
-use void::Void;
-use futures::future::FutureResult;
+use unsigned_varint::codec::UviBytes;
 use crate::handshake::Remote;
+use futures::future::{self, Ready};
+use futures::{Sink, Stream};
+use futures::prelude::*;
+use futures_codec::Framed;
+use libp2p_core::{identity, InboundUpgrade, OutboundUpgrade, UpgradeInfo, upgrade::Negotiated, PeerId, PublicKey};
+use log::debug;
+use rw_stream_sink::RwStreamSink;
+use std::{io, iter, pin::Pin, task::{Context, Poll}};
+use void::Void;
 
 mod error;
 mod handshake;
@@ -108,144 +111,144 @@ impl UpgradeInfo for PlainText2Config {
 
 impl<C> InboundUpgrade<C> for PlainText2Config
 where
-    C: AsyncRead + AsyncWrite + Send + 'static
+    C: AsyncRead + AsyncWrite + Send + Unpin + 'static
 {
     type Output = (PeerId, PlainTextOutput<Negotiated<C>>);
     type Error = PlainTextError;
-    type Future = Box<dyn Future<Item = Self::Output, Error = Self::Error> + Send>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
 
     fn upgrade_inbound(self, socket: Negotiated<C>, _: Self::Info) -> Self::Future {
-        Box::new(self.handshake(socket))
+        Box::pin(self.handshake(socket))
     }
 }
 
 impl<C> OutboundUpgrade<C> for PlainText2Config
 where
-    C: AsyncRead + AsyncWrite + Send + 'static
+    C: AsyncRead + AsyncWrite + Send + Unpin + 'static
 {
     type Output = (PeerId, PlainTextOutput<Negotiated<C>>);
     type Error = PlainTextError;
-    type Future = Box<dyn Future<Item = Self::Output, Error = Self::Error> + Send>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
 
     fn upgrade_outbound(self, socket: Negotiated<C>, _: Self::Info) -> Self::Future {
-        Box::new(self.handshake(socket))
+        Box::pin(self.handshake(socket))
     }
 }
 
 impl PlainText2Config {
-    fn handshake<T>(self, socket: T) -> impl Future<Item = (PeerId, PlainTextOutput<T>), Error = PlainTextError>
+    async fn handshake<T>(self, socket: T) -> Result<(PeerId, PlainTextOutput<T>), PlainTextError>
     where
-        T: AsyncRead + AsyncWrite + Send + 'static
+        T: AsyncRead + AsyncWrite + Send + Unpin + 'static
     {
         debug!("Starting plaintext upgrade");
-        PlainTextMiddleware::handshake(socket, self)
-            .map(|(stream_sink, remote)| {
-                let mapped = stream_sink.map_err(map_err as fn(_) -> _);
-                (
-                    remote.peer_id,
-                    PlainTextOutput {
-                        stream: RwStreamSink::new(mapped),
-                        remote_key: remote.public_key,
-                    }
-                )
-            })
+        let (stream_sink, remote) = PlainTextMiddleware::handshake(socket, self).await?;
+        let mapped = stream_sink.map_err(map_err as fn(_) -> _);
+        Ok((
+            remote.peer_id,
+            PlainTextOutput {
+                stream: RwStreamSink::new(mapped),
+                remote_key: remote.public_key,
+            }
+        ))
     }
 }
 
-#[inline]
 fn map_err(err: io::Error) -> io::Error {
     debug!("error during plaintext handshake {:?}", err);
     io::Error::new(io::ErrorKind::InvalidData, err)
 }
 
 pub struct PlainTextMiddleware<S> {
-    inner: Framed<S, BytesMut>,
+    inner: Framed<S, UviBytes<Vec<u8>>>,
 }
 
 impl<S> PlainTextMiddleware<S>
 where
-    S: AsyncRead + AsyncWrite + Send,
+    S: AsyncRead + AsyncWrite + Send + Unpin,
 {
-    fn handshake(socket: S, config: PlainText2Config)
-        -> impl Future<Item = (PlainTextMiddleware<S>, Remote), Error = PlainTextError>
+    async fn handshake(socket: S, config: PlainText2Config)
+        -> Result<(PlainTextMiddleware<S>, Remote), PlainTextError>
     {
-        handshake::handshake(socket, config).map(|(inner, remote)| {
-            (PlainTextMiddleware { inner }, remote)
-        })
+        let (inner, remote) = handshake::handshake(socket, config).await?;
+        Ok((PlainTextMiddleware { inner }, remote))
     }
 }
 
-impl<S> Sink for PlainTextMiddleware<S>
+impl<S> Sink<Vec<u8>> for PlainTextMiddleware<S>
 where
-    S: AsyncRead + AsyncWrite,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
-    type SinkItem = BytesMut;
-    type SinkError = io::Error;
+    type Error = io::Error;
 
-    #[inline]
-    fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
-        self.inner.start_send(item)
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        Sink::poll_ready(Pin::new(&mut self.inner), cx)
     }
 
-    #[inline]
-    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
-        self.inner.poll_complete()
+    fn start_send(mut self: Pin<&mut Self>, item: Vec<u8>) -> Result<(), Self::Error> {
+        Sink::start_send(Pin::new(&mut self.inner), item)
     }
 
-    #[inline]
-    fn close(&mut self) -> Poll<(), Self::SinkError> {
-        self.inner.close()
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        Sink::poll_flush(Pin::new(&mut self.inner), cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        Sink::poll_close(Pin::new(&mut self.inner), cx)
     }
 }
 
 impl<S> Stream for PlainTextMiddleware<S>
 where
-    S: AsyncRead + AsyncWrite,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
-    type Item = BytesMut;
-    type Error = io::Error;
+    type Item = Result<Vec<u8>, io::Error>;
 
-    #[inline]
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        self.inner.poll()
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // TODO: Too much of a hack? (BytesMut -> Vec<u8>)
+        match Stream::poll_next(Pin::new(&mut self.inner), cx) {
+            Poll::Ready(ready) => {
+                Poll::Ready(ready.map(|res| res.map(|buf| buf.to_vec())))
+            },
+            Poll::Pending => Poll::Pending,
+        }
     }
 }
 
 /// Output of the plaintext protocol.
 pub struct PlainTextOutput<S>
 where
-    S: AsyncRead + AsyncWrite,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
     /// The plaintext stream.
-    pub stream: RwStreamSink<StreamMapErr<PlainTextMiddleware<S>, fn(io::Error) -> io::Error>>,
+    pub stream: RwStreamSink<futures::stream::MapErr<PlainTextMiddleware<S>, fn(io::Error) -> io::Error>>,
     /// The public key of the remote.
     pub remote_key: PublicKey,
 }
 
-impl<S: AsyncRead + AsyncWrite> std::io::Read for PlainTextOutput<S> {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.stream.read(buf)
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for PlainTextOutput<S> {
+    fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context, buf: &mut [u8])
+        -> Poll<Result<usize, io::Error>>
+    {
+        AsyncRead::poll_read(Pin::new(&mut self.stream), cx, buf)
     }
 }
 
-impl<S: AsyncRead + AsyncWrite> AsyncRead for PlainTextOutput<S> {
-    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
-        self.stream.prepare_uninitialized_buffer(buf)
-    }
-}
-
-impl<S: AsyncRead + AsyncWrite> std::io::Write for PlainTextOutput<S> {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.stream.write(buf)
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for PlainTextOutput<S> {
+    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context, buf: &[u8])
+        -> Poll<Result<usize, io::Error>>
+    {
+        AsyncWrite::poll_write(Pin::new(&mut self.stream), cx, buf)
     }
 
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.stream.flush()
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context)
+        -> Poll<Result<(), io::Error>>
+    {
+        AsyncWrite::poll_flush(Pin::new(&mut self.stream), cx)
     }
-}
 
-impl<S: AsyncRead + AsyncWrite> AsyncWrite for PlainTextOutput<S> {
-    fn shutdown(&mut self) -> Poll<(), io::Error> {
-        self.stream.shutdown()
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context)
+        -> Poll<Result<(), io::Error>>
+    {
+        AsyncWrite::poll_close(Pin::new(&mut self.stream), cx)
     }
 }

--- a/protocols/plaintext/tests/smoke.rs
+++ b/protocols/plaintext/tests/smoke.rs
@@ -1,0 +1,119 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use libp2p_plaintext::PlainText2Config;
+use log::{info, debug};
+use libp2p_core::identity;
+use libp2p_core::transport::{Transport, ListenerEvent};
+use futures::io::{AsyncWriteExt, AsyncReadExt};
+use futures::stream::TryStreamExt;
+use libp2p_core::multiaddr::Multiaddr;
+use libp2p_core::upgrade;
+use quickcheck::QuickCheck;
+
+#[test]
+fn variable_msg_length() {
+    let _ = env_logger::try_init();
+
+    fn prop(msg: Vec<u8>) {
+        let mut msg_to_send = msg.clone();
+        let msg_to_receive = msg;
+
+        let server_id = identity::Keypair::generate_ed25519();
+        let server_id_public = server_id.public();
+
+        let client_id = identity::Keypair::generate_ed25519();
+        let client_id_public = client_id.public();
+
+        futures::executor::block_on(async {
+            let server_transport = libp2p_core::transport::MemoryTransport{}.and_then(
+                move |output, endpoint| {
+                    upgrade::apply(
+                        output,
+                        PlainText2Config{local_public_key: server_id_public},
+                        endpoint,
+                        libp2p_core::upgrade::Version::V1,
+                    )
+                }
+            );
+
+            let client_transport = libp2p_core::transport::MemoryTransport{}.and_then(
+                move |output, endpoint| {
+                    upgrade::apply(
+                        output,
+                        PlainText2Config{local_public_key: client_id_public},
+                        endpoint,
+                        libp2p_core::upgrade::Version::V1,
+                    )
+                }
+            );
+
+
+            let server_address: Multiaddr = format!(
+                "/memory/{}",
+                std::cmp::Ord::max(1, rand::random::<u64>())
+            ).parse().unwrap();
+
+            let mut server = server_transport.listen_on(server_address.clone()).unwrap();
+
+            // Ignore server listen address event.
+            let _ = server.try_next()
+                .await
+                .expect("some event")
+                .expect("no error")
+                .into_new_address()
+                .expect("listen address");
+
+            let client_fut = async {
+                info!("dialing {:?}", server_address);
+                let (received_server_id, mut client_channel) = client_transport.dial(server_address).unwrap().await.unwrap();
+                assert_eq!(received_server_id, server_id.public().into_peer_id());
+
+                debug!("Client: writing message.");
+                client_channel.write_all(&mut msg_to_send).await.expect("no error");
+                debug!("Client: flushing channel.");
+                client_channel.flush().await.expect("no error");
+            };
+
+            let server_fut = async {
+                let mut server_channel = server.try_next()
+                    .await
+                    .expect("some event")
+                    .map(ListenerEvent::into_upgrade)
+                    .expect("no error")
+                    .map(|client| client.0)
+                    .expect("listener upgrade xyz")
+                    .await
+                    .map(|(_, session)| session)
+                    .expect("no error");
+
+                let mut server_buffer = vec![0; msg_to_receive.len()];
+                info!("Server: reading message.");
+                server_channel.read_exact(&mut server_buffer).await.expect("reading client message");
+
+                assert_eq!(server_buffer, msg_to_receive);
+            };
+
+            futures::future::join(server_fut, client_fut).await;
+        })
+    }
+
+    QuickCheck::new().max_tests(30).quickcheck(prop as fn(Vec<u8>))
+}

--- a/protocols/plaintext/tests/smoke.rs
+++ b/protocols/plaintext/tests/smoke.rs
@@ -18,14 +18,16 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use libp2p_plaintext::PlainText2Config;
-use log::{info, debug};
-use libp2p_core::identity;
-use libp2p_core::transport::{Transport, ListenerEvent};
 use futures::io::{AsyncWriteExt, AsyncReadExt};
 use futures::stream::TryStreamExt;
-use libp2p_core::multiaddr::Multiaddr;
-use libp2p_core::upgrade;
+use libp2p_core::{
+    identity,
+    multiaddr::Multiaddr,
+    transport::{Transport, ListenerEvent},
+    upgrade,
+};
+use libp2p_plaintext::PlainText2Config;
+use log::debug;
 use quickcheck::QuickCheck;
 
 #[test]
@@ -82,7 +84,7 @@ fn variable_msg_length() {
                 .expect("listen address");
 
             let client_fut = async {
-                info!("dialing {:?}", server_address);
+                debug!("dialing {:?}", server_address);
                 let (received_server_id, mut client_channel) = client_transport.dial(server_address).unwrap().await.unwrap();
                 assert_eq!(received_server_id, server_id.public().into_peer_id());
 
@@ -105,7 +107,7 @@ fn variable_msg_length() {
                     .expect("no error");
 
                 let mut server_buffer = vec![0; msg_to_receive.len()];
-                info!("Server: reading message.");
+                debug!("Server: reading message.");
                 server_channel.read_exact(&mut server_buffer).await.expect("reading client message");
 
                 assert_eq!(server_buffer, msg_to_receive);

--- a/protocols/secio/src/codec/mod.rs
+++ b/protocols/secio/src/codec/mod.rs
@@ -103,6 +103,7 @@ impl Hmac {
 }
 
 /// Takes control of `socket`. Returns an object that implements `future::Sink` and
+// TODO: I don't think it is a BytesMut but a Vec<u8>, right?
 /// `future::Stream`. The `Stream` and `Sink` produce and accept `BytesMut` objects.
 ///
 /// The conversion between the stream/sink items and the socket is done with the given cipher and

--- a/protocols/secio/src/codec/mod.rs
+++ b/protocols/secio/src/codec/mod.rs
@@ -103,8 +103,7 @@ impl Hmac {
 }
 
 /// Takes control of `socket`. Returns an object that implements `future::Sink` and
-// TODO: I don't think it is a BytesMut but a Vec<u8>, right?
-/// `future::Stream`. The `Stream` and `Sink` produce and accept `BytesMut` objects.
+/// `future::Stream`. The `Stream` and `Sink` produce and accept `Vec<u8>` objects.
 ///
 /// The conversion between the stream/sink items and the socket is done with the given cipher and
 /// hash algorithm (which are generally decided during the handshake).


### PR DESCRIPTION
The plaintext 2.0 specification requires to use unsigned varints for
frame length delimiting instead of fixed 4 byte integer frame length
delimiting. This commit aligns the implementation with the
specification.