### PR TITLE
Several changes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default = ["secp256k1", "libp2p-websocket"]
 secp256k1 = ["libp2p-core/secp256k1", "libp2p-secio/secp256k1"]
 
 [dependencies]
-bytes = "0.4"
+bytes = "0.5"
 futures = "0.3.1"
 multiaddr = { package = "parity-multiaddr", version = "0.6.0", path = "misc/multiaddr" }
 multihash = { package = "parity-multihash", version = "0.2.0", path = "misc/multihash" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@ ed25519-dalek = "1.0.0-pre.3"
 failure = "0.1"
 fnv = "1.0"
 futures = { version = "0.3.1", features = ["compat", "io-compat", "executor", "thread-pool"] }
-futures-timer = "0.3"
+futures-timer = "2"
 lazy_static = "1.2"
 libsecp256k1 = { version = "0.3.1", optional = true }
 log = "0.4"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,7 +32,7 @@ rand = "0.7"
 rw-stream-sink = { version = "0.1.1", path = "../misc/rw-stream-sink" }
 sha2 = "0.8.0"
 smallvec = "1.0"
-unsigned-varint = { git = "https://github.com/twittner/unsigned-varint.git", branch = "bytes-0.5" }
+unsigned-varint = "0.3"
 void = "1"
 zeroize = "1"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,7 +26,7 @@ multihash = { package = "parity-multihash", version = "0.2.0", path = "../misc/m
 multistream-select = { version = "0.6.0", path = "../misc/multistream-select" }
 parking_lot = "0.9.0"
 pin-project = "0.4.6"
-protobuf = "2.8"
+protobuf = "= 2.8.1"
 quick-error = "1.2"
 rand = "0.7"
 rw-stream-sink = { version = "0.1.1", path = "../misc/rw-stream-sink" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 asn1_der = "0.6.1"
 bs58 = "0.3.0"
-bytes = "0.4"
+bytes = "0.5"
 ed25519-dalek = "1.0.0-pre.3"
 failure = "0.1"
 fnv = "1.0"
@@ -32,7 +32,7 @@ rand = "0.7"
 rw-stream-sink = { version = "0.1.1", path = "../misc/rw-stream-sink" }
 sha2 = "0.8.0"
 smallvec = "1.0"
-unsigned-varint = "0.2"
+unsigned-varint = { git = "https://github.com/twittner/unsigned-varint.git", branch = "bytes-0.5" }
 void = "1"
 zeroize = "1"
 

--- a/core/src/nodes/listeners.rs
+++ b/core/src/nodes/listeners.rs
@@ -358,7 +358,7 @@ mod tests {
 
     #[test]
     fn incoming_event() {
-        futures::executor::block_on(async move {
+        async_std::task::block_on(async move {
             let mem_transport = transport::MemoryTransport::default();
 
             let mut listeners = ListenersStream::new(mem_transport);

--- a/core/src/transport/memory.rs
+++ b/core/src/transport/memory.rs
@@ -19,7 +19,6 @@
 // DEALINGS IN THE SOFTWARE.
 
 use crate::{Transport, transport::{TransportError, ListenerEvent}};
-use bytes::IntoBuf;
 use fnv::FnvHashMap;
 use futures::{future::{self, Ready}, prelude::*, channel::mpsc, task::Context, task::Poll};
 use lazy_static::lazy_static;
@@ -271,8 +270,7 @@ impl<T> Sink<T> for Chan<T> {
     }
 }
 
-impl<T: IntoBuf> Into<RwStreamSink<Chan<T>>> for Chan<T> {
-    #[inline]
+impl<T: AsRef<[u8]>> Into<RwStreamSink<Chan<T>>> for Chan<T> {
     fn into(self) -> RwStreamSink<Chan<T>> {
         RwStreamSink::new(self)
     }

--- a/core/src/transport/timeout.rs
+++ b/core/src/transport/timeout.rs
@@ -172,10 +172,9 @@ where
             Poll::Ready(Err(err)) => return Poll::Ready(Err(TransportTimeoutError::Other(err))),
         }
 
-        match TryFuture::try_poll(Pin::new(&mut this.timer), cx) {
+        match Pin::new(&mut this.timer).poll(cx) {
             Poll::Pending => Poll::Pending,
-            Poll::Ready(Ok(())) => Poll::Ready(Err(TransportTimeoutError::Timeout)),
-            Poll::Ready(Err(err)) => Poll::Ready(Err(TransportTimeoutError::TimerError(err))),
+            Poll::Ready(()) => Poll::Ready(Err(TransportTimeoutError::Timeout))
         }
     }
 }

--- a/core/tests/network_dial_error.rs
+++ b/core/tests/network_dial_error.rs
@@ -113,7 +113,7 @@ fn deny_incoming_connec() {
 
     swarm1.listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
 
-    let address = futures::executor::block_on(future::poll_fn(|cx| {
+    let address = async_std::task::block_on(future::poll_fn(|cx| {
         if let Poll::Ready(NetworkEvent::NewListenerAddress { listen_addr, .. }) = swarm1.poll(cx) {
             Poll::Ready(listen_addr)
         } else {
@@ -126,7 +126,7 @@ fn deny_incoming_connec() {
         .into_not_connected().unwrap()
         .connect(address.clone(), TestHandler::default().into_node_handler_builder());
 
-    futures::executor::block_on(future::poll_fn(|cx| -> Poll<Result<(), io::Error>> {
+    async_std::task::block_on(future::poll_fn(|cx| -> Poll<Result<(), io::Error>> {
         match swarm1.poll(cx) {
             Poll::Ready(NetworkEvent::IncomingConnection(inc)) => drop(inc),
             Poll::Ready(_) => unreachable!(),
@@ -182,7 +182,7 @@ fn dial_self() {
 
     swarm.listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
 
-    let (address, mut swarm) = futures::executor::block_on(
+    let (address, mut swarm) = async_std::task::block_on(
         future::lazy(move |cx| {
             if let Poll::Ready(NetworkEvent::NewListenerAddress { listen_addr, .. }) = swarm.poll(cx) {
                 Ok::<_, void::Void>((listen_addr, swarm))
@@ -196,7 +196,7 @@ fn dial_self() {
 
     let mut got_dial_err = false;
     let mut got_inc_err = false;
-    futures::executor::block_on(future::poll_fn(|cx| -> Poll<Result<(), io::Error>> {
+    async_std::task::block_on(future::poll_fn(|cx| -> Poll<Result<(), io::Error>> {
         loop {
             match swarm.poll(cx) {
                 Poll::Ready(NetworkEvent::UnknownPeerDialError {
@@ -284,7 +284,7 @@ fn multiple_addresses_err() {
         .connect_iter(addresses.clone(), TestHandler::default().into_node_handler_builder())
         .unwrap();
 
-    futures::executor::block_on(future::poll_fn(|cx| -> Poll<Result<(), io::Error>> {
+    async_std::task::block_on(future::poll_fn(|cx| -> Poll<Result<(), io::Error>> {
         loop {
             match swarm.poll(cx) {
                 Poll::Ready(NetworkEvent::DialError {

--- a/core/tests/network_simult.rs
+++ b/core/tests/network_simult.rs
@@ -18,8 +18,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-mod util;
-
 use futures::prelude::*;
 use libp2p_core::{identity, upgrade, Transport};
 use libp2p_core::nodes::{Network, NetworkEvent, Peer};
@@ -111,10 +109,7 @@ fn raw_swarm_simultaneous_connect() {
             let transport = libp2p_tcp::TcpConfig::new()
                 .upgrade(upgrade::Version::V1Lazy)
                 .authenticate(libp2p_secio::SecioConfig::new(local_key))
-                .multiplex(libp2p_mplex::MplexConfig::new())
-                .and_then(|(peer, mplex), _| {
-                    util::CloseMuxer::new(mplex).map_ok(move |mplex| (peer, mplex))
-                });
+                .multiplex(libp2p_mplex::MplexConfig::new());
             Network::new(transport, local_public_key.into_peer_id())
         };
 
@@ -124,10 +119,7 @@ fn raw_swarm_simultaneous_connect() {
             let transport = libp2p_tcp::TcpConfig::new()
                 .upgrade(upgrade::Version::V1Lazy)
                 .authenticate(libp2p_secio::SecioConfig::new(local_key))
-                .multiplex(libp2p_mplex::MplexConfig::new())
-                .and_then(|(peer, mplex), _| {
-                    util::CloseMuxer::new(mplex).map_ok(move |mplex| (peer, mplex))
-                });
+                .multiplex(libp2p_mplex::MplexConfig::new());
             Network::new(transport, local_public_key.into_peer_id())
         };
 

--- a/core/tests/network_simult.rs
+++ b/core/tests/network_simult.rs
@@ -280,7 +280,7 @@ fn raw_swarm_simultaneous_connect() {
                 }
             });
 
-            if futures::executor::block_on(future) {
+            if async_std::task::block_on(future) {
                 // The test exercised what we wanted to exercise: a simultaneous connect.
                 break
             }

--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -17,7 +17,7 @@ data-encoding = "2.1"
 multihash = { package = "parity-multihash", version = "0.2.0", path = "../multihash" }
 percent-encoding = "2.1.0"
 serde = "1.0.70"
-unsigned-varint = "0.2"
+unsigned-varint = "0.3"
 url = { version = "2.1.0", default-features = false }
 
 [dev-dependencies]

--- a/misc/multiaddr/src/lib.rs
+++ b/misc/multiaddr/src/lib.rs
@@ -7,7 +7,7 @@ mod errors;
 mod from_url;
 mod util;
 
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use serde::{
     Deserialize,
     Deserializer,
@@ -290,10 +290,10 @@ impl From<Ipv6Addr> for Multiaddr {
     }
 }
 
-impl TryFrom<Bytes> for Multiaddr {
+impl TryFrom<Vec<u8>> for Multiaddr {
     type Error = Error;
 
-    fn try_from(v: Bytes) -> Result<Self> {
+    fn try_from(v: Vec<u8>) -> Result<Self> {
         // Check if the argument is a valid `Multiaddr` by reading its protocols.
         let mut slice = &v[..];
         while !slice.is_empty() {
@@ -301,22 +301,6 @@ impl TryFrom<Bytes> for Multiaddr {
             slice = s
         }
         Ok(Multiaddr { bytes: v.into() })
-    }
-}
-
-impl TryFrom<BytesMut> for Multiaddr {
-    type Error = Error;
-
-    fn try_from(v: BytesMut) -> Result<Self> {
-        Multiaddr::try_from(v.freeze())
-    }
-}
-
-impl TryFrom<Vec<u8>> for Multiaddr {
-    type Error = Error;
-
-    fn try_from(v: Vec<u8>) -> Result<Self> {
-        Multiaddr::try_from(Bytes::from(v))
     }
 }
 

--- a/misc/multihash/Cargo.toml
+++ b/misc/multihash/Cargo.toml
@@ -11,9 +11,9 @@ documentation = "https://docs.rs/parity-multihash/"
 
 [dependencies]
 blake2 = { version = "0.8", default-features = false }
-bytes = "0.4.12"
-rand = { version = "0.6", default-features = false, features = ["std"] }
+bytes = "0.5"
+rand = { version = "0.7", default-features = false, features = ["std"] }
 sha-1 = { version = "0.8", default-features = false }
 sha2 = { version = "0.8", default-features = false }
 sha3 = { version = "0.8", default-features = false }
-unsigned-varint = "0.2"
+unsigned-varint = { git = "https://github.com/twittner/unsigned-varint.git", branch = "bytes-0.5" }

--- a/misc/multihash/Cargo.toml
+++ b/misc/multihash/Cargo.toml
@@ -16,4 +16,4 @@ rand = { version = "0.7", default-features = false, features = ["std"] }
 sha-1 = { version = "0.8", default-features = false }
 sha2 = { version = "0.8", default-features = false }
 sha3 = { version = "0.8", default-features = false }
-unsigned-varint = { git = "https://github.com/twittner/unsigned-varint.git", branch = "bytes-0.5" }
+unsigned-varint = "0.3"

--- a/misc/multihash/src/lib.rs
+++ b/misc/multihash/src/lib.rs
@@ -247,7 +247,7 @@ impl<'a> MultihashRef<'a> {
     /// This operation allocates.
     pub fn into_owned(self) -> Multihash {
         Multihash {
-            bytes: Bytes::from(self.bytes)
+            bytes: Bytes::copy_from_slice(self.bytes)
         }
     }
 

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -10,12 +10,12 @@ categories = ["network-programming", "asynchronous"]
 edition = "2018"
 
 [dependencies]
-bytes = "0.4"
+bytes = "0.5"
 futures = "0.1"
 log = "0.4"
 smallvec = "1.0"
 tokio-io = "0.1"
-unsigned-varint = "0.2.2"
+unsigned-varint = { git = "https://github.com/twittner/unsigned-varint.git", branch = "bytes-0.5" }
 
 [dev-dependencies]
 tokio = "0.1"

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.1"
 log = "0.4"
 smallvec = "1.0"
 tokio-io = "0.1"
-unsigned-varint = { git = "https://github.com/twittner/unsigned-varint.git", branch = "bytes-0.5" }
+unsigned-varint = "0.3"
 
 [dev-dependencies]
 tokio = "0.1"

--- a/misc/multistream-select/src/length_delimited.rs
+++ b/misc/multistream-select/src/length_delimited.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use bytes::{Bytes, BytesMut, BufMut};
+use bytes::{Bytes, BytesMut, Buf, BufMut};
 use futures::{try_ready, Async, Poll, Sink, StartSend, Stream, AsyncSink};
 use std::{io, u16};
 use tokio_io::{AsyncRead, AsyncWrite};
@@ -136,7 +136,7 @@ impl<R> LengthDelimited<R> {
                     "Failed to write buffered frame."))
             }
 
-            self.write_buffer.split_to(n);
+            self.write_buffer.advance(n);
         }
 
         Ok(Async::Ready(()))

--- a/misc/multistream-select/src/protocol.rs
+++ b/misc/multistream-select/src/protocol.rs
@@ -143,7 +143,7 @@ impl TryFrom<&[u8]> for Protocol {
     type Error = ProtocolError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Self::try_from(Bytes::from(value))
+        Self::try_from(Bytes::copy_from_slice(value))
     }
 }
 
@@ -208,7 +208,7 @@ impl Message {
                     out_msg.push(b'\n')
                 }
                 dest.reserve(out_msg.len());
-                dest.put(out_msg);
+                dest.put(out_msg.as_ref());
                 Ok(())
             }
             Message::NotAvailable => {
@@ -254,7 +254,7 @@ impl Message {
             if len == 0 || len > rem.len() || rem[len - 1] != b'\n' {
                 return Err(ProtocolError::InvalidMessage)
             }
-            let p = Protocol::try_from(Bytes::from(&rem[.. len - 1]))?;
+            let p = Protocol::try_from(Bytes::copy_from_slice(&rem[.. len - 1]))?;
             protocols.push(p);
             remaining = &rem[len ..]
         }

--- a/misc/rw-stream-sink/Cargo.toml
+++ b/misc/rw-stream-sink/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-bytes = "0.4.12"
 futures = "0.3.1"
+static_assertions = "1"
 
 [dev-dependencies]
 async-std = "1.0"

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -10,14 +10,14 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-bytes = "0.4.5"
+bytes = "0.5"
 fnv = "1.0"
 futures = "0.3.1"
-futures_codec = "= 0.3.3"
+futures_codec = "0.3.4"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4"
 parking_lot = "0.9"
-unsigned-varint = { version = "0.2.3", features = ["futures-codec"] }
+unsigned-varint = { git = "https://github.com/twittner/unsigned-varint.git", branch = "bytes-0.5", features = ["futures-codec"] }
 
 [dev-dependencies]
 async-std = "1.0"

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -17,7 +17,7 @@ futures_codec = "0.3.4"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4"
 parking_lot = "0.9"
-unsigned-varint = { git = "https://github.com/twittner/unsigned-varint.git", branch = "bytes-0.5", features = ["futures-codec"] }
+unsigned-varint = { version = "0.3", features = ["futures-codec"] }
 
 [dev-dependencies]
 async-std = "1.0"

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 bytes = "0.4.5"
 fnv = "1.0"
 futures = "0.3.1"
-futures_codec = "0.3.1"
+futures_codec = "= 0.3.3"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4"
 parking_lot = "0.9"

--- a/muxers/mplex/src/lib.rs
+++ b/muxers/mplex/src/lib.rs
@@ -535,7 +535,7 @@ where C: AsyncRead + AsyncWrite + Unpin
 
         let elem = codec::Elem::Data {
             substream_id: substream.num,
-            data: From::from(&buf[..to_write]),
+            data: Bytes::copy_from_slice(&buf[..to_write]),
             endpoint: substream.endpoint,
         };
 

--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -15,4 +15,4 @@ libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4.8"
 parking_lot = "0.9"
 thiserror = "1.0"
-yamux = "0.3"
+yamux = "0.4"

--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -15,4 +15,4 @@ libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4.8"
 parking_lot = "0.9"
 thiserror = "1.0"
-yamux = { git = "https://github.com/paritytech/yamux.git", branch = "develop" }
+yamux = "0.3"

--- a/protocols/deflate/src/lib.rs
+++ b/protocols/deflate/src/lib.rs
@@ -71,6 +71,7 @@ where
 }
 
 /// Decodes and encodes traffic using DEFLATE.
+#[derive(Debug)]
 pub struct DeflateOutput<S> {
     /// Inner stream where we read compressed data from and write compressed data to.
     inner: S,

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -11,12 +11,12 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 bs58 = "0.3.0"
-bytes = "0.4"
+bytes = "0.5"
 cuckoofilter = "0.3.2"
 fnv = "1.0"
 futures = "0.3.1"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 libp2p-swarm = { version = "0.3.0", path = "../../swarm" }
 protobuf = "2.8"
-rand = "0.6"
+rand = "0.7"
 smallvec = "1.0"

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -17,6 +17,6 @@ fnv = "1.0"
 futures = "0.3.1"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 libp2p-swarm = { version = "0.3.0", path = "../../swarm" }
-protobuf = "2.8"
+protobuf = "= 2.8.1"
 rand = "0.7"
 smallvec = "1.0"

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-bytes = "0.4"
-futures_codec = "= 0.3.3"
+bytes = "0.5"
+futures_codec = "0.3.4"
 futures = "0.3.1"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 libp2p-swarm = { version = "0.3.0", path = "../../swarm" }
@@ -20,7 +20,7 @@ multiaddr = { package = "parity-multiaddr", version = "0.6.0", path = "../../mis
 protobuf = "2.8"
 smallvec = "1.0"
 wasm-timer = "0.2"
-unsigned-varint = { version = "0.2.3", features = ["futures-codec"] }
+unsigned-varint = { git = "https://github.com/twittner/unsigned-varint.git", branch = "bytes-0.5", features = ["futures-codec"] }
 
 [dev-dependencies]
 async-std = "1.0"

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 bytes = "0.4"
-futures_codec = "0.3.1"
+futures_codec = "= 0.3.3"
 futures = "0.3.1"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 libp2p-swarm = { version = "0.3.0", path = "../../swarm" }

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -17,7 +17,7 @@ libp2p-core = { version = "0.13.0", path = "../../core" }
 libp2p-swarm = { version = "0.3.0", path = "../../swarm" }
 log = "0.4.1"
 multiaddr = { package = "parity-multiaddr", version = "0.6.0", path = "../../misc/multiaddr" }
-protobuf = "2.8"
+protobuf = "= 2.8.1"
 smallvec = "1.0"
 wasm-timer = "0.2"
 unsigned-varint = { version = "0.3", features = ["futures-codec"] }

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -20,7 +20,7 @@ multiaddr = { package = "parity-multiaddr", version = "0.6.0", path = "../../mis
 protobuf = "2.8"
 smallvec = "1.0"
 wasm-timer = "0.2"
-unsigned-varint = { git = "https://github.com/twittner/unsigned-varint.git", branch = "bytes-0.5", features = ["futures-codec"] }
+unsigned-varint = { version = "0.3", features = ["futures-codec"] }
 
 [dev-dependencies]
 async-std = "1.0"

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -315,7 +315,7 @@ mod tests {
         // it will permit the connection to be closed, as defined by
         // `IdentifyHandler::connection_keep_alive`. Hence the test succeeds if
         // either `Identified` event arrives correctly.
-        futures::executor::block_on(async move {
+        async_std::task::block_on(async move {
             loop {
                 match future::select(swarm1.next(), swarm2.next()).await.factor_second().0 {
                     future::Either::Left(Some(Ok(IdentifyEvent::Received { info, .. }))) => {

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -14,7 +14,7 @@ arrayvec = "0.5.1"
 bytes = "0.4"
 either = "1.5"
 fnv = "1.0"
-futures_codec = "0.3.1"
+futures_codec = "= 0.3.3"
 futures = "0.3.1"
 log = "0.4"
 libp2p-core = { version = "0.13.0", path = "../../core" }

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -11,10 +11,10 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 arrayvec = "0.5.1"
-bytes = "0.4"
+bytes = "0.5"
 either = "1.5"
 fnv = "1.0"
-futures_codec = "= 0.3.3"
+futures_codec = "0.3.4"
 futures = "0.3.1"
 log = "0.4"
 libp2p-core = { version = "0.13.0", path = "../../core" }
@@ -27,7 +27,7 @@ sha2 = "0.8.0"
 smallvec = "1.0"
 wasm-timer = "0.2"
 uint = "0.8"
-unsigned-varint = { version = "0.2.3", features = ["futures-codec"] }
+unsigned-varint = { git = "https://github.com/twittner/unsigned-varint.git", branch = "bytes-0.5", features = ["futures-codec"] }
 void = "1.0"
 
 [dev-dependencies]

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -21,7 +21,7 @@ libp2p-core = { version = "0.13.0", path = "../../core" }
 libp2p-swarm = { version = "0.3.0", path = "../../swarm" }
 multiaddr = { package = "parity-multiaddr", version = "0.6.0", path = "../../misc/multiaddr" }
 multihash = { package = "parity-multihash", version = "0.2.0", path = "../../misc/multihash" }
-protobuf = "2.8"
+protobuf = "= 2.8.1"
 rand = "0.7.2"
 sha2 = "0.8.0"
 smallvec = "1.0"

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -27,7 +27,7 @@ sha2 = "0.8.0"
 smallvec = "1.0"
 wasm-timer = "0.2"
 uint = "0.8"
-unsigned-varint = { git = "https://github.com/twittner/unsigned-varint.git", branch = "bytes-0.5", features = ["futures-codec"] }
+unsigned-varint = { version = "0.3", features = ["futures-codec"] }
 void = "1.0"
 
 [dev-dependencies]

--- a/protocols/kad/src/record.rs
+++ b/protocols/kad/src/record.rs
@@ -35,7 +35,7 @@ pub struct Key(Bytes);
 impl Key {
     /// Creates a new key from the bytes of the input.
     pub fn new<K: AsRef<[u8]>>(key: &K) -> Self {
-        Key(Bytes::from(key.as_ref()))
+        Key(Bytes::copy_from_slice(key.as_ref()))
     }
 
     /// Copies the bytes of the key into a new vector.

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/libp2p/rust-libp2p"
 edition = "2018"
 
 [dependencies]
-bytes = "0.4"
+bytes = "0.5"
 curve25519-dalek = "1"
 futures = "0.3.1"
 lazy_static = "1.2"

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -14,8 +14,8 @@ futures = "0.3.1"
 lazy_static = "1.2"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4"
-protobuf = "2.8"
-rand = "^0.7.2"
+protobuf = "= 2.8.1"
+rand = "0.7.2"
 ring = { version = "0.16.9", features = ["alloc"], default-features = false }
 snow = { version = "0.6.1", features = ["ring-resolver"], default-features = false }
 x25519-dalek = "0.5"

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -10,15 +10,15 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-bytes = "0.4"
+bytes = "0.5"
+futures = "0.3.1"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 libp2p-swarm = { version = "0.3.0", path = "../../swarm" }
 log = "0.4.1"
 multiaddr = { package = "parity-multiaddr", version = "0.6.0", path = "../../misc/multiaddr" }
-futures = "0.3.1"
 rand = "0.7.2"
-wasm-timer = "0.2"
 void = "1.0"
+wasm-timer = "0.2"
 
 [dev-dependencies]
 async-std = "1.0"

--- a/protocols/ping/src/handler.rs
+++ b/protocols/ping/src/handler.rs
@@ -282,7 +282,7 @@ mod tests {
     fn tick(h: &mut PingHandler<TcpStream>)
         -> ProtocolsHandlerEvent<protocol::Ping, (), PingResult, PingFailure>
     {
-        futures::executor::block_on(future::poll_fn(|cx| h.poll(cx) ))
+        async_std::task::block_on(future::poll_fn(|cx| h.poll(cx) ))
     }
 
     #[test]

--- a/protocols/ping/tests/ping.rs
+++ b/protocols/ping/tests/ping.rs
@@ -84,7 +84,7 @@ fn ping() {
     };
 
     let result = future::select(Box::pin(peer1), Box::pin(peer2));
-    let ((p1, p2, rtt), _) = futures::executor::block_on(result).factor_first();
+    let ((p1, p2, rtt), _) = async_std::task::block_on(result).factor_first();
     assert!(p1 == peer1_id && p2 == peer2_id || p1 == peer2_id && p2 == peer1_id);
     assert!(rtt < Duration::from_millis(50));
 }

--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -17,7 +17,7 @@ libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4.8"
 protobuf = "2.8.1"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
-unsigned-varint = { git = "https://github.com/twittner/unsigned-varint.git", branch = "bytes-0.5", features = ["futures-codec"] }
+unsigned-varint = { version = "0.3", features = ["futures-codec"] }
 void = "1.0.2"
 
 [dev-dependencies]

--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -10,14 +10,14 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-bytes = "0.4.12"
+bytes = "0.5"
 futures = "0.3.1"
-futures_codec = "= 0.3.3"
+futures_codec = "0.3.4"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4.8"
 protobuf = "2.8.1"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
-unsigned-varint = { version = "0.2.3", features = ["futures-codec"] }
+unsigned-varint = { git = "https://github.com/twittner/unsigned-varint.git", branch = "bytes-0.5", features = ["futures-codec"] }
 void = "1.0.2"
 
 [dev-dependencies]

--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 bytes = "0.4.12"
 futures = "0.3.1"
-futures_codec = "0.3.1"
+futures_codec = "= 0.3.3"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4.8"
 protobuf = "2.8.1"

--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3.1"
 futures_codec = "0.3.4"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4.8"
-protobuf = "2.8.1"
+protobuf = "= 2.8.1"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
 unsigned-varint = { version = "0.3", features = ["futures-codec"] }
 void = "1.0.2"

--- a/protocols/plaintext/src/handshake.rs
+++ b/protocols/plaintext/src/handshake.rs
@@ -120,7 +120,7 @@ where
     let context = HandshakeContext::new(config)?;
 
     trace!("sending exchange to remote");
-    socket.send(BytesMut::from(context.state.exchange_bytes.clone())).await?;
+    socket.send(BytesMut::from(&context.state.exchange_bytes[..])).await?;
 
     trace!("receiving the remote's exchange");
     let context = match socket.next().await {

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -19,7 +19,7 @@ lazy_static = "1.2.0"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4.6"
 protobuf = "2.8"
-quicksink = { git = "https://github.com/paritytech/quicksink.git" }
+quicksink = "0.1"
 rand = "0.7"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
 sha2 = "0.8.0"

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -18,7 +18,7 @@ hmac = "0.7.0"
 lazy_static = "1.2.0"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4.6"
-protobuf = "2.8"
+protobuf = "= 2.8.1"
 quicksink = "0.1"
 rand = "0.7"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }

--- a/protocols/secio/src/codec/mod.rs
+++ b/protocols/secio/src/codec/mod.rs
@@ -156,7 +156,7 @@ mod tests {
         );
 
         let data = b"hello world";
-        futures::executor::block_on(async move {
+        async_std::task::block_on(async move {
             encoder.send(data.to_vec()).await.unwrap();
             let rx = decoder.next().await.unwrap().unwrap();
             assert_eq!(rx, data);
@@ -209,7 +209,7 @@ mod tests {
             codec.send(data.to_vec().into()).await.unwrap();
         };
 
-        futures::executor::block_on(future::join(client, server));
+        async_std::task::block_on(future::join(client, server));
     }
 
     #[test]

--- a/protocols/secio/src/handshake.rs
+++ b/protocols/secio/src/handshake.rs
@@ -419,7 +419,7 @@ mod tests {
             }
         });
 
-        futures::executor::block_on(async move {
+        async_std::task::block_on(async move {
             let listen_addr = l_a_rx.await.unwrap();
             let connec = async_std::net::TcpStream::connect(&listen_addr).await.unwrap();
             let mut codec = handshake(connec, key2).await.unwrap().0;

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 async-std = "1.0"
-bytes = "0.4.12"
+bytes = "0.5"
 futures = "0.3.1"
 futures-timer = "2.0"
 get_if_addrs = "0.5.3"

--- a/transports/tcp/src/lib.rs
+++ b/transports/tcp/src/lib.rs
@@ -486,7 +486,7 @@ mod tests {
             .for_each(|_| futures::future::ready(()));
 
         let client = TcpConfig::new().dial(addr).expect("dialer");
-        futures::executor::block_on(futures::future::join(server, client)).1.unwrap();
+        async_std::task::block_on(futures::future::join(server, client)).1.unwrap();
     }
 
     #[test]

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -16,7 +16,7 @@ either = "1.5.3"
 futures = "0.3.1"
 libp2p-core = { version = "0.13.0", path = "../../core" }
 log = "0.4.8"
-quicksink = { git = "https://github.com/paritytech/quicksink.git" }
+quicksink = "0.1"
 rustls = "0.16"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
 soketto = { git = "https://github.com/paritytech/soketto.git", branch = "develop", features = ["deflate"] }

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.8"
 quicksink = "0.1"
 rustls = "0.16"
 rw-stream-sink = { version = "0.1.1", path = "../../misc/rw-stream-sink" }
-soketto = { git = "https://github.com/paritytech/soketto.git", branch = "develop", features = ["deflate"] }
+soketto = { version = "0.3", features = ["deflate"] }
 url = "2.1"
 webpki = "0.21"
 webpki-roots = "0.18"

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 async-tls = "0.6"
-bytes = "0.4.12"
+bytes = "0.5"
 either = "1.5.3"
 futures = "0.3.1"
 libp2p-core = { version = "0.13.0", path = "../../core" }


### PR DESCRIPTION
- ~Pin `futures_codec` to version 0.3.3 as later versions require at least `bytes-0.5` which he have not upgraded to yet.~ Update to `bytes` v0.5 except for `multiaddr`.
- Replace `futures::executor::block_on` with `async_std::task::block_on` where `async-std` is already a dependency to work around an issue with `park`/`unpark` behaviour.
- Use the published versions of `quicksink`, `soketto` and `yamux`.
- Use `futures-timer` version 2 in `core` which removes the last (transitive) dependency to `futures-preview`.

Depends on https://github.com/paritytech/unsigned-varint/pull/23.