### PR TITLE
protocols/kad: Implement S-Kademlia's lookup over disjoint paths

### DIFF
--- a/protocols/kad/src/query/peers/closest.rs
+++ b/protocols/kad/src/query/peers/closest.rs
@@ -325,7 +325,7 @@ impl ClosestPeersIter {
                         *cnt += 1;
                         // If `num_results` successful results have been delivered for the
                         // closest peers, the iterator is done.
-                        if *cnt > self.config.num_results {
+                        if *cnt >= self.config.num_results {
                             self.state = State::Finished;
                             return PeersIterState::Finished
                         }


### PR DESCRIPTION
The extension paper S-Kademlia [1] includes a proposal for lookups over
disjoint paths. Within vanilla Kademlia, queries keep track of the
closest nodes in a single bucket. Any adversary along the path can thus
influence all future paths, in case they can come up with the
next-closest (not overall closest) hops. S-Kademlia tries to solve the
attack above by querying over disjoint paths using multiple buckets.

To adjust the libp2p Kademlia implementation accordingly this change-set
introduces the notion of `PathId`s into the `ClosestPeersIter` and the
ability to specify the amount of disjoint paths to pursue in the
`ClosestPeersIterConfig`.

`ClosestPeersIter` explores each path in a round-robin fashion. It
iterates the not-yet-contacted nodes one by one starting with the
closest one. When the given peer origins from the initial set or from a
past query with the path id currently selected, it is tagged with that
path id and returned to the upper layer to be queried.

Once iterated through all peers without success, one chooses the one
with the lowest distance from the target detached from its path id (a
bit like a work-steeling queue).

Setting the `disjoint_paths` to `1` within the `ClosestPeersIterConfig`
effectively disables the feature.

[1] http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.68.4986&rep=rep1&type=pdf

### Status

This is still a work-in-progress pull request. I think the overall design of the change is already worth discussing (e.g. do we want this in the first place, should this be a separate `ClosestPeersIter`, ...). This is the least intrusive change, probably not as resilient as one could be and definitely not complete in regards to @infinity0 [research](https://forum.web3.foundation/t/s-kademlia-and-multipaths/310). There is still a borrowing issue, some clean-up and plenty more tests to write.