### PR TITLE
core/src: Remove poll_broadcast connection notification mechanism

### DIFF
--- a/core/src/connection/manager.rs
+++ b/core/src/connection/manager.rs
@@ -134,9 +134,6 @@ where
 #[derive(Debug)]
 struct TaskInfo<I, C> {
     /// Channel endpoint to send messages to the task.
-    //
-    // Note: Only established tasks can handle commands. Do not send commands to
-    // pending tasks (see `[<Task as Future>::poll]`).
     sender: mpsc::Sender<task::Command<I>>,
     /// The state of the task as seen by the `Manager`.
     state: TaskState<C>,

--- a/core/src/connection/manager.rs
+++ b/core/src/connection/manager.rs
@@ -133,7 +133,10 @@ where
 /// the associated user data.
 #[derive(Debug)]
 struct TaskInfo<I, C> {
-    /// channel endpoint to send messages to the task
+    /// Channel endpoint to send messages to the task.
+    //
+    // Note: Only established tasks can handle commands. Do not send commands to
+    // pending tasks (see `[<Task as Future>::poll]`).
     sender: mpsc::Sender<task::Command<I>>,
     /// The state of the task as seen by the `Manager`.
     state: TaskState<C>,
@@ -284,40 +287,6 @@ impl<I, O, H, TE, HE, C> Manager<I, O, H, TE, HE, C> {
         }
 
         ConnectionId(task_id)
-    }
-
-    /// Notifies the handlers of all managed connections of an event.
-    ///
-    /// This function is "atomic", in the sense that if `Poll::Pending` is
-    /// returned then no event has been sent.
-    #[must_use]
-    pub fn poll_broadcast(&mut self, event: &I, cx: &mut Context) -> Poll<()>
-    where
-        I: Clone
-    {
-        for task in self.tasks.values_mut() {
-            if let Poll::Pending = task.sender.poll_ready(cx) { // (*)
-                return Poll::Pending;
-            }
-        }
-
-        for (id, task) in self.tasks.iter_mut() {
-            let cmd = task::Command::NotifyHandler(event.clone());
-            match task.sender.start_send(cmd) {
-                Ok(()) => {},
-                Err(e) if e.is_full() => unreachable!("by (*)"),
-                Err(e) if e.is_disconnected() => {
-                    // The background task ended. The manager will eventually be
-                    // informed through an `Error` event from the task.
-                    log::trace!("Connection dropped: {:?}", id);
-                },
-                Err(e) => {
-                    log::error!("Unexpected error: {:?}", e);
-                }
-            }
-        }
-
-        Poll::Ready(())
     }
 
     /// Gets an entry for a managed connection, if it exists.

--- a/core/src/connection/pool.rs
+++ b/core/src/connection/pool.rs
@@ -330,18 +330,6 @@ where
         id
     }
 
-    /// Sends an event to all nodes.
-    ///
-    /// This function is "atomic", in the sense that if `Poll::Pending` is returned then no event
-    /// has been sent to any node yet.
-    #[must_use]
-    pub fn poll_broadcast(&mut self, event: &TInEvent, cx: &mut Context) -> Poll<()>
-    where
-        TInEvent: Clone
-    {
-        self.manager.poll_broadcast(event, cx)
-    }
-
     /// Adds an existing established connection to the pool.
     ///
     /// Returns the assigned connection ID on success. An error is returned

--- a/core/src/network.rs
+++ b/core/src/network.rs
@@ -269,18 +269,6 @@ where
             })
     }
 
-    /// Notifies the connection handler of _every_ connection of _every_ peer of an event.
-    ///
-    /// This function is "atomic", in the sense that if `Poll::Pending` is returned then no event
-    /// has been sent to any node yet.
-    #[must_use]
-    pub fn poll_broadcast(&mut self, event: &TInEvent, cx: &mut Context) -> Poll<()>
-    where
-        TInEvent: Clone
-    {
-        self.pool.poll_broadcast(event, cx)
-    }
-
     /// Returns a list of all connected peers, i.e. peers to whom the `Network`
     /// has at least one established connection.
     pub fn connected_peers(&self) -> impl Iterator<Item = &TPeerId> {
@@ -641,4 +629,3 @@ impl NetworkConfig {
         self
     }
 }
-


### PR DESCRIPTION
The `Network::poll_broadcast` function has not proven to be useful. This
commit removes the mechanism all the way down to the connection manager.

With `poll_broadcast` gone there is no mechanism left to send commands
to pending connections. Thereby command buffering for pending
connections is not needed anymore and is thus removed in this commit as
well.

---

Fixes #1465.

Replaces https://github.com/libp2p/rust-libp2p/pull/1501.