### PR TITLE
Allow multiple pings over one connection

### DIFF
--- a/protocols/ping/src/protocol.rs
+++ b/protocols/ping/src/protocol.rs
@@ -23,7 +23,7 @@ use libp2p_core::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use log::debug;
 use rand::{distributions, prelude::*};
 use std::{io, iter, time::Duration};
-use wasm_timer::{Instant, ext::TryFutureExt};
+use wasm_timer::Instant;
 
 /// Represents a prototype for an upgrade to handle the ping protocol.
 ///
@@ -44,7 +44,6 @@ use wasm_timer::{Instant, ext::TryFutureExt};
 #[derive(Default, Debug, Copy, Clone)]
 pub struct Ping;
 
-const PING_TIMEOUT: Duration = Duration::from_secs(60);
 const PING_SIZE: usize = 32;
 
 impl UpgradeInfo for Ping {
@@ -67,7 +66,7 @@ where
     fn upgrade_inbound(self, mut socket: TSocket, _: Self::Info) -> Self::Future {
         async move {
             let mut payload = [0u8; PING_SIZE];
-            while let Ok(_) = socket.read_exact(&mut payload).timeout(PING_TIMEOUT).await {
+            while let Ok(_) = socket.read_exact(&mut payload).await {
                 socket.write_all(&payload).await?;
             }
             Ok(())

--- a/protocols/ping/src/protocol.rs
+++ b/protocols/ping/src/protocol.rs
@@ -23,7 +23,7 @@ use libp2p_core::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use log::debug;
 use rand::{distributions, prelude::*};
 use std::{io, iter, time::Duration};
-use wasm_timer::Instant;
+use wasm_timer::{Instant, ext::TryFutureExt};
 
 /// Represents a prototype for an upgrade to handle the ping protocol.
 ///
@@ -44,6 +44,9 @@ use wasm_timer::Instant;
 #[derive(Default, Debug, Copy, Clone)]
 pub struct Ping;
 
+const PING_TIMEOUT: Duration = Duration::from_secs(60);
+const PING_SIZE: usize = 32;
+
 impl UpgradeInfo for Ping {
     type Info = &'static [u8];
     type InfoIter = iter::Once<Self::Info>;
@@ -63,10 +66,10 @@ where
 
     fn upgrade_inbound(self, mut socket: TSocket, _: Self::Info) -> Self::Future {
         async move {
-            let mut payload = [0u8; 32];
-            socket.read_exact(&mut payload).await?;
-            socket.write_all(&payload).await?;
-            socket.close().await?;
+            let mut payload = [0u8; PING_SIZE];
+            while let Ok(_) = socket.read_exact(&mut payload).timeout(PING_TIMEOUT).await {
+                socket.write_all(&payload).await?;
+            }
             Ok(())
         }.boxed()
     }


### PR DESCRIPTION
Tiny one. This is so that pinging a rust-libp2p node from ipfs works even without passing -n 1

Before:
```
$ ipfs ping /ip4/127.0.0.1/tcp/33542/ipfs/12D3KooWRpXY8AwbhF9syneVPb6cyrsC9KYSjRywLPWb4mRNaqMu
PING 12D3KooWRpXY8AwbhF9syneVPb6cyrsC9KYSjRywLPWb4mRNaqMu.
Pong received: time=6.79 ms
Ping error: EOF
Ping error: stream reset
Ping error: stream reset
```

After:
```
$ ipfs ping  /ip4/127.0.0.1/tcp/39053/ipfs/12D3KooWFewRGcMQTDJEtYrCkAFfqXDEBQNG7BHgisfJHS9Fqt2S
PING 12D3KooWFewRGcMQTDJEtYrCkAFfqXDEBQNG7BHgisfJHS9Fqt2S.
Pong received: time=2.01 ms
Pong received: time=1.35 ms
Pong received: time=2.62 ms
Pong received: time=2.00 ms
Pong received: time=2.33 ms
Pong received: time=2.10 ms
Pong received: time=2.16 ms
Pong received: time=2.13 ms
Pong received: time=2.43 ms
Pong received: time=1.52 ms
Average latency: 2.07ms
```

Could not find a spec, so I went with this: https://github.com/libp2p/go-libp2p/blob/master/p2p/protocol/ping/ping.go