### PR TITLE
Clean up libp2p-core tests.

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -42,7 +42,6 @@ ring = { version = "0.16.9", features = ["alloc", "std"], default-features = fal
 async-std = "1.0"
 libp2p-mplex = { version = "0.16.0", path = "../muxers/mplex" }
 libp2p-secio = { version = "0.16.0", path = "../protocols/secio" }
-libp2p-swarm = { version = "0.16.0", path = "../swarm" }
 libp2p-tcp = { version = "0.16.0", path = "../transports/tcp" }
 quickcheck = "0.9.0"
 wasm-timer = "0.2"

--- a/core/tests/util.rs
+++ b/core/tests/util.rs
@@ -3,7 +3,38 @@
 
 use futures::prelude::*;
 use libp2p_core::muxing::StreamMuxer;
-use std::{pin::Pin, task::Context, task::Poll};
+use libp2p_core::{
+    connection::{
+        ConnectionHandler,
+        ConnectionHandlerEvent,
+        Substream,
+        SubstreamEndpoint,
+    },
+    muxing::StreamMuxerBox,
+};
+use std::{io, pin::Pin, task::Context, task::Poll};
+
+pub struct TestHandler();
+
+impl ConnectionHandler for TestHandler {
+    type InEvent = ();
+    type OutEvent = ();
+    type Error = io::Error;
+    type Substream = Substream<StreamMuxerBox>;
+    type OutboundOpenInfo = ();
+
+    fn inject_substream(&mut self, _: Self::Substream, _: SubstreamEndpoint<Self::OutboundOpenInfo>)
+    {}
+
+    fn inject_event(&mut self, _: Self::InEvent)
+    {}
+
+    fn poll(&mut self, _: &mut Context)
+        -> Poll<Result<ConnectionHandlerEvent<Self::OutboundOpenInfo, Self::OutEvent>, Self::Error>>
+    {
+        Poll::Ready(Ok(ConnectionHandlerEvent::Custom(())))
+    }
+}
 
 pub struct CloseMuxer<M> {
     state: CloseMuxerState<M>,


### PR DESCRIPTION
This PR cleans up the integration tests in `libp2p-core` by removing the dependency on `libp2p-swarm`, which should make the tests a bit clearer since they no longer refer to either unused or unnecessary notions from `libp2p-swarm` and its `ProtocolsHandler`.