### PR TITLE
protocols/kad: Do not attempt to store expired record in record store

### DIFF
--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -981,7 +981,7 @@ where
         // overridden as it avoids having to load the existing record in the
         // first place.
 
-        if !record.is_expired(Instant::now()) {
+        if !record.is_expired(now) {
             // The record is cloned because of the weird libp2p protocol
             // requirement to send back the value in the response, although this
             // is a waste of resources.
@@ -1004,10 +1004,7 @@ where
         // case where the record is discarded due to being expired. Given that
         // the remote sent the local node a [`KademliaHandlerEvent::PutRecord`]
         // request, the remote perceives the local node as one node among the k
-        // closest nodes to the target. Returning a [`KademliaHandlerIn::Reset`]
-        // instead of an [`KademliaHandlerIn::PutRecordRes`] to have the remote
-        // try another node would only result in the remote node to contact an
-        // even more distant node. In addition returning
+        // closest nodes to the target. In addition returning
         // [`KademliaHandlerIn::PutRecordRes`] does not reveal any internal
         // information to a possibly malicious remote node.
         self.queued_events.push_back(NetworkBehaviourAction::NotifyHandler {


### PR DESCRIPTION
`Kademlia::record_received` calculates the expiration time of a record
before inserting it into the record store. Instead of inserting the
record into the record store in any case, with this patch the record is
only inserted if it is not expired. If the record is expired a
`KademliaHandlerIn::Reset` for the given (sub) stream is triggered.

This would serve as a tiny defense mechanism against an attacker trying
to fill a node's record store with expired records before the record
store's clean up procedure removes the records.

---

This is a follow up for https://github.com/libp2p/rust-libp2p/pull/1492#discussion_r391765926. Instead of an issue I created a pull request right away given that the change set should be reasonably small.

**Major discussion point: Should we trigger a `KademliaHandlerIn::PutRecordRes` or a `KademliaHandlerIn::Reset` when the record is expired?**

 As far as I can tell the former would inform the remote that the value [was indeed put](https://github.com/libp2p/rust-libp2p/blob/master/protocols/kad/src/handler.rs#L573) into the record store whereas the latter would simply have the remote [remove the substream](https://github.com/libp2p/rust-libp2p/blob/master/protocols/kad/src/handler.rs#L461). The former would lead to an `on_success` call on the query, the latter would have the query retry another node.

Consulting the [specification](https://github.com/libp2p/specs/pull/108) did not reveal any suggestions. Reading the go implementation I failed to determine where the [handler for a put event](https://github.com/libp2p/go-libp2p-kad-dht/blob/95964c0eac86887e54559a689f7e8f68b4a0f69f/handlers.go#L157) determines whether a given record is expired, given that it only seems to instantiate a [`PublicKeyValidator`](https://github.com/libp2p/go-libp2p-record/blob/master/pubkey.go#L20).

I decided for resetting the connection and thereby not (wrongly) acknowledging that the node cached the record. What do you think? 