### PR TITLE
Force prost 0.6.1

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ multihash = { package = "parity-multihash", version = "0.2.1", path = "../misc/m
 multistream-select = { version = "0.7.0", path = "../misc/multistream-select" }
 parking_lot = "0.10.0"
 pin-project = "0.4.6"
-prost = "0.6"
+prost = "0.6.1"
 rand = "0.7"
 rw-stream-sink = { version = "0.2.0", path = "../misc/rw-stream-sink" }
 sha2 = "0.8.0"

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -16,7 +16,7 @@ fnv = "1.0"
 futures = "0.3.1"
 libp2p-core = { version = "0.14.0-alpha.1", path = "../../core" }
 libp2p-swarm = { version = "0.4.0-alpha.1", path = "../../swarm" }
-prost = "0.6"
+prost = "0.6.1"
 rand = "0.7"
 smallvec = "1.0"
 

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.1"
 libp2p-core = { version = "0.14.0-alpha.1", path = "../../core" }
 libp2p-swarm = { version = "0.4.0-alpha.1", path = "../../swarm" }
 log = "0.4.1"
-prost = "0.6"
+prost = "0.6.1"
 smallvec = "1.0"
 wasm-timer = "0.2"
 

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4"
 libp2p-core = { version = "0.14.0-alpha.1", path = "../../core" }
 libp2p-swarm = { version = "0.4.0-alpha.1", path = "../../swarm" }
 multihash = { package = "parity-multihash", version = "0.2.1", path = "../../misc/multihash" }
-prost = "0.6"
+prost = "0.6.1"
 rand = "0.7.2"
 sha2 = "0.8.0"
 smallvec = "1.0"

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.3.1"
 lazy_static = "1.2"
 libp2p-core = { version = "0.14.0-alpha.1", path = "../../core" }
 log = "0.4"
-prost = "0.6"
+prost = "0.6.1"
 rand = "0.7.2"
 ring = { version = "0.16.9", features = ["alloc"], default-features = false }
 snow = { version = "0.6.1", features = ["ring-resolver"], default-features = false }

--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3.1"
 futures_codec = "0.3.4"
 libp2p-core = { version = "0.14.0-alpha.1", path = "../../core" }
 log = "0.4.8"
-prost = "0.6"
+prost = "0.6.1"
 rw-stream-sink = { version = "0.2.0", path = "../../misc/rw-stream-sink" }
 unsigned-varint = { version = "0.3", features = ["futures-codec"] }
 void = "1.0.2"

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -18,7 +18,7 @@ hmac = "0.7.0"
 lazy_static = "1.2.0"
 libp2p-core = { version = "0.14.0-alpha.1", path = "../../core" }
 log = "0.4.6"
-prost = "0.6"
+prost = "0.6.1"
 pin-project = "0.4.6"
 quicksink = "0.1"
 rand = "0.7"


### PR DESCRIPTION
For the sake of it, let's force users to not use prost 0.6.0 that has a security vulnerability.