### PR TITLE
core/src/connection: Bound task event buffer during conn establishment

### DIFF
--- a/core/src/connection/error.rs
+++ b/core/src/connection/error.rs
@@ -78,6 +78,10 @@ pub enum PendingConnectionError<TTransErr> {
     /// match the one that was expected or is otherwise invalid.
     InvalidPeerId,
 
+    /// The buffer of events send from the [`Manager`] to the [`Task`] during
+    /// connection establishment reached its limit.
+    EventBufferLimitReached,
+
     /// An I/O error occurred on the connection.
     // TODO: Eventually this should also be a custom error?
     IO(io::Error),
@@ -89,13 +93,17 @@ where
     TTransErr: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Pending connection: ")?;
+
         match self {
             PendingConnectionError::IO(err) =>
-                write!(f, "Pending connection: I/O error: {}", err),
+                write!(f, "I/O error: {}", err),
             PendingConnectionError::Transport(err) =>
-                write!(f, "Pending connection: Transport error: {}", err),
+                write!(f, "Transport error: {}", err),
             PendingConnectionError::InvalidPeerId =>
-                write!(f, "Pending connection: Invalid peer ID."),
+                write!(f, "Invalid peer ID."),
+            PendingConnectionError::EventBufferLimitReached =>
+                write!(f, "Event buffer limit reached."),
         }
     }
 }
@@ -110,6 +118,7 @@ where
             PendingConnectionError::IO(err) => Some(err),
             PendingConnectionError::Transport(err) => Some(err),
             PendingConnectionError::InvalidPeerId => None,
+            PendingConnectionError::EventBufferLimitReached => None,
         }
     }
 }

--- a/core/src/connection/error.rs
+++ b/core/src/connection/error.rs
@@ -78,8 +78,10 @@ pub enum PendingConnectionError<TTransErr> {
     /// match the one that was expected or is otherwise invalid.
     InvalidPeerId,
 
-    /// The buffer of events send from the [`Manager`] to the [`Task`] during
-    /// connection establishment reached its limit.
+    /// The buffer of events send from the
+    /// [`crate::connection::manager::Manager`] to the
+    /// [`crate::connection::manager::Task`] during connection establishment
+    /// reached its limit.
     EventBufferLimitReached,
 
     /// An I/O error occurred on the connection.

--- a/core/src/connection/manager/task.rs
+++ b/core/src/connection/manager/task.rs
@@ -113,7 +113,7 @@ where
             state: State::Pending {
                 future: Box::pin(future),
                 handler,
-                events: CappedVec::new(MAX_EVENT_BUFFERING)
+                events: BoundedVec::new(MAX_EVENT_BUFFERING)
             },
         }
     }
@@ -154,9 +154,9 @@ where
         /// because we have to detect if the connection attempt has been aborted (by
         /// dropping the corresponding `sender` owned by the manager).
         ///
-        /// To prevent `events` to grow unbounded a [`CappedVec`] is used instead of
+        /// To prevent `events` to grow unbounded a [`BoundedVec`] is used instead of
         /// a [`Vec`].
-        events: CappedVec<I>
+        events: BoundedVec<I>
     },
 
     /// The connection is established and a new event is ready to be emitted.
@@ -177,15 +177,15 @@ where
     Done
 }
 
-/// A [`Vec`] with an upper size limit.
-struct CappedVec<T> {
+/// A [`Vec`] with an upper size bound.
+struct BoundedVec<T> {
     limit: usize,
     vec: Vec<T>
 }
 
-impl<T> CappedVec<T> {
+impl<T> BoundedVec<T> {
     fn new(limit: usize) -> Self {
-        CappedVec {
+        BoundedVec {
             limit,
             vec: vec![],
         }
@@ -201,7 +201,7 @@ impl<T> CappedVec<T> {
     }
 }
 
-impl<T> IntoIterator for CappedVec<T> {
+impl<T> IntoIterator for BoundedVec<T> {
     type Item = T;
     type IntoIter = <Vec<T> as IntoIterator>::IntoIter;
 


### PR DESCRIPTION
This commit adds a size limit to the event buffer that is filled during
connection establishment and forwarded in bulk to the handler once the
connection is established.

When the size limit is reached an `EventBufferLimitReached` error is
triggered and send to the manager which will in turn drop its connection
to the task signaling it to shutdown.

The above buffer is already bound by the connection establishment
timeout. This commit adds an additional size bound to the buffer.

Fixes https://github.com/libp2p/rust-libp2p/issues/1465.