### PR TITLE
Fix parsed is null error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - `libp2p-floodsub`: Allow sent messages seen as subscribed.
   [PR 1520](https://github.com/libp2p/rust-libp2p/pull/1520)
 
+- `libp2p-wasm-ext`: Fix "parsed is null" errors being thrown.
+  [PR 1535](https://github.com/libp2p/rust-libp2p/pull/1535)
+
 # Version 0.17.0 (2020-04-02)
 
 - `libp2p-core`: Finished "identity hashing" for peer IDs migration.

--- a/transports/wasm-ext/src/websockets.js
+++ b/transports/wasm-ext/src/websockets.js
@@ -33,12 +33,12 @@ export const websocket_transport = () => {
 // TODO: support dns addresses as well
 const multiaddr_to_ws = (addr) => {
 	let parsed = addr.match(/^\/(ip4|ip6|dns4|dns6)\/(.*?)\/tcp\/(.*?)\/(ws|wss|x-parity-ws\/(.*)|x-parity-wss\/(.*))$/);
-	let proto = 'wss';
-	if (parsed[4] == 'ws' || parsed[4] == 'x-parity-ws') {
-		proto = 'ws';
-	}
-	let url = decodeURIComponent(parsed[5] || parsed[6] || '');
 	if (parsed != null) {
+		let proto = 'wss';
+		if (parsed[4] == 'ws' || parsed[4] == 'x-parity-ws') {
+			proto = 'ws';
+		}
+		let url = decodeURIComponent(parsed[5] || parsed[6] || '');
 		if (parsed[1] == 'ip6') {
 			return proto + "://[" + parsed[2] + "]:" + parsed[3] + url;
 		} else {


### PR DESCRIPTION
cc @expenses 

This JS code hasn't really been properly reviewed by anyone unfortunately, and jumped a bit suddenly from "quickly written code to prototype" to "thing that we expect to be robust".

One consequence is that for some reason we checked `parsed != null` only after using `parsed`.

