### PR TITLE
Add support for PINGs and PONGs to websockets.

### DIFF
--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.8"
 quicksink = { git = "https://github.com/paritytech/quicksink.git" }
 rustls = "0.16"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
-soketto = { git = "https://github.com/paritytech/soketto.git", branch = "develop", features = ["deflate"] }
+soketto = { git = "https://github.com/twittner/soketto.git", branch = "ping-pong", features = ["deflate"] }
 url = "2.1"
 webpki = "0.21"
 webpki-roots = "0.18"

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.8"
 quicksink = { git = "https://github.com/paritytech/quicksink.git" }
 rustls = "0.16"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
-soketto = { git = "https://github.com/twittner/soketto.git", branch = "ping-pong", features = ["deflate"] }
+soketto = { git = "https://github.com/paritytech/soketto.git", branch = "develop", features = ["deflate"] }
 url = "2.1"
 webpki = "0.21"
 webpki-roots = "0.18"


### PR DESCRIPTION
`websocket::framed::Connection` (formerly `websocket::framed::BytesConnection`) now uses the more structured types `IncomingData` and `OutgoingData` which mirror the data types in soketto (which are not exposed). This allows adding `Connection::send_ping` and `Connection::send_pong` methods.

The toplevel websocket transport defines `websocket::BytesConnection` as a wrapper around `websocket::framed::Connection` and handles only binary data.

Depends on https://github.com/paritytech/soketto/pull/9.