### PR TITLE
protocols/kad: Fix right shift overflow panic in record_received 

### DIFF
--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -946,8 +946,6 @@ where
             return
         }
 
-        let now = Instant::now();
-
         // Calculate the expiration exponentially inversely proportional to the
         // number of nodes between the local node and the closest node to the key
         // (beyond the replication factor). This ensures avoiding over-caching
@@ -956,9 +954,7 @@ where
         let num_between = self.kbuckets.count_nodes_between(&target);
         let k = self.queries.config().replication_factor.get();
         let num_beyond_k = (usize::max(k, num_between) - k) as u32;
-        let expiration = self.record_ttl.map(|ttl|
-            now + Duration::from_secs(ttl.as_secs().checked_shr(num_beyond_k).unwrap_or(0))
-        );
+        let expiration = exp_decr_expiration(self.record_ttl, num_beyond_k);
         // The smaller TTL prevails. Only if neither TTL is set is the record
         // stored "forever".
         record.expires = record.expires.or(expiration).min(expiration);
@@ -1028,6 +1024,15 @@ where
             }
         }
     }
+}
+
+/// Calculate exponentially decreasing expiration from a default time-to-live by a factor.
+fn exp_decr_expiration(default_ttl: Option<Duration>, factor: u32) -> Option<Instant> {
+    default_ttl.map(|ttl| Instant::now() + Duration::from_secs(
+        ttl.as_secs()
+            .checked_shr(factor)
+            .unwrap_or(0),
+    ))
 }
 
 impl<TStore> NetworkBehaviour for Kademlia<TStore>

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -957,7 +957,7 @@ where
         let k = self.queries.config().replication_factor.get();
         let num_beyond_k = (usize::max(k, num_between) - k) as u32;
         let expiration = self.record_ttl.map(|ttl|
-            now + Duration::from_secs(ttl.as_secs() >> num_beyond_k)
+            now + Duration::from_secs(ttl.as_secs().checked_shr(num_beyond_k).unwrap_or(0))
         );
         // The smaller TTL prevails. Only if neither TTL is set is the record
         // stored "forever".
@@ -1911,4 +1911,3 @@ impl QueryInfo {
         }
     }
 }
-

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -685,7 +685,6 @@ fn exceed_jobs_max_queries() {
     )
 }
 
-#[test]
 // Within `Behaviour::record_received` the exponentially decreasing expiration
 // based on the distance to the target for a record is calculated as following:
 //
@@ -697,6 +696,7 @@ fn exceed_jobs_max_queries() {
 //
 // The configured record time-to-live is a u64. If `n` is larger or equal to 64
 // the right shift will lead to an overflow which panics in debug mode.
+#[test]
 fn record_received_no_right_shift_overflow() {
     // This will likely generate enough keys to have equal to or more than 64
     // peers between the record key and the node's local key.

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -685,12 +685,12 @@ fn exceed_jobs_max_queries() {
 
 #[test]
 fn exp_decr_expiration_overflow() {
-    fn prop_no_panic(ttl: Option<Duration>, factor: u32) {
-        exp_decr_expiration(ttl, factor);
+    fn prop_no_panic(ttl: Duration, factor: u32) {
+        exp_decrease(ttl, factor);
     }
 
     // Right shifting a u64 by >63 results in a panic.
-    prop_no_panic(KademliaConfig::default().record_ttl, 64);
+    prop_no_panic(KademliaConfig::default().record_ttl.unwrap(), 64);
 
     quickcheck(prop_no_panic as fn(_, _))
 }

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -364,6 +364,15 @@ pub struct KademliaRequestId {
     connec_unique_id: UniqueConnecId,
 }
 
+#[cfg(test)]
+impl Default for KademliaRequestId {
+    fn default() -> Self {
+        KademliaRequestId {
+            connec_unique_id: UniqueConnecId(0),
+        }
+    }
+}
+
 /// Unique identifier for a connection.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct UniqueConnecId(u64);

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -364,15 +364,6 @@ pub struct KademliaRequestId {
     connec_unique_id: UniqueConnecId,
 }
 
-#[cfg(test)]
-impl Default for KademliaRequestId {
-    fn default() -> Self {
-        KademliaRequestId {
-            connec_unique_id: UniqueConnecId(0),
-        }
-    }
-}
-
 /// Unique identifier for a connection.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct UniqueConnecId(u64);


### PR DESCRIPTION
Within `Behaviour::record_received` the exponentially decreasing
expiration based on the distance to the target for a record is
calculated as following:

1. Calculate the amount of nodes between us and the record key beyond
the k replication constant as `n`.

2. Shift the configured record time-to-live `n` times to the right to
calculate an exponentially decreasing expiration.

The configured record time-to-live is a u64. If `n` is larger or equal
to 64 the right shift will lead to an overflow which panics in debug
mode.

This patch uses a checked right shift instead, defaulting to 0 (`now +
0`) for the expiration on overflow.

Fixes https://github.com/libp2p/rust-libp2p/issues/1491.