### PR TITLE
Fix timeout on OneShotHandler

### DIFF
--- a/swarm/src/protocols_handler/one_shot.rs
+++ b/swarm/src/protocols_handler/one_shot.rs
@@ -224,7 +224,8 @@ where
                 self.dial_negotiated += 1;
                 return Poll::Ready(
                     ProtocolsHandlerEvent::OutboundSubstreamRequest {
-                        protocol: SubstreamProtocol::new(self.dial_queue.remove(0)),
+                        protocol: SubstreamProtocol::new(self.dial_queue.remove(0))
+                            .with_timeout(self.inactive_timeout),
                         info: (),
                     },
                 );


### PR DESCRIPTION
Fixes: https://github.com/libp2p/rust-libp2p/issues/1511

`OneShotHandler` opened new `SubstreamProtocol`s with default timeout, however the handler could have been configured with different timeout.