### PR TITLE
Fix possible incorrect return value from <LengthDelimitedReader as io::Write>::write().

### DIFF
--- a/misc/multistream-select/src/length_delimited.rs
+++ b/misc/multistream-select/src/length_delimited.rs
@@ -323,27 +323,11 @@ where
     R: AsyncWrite
 {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        // Try to drain the write buffer together with writing `buf`.
-        if !self.inner.write_buffer.is_empty() {
-            let n = self.inner.write_buffer.len();
-            self.inner.write_buffer.extend_from_slice(buf);
-            let result = self.inner.poll_write_buffer();
-            let written = n + buf.len() - self.inner.write_buffer.len();
-            if written == 0 {
-                self.inner.write_buffer.split_off(n); // Never grow the buffer.
-                if let Err(e) = result {
-                    return Err(e)
-                }
+        while !self.inner.write_buffer.is_empty() {
+            if self.inner.poll_write_buffer()?.is_not_ready() {
                 return Err(io::ErrorKind::WouldBlock.into())
             }
-            if written < buf.len() {
-                debug_assert!(self.inner.write_buffer.len() > n);
-                self.inner.write_buffer.split_off(n); // Never grow the buffer.
-                return Ok(written)
-            }
-            return Ok(buf.len())
         }
-
         self.inner_mut().write(buf)
     }
 

--- a/misc/multistream-select/src/negotiated.rs
+++ b/misc/multistream-select/src/negotiated.rs
@@ -242,12 +242,14 @@ where
                         Ok(n) => {
                             remaining.split_to(n);
                             if !remaining.is_empty() {
-                                let written = if n < buf.len() {
-                                    remaining.split_off(remaining_len);
-                                    n
-                                } else {
-                                    buf.len()
-                                };
+                                let written =
+                                    if n < buf.len() {
+                                        debug_assert!(remaining.len() > remaining_len);
+                                        remaining.split_off(remaining_len);
+                                        n
+                                    } else {
+                                        buf.len()
+                                    };
                                 debug_assert!(remaining.len() <= remaining_len);
                                 Ok(written)
                             } else {


### PR DESCRIPTION
Due to not taking into account `buf.len()` when computing `written`, it may be incorrectly judged less than `buf.len()`, which can result in duplicate data being written as well as potentially arithmetic overflow. This is essentially a backport of what was fixed for the `stable-futures` branch [here](https://github.com/libp2p/rust-libp2p/pull/1335#discussion_r355373145). However, instead of removing the optimisation of writing out the entire data in one go, as done there, this just corrects the oversight of not taking `buf.len()` into account when computing `written` in the `io::Write` impl of `LengthDelimitedReader`. The rest of the diff just adds some debug assertions for further clarity.

I'm not opposed to removing this kind of optimisation entirely, as it is evidently non-trivial to get right, though I think it should then also be removed from the `io::Write` impl of `Negotiated`, which does the same thing in the context of an owned buffer (and can be used to compare the implementations).