### PR TITLE
Bump parity-multiaddr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ secp256k1 = ["libp2p-core/secp256k1", "libp2p-secio/secp256k1"]
 [dependencies]
 bytes = "0.5"
 futures = "0.3.1"
-multiaddr = { package = "parity-multiaddr", version = "0.7.2", path = "misc/multiaddr" }
+multiaddr = { package = "parity-multiaddr", version = "0.8.0", path = "misc/multiaddr" }
 multihash = "0.10"
 lazy_static = "1.2"
 libp2p-mplex = { version = "0.17.0", path = "muxers/mplex", optional = true }
@@ -65,7 +65,7 @@ libp2p-gossipsub = { version = "0.17.0", path = "./protocols/gossipsub", optiona
 libp2p-ping = { version = "0.17.0", path = "protocols/ping", optional = true }
 libp2p-plaintext = { version = "0.17.0", path = "protocols/plaintext", optional = true }
 libp2p-pnet = { version = "0.17.0", path = "protocols/pnet", optional = true }
-libp2p-core = { version = "0.17.0", path = "core" }
+libp2p-core = { version = "0.17.1", path = "core" }
 libp2p-core-derive = { version = "0.17.0", path = "misc/core-derive" }
 libp2p-secio = { version = "0.17.0", path = "protocols/secio", default-features = false, optional = true }
 libp2p-swarm = { version = "0.17.0", path = "swarm" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-core"
 edition = "2018"
 description = "Core traits and structs of libp2p"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -20,7 +20,7 @@ futures-timer = "3"
 lazy_static = "1.2"
 libsecp256k1 = { version = "0.3.1", optional = true }
 log = "0.4"
-multiaddr = { package = "parity-multiaddr", version = "0.7.3", path = "../misc/multiaddr" }
+multiaddr = { package = "parity-multiaddr", version = "0.8.0", path = "../misc/multiaddr" }
 multihash = "0.10"
 multistream-select = { version = "0.8.0", path = "../misc/multistream-select" }
 parking_lot = "0.10.0"

--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -6,7 +6,7 @@ description = "Implementation of the multiaddr format"
 homepage = "https://github.com/libp2p/rust-libp2p"
 keywords = ["multiaddr", "ipfs"]
 license = "MIT"
-version = "0.7.3"
+version = "0.8.0"
 
 [dependencies]
 arrayref = "0.3"


### PR DESCRIPTION
Here's the situation:

- `parity-multiaddr` v0.7.2 on crates.io depends on `parity-multihash`.
- `parity-multiaddr` on the master branch depends on `multihash`.
- `libp2p-core` on the master branch depends on both `parity-multiaddr` v0.7.2 and `multihash` (not `parity-multihash`).

This causes compilation issues in `libp2p-mdns` because `libp2p_core::multihash::Multihash` is not the same type as `libp2p_core::multiaddr::multihash::Multihash`.

I noticed this issue while publishing version 0.17.0. Version 0.17.0 has been published except for `libp2p-mdns` (which has this compilation error) and `libp2p`.

Therefore this PR properly bumps `parity-multiaddr` to v0.8, and bumps `libp2p-core` to 0.17.1 in order to publish a fixed version.
