### PR TITLE
Provides a debug instance for an RSA public key...

### DIFF
--- a/core/src/identity/rsa.rs
+++ b/core/src/identity/rsa.rs
@@ -26,7 +26,7 @@ use super::error::*;
 use ring::rand::SystemRandom;
 use ring::signature::{self, RsaKeyPair, RSA_PKCS1_SHA256, RSA_PKCS1_2048_8192_SHA256};
 use ring::signature::KeyPair;
-use std::sync::Arc;
+use std::{fmt::{self, Write}, sync::Arc};
 use zeroize::Zeroize;
 
 /// An RSA keypair.
@@ -62,7 +62,7 @@ impl Keypair {
 }
 
 /// An RSA public key.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct PublicKey(Vec<u8>);
 
 impl PublicKey {
@@ -104,6 +104,24 @@ impl PublicKey {
         Asn1SubjectPublicKeyInfo::deserialize(pk.iter())
             .map_err(|e| DecodingError::new("RSA X.509").source(e))
             .map(|spki| spki.subjectPublicKey.0)
+    }
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    let mut hex = String::with_capacity(bytes.len() * 2);
+
+    for byte in bytes {
+        write!(hex, "{:02x}", byte).expect("Can't fail on writing to string");
+    }
+
+    hex
+}
+
+impl fmt::Debug for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PublicKey")
+            .field("pkcs1", &to_hex(&self.0))
+            .finish()
     }
 }
 

--- a/core/src/identity/rsa.rs
+++ b/core/src/identity/rsa.rs
@@ -109,17 +109,15 @@ impl PublicKey {
 
 impl fmt::Debug for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fn to_hex(bytes: &[u8]) -> String {
-            let mut hex = String::with_capacity(bytes.len() * 2);
+        let bytes = &self.0;
+        let mut hex = String::with_capacity(bytes.len() * 2);
 
-            for byte in bytes {
-                write!(hex, "{:02x}", byte).expect("Can't fail on writing to string");
-            }
-
-            hex
+        for byte in bytes {
+            write!(hex, "{:02x}", byte).expect("Can't fail on writing to string");
         }
+
         f.debug_struct("PublicKey")
-            .field("pkcs1", &to_hex(&self.0))
+            .field("pkcs1", &hex)
             .finish()
     }
 }

--- a/core/src/identity/rsa.rs
+++ b/core/src/identity/rsa.rs
@@ -107,18 +107,17 @@ impl PublicKey {
     }
 }
 
-fn to_hex(bytes: &[u8]) -> String {
-    let mut hex = String::with_capacity(bytes.len() * 2);
-
-    for byte in bytes {
-        write!(hex, "{:02x}", byte).expect("Can't fail on writing to string");
-    }
-
-    hex
-}
-
 impl fmt::Debug for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn to_hex(bytes: &[u8]) -> String {
+            let mut hex = String::with_capacity(bytes.len() * 2);
+
+            for byte in bytes {
+                write!(hex, "{:02x}", byte).expect("Can't fail on writing to string");
+            }
+
+            hex
+        }
         f.debug_struct("PublicKey")
             .field("pkcs1", &to_hex(&self.0))
             .finish()


### PR DESCRIPTION
that is a bit easier on the eyes than the raw Vec<u8>

Not sure if I should copypasta the to_hex method or add a https://crates.io/crates/hex dependency. I decided to err on the side of fewer deps. Let me know if I should change that.

Before:

PublicKey([48, 130, 2, 10, 2, 130, 2, 1, 0, 168, 190, 58, 255, 224, 80, 95, 255, 134, 239, 191, 109, 220, 179, 18, 77, 73, 132, 103, 194, 246, 209, 183, 232, 42, 177, 97, 118, 83, 19, 191, 82, 89, 218, 213, 138, 198, 251, 162, 226, 97, 66, 232, 2, 72, 159, 10, 105, 76, 52, 35, 163, 87, 93, 183, 204, 163, 170, 58, 125, 97, 11, 18, 36, 220, 219, 230, 250, 104, 27, 73, 140, 68, 233, 68, 186, 160, 250, 145, 148, 18, 92, 137, 128, 160, 152, 188, 180, 134, 145, 56, 193, 173, 207, 42, 124, 197, 168, 223, 80, 179, 26, 114, 47, 15, 227, 51, 138, 48, 112, 141, 180, 187, 14, 251, 113, 31, 237, 146, 151, 73, 206, 223, 126, 184, 169, 202, 107, 252, 199, 185, 71, 113, 117, 53, 87, 194, 8, 6, 128, 23, 140, 113, 60, 112, 229, 239, 231, 1, 242, 87, 235, 10, 174, 235, 239, 97, 168, 223, 105, 157, 49, 29, 222, 2, 147, 117, 204, 15, 67, 2, 37, 173, 146, 95, 57, 68, 204, 187, 182, 191, 65, 0, 166, 146, 175, 186, 105, 37, 182, 128, 164, 180, 200, 101, 50, 133, 153, 96, 202, 176, 94, 69, 17, 186, 251, 201, 18, 160, 184, 83, 45, 90, 190, 6, 42, 86, 33, 80, 164, 172, 98, 81, 23, 24, 86, 191, 88, 11, 17, 179, 222, 43, 211, 26, 58, 200, 51, 95, 130, 45, 105, 47, 175, 84, 180, 34, 218, 44, 151, 32, 239, 189, 219, 156, 160, 179, 229, 241, 85, 53, 57, 140, 162, 31, 242, 195, 207, 252, 242, 151, 170, 215, 176, 155, 83, 142, 162, 210, 123, 37, 144, 34, 150, 172, 197, 172, 208, 255, 179, 207, 184, 58, 79, 64, 237, 62, 50, 124, 236, 7, 254, 54, 152, 150, 173, 130, 25, 85, 60, 44, 249, 34, 230, 25, 7, 162, 137, 173, 1, 13, 95, 99, 174, 84, 97, 30, 239, 55, 97, 192, 100, 17, 227, 19, 19, 13, 227, 86, 42, 235, 24, 52, 245, 39, 140, 187, 38, 210, 115, 144, 100, 184, 7, 40, 88, 162, 120, 144, 237, 58, 175, 242, 33, 245, 166, 188, 214, 202, 191, 177, 120, 192, 238, 219, 113, 249, 53, 237, 109, 187, 136, 233, 140, 205, 92, 135, 238, 191, 164, 226, 188, 146, 35, 84, 231, 101, 86, 41, 65, 183, 61, 55, 241, 202, 116, 251, 50, 18, 29, 95, 100, 149, 41, 196, 185, 206, 203, 49, 187, 191, 150, 43, 133, 244, 123, 218, 159, 135, 25, 110, 215, 149, 135, 176, 84, 200, 203, 90, 0, 206, 86, 52, 94, 192, 136, 96, 217, 51, 75, 244, 118, 161, 203, 71, 133, 56, 58, 100, 201, 187, 85, 125, 78, 191, 253, 70, 103, 209, 173, 3, 225, 109, 197, 144, 223, 72, 137, 197, 223, 151, 219, 67, 220, 68, 35, 64, 244, 15, 90, 177, 201, 27, 28, 0, 82, 39, 245, 80, 133, 218, 224, 52, 175, 206, 199, 45, 118, 50, 140, 11, 255, 2, 3, 1, 0, 1])

After:

PublicKey { pkcs1: "3082020a0282020100a8be3affe0505fff86efbf6ddcb3124d498467c2f6d1b7e82ab161765313bf5259dad58ac6fba2e26142e802489f0a694c3423a3575db7cca3aa3a7d610b1224dcdbe6fa681b498c44e944baa0fa9194125c8980a098bcb4869138c1adcf2a7cc5a8df50b31a722f0fe3338a30708db4bb0efb711fed929749cedf7eb8a9ca6bfcc7b94771753557c2080680178c713c70e5efe701f257eb0aaeebef61a8df699d311dde029375cc0f430225ad925f3944ccbbb6bf4100a692afba6925b680a4b4c86532859960cab05e4511bafbc912a0b8532d5abe062a562150a4ac6251171856bf580b11b3de2bd31a3ac8335f822d692faf54b422da2c9720efbddb9ca0b3e5f15535398ca21ff2c3cffcf297aad7b09b538ea2d27b25902296acc5acd0ffb3cfb83a4f40ed3e327cec07fe369896ad8219553c2cf922e61907a289ad010d5f63ae54611eef3761c06411e313130de3562aeb1834f5278cbb26d2739064b8072858a27890ed3aaff221f5a6bcd6cabfb178c0eedb71f935ed6dbb88e98ccd5c87eebfa4e2bc922354e765562941b73d37f1ca74fb32121d5f649529c4b9cecb31bbbf962b85f47bda9f87196ed79587b054c8cb5a00ce56345ec08860d9334bf476a1cb4785383a64c9bb557d4ebffd4667d1ad03e16dc590df4889c5df97db43dc442340f40f5ab1c91b1c005227f55085dae034afcec72d76328c0bff0203010001" }