### PR TITLE
Add addresses field for closing listeners

### DIFF
--- a/core/src/connection/listeners.rs
+++ b/core/src/connection/listeners.rs
@@ -285,14 +285,14 @@ where
                 Poll::Ready(None) => {
                     return Poll::Ready(ListenersEvent::Closed {
                         listener_id: *listener_project.id,
-                        addresses: listener.addresses.to_vec(),
+                        addresses: listener_project.addresses.drain(..).collect(),
                         reason: Ok(()),
                     })
                 }
                 Poll::Ready(Some(Err(err))) => {
                     return Poll::Ready(ListenersEvent::Closed {
                         listener_id: *listener_project.id,
-                        addresses: listener.addresses.to_vec(),
+                        addresses: listener_project.addresses.drain(..).collect(),
                         reason: Err(err),
                     })
                 }

--- a/core/src/connection/listeners.rs
+++ b/core/src/connection/listeners.rs
@@ -149,7 +149,7 @@ where
         /// The ID of the listener that closed.
         listener_id: ListenerId,
         /// The addresses that the listener was listening on.
-        addresses: SmallVec<[Multiaddr; 4]>,
+        addresses: Vec<Multiaddr>,
         /// Reason for the closure. Contains `Ok(())` if the stream produced `None`, or `Err`
         /// if the stream produced an error.
         reason: Result<(), TTrans::Error>,
@@ -285,14 +285,14 @@ where
                 Poll::Ready(None) => {
                     return Poll::Ready(ListenersEvent::Closed {
                         listener_id: *listener_project.id,
-                        addresses: listener.addresses.clone(),
+                        addresses: listener.addresses.to_vec(),
                         reason: Ok(()),
                     })
                 }
                 Poll::Ready(Some(Err(err))) => {
                     return Poll::Ready(ListenersEvent::Closed {
                         listener_id: *listener_project.id,
-                        addresses: listener.addresses.clone(),
+                        addresses: listener.addresses.to_vec(),
                         reason: Err(err),
                     })
                 }

--- a/core/src/connection/listeners.rs
+++ b/core/src/connection/listeners.rs
@@ -148,6 +148,8 @@ where
     Closed {
         /// The ID of the listener that closed.
         listener_id: ListenerId,
+        /// The addresses that the listener was listening on.
+        addresses: SmallVec<[Multiaddr; 4]>,
         /// Reason for the closure. Contains `Ok(())` if the stream produced `None`, or `Err`
         /// if the stream produced an error.
         reason: Result<(), TTrans::Error>,
@@ -283,12 +285,14 @@ where
                 Poll::Ready(None) => {
                     return Poll::Ready(ListenersEvent::Closed {
                         listener_id: *listener_project.id,
+                        addresses: listener.addresses.clone(),
                         reason: Ok(()),
                     })
                 }
                 Poll::Ready(Some(Err(err))) => {
                     return Poll::Ready(ListenersEvent::Closed {
                         listener_id: *listener_project.id,
+                        addresses: listener.addresses.clone(),
                         reason: Err(err),
                     })
                 }
@@ -351,9 +355,10 @@ where
                 .field("listener_id", listener_id)
                 .field("local_addr", local_addr)
                 .finish(),
-            ListenersEvent::Closed { listener_id, reason } => f
+            ListenersEvent::Closed { listener_id, addresses, reason } => f
                 .debug_struct("ListenersEvent::Closed")
                 .field("listener_id", listener_id)
+                .field("addresses", addresses)
                 .field("reason", reason)
                 .finish(),
             ListenersEvent::Error { listener_id, error } => f

--- a/core/src/network.rs
+++ b/core/src/network.rs
@@ -357,8 +357,8 @@ where
             Poll::Ready(ListenersEvent::AddressExpired { listener_id, listen_addr }) => {
                 return Poll::Ready(NetworkEvent::ExpiredListenerAddress { listener_id, listen_addr })
             }
-            Poll::Ready(ListenersEvent::Closed { listener_id, reason }) => {
-                return Poll::Ready(NetworkEvent::ListenerClosed { listener_id, reason })
+            Poll::Ready(ListenersEvent::Closed { listener_id, addresses, reason }) => {
+                return Poll::Ready(NetworkEvent::ListenerClosed { listener_id, addresses, reason })
             }
             Poll::Ready(ListenersEvent::Error { listener_id, error }) => {
                 return Poll::Ready(NetworkEvent::ListenerError { listener_id, error })

--- a/core/src/network/event.rs
+++ b/core/src/network/event.rs
@@ -44,6 +44,7 @@ use crate::{
 };
 use futures::prelude::*;
 use std::{error, fmt, hash::Hash};
+use smallvec::SmallVec;
 
 /// Event that can happen on the `Network`.
 pub enum NetworkEvent<'a, TTrans, TInEvent, TOutEvent, THandler, TConnInfo, TPeerId>
@@ -55,6 +56,8 @@ where
     ListenerClosed {
         /// The listener ID that closed.
         listener_id: ListenerId,
+        /// The addresses that the listener was listening on.
+        addresses: SmallVec<[Multiaddr; 4]>,
         /// Reason for the closure. Contains `Ok(())` if the stream produced `None`, or `Err`
         /// if the stream produced an error.
         reason: Result<(), TTrans::Error>,
@@ -183,9 +186,10 @@ where
                     .field("listen_addr", listen_addr)
                     .finish()
             }
-            NetworkEvent::ListenerClosed { listener_id, reason } => {
+            NetworkEvent::ListenerClosed { listener_id, addresses, reason } => {
                 f.debug_struct("ListenerClosed")
                     .field("listener_id", listener_id)
+                    .field("addresses", addresses)
                     .field("reason", reason)
                     .finish()
             }

--- a/core/src/network/event.rs
+++ b/core/src/network/event.rs
@@ -44,7 +44,6 @@ use crate::{
 };
 use futures::prelude::*;
 use std::{error, fmt, hash::Hash};
-use smallvec::SmallVec;
 
 /// Event that can happen on the `Network`.
 pub enum NetworkEvent<'a, TTrans, TInEvent, TOutEvent, THandler, TConnInfo, TPeerId>
@@ -57,7 +56,7 @@ where
         /// The listener ID that closed.
         listener_id: ListenerId,
         /// The addresses that the listener was listening on.
-        addresses: SmallVec<[Multiaddr; 4]>,
+        addresses: Vec<Multiaddr>,
         /// Reason for the closure. Contains `Ok(())` if the stream produced `None`, or `Err`
         /// if the stream produced an error.
         reason: Result<(), TTrans::Error>,
@@ -347,4 +346,3 @@ where
         self.info().to_connected_point()
     }
 }
-

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -445,9 +445,12 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                     this.behaviour.inject_expired_listen_addr(&listen_addr);
                     return Poll::Ready(SwarmEvent::ExpiredListenAddr(listen_addr));
                 }
-                Poll::Ready(NetworkEvent::ListenerClosed { listener_id, reason }) => {
+                Poll::Ready(NetworkEvent::ListenerClosed { listener_id, addresses, reason }) => {
                     log::debug!("Listener {:?}; Closed by {:?}.", listener_id, reason);
                     this.behaviour.inject_listener_closed(listener_id);
+                    for addr in addresses.iter() {
+                        this.behaviour.inject_expired_listen_addr(addr);
+                    }
                 }
                 Poll::Ready(NetworkEvent::ListenerError { listener_id, error }) =>
                     this.behaviour.inject_listener_error(listener_id, &error),

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -447,10 +447,10 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                 }
                 Poll::Ready(NetworkEvent::ListenerClosed { listener_id, addresses, reason }) => {
                     log::debug!("Listener {:?}; Closed by {:?}.", listener_id, reason);
-                    this.behaviour.inject_listener_closed(listener_id);
                     for addr in addresses.iter() {
                         this.behaviour.inject_expired_listen_addr(addr);
                     }
+                    this.behaviour.inject_listener_closed(listener_id);
                 }
                 Poll::Ready(NetworkEvent::ListenerError { listener_id, error }) =>
                     this.behaviour.inject_listener_error(listener_id, &error),


### PR DESCRIPTION
We would like to be able expire addresses when a listener closes.

Add an `addresses` field to the `ListenersEvent` and the `ListenerClosed` to hold the addresses of a listener that has just closed.  When we return a `ListenerClosed` network event, loop over the addresses and call `inject_expired_listen_address()` on each one.

Fixes: https://github.com/libp2p/rust-libp2p/issues/1482