### PR TITLE
Bump bytes to 0.5

### DIFF
--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.6.0"
 arrayref = "0.3"
 bs58 = "0.3.0"
 byteorder = "1.3.1"
-bytes = "0.4.12"
+bytes = "0.5"
 data-encoding = "2.1"
 multihash = { package = "parity-multihash", version = "0.2.0", path = "../multihash" }
 percent-encoding = "2.1.0"


### PR DESCRIPTION
`bytes` 0.5 had a couple of breaking changes, specially the split of
`Bytes` and `BytesMut`.

Given how much this code use methods avaialable only on `BytesMut`, this
comit changes the internal field to use this struct and some smaller
code changes to adapt to it.

Closes https://github.com/libp2p/rust-libp2p/issues/1351