### PR TITLE
Multiaddr: Replace Arc<Vec<u8>> with inline storage

### DIFF
--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -25,3 +25,8 @@ bincode = "1"
 quickcheck = "0.9.0"
 rand = "0.7.2"
 serde_json = "1.0"
+criterion = "0.3"
+
+[[bench]]
+name = "clone"
+harness = false

--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -19,7 +19,7 @@ serde = "1.0.70"
 static_assertions = "1.1"
 unsigned-varint = "0.3"
 url = { version = "2.1.0", default-features = false }
-smallvec = "1.0"
+smallvec = { version = "1.0", features = ["write"] }
 
 [dev-dependencies]
 bincode = "1"

--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -19,6 +19,7 @@ serde = "1.0.70"
 static_assertions = "1.1"
 unsigned-varint = "0.3"
 url = { version = "2.1.0", default-features = false }
+smallvec = "1.0"
 
 [dev-dependencies]
 bincode = "1"

--- a/misc/multiaddr/benches/clone.rs
+++ b/misc/multiaddr/benches/clone.rs
@@ -1,0 +1,52 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//! This benchmark tests the speed of cloning of the largest possible inlined
+//! multiaddr vs the smalles possible heap allocated multiaddr.
+//!
+//! Note that the main point of the storage optimization is not to speed up clone
+//! but to avoid allocating on the heap at all, but still you see a nice benefit
+//! in the speed of cloning.
+use criterion::{Bencher, Criterion, criterion_main, criterion_group, black_box};
+use parity_multiaddr::Multiaddr;
+
+fn do_clone(multiaddr: &Multiaddr) -> usize {
+    let mut res = 0usize;
+    for _ in 0..10 {
+        res += multiaddr.clone().as_ref().len()
+    }
+    res
+}
+
+fn clone(bench: &mut Bencher, addr: &Multiaddr) {
+    bench.iter(|| do_clone(black_box(addr)))
+}
+
+fn criterion_benchmarks(bench: &mut Criterion) {
+    let inlined: Multiaddr = "/dns4/01234567890123456789123/tcp/80/ws".parse().unwrap();
+    let heap: Multiaddr = "/dns4/0123456789012345678901234/tcp/80/ws".parse().unwrap();
+    assert_eq!(inlined.as_ref().len(), 30);
+    assert_eq!(heap.as_ref().len(), 32);
+
+    bench.bench_function("clone 10 max inlined", |b| clone(b, &inlined));
+    bench.bench_function("clone 10 min heap", |b| clone(b, &heap));
+}
+
+criterion_group!(benches, criterion_benchmarks);
+criterion_main!(benches);

--- a/misc/multiaddr/src/storage.rs
+++ b/misc/multiaddr/src/storage.rs
@@ -1,7 +1,12 @@
 use std::sync::Arc;
 
-/// MAX_INLINE is the maximum size of a multiaddr that can be stored inline
-const MAX_INLINE: usize = 38;
+/// MAX_INLINE is the maximum size of a multiaddr that can be stored inline.
+/// There is an overhead of 2 bytes, 1 for the length and 1 for the enum discriminator.
+/// 30 is chosen so that the overall size is 32. This should still be big enough to fit
+/// a multiaddr containing an ipv4 or ipv6 address and port.
+///
+/// More complex multiaddrs like those containing peer ids will be stored on the heap.
+const MAX_INLINE: usize = 30;
 
 #[derive(Clone)]
 pub(crate) enum Storage {
@@ -42,7 +47,7 @@ mod tests {
     #[test]
     fn struct_size() {
         // this should be true for both 32 and 64 bit archs
-        assert_eq!(std::mem::size_of::<Storage>(), 40);
+        assert_eq!(std::mem::size_of::<Storage>(), 32);
     }
 
     #[test]

--- a/misc/multiaddr/src/storage.rs
+++ b/misc/multiaddr/src/storage.rs
@@ -1,3 +1,22 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
 use std::sync::Arc;
 
 /// MAX_INLINE is the maximum size of a multiaddr that can be stored inline.
@@ -41,8 +60,22 @@ impl Storage {
 
 #[cfg(test)]
 mod tests {
+    use crate::Multiaddr;
     use super::{Storage, MAX_INLINE};
     use quickcheck::quickcheck;
+
+    #[test]
+    fn multihash_size() {
+        fn assert_size(ma: &str, n: usize, inline: bool) {
+            let ma: Multiaddr = ma.parse().unwrap();
+            assert_eq!(ma.as_ref().len(), n);
+            assert_eq!(n <= MAX_INLINE, inline);
+        }
+        assert_size("/ip4/127.0.0.1", 5, true);
+        assert_size("/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000", 20, true);
+        assert_size("/dns4/0123456789012345678901234/tcp/8000", 30, true);
+        assert_size("/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC", 59, false);
+    }
 
     #[test]
     fn struct_size() {

--- a/misc/multiaddr/src/storage.rs
+++ b/misc/multiaddr/src/storage.rs
@@ -1,0 +1,71 @@
+use std::sync::Arc;
+
+/// MAX_INLINE is the maximum size of a multiaddr that can be stored inline
+const MAX_INLINE: usize = 38;
+
+#[derive(Clone)]
+pub(crate) enum Storage {
+    /// hash is stored inline if it is smaller than MAX_INLINE
+    Inline(u8, [u8; MAX_INLINE]),
+    /// hash is stored on the heap. this must be only used if the hash is actually larger than
+    /// MAX_INLINE bytes to ensure an unique representation.
+    Heap(Arc<[u8]>),
+}
+
+impl Storage {
+    /// The raw bytes.
+    pub fn bytes(&self) -> &[u8] {
+        match self {
+            Storage::Inline(len, bytes) => &bytes[..(*len as usize)],
+            Storage::Heap(data) => &data,
+        }
+    }
+
+    /// creates storage from a vec. For a size up to MAX_INLINE, this will not allocate.
+    pub fn from_slice(slice: &[u8]) -> Self {
+        let len = slice.len();
+        if len <= MAX_INLINE {
+            let mut data: [u8; MAX_INLINE] = [0; MAX_INLINE];
+            data[..len].copy_from_slice(slice);
+            Storage::Inline(len as u8, data)
+        } else {
+            Storage::Heap(slice.into())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Storage, MAX_INLINE};
+    use quickcheck::quickcheck;
+
+    #[test]
+    fn struct_size() {
+        // this should be true for both 32 and 64 bit archs
+        assert_eq!(std::mem::size_of::<Storage>(), 40);
+    }
+
+    #[test]
+    fn roundtrip() {
+        // check that .bytes() returns whatever the storage was created with
+        for i in 0..((MAX_INLINE + 10) as u8) {
+            let data = (0..i).collect::<Vec<u8>>();
+            let storage = Storage::from_slice(&data);
+            assert_eq!(data, storage.bytes());
+        }
+    }
+
+    fn check_invariants(storage: Storage) -> bool {
+        match storage {
+            Storage::Inline(len, _) => len as usize <= MAX_INLINE,
+            Storage::Heap(arc) => arc.len() > MAX_INLINE,
+        }
+    }
+
+    quickcheck! {
+        fn roundtrip_check(data: Vec<u8>) -> bool {
+            let storage = Storage::from_slice(&data);
+            storage.bytes() == data.as_slice() && check_invariants(storage)
+        }
+    }
+}

--- a/misc/multiaddr/src/storage.rs
+++ b/misc/multiaddr/src/storage.rs
@@ -8,7 +8,7 @@ pub(crate) enum Storage {
     /// hash is stored inline if it is smaller than MAX_INLINE
     Inline(u8, [u8; MAX_INLINE]),
     /// hash is stored on the heap. this must be only used if the hash is actually larger than
-    /// MAX_INLINE bytes to ensure an unique representation.
+    /// MAX_INLINE bytes to ensure a unique representation.
     Heap(Arc<[u8]>),
 }
 

--- a/misc/multiaddr/src/storage.rs
+++ b/misc/multiaddr/src/storage.rs
@@ -45,7 +45,8 @@ impl Storage {
         }
     }
 
-    /// creates storage from a vec. For a size up to MAX_INLINE, this will not allocate.
+    /// Creates storage from a slice.
+    /// For a size up to MAX_INLINE, this will not allocate.
     pub fn from_slice(slice: &[u8]) -> Self {
         let len = slice.len();
         if len <= MAX_INLINE {


### PR DESCRIPTION
Storage stores small bytes inline, and spills to the heap only once that is no longer possible.

A typical small multiaddr consisting of e.g. ip4 host/port, ip6 host/port etc. will be stored inline. Only some complex multiaddrs containing multiple peer ids will be stored on the heap as an Arc<[u8]>.

The `push` and `with` fns allocate temporary vectors, but I think this is an acceptable tradeoff for making the in memory representation of multiaddrs much smaller. Many of the multiadds that you have you don't ever manually build but get from somewhere else.