### PR TITLE
Fix WouldBlock being returned in wasm-ext

### DIFF
--- a/protocols/noise/src/io.rs
+++ b/protocols/noise/src/io.rs
@@ -433,7 +433,7 @@ impl<T: AsyncWrite + Unpin> AsyncWrite for NoiseOutput<T> {
 ///
 /// Panics if `off >= 2`.
 ///
-/// When [`io::ErrorKind::WouldBlock`] is returned, the given buffer and offset
+/// When [`Poll::Pending`] is returned, the given buffer and offset
 /// may have been updated (i.e. a byte may have been read) and must be preserved
 /// for the next invocation.
 ///
@@ -466,7 +466,7 @@ fn read_frame_len<R: AsyncRead + Unpin>(
 ///
 /// Panics if `off >= 2`.
 ///
-/// When [`io::ErrorKind::WouldBlock`] is returned, the given offset
+/// When [`Poll::Pending`] is returned, the given offset
 /// may have been updated (i.e. a byte may have been written) and must
 /// be preserved for the next invocation.
 ///

--- a/transports/wasm-ext/src/lib.rs
+++ b/transports/wasm-ext/src/lib.rs
@@ -395,7 +395,7 @@ impl AsyncRead for Connection {
                         Poll::Ready(Err(err)) => break Poll::Ready(Err(io::Error::from(JsErr::from(err)))),
                         Poll::Pending => {
                             self.read_state = ConnectionReadState::Waiting(promise);
-                            break Poll::Ready(Err(io::ErrorKind::WouldBlock.into()));
+                            break Poll::Pending;
                         }
                     };
 


### PR DESCRIPTION
This got lost in translation when converting from the `Read` trait (where `WouldBlock` is the equivalent of `Pending`) to the `AsyncRead` trait.