### PR TITLE
Support tokio in libp2p-tcp and libp2p-uds

### DIFF
--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -10,10 +10,14 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-std = "1.0"
+async-std = { version = "1.0", optional = true }
 futures = "0.3.1"
 futures-timer = "2.0"
 get_if_addrs = "0.5.3"
 ipnet = "2.0.0"
 libp2p-core = { version = "0.14.0-alpha.1", path = "../../core" }
 log = "0.4.1"
+tokio = { version = "0.2", default-features = false, features = ["tcp"], optional = true }
+
+[features]
+default = ["async-std"]

--- a/transports/uds/Cargo.toml
+++ b/transports/uds/Cargo.toml
@@ -10,10 +10,14 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [target.'cfg(all(unix, not(any(target_os = "emscripten", target_os = "unknown"))))'.dependencies]
-async-std = "1.0"
+async-std = { version = "1.0", optional = true }
 libp2p-core = { version = "0.14.0-alpha.1", path = "../../core" }
 log = "0.4.1"
 futures = "0.3.1"
+tokio = { version = "0.2", default-features = false, features = ["uds"], optional = true }
 
 [target.'cfg(all(unix, not(any(target_os = "emscripten", target_os = "unknown"))))'.dev-dependencies]
 tempfile = "3.0"
+
+[features]
+default = ["async-std"]


### PR DESCRIPTION
This adds two new structs `TokioTcpConfig` and `TokioUdsConfig` that are available when the `tokio` feature is enabled in respectively `libp2p-tcp` and `libp2p-uds`.

Additionally, the `TcpConfig` and `UdsConfig` struct now require the `async-std` feature to be enabled. It is enabled by default in `libp2p-tcp` and `libp2p-uds`.

See #1318 for context

What this PR does is wrap all the code within a macro named `codegen!` that is then invoked once for async-std and once for tokio. In the end this is the less bad solution in my opinon.
I went for leaving everything at indentation level 0 despite being within a macro, but that could be changed.