### PR TITLE
Fix copy-paste error in doc string

### DIFF
--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -37,8 +37,7 @@ use std::{collections::VecDeque, iter, marker::PhantomData};
 use std::collections::hash_map::{DefaultHasher, HashMap};
 use std::task::{Context, Poll};
 
-/// Network behaviour that automatically identifies nodes periodically, and returns information
-/// about them.
+/// Network behaviour that handles the floodsub protocol.
 pub struct Floodsub<TSubstream> {
     /// Events that need to be yielded to the outside when polling.
     events: VecDeque<NetworkBehaviourAction<FloodsubRpc, FloodsubEvent>>,

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -46,8 +46,7 @@ use wasm_timer::{Instant, Interval};
 
 mod tests;
 
-/// Network behaviour that automatically identifies nodes periodically, and returns information
-/// about them.
+/// Network behaviour that handles the gossipsub protocol.
 pub struct Gossipsub<TSubstream> {
     /// Configuration providing gossipsub performance parameters.
     config: GossipsubConfig,


### PR DESCRIPTION
It seems they were copied from `Identify` and left unchanged.