### PR TITLE
Reexport MemoryStoreConfig

### DIFF
--- a/protocols/kad/src/record/store.rs
+++ b/protocols/kad/src/record/store.rs
@@ -20,7 +20,7 @@
 
 mod memory;
 
-pub use memory::MemoryStore;
+pub use memory::{MemoryStore, MemoryStoreConfig};
 
 use crate::K_VALUE;
 use super::*;


### PR DESCRIPTION
Right now it isn't possible to use `MemoryStore::with_config` from outside of `libp2p-kad`, because you can't build a `MemoryStoreConfig`.