### PR TITLE
Permit concurrent dialing attempts per peer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version ???
 
+- `libp2p-core`, `libp2p-swarm`: Added support for multiple dialing
+  attempts per peer, with a configurable limit.
+  [PR 1506](https://github.com/libp2p/rust-libp2p/pull/1506)
+
 - `libp2p-noise`: Added the `X25519Spec` protocol suite which uses
   libp2p-noise-spec compliant signatures on static keys as well as the
   `/noise` protocol upgrade, hence providing a libp2p-noise-spec compliant

--- a/core/src/connection/pool.rs
+++ b/core/src/connection/pool.rs
@@ -866,7 +866,7 @@ impl PoolLimits {
     where
         F: FnOnce() -> usize
     {
-        Self::check(current, self.max_pending_incoming)
+        Self::check(current, self.max_incoming)
     }
 
     fn check_outgoing_per_peer<F>(&self, current: F) -> Result<(), ConnectionLimit>

--- a/core/src/connection/pool.rs
+++ b/core/src/connection/pool.rs
@@ -225,12 +225,7 @@ where
         TPeerId: Clone + Send + 'static,
     {
         let endpoint = info.to_connected_point();
-        if let Some(limit) = self.limits.max_incoming {
-            let current = self.iter_pending_incoming().count();
-            if current >= limit {
-                return Err(ConnectionLimit { limit, current })
-            }
-        }
+        self.limits.check_incoming(|| self.iter_pending_incoming().count())?;
         Ok(self.add_pending(future, handler, endpoint, None))
     }
 
@@ -267,6 +262,11 @@ where
         TPeerId: Clone + Send + 'static,
     {
         self.limits.check_outgoing(|| self.iter_pending_outgoing().count())?;
+
+        if let Some(peer) = &info.peer_id {
+            self.limits.check_outgoing_per_peer(|| self.num_peer_outgoing(peer))?;
+        }
+
         let endpoint = info.to_connected_point();
         Ok(self.add_pending(future, handler, endpoint, info.peer_id.cloned()))
     }
@@ -463,6 +463,13 @@ where
     /// Counts the number of established connections to the given peer.
     pub fn num_peer_established(&self, peer: &TPeerId) -> usize {
         self.established.get(peer).map_or(0, |conns| conns.len())
+    }
+
+    /// Counts the number of pending outgoing connections to the given peer.
+    pub fn num_peer_outgoing(&self, peer: &TPeerId) -> usize {
+        self.iter_pending_outgoing()
+            .filter(|info| info.peer_id == Some(peer))
+            .count()
     }
 
     /// Returns an iterator over all established connections of `peer`.
@@ -837,6 +844,7 @@ pub struct PoolLimits {
     pub max_outgoing: Option<usize>,
     pub max_incoming: Option<usize>,
     pub max_established_per_peer: Option<usize>,
+    pub max_outgoing_per_peer: Option<usize>,
 }
 
 impl PoolLimits {
@@ -852,6 +860,20 @@ impl PoolLimits {
         F: FnOnce() -> usize
     {
         Self::check(current, self.max_outgoing)
+    }
+
+    fn check_incoming<F>(&self, current: F) -> Result<(), ConnectionLimit>
+    where
+        F: FnOnce() -> usize
+    {
+        Self::check(current, self.max_pending_incoming)
+    }
+
+    fn check_outgoing_per_peer<F>(&self, current: F) -> Result<(), ConnectionLimit>
+    where
+        F: FnOnce() -> usize
+    {
+        Self::check(current, self.max_outgoing_per_peer)
     }
 
     fn check<F>(current: F, limit: Option<usize>) -> Result<(), ConnectionLimit>

--- a/core/src/network.rs
+++ b/core/src/network.rs
@@ -50,6 +50,7 @@ use crate::{
 };
 use fnv::{FnvHashMap};
 use futures::{prelude::*, future};
+use smallvec::SmallVec;
 use std::{
     collections::hash_map,
     convert::TryFrom as _,
@@ -78,21 +79,17 @@ where
 
     /// The ongoing dialing attempts.
     ///
-    /// The `Network` enforces a single ongoing dialing attempt per peer,
-    /// even if multiple (established) connections per peer are allowed.
-    /// However, a single dialing attempt operates on a list of addresses
-    /// to connect to, which can be extended with new addresses while
-    /// the connection attempt is still in progress. Thereby each
-    /// dialing attempt is associated with a new connection and hence a new
-    /// connection ID.
+    /// There may be multiple ongoing dialing attempts to the same peer.
+    /// Each dialing attempt is associated with a new connection and hence
+    /// a new connection ID.
     ///
     /// > **Note**: `dialing` must be consistent with the pending outgoing
     /// > connections in `pool`. That is, for every entry in `dialing`
     /// > there must exist a pending outgoing connection in `pool` with
     /// > the same connection ID. This is ensured by the implementation of
     /// > `Network` (see `dial_peer_impl` and `on_connection_failed`)
-    /// > together with the implementation of `DialingConnection::abort`.
-    dialing: FnvHashMap<TPeerId, peer::DialingAttempt>,
+    /// > together with the implementation of `DialingAttempt::abort`.
+    dialing: FnvHashMap<TPeerId, SmallVec<[peer::DialingState; 10]>>,
 }
 
 impl<TTrans, TInEvent, TOutEvent, THandler, TConnInfo, TPeerId> fmt::Debug for
@@ -381,8 +378,11 @@ where
             Poll::Pending => return Poll::Pending,
             Poll::Ready(PoolEvent::ConnectionEstablished { connection, num_established }) => {
                 match self.dialing.entry(connection.peer_id().clone()) {
-                    hash_map::Entry::Occupied(e) if e.get().id == connection.id() => {
-                        e.remove();
+                    hash_map::Entry::Occupied(mut e) => {
+                        e.get_mut().retain(|s| s.current.0 != connection.id());
+                        if e.get().is_empty() {
+                            e.remove();
+                        }
                     },
                     _ => {}
                 }
@@ -453,7 +453,7 @@ fn dial_peer_impl<TMuxer, TInEvent, TOutEvent, THandler, TTrans, TConnInfo, TPee
     transport: TTrans,
     pool: &mut Pool<TInEvent, TOutEvent, THandler, TTrans::Error,
         <THandler::Handler as ConnectionHandler>::Error, TConnInfo, TPeerId>,
-    dialing: &mut FnvHashMap<TPeerId, peer::DialingAttempt>,
+    dialing: &mut FnvHashMap<TPeerId, SmallVec<[peer::DialingState; 10]>>,
     opts: DialingOpts<TPeerId, THandler>
 ) -> Result<ConnectionId, ConnectionLimit>
 where
@@ -489,14 +489,12 @@ where
     };
 
     if let Ok(id) = &result {
-        let former = dialing.insert(opts.peer,
-            peer::DialingAttempt {
-                id: *id,
-                current: opts.address,
-                next: opts.remaining,
+        dialing.entry(opts.peer).or_default().push(
+            peer::DialingState {
+                current: (*id, opts.address),
+                remaining: opts.remaining,
             },
         );
-        debug_assert!(former.is_none());
     }
 
     result
@@ -508,7 +506,7 @@ where
 /// If the failed connection attempt was a dialing attempt and there
 /// are more addresses to try, new `DialingOpts` are returned.
 fn on_connection_failed<'a, TTrans, TInEvent, TOutEvent, THandler, TConnInfo, TPeerId>(
-    dialing: &mut FnvHashMap<TPeerId, peer::DialingAttempt>,
+    dialing: &mut FnvHashMap<TPeerId, SmallVec<[peer::DialingState; 10]>>,
     id: ConnectionId,
     endpoint: ConnectedPoint,
     error: PendingConnectionError<TTrans::Error>,
@@ -521,26 +519,33 @@ where
     TPeerId: Eq + Hash + Clone,
 {
     // Check if the failed connection is associated with a dialing attempt.
-    // TODO: could be more optimal than iterating over everything
-    let dialing_peer = dialing.iter() // (1)
-        .find(|(_, a)| a.id == id)
-        .map(|(p, _)| p.clone());
+    let dialing_failed = dialing.iter_mut()
+        .find_map(|(peer, attempts)| {
+            if let Some(pos) = attempts.iter().position(|s| s.current.0 == id) {
+                let attempt = attempts.remove(pos);
+                let last = attempts.is_empty();
+                Some((peer.clone(), attempt, last))
+            } else {
+                None
+            }
+        });
 
-    if let Some(peer_id) = dialing_peer {
-        // A pending outgoing connection to a known peer failed.
-        let mut attempt = dialing.remove(&peer_id).expect("by (1)");
+    if let Some((peer_id, mut attempt, last)) = dialing_failed {
+        if last {
+            dialing.remove(&peer_id);
+        }
 
-        let num_remain = u32::try_from(attempt.next.len()).unwrap();
-        let failed_addr = attempt.current.clone();
+        let num_remain = u32::try_from(attempt.remaining.len()).unwrap();
+        let failed_addr = attempt.current.1.clone();
 
         let opts =
             if num_remain > 0 {
-                let next_attempt = attempt.next.remove(0);
+                let next_attempt = attempt.remaining.remove(0);
                 let opts = DialingOpts {
                     peer: peer_id.clone(),
                     handler,
                     address: next_attempt,
-                    remaining: attempt.next
+                    remaining: attempt.remaining
                 };
                 Some(opts)
             } else {
@@ -575,9 +580,13 @@ where
 /// Information about the network obtained by [`Network::info()`].
 #[derive(Clone, Debug)]
 pub struct NetworkInfo {
+    /// The total number of connected peers.
     pub num_peers: usize,
+    /// The total number of connections, both established and pending.
     pub num_connections: usize,
+    /// The total number of pending connections, both incoming and outgoing.
     pub num_connections_pending: usize,
+    /// The total number of established connections.
     pub num_connections_established: usize,
 }
 
@@ -625,6 +634,11 @@ impl NetworkConfig {
 
     pub fn set_established_per_peer_limit(&mut self, n: usize) -> &mut Self {
         self.pool_limits.max_established_per_peer = Some(n);
+        self
+    }
+
+    pub fn set_outgoing_per_peer_limit(&mut self, n: usize) -> &mut Self {
+        self.pool_limits.max_outgoing_per_peer = Some(n);
         self
     }
 }

--- a/core/tests/network_dial_error.rs
+++ b/core/tests/network_dial_error.rs
@@ -251,7 +251,7 @@ fn connection_limit() {
 
     let mut cfg = NetworkConfig::default();
     cfg.set_outgoing_per_peer_limit(outgoing_per_peer_limit);
-    cfg.set_pending_outgoing_limit(outgoing_limit);
+    cfg.set_outgoing_limit(outgoing_limit);
     let mut network = new_network(cfg);
 
     let target = PeerId::random();

--- a/core/tests/network_dial_error.rs
+++ b/core/tests/network_dial_error.rs
@@ -22,47 +22,60 @@ mod util;
 
 use futures::prelude::*;
 use libp2p_core::identity;
-use libp2p_core::multiaddr::multiaddr;
+use libp2p_core::multiaddr::{multiaddr, Multiaddr};
 use libp2p_core::{
     Network,
     PeerId,
     Transport,
     connection::PendingConnectionError,
     muxing::StreamMuxerBox,
-    network::NetworkEvent,
+    network::{NetworkEvent, NetworkConfig},
+    transport,
     upgrade,
 };
+use rand::Rng;
 use rand::seq::SliceRandom;
-use std::{io, task::Poll};
+use std::{io, error::Error, fmt, task::Poll};
 use util::TestHandler;
 
-type TestNetwork<TTrans> = Network<TTrans, (), (), TestHandler>;
+type TestNetwork = Network<TestTransport, (), (), TestHandler>;
+type TestTransport = transport::boxed::Boxed<(PeerId, StreamMuxerBox), BoxError>;
+
+#[derive(Debug)]
+struct BoxError(Box<dyn Error + Send + 'static>);
+
+impl Error for BoxError {}
+
+impl fmt::Display for BoxError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Transport error: {}", self.0)
+    }
+}
+
+fn new_network(cfg: NetworkConfig) -> TestNetwork {
+    let local_key = identity::Keypair::generate_ed25519();
+    let local_public_key = local_key.public();
+    let transport: TestTransport = libp2p_tcp::TcpConfig::new()
+        .upgrade(upgrade::Version::V1)
+        .authenticate(libp2p_secio::SecioConfig::new(local_key))
+        .multiplex(libp2p_mplex::MplexConfig::new())
+        .map(|(conn_info, muxer), _| (conn_info, StreamMuxerBox::new(muxer)))
+        .and_then(|(peer, mplex), _| {
+            // Gracefully close the connection to allow protocol
+            // negotiation to complete.
+            util::CloseMuxer::new(mplex).map_ok(move |mplex| (peer, mplex))
+        })
+        .map_err(|e| BoxError(Box::new(e)))
+        .boxed();
+    TestNetwork::new(transport, local_public_key.into(), cfg)
+}
 
 #[test]
 fn deny_incoming_connec() {
     // Checks whether refusing an incoming connection on a swarm triggers the correct events.
 
-    let mut swarm1 = {
-        let local_key = identity::Keypair::generate_ed25519();
-        let local_public_key = local_key.public();
-        let transport = libp2p_tcp::TcpConfig::new()
-            .upgrade(upgrade::Version::V1)
-            .authenticate(libp2p_secio::SecioConfig::new(local_key))
-            .multiplex(libp2p_mplex::MplexConfig::new())
-            .map(|(conn_info, muxer), _| (conn_info, StreamMuxerBox::new(muxer)));
-        TestNetwork::new(transport, local_public_key.into(), Default::default())
-    };
-
-    let mut swarm2 = {
-        let local_key = identity::Keypair::generate_ed25519();
-        let local_public_key = local_key.public();
-        let transport = libp2p_tcp::TcpConfig::new()
-            .upgrade(upgrade::Version::V1)
-            .authenticate(libp2p_secio::SecioConfig::new(local_key))
-            .multiplex(libp2p_mplex::MplexConfig::new())
-            .map(|(conn_info, muxer), _| (conn_info, StreamMuxerBox::new(muxer)));
-        TestNetwork::new(transport, local_public_key.into(), Default::default())
-    };
+    let mut swarm1 = new_network(NetworkConfig::default());
+    let mut swarm2 = new_network(NetworkConfig::default());
 
     swarm1.listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
 
@@ -76,8 +89,7 @@ fn deny_incoming_connec() {
 
     swarm2
         .peer(swarm1.local_peer_id().clone())
-        .into_disconnected().unwrap()
-        .connect(address.clone(), Vec::new(), TestHandler())
+        .dial(address.clone(), Vec::new(), TestHandler())
         .unwrap();
 
     async_std::task::block_on(future::poll_fn(|cx| -> Poll<Result<(), io::Error>> {
@@ -119,22 +131,7 @@ fn dial_self() {
     //
     // The last two can happen in any order.
 
-    let mut swarm = {
-        let local_key = identity::Keypair::generate_ed25519();
-        let local_public_key = local_key.public();
-        let transport = libp2p_tcp::TcpConfig::new()
-            .upgrade(upgrade::Version::V1)
-            .authenticate(libp2p_secio::SecioConfig::new(local_key))
-            .multiplex(libp2p_mplex::MplexConfig::new())
-            .and_then(|(peer, mplex), _| {
-                // Gracefully close the connection to allow protocol
-                // negotiation to complete.
-                util::CloseMuxer::new(mplex).map_ok(move |mplex| (peer, mplex))
-            })
-            .map(|(conn_info, muxer), _| (conn_info, StreamMuxerBox::new(muxer)));
-        TestNetwork::new(transport, local_public_key.into(), Default::default())
-    };
-
+    let mut swarm = new_network(NetworkConfig::default());
     swarm.listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
 
     let (local_address, mut swarm) = async_std::task::block_on(
@@ -193,36 +190,16 @@ fn dial_self() {
 fn dial_self_by_id() {
     // Trying to dial self by passing the same `PeerId` shouldn't even be possible in the first
     // place.
-
-    let mut swarm = {
-        let local_key = identity::Keypair::generate_ed25519();
-        let local_public_key = local_key.public();
-        let transport = libp2p_tcp::TcpConfig::new()
-            .upgrade(upgrade::Version::V1)
-            .authenticate(libp2p_secio::SecioConfig::new(local_key))
-            .multiplex(libp2p_mplex::MplexConfig::new())
-            .map(|(conn_info, muxer), _| (conn_info, StreamMuxerBox::new(muxer)));
-        TestNetwork::new(transport, local_public_key.into(), Default::default())
-    };
-
+    let mut swarm = new_network(NetworkConfig::default());
     let peer_id = swarm.local_peer_id().clone();
     assert!(swarm.peer(peer_id).into_disconnected().is_none());
 }
 
 #[test]
 fn multiple_addresses_err() {
-    // Tries dialing multiple addresses, and makes sure there's one dialing error per addresses.
+    // Tries dialing multiple addresses, and makes sure there's one dialing error per address.
 
-    let mut swarm = {
-        let local_key = identity::Keypair::generate_ed25519();
-        let local_public_key = local_key.public();
-        let transport = libp2p_tcp::TcpConfig::new()
-            .upgrade(upgrade::Version::V1)
-            .authenticate(libp2p_secio::SecioConfig::new(local_key))
-            .multiplex(libp2p_mplex::MplexConfig::new())
-            .map(|(conn_info, muxer), _| (conn_info, StreamMuxerBox::new(muxer)));
-        TestNetwork::new(transport, local_public_key.into(), Default::default())
-    };
+    let mut swarm = new_network(NetworkConfig::default());
 
     let mut addresses = Vec::new();
     for _ in 0 .. 3 {
@@ -238,8 +215,7 @@ fn multiple_addresses_err() {
 
     let target = PeerId::random();
     swarm.peer(target.clone())
-        .into_disconnected().unwrap()
-        .connect(first, rest, TestHandler())
+        .dial(first, rest, TestHandler())
         .unwrap();
 
     async_std::task::block_on(future::poll_fn(|cx| -> Poll<Result<(), io::Error>> {
@@ -266,4 +242,45 @@ fn multiple_addresses_err() {
             }
         }
     })).unwrap();
+}
+
+#[test]
+fn connection_limit() {
+    let outgoing_per_peer_limit = rand::thread_rng().gen_range(1, 10);
+    let outgoing_limit = 2 * outgoing_per_peer_limit;
+
+    let mut cfg = NetworkConfig::default();
+    cfg.set_outgoing_per_peer_limit(outgoing_per_peer_limit);
+    cfg.set_pending_outgoing_limit(outgoing_limit);
+    let mut network = new_network(cfg);
+
+    let target = PeerId::random();
+    for _ in 0 .. outgoing_per_peer_limit {
+        network.peer(target.clone())
+            .dial(Multiaddr::empty(), Vec::new(), TestHandler())
+            .ok()
+            .expect("Unexpected connection limit.");
+    }
+
+    let err = network.peer(target)
+        .dial(Multiaddr::empty(), Vec::new(), TestHandler())
+        .expect_err("Unexpected dialing success.");
+
+    assert_eq!(err.current, outgoing_per_peer_limit);
+    assert_eq!(err.limit, outgoing_per_peer_limit);
+
+    let target2 = PeerId::random();
+    for _ in outgoing_per_peer_limit .. outgoing_limit {
+        network.peer(target2.clone())
+            .dial(Multiaddr::empty(), Vec::new(), TestHandler())
+            .ok()
+            .expect("Unexpected connection limit.");
+    }
+
+    let err = network.peer(target2)
+        .dial(Multiaddr::empty(), Vec::new(), TestHandler())
+        .expect_err("Unexpected dialing success.");
+
+    assert_eq!(err.current, outgoing_limit);
+    assert_eq!(err.limit, outgoing_limit);
 }

--- a/swarm/src/behaviour.rs
+++ b/swarm/src/behaviour.rs
@@ -291,12 +291,10 @@ pub enum DialPeerCondition {
     /// If there is an ongoing dialing attempt, the addresses reported by
     /// [`NetworkBehaviour::addresses_of_peer`] are added to the ongoing
     /// dialing attempt, ignoring duplicates.
-    ///
-    /// This condition implies [`DialPeerCondition::Disconnected`].
     NotDialing,
-    // TODO: Once multiple dialing attempts per peer are permitted.
-    //       See https://github.com/libp2p/rust-libp2p/pull/1506.
-    // Always,
+    /// A new dialing attempt is always initiated, only subject to the
+    /// configured connection limits.
+    Always,
 }
 
 impl Default for DialPeerCondition {

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1073,7 +1073,7 @@ where TBehaviour: NetworkBehaviour,
     }
 }
 
-/// The possible failures of [`Swarm::dial`].
+/// The possible failures of [`ExpandedSwarm::dial`].
 #[derive(Debug)]
 pub enum DialError {
     /// The configured limit for simultaneous outgoing connections

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -670,6 +670,10 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                         this.behaviour.inject_dial_failure(&peer_id);
                     } else {
                         let result = match condition {
+                            DialPeerCondition::Always =>
+                            {
+                                ExpandedSwarm::dial(this, &peer_id)
+                            }
                             DialPeerCondition::Disconnected
                                 if this.network.is_disconnected(&peer_id) =>
                             {


### PR DESCRIPTION
This is a follow-up to https://github.com/libp2p/rust-libp2p/pull/1440 and relates to https://github.com/libp2p/rust-libp2p/issues/925. This PR permits multiple dialing attempts per peer.  The essence of the changes are that the `Peer` API in `libp2p-core` now provides `Peer::dial()`, i.e. regardless of the state in which the peer is. Previously dialing was only permitted on a `ConnectedPeer` or `DisconnectedPeer`. A dialing attempt is always made up of one or more addresses tried sequentially, as before, but now there can be multiple dialing attempts per peer. A configurable per-peer limit for outgoing connections and thus concurrent dialing attempts is also included. A `NetworkBehaviour` can now always request a new dialing attempt via `DialPeerCondition::Always` in `NetworkBehaviourAction::DialPeer`.

Another change included here is that `Swarm::dial` now returns `Result<(), DialError>` instead of `Result<bool, ConnectionLimit>`, i.e. the case of dialing failing because `NetworkBehaviour::addresses_of_peer` returning no addresses is now treated as an error (`DialError::NoAddresses`). This has the (I think) desirable effect of having a `NetworkBehaviourAction::DialPeer` request always be paired with a final call to `inject_connection_established` or `inject_dial_failure`. A behaviour may otherwise potentially keep state around for a dialing attempt that it thinks it emitted but for which it never got informed about a result.