### PR TITLE
Fix link to upgrade::Builder

### DIFF
--- a/core/src/transport/mod.rs
+++ b/core/src/transport/mod.rs
@@ -208,7 +208,8 @@ pub trait Transport {
         timeout::TransportTimeout::with_ingoing_timeout(self, timeout)
     }
 
-    /// Begins a series of protocol upgrades via an [`upgrade::Builder`].
+    /// Begins a series of protocol upgrades via an
+    /// [`upgrade::Builder`](core::transport::upgrade::Builder).
     fn upgrade(self, version: upgrade::Version) -> upgrade::Builder<Self>
     where
         Self: Sized,


### PR DESCRIPTION
The auto-linking didn't work properly as there is a method called `upgrade`
within the transport module.