### PR TITLE
Bump dependencies, respecting semver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ default = ["secp256k1", "libp2p-websocket"]
 secp256k1 = ["libp2p-core/secp256k1", "libp2p-secio/secp256k1"]
 
 [dependencies]
-bytes = "0.4"
-futures = "0.1"
+bytes = "0.4.12"
+futures = "0.1.29"
 multiaddr = { package = "parity-multiaddr", version = "0.6.0", path = "misc/multiaddr" }
 multihash = { package = "parity-multihash", version = "0.2.0", path = "misc/multihash" }
-lazy_static = "1.2"
+lazy_static = "1.4.0"
 libp2p-mplex = { version = "0.13.0", path = "muxers/mplex" }
 libp2p-identify = { version = "0.13.1", path = "protocols/identify" }
 libp2p-kad = { version = "0.13.1", path = "protocols/kad" }
@@ -33,11 +33,11 @@ libp2p-uds = { version = "0.13.0", path = "transports/uds" }
 libp2p-wasm-ext = { version = "0.6.0", path = "transports/wasm-ext" }
 libp2p-yamux = { version = "0.13.0", path = "muxers/yamux" }
 parking_lot = "0.9.0"
-smallvec = "0.6"
-tokio-codec = "0.1"
-tokio-executor = "0.1"
-tokio-io = "0.1"
-wasm-timer = "0.1"
+smallvec = "0.6.13"
+tokio-codec = "0.1.1"
+tokio-executor = "0.1.8"
+tokio-io = "0.1.12"
+wasm-timer = "0.1.3"
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "unknown")))'.dependencies]
 libp2p-deflate = { version = "0.5.0", path = "protocols/deflate" }
@@ -49,8 +49,8 @@ libp2p-websocket = { version = "0.13.0", path = "transports/websocket", optional
 
 [dev-dependencies]
 env_logger = "0.7.1"
-tokio = "0.1"
-tokio-stdin-stdout = "0.1"
+tokio = "0.1.22"
+tokio-stdin-stdout = "0.1.5"
 
 [workspace]
 members = [

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,32 +10,32 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-asn1_der = "0.6.1"
+asn1_der = "0.6.3"
 bs58 = "0.3.0"
-bytes = "0.4"
+bytes = "0.4.12"
 ed25519-dalek = "1.0.0-pre.2"
-failure = "0.1"
-fnv = "1.0"
-lazy_static = "1.2"
-log = "0.4"
+failure = "0.1.6"
+fnv = "1.0.6"
+lazy_static = "1.4.0"
+log = "0.4.8"
 multiaddr = { package = "parity-multiaddr", version = "0.6.0", path = "../misc/multiaddr" }
 multihash = { package = "parity-multihash", version = "0.2.0", path = "../misc/multihash" }
 multistream-select = { version = "0.6.0", path = "../misc/multistream-select" }
-futures = "0.1"
+futures = "0.1.29"
 parking_lot = "0.9.0"
-protobuf = "2.8"
-quick-error = "1.2"
-rand = "0.7"
+protobuf = "2.8.1"
+quick-error = "1.2.2"
+rand = "0.7.2"
 rw-stream-sink = { version = "0.1.1", path = "../misc/rw-stream-sink" }
-libsecp256k1 = { version = "0.3.1", optional = true }
+libsecp256k1 = { version = "0.3.2", optional = true }
 sha2 = "0.8.0"
-smallvec = "0.6"
-tokio-executor = "0.1.4"
-tokio-io = "0.1"
-wasm-timer = "0.1"
-unsigned-varint = "0.2"
-void = "1"
-zeroize = "1"
+smallvec = "0.6.13"
+tokio-executor = "0.1.8"
+tokio-io = "0.1.12"
+wasm-timer = "0.1.3"
+unsigned-varint = "0.2.3"
+void = "1.0.2"
+zeroize = "1.0.0"
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "unknown")))'.dependencies]
 ring = { version = "0.16.9", features = ["alloc", "std"], default-features = false }
@@ -48,10 +48,10 @@ libp2p-mplex = { version = "0.13.0", path = "../muxers/mplex" }
 libp2p-secio = { version = "0.13.0", path = "../protocols/secio" }
 rand = "0.7.2"
 quickcheck = "0.9.0"
-tokio = "0.1"
-wasm-timer = "0.1"
-assert_matches = "1.3"
-tokio-mock-task = "0.1"
+tokio = "0.1.22"
+wasm-timer = "0.1.3"
+assert_matches = "1.3.0"
+tokio-mock-task = "0.1.1"
 
 [features]
 default = ["secp256k1"]

--- a/misc/core-derive/Cargo.toml
+++ b/misc/core-derive/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["network-programming", "asynchronous"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0", default-features = false, features = ["clone-impls", "derive", "parsing", "printing", "proc-macro"] }
-quote = "1.0"
+syn = { version = "1.0.8", default-features = false, features = ["clone-impls", "derive", "parsing", "printing", "proc-macro"] }
+quote = "1.0.2"
 
 [dev-dependencies]
 libp2p = { version = "0.13.0", path = "../.." }

--- a/misc/mdns/Cargo.toml
+++ b/misc/mdns/Cargo.toml
@@ -10,21 +10,21 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-data-encoding = "2.0"
-dns-parser = "0.8"
-futures = "0.1"
+data-encoding = "2.1.2"
+dns-parser = "0.8.0"
+futures = "0.1.29"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 libp2p-swarm = { version = "0.3.0", path = "../../swarm" }
-log = "0.4"
+log = "0.4.8"
 multiaddr = { package = "parity-multiaddr", version = "0.6.0", path = "../multiaddr" }
-net2 = "0.2"
-rand = "0.6"
-smallvec = "0.6"
-tokio-io = "0.1"
-tokio-reactor = "0.1"
-wasm-timer = "0.1"
-tokio-udp = "0.1"
-void = "1.0"
+net2 = "0.2.33"
+rand = "0.6.5"
+smallvec = "0.6.13"
+tokio-io = "0.1.12"
+tokio-reactor = "0.1.10"
+wasm-timer = "0.1.3"
+tokio-udp = "0.1.5"
+void = "1.0.2"
 
 [dev-dependencies]
-tokio = "0.1"
+tokio = "0.1.22"

--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -9,21 +9,21 @@ license = "MIT"
 version = "0.6.0"
 
 [dependencies]
-arrayref = "0.3"
+arrayref = "0.3.5"
 bs58 = "0.3.0"
-byteorder = "1.3.1"
+byteorder = "1.3.2"
 bytes = "0.4.12"
-data-encoding = "2.1"
+data-encoding = "2.1.2"
 multihash = { package = "parity-multihash", version = "0.2.0", path = "../multihash" }
 percent-encoding = "2.1.0"
-serde = "1.0.70"
-unsigned-varint = "0.2"
+serde = "1.0.102"
+unsigned-varint = "0.2.3"
 url = { version = "2.1.0", default-features = false }
 
 [dev-dependencies]
-bincode = "1"
+bincode = "1.2.0"
 bs58 = "0.3.0"
-data-encoding = "2"
+data-encoding = "2.1.2"
 quickcheck = "0.9.0"
 rand = "0.7.2"
-serde_json = "1.0"
+serde_json = "1.0.41"

--- a/misc/multihash/Cargo.toml
+++ b/misc/multihash/Cargo.toml
@@ -10,10 +10,10 @@ license = "MIT"
 documentation = "https://docs.rs/parity-multihash/"
 
 [dependencies]
-blake2 = { version = "0.8", default-features = false }
+blake2 = { version = "0.8.1", default-features = false }
 bytes = "0.4.12"
-rand = { version = "0.6", default-features = false, features = ["std"] }
-sha-1 = { version = "0.8", default-features = false }
-sha2 = { version = "0.8", default-features = false }
-sha3 = { version = "0.8", default-features = false }
-unsigned-varint = "0.2"
+rand = { version = "0.6.5", default-features = false, features = ["std"] }
+sha-1 = { version = "0.8.1", default-features = false }
+sha2 = { version = "0.8.0", default-features = false }
+sha3 = { version = "0.8.2", default-features = false }
+unsigned-varint = "0.2.3"

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -10,15 +10,15 @@ categories = ["network-programming", "asynchronous"]
 edition = "2018"
 
 [dependencies]
-bytes = "0.4"
-futures = "0.1"
-log = "0.4"
-smallvec = "0.6"
-tokio-io = "0.1"
-unsigned-varint = "0.2.2"
+bytes = "0.4.12"
+futures = "0.1.29"
+log = "0.4.8"
+smallvec = "0.6.13"
+tokio-io = "0.1.12"
+unsigned-varint = "0.2.3"
 
 [dev-dependencies]
-tokio = "0.1"
-tokio-tcp = "0.1"
+tokio = "0.1.22"
+tokio-tcp = "0.1.3"
 quickcheck = "0.9.0"
 rand = "0.7.2"

--- a/misc/peer-id-generator/Cargo.toml
+++ b/misc/peer-id-generator/Cargo.toml
@@ -12,4 +12,4 @@ publish = false
 
 [dependencies]
 libp2p-core = { version = "0.13.0", path = "../../core" }
-num_cpus = "1.8"
+num_cpus = "1.11.1"

--- a/misc/rw-stream-sink/Cargo.toml
+++ b/misc/rw-stream-sink/Cargo.toml
@@ -10,6 +10,6 @@ keywords = ["networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-bytes = "0.4"
-futures = "0.1"
-tokio-io = "0.1"
+bytes = "0.4.12"
+futures = "0.1.29"
+tokio-io = "0.1.12"

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -10,16 +10,16 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-bytes = "0.4.5"
-fnv = "1.0"
-futures = "0.1"
+bytes = "0.4.12"
+fnv = "1.0.6"
+futures = "0.1.29"
 libp2p-core = { version = "0.13.0", path = "../../core" }
-log = "0.4"
-parking_lot = "0.9"
-tokio-codec = "0.1"
-tokio-io = "0.1"
-unsigned-varint = { version = "0.2.1", features = ["codec"] }
+log = "0.4.8"
+parking_lot = "0.9.0"
+tokio-codec = "0.1.1"
+tokio-io = "0.1.12"
+unsigned-varint = { version = "0.2.3", features = ["codec"] }
 
 [dev-dependencies]
 libp2p-tcp = { version = "0.13.0", path = "../../transports/tcp" }
-tokio = "0.1"
+tokio = "0.1.22"

--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-futures = "0.1"
+futures = "0.1.29"
 libp2p-core = { version = "0.13.0", path = "../../core" }
-log = "0.4"
-tokio-io = "0.1"
-yamux = "0.2.1"
+log = "0.4.8"
+tokio-io = "0.1.12"
+yamux = "0.2.2"

--- a/protocols/deflate/Cargo.toml
+++ b/protocols/deflate/Cargo.toml
@@ -10,14 +10,14 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-futures = "0.1"
+futures = "0.1.29"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 tokio-io = "0.1.12"
-flate2 = { version = "1.0", features = ["tokio"] }
+flate2 = { version = "1.0.13", features = ["tokio"] }
 
 [dev-dependencies]
 env_logger = "0.7.1"
 libp2p-tcp = { version = "0.13.0", path = "../../transports/tcp" }
 quickcheck = "0.9.0"
-tokio = "0.1"
-log = "0.4"
+tokio = "0.1.22"
+log = "0.4.8"

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -11,13 +11,13 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 bs58 = "0.3.0"
-bytes = "0.4"
+bytes = "0.4.12"
 cuckoofilter = "0.3.2"
-fnv = "1.0"
-futures = "0.1"
+fnv = "1.0.6"
+futures = "0.1.29"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 libp2p-swarm = { version = "0.3.0", path = "../../swarm" }
-protobuf = "2.8"
-rand = "0.6"
-smallvec = "0.6.5"
-tokio-io = "0.1"
+protobuf = "2.8.1"
+rand = "0.6.5"
+smallvec = "0.6.13"
+tokio-io = "0.1.12"

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -10,22 +10,22 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-bytes = "0.4"
-futures = "0.1"
+bytes = "0.4.12"
+futures = "0.1.29"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 libp2p-swarm = { version = "0.3.0", path = "../../swarm" }
-log = "0.4.1"
+log = "0.4.8"
 multiaddr = { package = "parity-multiaddr", version = "0.6.0", path = "../../misc/multiaddr" }
-protobuf = "2.8"
-smallvec = "0.6"
-tokio-codec = "0.1"
-tokio-io = "0.1.0"
-wasm-timer = "0.1"
-unsigned-varint = { version = "0.2.1", features = ["codec"] }
+protobuf = "2.8.1"
+smallvec = "0.6.13"
+tokio-codec = "0.1.1"
+tokio-io = "0.1.12"
+wasm-timer = "0.1.3"
+unsigned-varint = { version = "0.2.3", features = ["codec"] }
 
 [dev-dependencies]
 libp2p-mplex = { version = "0.13.0", path = "../../muxers/mplex" }
 libp2p-secio = { version = "0.13.0", path = "../../protocols/secio" }
 libp2p-tcp = { version = "0.13.0", path = "../../transports/tcp" }
-rand = "0.6"
-tokio = "0.1"
+rand = "0.6.5"
+tokio = "0.1.22"

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -11,25 +11,25 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 arrayvec = "0.5.1"
-bytes = "0.4"
-either = "1.5"
-fnv = "1.0"
-futures = "0.1"
-log = "0.4"
+bytes = "0.4.12"
+either = "1.5.3"
+fnv = "1.0.6"
+futures = "0.1.29"
+log = "0.4.8"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 libp2p-swarm = { version = "0.3.0", path = "../../swarm" }
 multiaddr = { package = "parity-multiaddr", version = "0.6.0", path = "../../misc/multiaddr" }
 multihash = { package = "parity-multihash", version = "0.2.0", path = "../../misc/multihash" }
-protobuf = "2.8"
+protobuf = "2.8.1"
 rand = "0.7.2"
 sha2 = "0.8.0"
-smallvec = "0.6"
-tokio-codec = "0.1"
-tokio-io = "0.1"
-wasm-timer = "0.1"
-uint = "0.8"
-unsigned-varint = { version = "0.2.1", features = ["codec"] }
-void = "1.0"
+smallvec = "0.6.13"
+tokio-codec = "0.1.1"
+tokio-io = "0.1.12"
+wasm-timer = "0.1.3"
+uint = "0.8.2"
+unsigned-varint = { version = "0.2.3", features = ["codec"] }
+void = "1.0.2"
 
 [dev-dependencies]
 libp2p-secio = { version = "0.13.0", path = "../secio" }
@@ -37,4 +37,4 @@ libp2p-tcp = { version = "0.13.0", path = "../../transports/tcp" }
 libp2p-yamux = { version = "0.13.0", path = "../../muxers/yamux" }
 quickcheck = "0.9.0"
 rand = "0.7.2"
-tokio = "0.1"
+tokio = "0.1.22"

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -8,23 +8,23 @@ repository = "https://github.com/libp2p/rust-libp2p"
 edition = "2018"
 
 [dependencies]
-bytes = "0.4"
-curve25519-dalek = "1"
-futures = "0.1"
-lazy_static = "1.2"
+bytes = "0.4.12"
+curve25519-dalek = "1.2.3"
+futures = "0.1.29"
+lazy_static = "1.4.0"
 libp2p-core = { version = "0.13.0", path = "../../core" }
-log = "0.4"
-protobuf = "2.8"
-rand = "^0.7.2"
+log = "0.4.8"
+protobuf = "2.8.1"
+rand = "0.7.2"
 ring = { version = "0.16.9", features = ["alloc"], default-features = false }
 snow = { version = "0.6.1", features = ["ring-resolver"], default-features = false }
-tokio-io = "0.1"
-x25519-dalek = "0.5"
-zeroize = "1"
+tokio-io = "0.1.12"
+x25519-dalek = "0.5.2"
+zeroize = "1.0.0"
 
 [dev-dependencies]
 env_logger = "0.7.1"
 libp2p-tcp = { version = "0.13.0", path = "../../transports/tcp" }
 quickcheck = "0.9.0"
-tokio = "0.1"
-sodiumoxide = "^0.2.5"
+tokio = "0.1.22"
+sodiumoxide = "0.2.5"

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -10,21 +10,21 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-bytes = "0.4"
+bytes = "0.4.12"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 libp2p-swarm = { version = "0.3.0", path = "../../swarm" }
-log = "0.4.1"
+log = "0.4.8"
 multiaddr = { package = "parity-multiaddr", version = "0.6.0", path = "../../misc/multiaddr" }
-futures = "0.1"
+futures = "0.1.29"
 rand = "0.7.2"
-tokio-io = "0.1"
-wasm-timer = "0.1"
-void = "1.0"
+tokio-io = "0.1.12"
+wasm-timer = "0.1.3"
+void = "1.0.2"
 
 [dev-dependencies]
 libp2p-tcp = { version = "0.13.0", path = "../../transports/tcp" }
 libp2p-secio = { version = "0.13.0", path = "../../protocols/secio" }
 libp2p-yamux = { version = "0.13.0", path = "../../muxers/yamux" }
 quickcheck = "0.9.0"
-tokio = "0.1"
-tokio-tcp = "0.1"
+tokio = "0.1.22"
+tokio-tcp = "0.1.3"

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -10,33 +10,33 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-bytes = "0.4"
-futures = "0.1"
+bytes = "0.4.12"
+futures = "0.1.29"
 libp2p-core = { version = "0.13.0", path = "../../core" }
-log = "0.4.6"
-protobuf = "2.8"
+log = "0.4.8"
+protobuf = "2.8.1"
 rand = "0.6.5"
-aes-ctr = "0.3"
-aesni = { version = "0.6", features = ["nocheck"], optional = true }
+aes-ctr = "0.3.0"
+aesni = { version = "0.6.0", features = ["nocheck"], optional = true }
 twofish = "0.2.0"
-ctr = "0.3"
-lazy_static = "1.2.0"
+ctr = "0.3.2"
+lazy_static = "1.4.0"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
-tokio-io = "0.1.0"
+tokio-io = "0.1.12"
 tokio-codec = "0.1.1"
 sha2 = "0.8.0"
-hmac = "0.7.0"
+hmac = "0.7.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ring = { version = "0.16.9", features = ["alloc"], default-features = false }
 untrusted = "0.7.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3.10"
-parity-send-wrapper = "0.1"
-wasm-bindgen = "0.2.33"
-wasm-bindgen-futures = "0.3.10"
-web-sys = { version = "0.3.10", features = ["Crypto", "CryptoKey", "SubtleCrypto", "Window"] }
+js-sys = "0.3.32"
+parity-send-wrapper = "0.1.0"
+wasm-bindgen = "0.2.55"
+wasm-bindgen-futures = "0.3.27"
+web-sys = { version = "0.3.32", features = ["Crypto", "CryptoKey", "SubtleCrypto", "Window"] }
 
 [features]
 default = ["secp256k1"]
@@ -47,8 +47,8 @@ aes-all = ["aesni"]
 criterion = "0.3.0"
 libp2p-tcp = { version = "0.13.0", path = "../../transports/tcp" }
 libp2p-mplex = { version = "0.13.0", path = "../../muxers/mplex" }
-tokio = "0.1"
-tokio-tcp = "0.1"
+tokio = "0.1.22"
+tokio-tcp = "0.1.3"
 
 [[bench]]
 name = "bench"

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -10,12 +10,12 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-futures = "0.1"
+futures = "0.1.29"
 libp2p-core = { version = "0.13.0", path = "../core" }
-smallvec = "0.6"
-tokio-io = "0.1"
-wasm-timer = "0.1"
-void = "1"
+smallvec = "0.6.13"
+tokio-io = "0.1.12"
+wasm-timer = "0.1.3"
+void = "1.0.2"
 
 [dev-dependencies]
 libp2p-mplex = { version = "0.13.0", path = "../muxers/mplex" }

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -11,9 +11,9 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 libp2p-core = { version = "0.13.0", path = "../../core" }
-log = "0.4.1"
-futures = "0.1"
-tokio-dns-unofficial = "0.4"
+log = "0.4.8"
+futures = "0.1.29"
+tokio-dns-unofficial = "0.4.0"
 
 [dev-dependencies]
 libp2p-tcp = { version = "0.13.0", path = "../../transports/tcp" }

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -10,15 +10,15 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-bytes = "0.4"
+bytes = "0.4.12"
 get_if_addrs = "0.5.3"
-ipnet = "2.0.0"
+ipnet = "2.1.0"
 libp2p-core = { version = "0.13.0", path = "../../core" }
-log = "0.4.1"
-futures = "0.1"
-tokio-io = "0.1"
-tokio-timer = "0.2"
-tokio-tcp = "0.1"
+log = "0.4.8"
+futures = "0.1.29"
+tokio-io = "0.1.12"
+tokio-timer = "0.2.11"
+tokio-tcp = "0.1.3"
 
 [dev-dependencies]
-tokio = "0.1"
+tokio = "0.1.22"

--- a/transports/uds/Cargo.toml
+++ b/transports/uds/Cargo.toml
@@ -11,11 +11,11 @@ categories = ["network-programming", "asynchronous"]
 
 [target.'cfg(all(unix, not(any(target_os = "emscripten", target_os = "unknown"))))'.dependencies]
 libp2p-core = { version = "0.13.0", path = "../../core" }
-log = "0.4.1"
-futures = "0.1"
-tokio-uds = "0.2"
+log = "0.4.8"
+futures = "0.1.29"
+tokio-uds = "0.2.5"
 
 [target.'cfg(all(unix, not(any(target_os = "emscripten", target_os = "unknown"))))'.dev-dependencies]
-tempfile = "3.0"
-tokio = "0.1"
-tokio-io = "0.1"
+tempfile = "3.1.0"
+tokio = "0.1.22"
+tokio-io = "0.1.12"

--- a/transports/wasm-ext/Cargo.toml
+++ b/transports/wasm-ext/Cargo.toml
@@ -10,10 +10,10 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-futures = "0.1"
-js-sys = "0.3.19"
+futures = "0.1.29"
+js-sys = "0.3.32"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 parity-send-wrapper = "0.1.0"
-tokio-io = "0.1"
-wasm-bindgen = "0.2.42"
-wasm-bindgen-futures = "0.3.19"
+tokio-io = "0.1.12"
+wasm-bindgen = "0.2.55"
+wasm-bindgen-futures = "0.3.27"

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -10,18 +10,18 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-bytes = "0.4.6"
-futures = "0.1"
+bytes = "0.4.12"
+futures = "0.1.29"
 libp2p-core = { version = "0.13.0", path = "../../core" }
-log = "0.4.1"
+log = "0.4.8"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
 tokio-codec = "0.1.1"
 tokio-io = "0.1.12"
-tokio-rustls = "0.10.1"
+tokio-rustls = "0.10.2"
 soketto = { version = "0.2.3", features = ["deflate"] }
 url = "2.1.0"
 webpki-roots = "0.18.0"
 
 [dev-dependencies]
 libp2p-tcp = { version = "0.13.0", path = "../tcp" }
-tokio = "0.1.20"
+tokio = "0.1.22"


### PR DESCRIPTION
This is done using `cargo update && cargo upgrade --all --to-lockfile`.