### PR TITLE
Cleanups in libp2p-core in stable-futures branch

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,6 +25,7 @@ multiaddr = { package = "parity-multiaddr", version = "0.6.0", path = "../misc/m
 multihash = { package = "parity-multihash", version = "0.2.0", path = "../misc/multihash" }
 multistream-select = { version = "0.6.0", path = "../misc/multistream-select" }
 parking_lot = "0.9.0"
+pin-project = "0.4.6"
 protobuf = "2.8"
 quick-error = "1.2"
 rand = "0.7"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -18,8 +18,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-#![cfg_attr(feature = "async-await", feature(async_await))]
-
 //! Transports, upgrades, multiplexing and node handling of *libp2p*.
 //!
 //! The main concepts of libp2p-core are:

--- a/core/src/transport/choice.rs
+++ b/core/src/transport/choice.rs
@@ -35,13 +35,7 @@ impl<A, B> OrTransport<A, B> {
 impl<A, B> Transport for OrTransport<A, B>
 where
     B: Transport,
-    B::Dial: Unpin,
-    B::Listener: Unpin,
-    B::ListenerUpgrade: Unpin,
     A: Transport,
-    A::Dial: Unpin,
-    A::Listener: Unpin,
-    A::ListenerUpgrade: Unpin,
 {
     type Output = EitherOutput<A::Output, B::Output>;
     type Error = EitherError<A::Error, B::Error>;

--- a/core/src/upgrade/either.rs
+++ b/core/src/upgrade/either.rs
@@ -50,9 +50,7 @@ where
 impl<C, A, B, TA, TB, EA, EB> InboundUpgrade<C> for EitherUpgrade<A, B>
 where
     A: InboundUpgrade<C, Output = TA, Error = EA>,
-    <A as InboundUpgrade<C>>::Future: Unpin,
     B: InboundUpgrade<C, Output = TB, Error = EB>,
-    <B as InboundUpgrade<C>>::Future: Unpin,
 {
     type Output = EitherOutput<TA, TB>;
     type Error = EitherError<EA, EB>;
@@ -70,9 +68,7 @@ where
 impl<C, A, B, TA, TB, EA, EB> OutboundUpgrade<C> for EitherUpgrade<A, B>
 where
     A: OutboundUpgrade<C, Output = TA, Error = EA>,
-    <A as OutboundUpgrade<C>>::Future: Unpin,
     B: OutboundUpgrade<C, Output = TB, Error = EB>,
-    <B as OutboundUpgrade<C>>::Future: Unpin,
 {
     type Output = EitherOutput<TA, TB>;
     type Error = EitherError<EA, EB>;

--- a/core/src/upgrade/mod.rs
+++ b/core/src/upgrade/mod.rs
@@ -144,7 +144,6 @@ pub trait InboundUpgrade<C>: UpgradeInfo {
     /// Possible error during the handshake.
     type Error;
     /// Future that performs the handshake with the remote.
-    // TODO: remove Unpin
     type Future: Future<Output = Result<Self::Output, Self::Error>> + Unpin;
 
     /// After we have determined that the remote supports one of the protocols we support, this
@@ -185,7 +184,6 @@ pub trait OutboundUpgrade<C>: UpgradeInfo {
     /// Possible error during the handshake.
     type Error;
     /// Future that performs the handshake with the remote.
-    // TODO: remove Unpin
     type Future: Future<Output = Result<Self::Output, Self::Error>> + Unpin;
 
     /// After we have determined that the remote supports one of the protocols we support, this

--- a/core/src/upgrade/select.rs
+++ b/core/src/upgrade/select.rs
@@ -76,9 +76,7 @@ where
 impl<C, A, B, TA, TB, EA, EB> OutboundUpgrade<C> for SelectUpgrade<A, B>
 where
     A: OutboundUpgrade<C, Output = TA, Error = EA>,
-    <A as OutboundUpgrade<C>>::Future: Unpin,
     B: OutboundUpgrade<C, Output = TB, Error = EB>,
-    <B as OutboundUpgrade<C>>::Future: Unpin,
 {
     type Output = EitherOutput<TA, TB>;
     type Error = EitherError<EA, EB>;

--- a/core/src/upgrade/select.rs
+++ b/core/src/upgrade/select.rs
@@ -59,9 +59,7 @@ where
 impl<C, A, B, TA, TB, EA, EB> InboundUpgrade<C> for SelectUpgrade<A, B>
 where
     A: InboundUpgrade<C, Output = TA, Error = EA>,
-    <A as InboundUpgrade<C>>::Future: Unpin,
     B: InboundUpgrade<C, Output = TB, Error = EB>,
-    <B as InboundUpgrade<C>>::Future: Unpin,
 {
     type Output = EitherOutput<TA, TB>;
     type Error = EitherError<EA, EB>;


### PR DESCRIPTION
Removes a few left-overs, and lots of `Unpin` trait bounds replaced with `pin-project`.