### PR TITLE
Use soketto's `reader-writer-split` branch.

### DIFF
--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -10,15 +10,16 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-tls = "0.5"
+async-tls = "0.6"
 bytes = "0.4.12"
 either = "1.5.3"
-futures-preview = "0.3.0-alpha.18"
+futures = "0.3.1"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4.8"
+quicksink = { git = "https://github.com/twittner/quicksink.git" }
 rustls = "0.16"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
-soketto = { git = "https://github.com/paritytech/soketto.git", branch = "develop", features = ["deflate"] }
+soketto = { git = "https://github.com/twittner/soketto.git", branch = "reader-writer-split", features = ["deflate"] }
 url = "2.1"
 webpki = "0.21"
 webpki-roots = "0.18"

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -16,7 +16,7 @@ either = "1.5.3"
 futures = "0.3.1"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4.8"
-quicksink = { git = "https://github.com/twittner/quicksink.git" }
+quicksink = { git = "https://github.com/paritytech/quicksink.git", branch = "develop" }
 rustls = "0.16"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
 soketto = { git = "https://github.com/twittner/soketto.git", branch = "reader-writer-split", features = ["deflate"] }

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -16,10 +16,10 @@ either = "1.5.3"
 futures = "0.3.1"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4.8"
-quicksink = { git = "https://github.com/paritytech/quicksink.git", branch = "develop" }
+quicksink = { git = "https://github.com/paritytech/quicksink.git" }
 rustls = "0.16"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
-soketto = { git = "https://github.com/twittner/soketto.git", branch = "reader-writer-split", features = ["deflate"] }
+soketto = { git = "https://github.com/paritytech/soketto.git", branch = "develop", features = ["deflate"] }
 url = "2.1"
 webpki = "0.21"
 webpki-roots = "0.18"


### PR DESCRIPTION
Updates to a soketto version that uses futures-0.3.x. Depends on https://github.com/paritytech/soketto/pull/8 and https://github.com/paritytech/quicksink/pull/1.