### PR TITLE
secio: Back to 4-byte BE length prefix.

### DIFF
--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -12,20 +12,19 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 aes-ctr = "0.3"
 aesni = { version = "0.6", features = ["nocheck"], optional = true }
-bytes = "0.4.12"
 ctr = "0.3"
 futures = "0.3.1"
-futures_codec = "0.3.1"
 hmac = "0.7.0"
 lazy_static = "1.2.0"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4.6"
 protobuf = "2.8"
-rand = "0.6.5"
+quicksink = { git = "https://github.com/paritytech/quicksink.git" }
+rand = "0.7"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
 sha2 = "0.8.0"
+static_assertions = "1"
 twofish = "0.2.0"
-unsigned-varint = { version = "0.2.3", features = ["futures-codec"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ring = { version = "0.16.9", features = ["alloc"], default-features = false }

--- a/protocols/secio/src/codec/decode.rs
+++ b/protocols/secio/src/codec/decode.rs
@@ -59,7 +59,7 @@ impl<S> DecoderMiddleware<S> {
 
 impl<S> Stream for DecoderMiddleware<S>
 where
-    S: TryStream<Ok = bytes::BytesMut> + Unpin,
+    S: TryStream<Ok = Vec<u8>> + Unpin,
     S::Error: Into<SecioError>,
 {
     type Item = Result<Vec<u8>, SecioError>;
@@ -87,10 +87,9 @@ where
             }
         }
 
-        let mut data_buf = frame.to_vec();
+        let mut data_buf = frame;
         data_buf.truncate(content_length);
-        self.cipher_state
-            .decrypt(&mut data_buf);
+        self.cipher_state.decrypt(&mut data_buf);
 
         if !self.nonce.is_empty() {
             let n = min(data_buf.len(), self.nonce.len());

--- a/protocols/secio/src/codec/len_prefix.rs
+++ b/protocols/secio/src/codec/len_prefix.rs
@@ -1,0 +1,116 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use futures::{prelude::*, stream::BoxStream};
+use quicksink::Action;
+use std::{fmt, io, pin::Pin, task::{Context, Poll}};
+
+/// `Stream` & `Sink` that reads and writes a length prefix in front of the actual data.
+pub struct LenPrefixCodec<T> {
+    stream: BoxStream<'static, io::Result<Vec<u8>>>,
+    sink: Pin<Box<dyn Sink<Vec<u8>, Error = io::Error> + Send>>,
+    _mark: std::marker::PhantomData<T>
+}
+
+impl<T> fmt::Debug for LenPrefixCodec<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("LenPrefixCodec")
+    }
+}
+
+static_assertions::const_assert! {
+    std::mem::size_of::<u32>() <= std::mem::size_of::<usize>()
+}
+
+impl<T> LenPrefixCodec<T>
+where
+    T: AsyncRead + AsyncWrite + Unpin + Send + 'static
+{
+    pub fn new(socket: T) -> Self {
+        let (r, w) = socket.split();
+
+        let stream = futures::stream::unfold(r, |mut r| async {
+            let mut len = [0; 4];
+            if let Err(e) = r.read_exact(&mut len).await {
+                if e.kind() == io::ErrorKind::UnexpectedEof {
+                    return None
+                }
+                return Some((Err(e), r))
+            }
+            let mut v = vec![0; u32::from_be_bytes(len) as usize];
+            if let Err(e) = r.read_exact(&mut v).await {
+                return Some((Err(e), r))
+            }
+            Some((Ok(v), r))
+        });
+
+        let sink = quicksink::make_sink(w, |mut w, action: Action<Vec<u8>>| async {
+            match action {
+                Action::Send(data) => {
+                    w.write_all(&(data.len() as u32).to_be_bytes()).await?;
+                    w.write_all(&data).await?
+                }
+                Action::Flush => w.flush().await?,
+                Action::Close => w.close().await?
+            }
+            Ok(w)
+        });
+
+        LenPrefixCodec {
+            stream: stream.boxed(),
+            sink: Box::pin(sink),
+            _mark: std::marker::PhantomData
+        }
+    }
+}
+
+impl<T> Stream for LenPrefixCodec<T>
+where
+    T: AsyncRead + AsyncWrite + Unpin + Send + 'static
+{
+    type Item = io::Result<Vec<u8>>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        self.stream.poll_next_unpin(cx)
+    }
+}
+
+impl<T> Sink<Vec<u8>> for LenPrefixCodec<T>
+where
+    T: AsyncRead + AsyncWrite + Unpin + Send + 'static
+{
+    type Error = io::Error;
+
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.sink).poll_ready(cx)
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: Vec<u8>) -> Result<(), Self::Error> {
+        Pin::new(&mut self.sink).start_send(item)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.sink).poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.sink).poll_close(cx)
+    }
+}

--- a/protocols/secio/src/codec/mod.rs
+++ b/protocols/secio/src/codec/mod.rs
@@ -182,7 +182,7 @@ mod tests {
 
             let (connec, _) = listener.accept().await.unwrap();
             let codec = full_codec(
-                LenPrefixCodec::new(connec),
+                LenPrefixCodec::new(connec, 1024),
                 ctr(cipher, &cipher_key[..key_size], &NULL_IV[..]),
                 Hmac::from_key(Digest::Sha256, &hmac_key),
                 ctr(cipher, &cipher_key[..key_size], &NULL_IV[..]),
@@ -198,7 +198,7 @@ mod tests {
             let listener_addr = l_a_rx.await.unwrap();
             let stream = TcpStream::connect(&listener_addr).await.unwrap();
             let mut codec = full_codec(
-                LenPrefixCodec::new(stream),
+                LenPrefixCodec::new(stream, 1024),
                 ctr(cipher, &cipher_key_clone[..key_size], &NULL_IV[..]),
                 Hmac::from_key(Digest::Sha256, &hmac_key_clone),
                 ctr(cipher, &cipher_key_clone[..key_size], &NULL_IV[..]),

--- a/protocols/secio/src/handshake.rs
+++ b/protocols/secio/src/handshake.rs
@@ -18,22 +18,23 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use crate::SecioConfig;
 use crate::algo_support;
-use crate::codec::{full_codec, FullCodec, Hmac};
-use crate::stream_cipher::ctr;
+use crate::codec::{full_codec, FullCodec, Hmac, LenPrefixCodec};
 use crate::error::SecioError;
 use crate::exchange;
+use crate::stream_cipher::ctr;
+use crate::structs_proto::{Exchange, Propose};
 use futures::prelude::*;
 use libp2p_core::PublicKey;
 use log::{debug, trace};
-use protobuf::parse_from_bytes as protobuf_parse_from_bytes;
 use protobuf::Message as ProtobufMessage;
+use protobuf::parse_from_bytes as protobuf_parse_from_bytes;
 use rand::{self, RngCore};
 use sha2::{Digest as ShaDigestTrait, Sha256};
 use std::cmp::{self, Ordering};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
-use crate::structs_proto::{Exchange, Propose};
-use crate::SecioConfig;
+
 
 /// Performs a handshake on the given socket.
 ///
@@ -44,16 +45,12 @@ use crate::SecioConfig;
 /// On success, returns an object that implements the `Sink` and `Stream` trait whose items are
 /// buffers of data, plus the public key of the remote, plus the ephemeral public key used during
 /// negotiation.
-pub async fn handshake<'a, S: 'a>(socket: S, config: SecioConfig)
+pub async fn handshake<S>(socket: S, config: SecioConfig)
     -> Result<(FullCodec<S>, PublicKey, Vec<u8>), SecioError>
 where
-    S: AsyncRead + AsyncWrite + Send + Unpin,
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static
 {
-    // The handshake messages all start with a variable-length integer indicating the size.
-    let mut socket = futures_codec::Framed::new(
-        socket,
-        unsigned_varint::codec::UviBytes::<Vec<u8>>::default()
-    );
+    let mut socket = LenPrefixCodec::new(socket);
 
     let local_nonce = {
         let mut local_nonce = [0; 16];

--- a/protocols/secio/src/handshake.rs
+++ b/protocols/secio/src/handshake.rs
@@ -50,7 +50,7 @@ pub async fn handshake<S>(socket: S, config: SecioConfig)
 where
     S: AsyncRead + AsyncWrite + Send + Unpin + 'static
 {
-    let mut socket = LenPrefixCodec::new(socket);
+    let mut socket = LenPrefixCodec::new(socket, config.max_frame_len);
 
     let local_nonce = {
         let mut local_nonce = [0; 16];

--- a/protocols/secio/src/lib.rs
+++ b/protocols/secio/src/lib.rs
@@ -85,7 +85,8 @@ pub struct SecioConfig {
     pub(crate) key: identity::Keypair,
     pub(crate) agreements_prop: Option<String>,
     pub(crate) ciphers_prop: Option<String>,
-    pub(crate) digests_prop: Option<String>
+    pub(crate) digests_prop: Option<String>,
+    pub(crate) max_frame_len: usize
 }
 
 impl SecioConfig {
@@ -95,7 +96,8 @@ impl SecioConfig {
             key: kp,
             agreements_prop: None,
             ciphers_prop: None,
-            digests_prop: None
+            digests_prop: None,
+            max_frame_len: 8 * 1024 * 1024
         }
     }
 
@@ -123,6 +125,12 @@ impl SecioConfig {
         I: IntoIterator<Item=&'a Digest>
     {
         self.digests_prop = Some(algo_support::digests_proposition(xs));
+        self
+    }
+
+    /// Override the default max. frame length of 8MiB.
+    pub fn max_frame_len(mut self, n: usize) -> Self {
+        self.max_frame_len = n;
         self
     }
 

--- a/protocols/secio/src/lib.rs
+++ b/protocols/secio/src/lib.rs
@@ -148,7 +148,7 @@ impl SecioConfig {
 /// Output of the secio protocol.
 pub struct SecioOutput<S>
 where
-    S: AsyncRead + AsyncWrite + Unpin
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static
 {
     /// The encrypted stream.
     pub stream: RwStreamSink<StreamMapErr<SecioMiddleware<S>, fn(SecioError) -> io::Error>>,
@@ -193,7 +193,10 @@ where
     }
 }
 
-impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for SecioOutput<S> {
+impl<S> AsyncRead for SecioOutput<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static
+{
     fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context, buf: &mut [u8])
         -> Poll<Result<usize, io::Error>>
     {
@@ -201,7 +204,10 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for SecioOutput<S> {
     }
 }
 
-impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for SecioOutput<S> {
+impl<S> AsyncWrite for SecioOutput<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static
+{
     fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context, buf: &[u8])
         -> Poll<Result<usize, io::Error>>
     {
@@ -254,7 +260,7 @@ where
 
 impl<S> Sink<Vec<u8>> for SecioMiddleware<S>
 where
-    S: AsyncRead + AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static
 {
     type Error = io::Error;
 
@@ -277,7 +283,7 @@ where
 
 impl<S> Stream for SecioMiddleware<S>
 where
-    S: AsyncRead + AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static
 {
     type Item = Result<Vec<u8>, SecioError>;
 


### PR DESCRIPTION
The secio spec states that each frame must be prefixed with a 32-bit big endian length prefix so we can not use an unsigned varint here.