### PR TITLE
Re-export OneShotHandlerConfig. Make fields public.

### DIFF
--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -77,6 +77,7 @@ pub use protocols_handler::{
     ProtocolsHandlerSelect,
     ProtocolsHandlerUpgrErr,
     OneShotHandler,
+    OneShotHandlerConfig,
     SubstreamProtocol
 };
 

--- a/swarm/src/protocols_handler.rs
+++ b/swarm/src/protocols_handler.rs
@@ -63,7 +63,7 @@ pub use dummy::DummyProtocolsHandler;
 pub use map_in::MapInEvent;
 pub use map_out::MapOutEvent;
 pub use node_handler::{NodeHandlerWrapper, NodeHandlerWrapperBuilder, NodeHandlerWrapperError};
-pub use one_shot::OneShotHandler;
+pub use one_shot::{OneShotHandler, OneShotHandlerConfig};
 pub use select::{IntoProtocolsHandlerSelect, ProtocolsHandlerSelect};
 
 /// A handler for a set of protocols used on a connection with a remote.

--- a/swarm/src/protocols_handler/one_shot.rs
+++ b/swarm/src/protocols_handler/one_shot.rs
@@ -245,9 +245,9 @@ where
 #[derive(Debug)]
 pub struct OneShotHandlerConfig {
     /// After the given duration has elapsed, an inactive connection will shutdown.
-    inactive_timeout: Duration,
+    pub inactive_timeout: Duration,
     /// Timeout duration for each newly opened outbound substream.
-    substream_timeout: Duration,
+    pub substream_timeout: Duration,
 }
 
 impl Default for OneShotHandlerConfig {


### PR DESCRIPTION
This is supposed to address the issues I ran into with the recent introduction of `OneShotHandlerConfig`: https://github.com/libp2p/rust-libp2p/pull/1521#issuecomment-607254753.