### PR TITLE
Onion3Addr::acquire: fix bug due to differing lifetimes

### DIFF
--- a/misc/multiaddr/src/onion_addr.rs
+++ b/misc/multiaddr/src/onion_addr.rs
@@ -20,7 +20,7 @@ impl<'a> Onion3Addr<'a> {
 
     /// Consume this instance and create an owned version containing the same address
     pub fn acquire<'b>(self) -> Onion3Addr<'b> {
-        Self(Cow::Owned(self.0.into_owned()), self.1)
+        Onion3Addr(Cow::Owned(self.0.into_owned()), self.1)
     }
 }
 


### PR DESCRIPTION
Because the `Self` type is `Onion3Addr<'a>` and the return type uses `'b`, the usage of `Self` as a constructor is illegal as per https://crater-reports.s3.amazonaws.com/pr-69340/try%239ff4d07208097950831ed4ea9d76feb1eafc8baa/reg/libp2p-plaintext-0.15.0/log.txt and the bug fix in https://github.com/rust-lang/rust/pull/69340. This PR fixes that problem for you.