### PR TITLE
Disambiguate calls to NetworkBehaviour::inject_event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Version ???
 
+- `libp2p-core-derive`: Disambiguate calls to `NetworkBehaviour::inject_event`.
+  [PR 1543](https://github.com/libp2p/rust-libp2p/pull/1543)
+
 - `libp2p-floodsub`: Allow sent messages seen as subscribed.
   [PR 1520](https://github.com/libp2p/rust-libp2p/pull/1520)
 

--- a/misc/core-derive/src/lib.rs
+++ b/misc/core-derive/src/lib.rs
@@ -293,8 +293,8 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
         }
 
         Some(match field.ident {
-            Some(ref i) => quote!{ #elem => $trait_to_impl::inject_event(&mut self.#i, peer_id, connection_id, ev) },
-            None => quote!{ #elem => $trait_to_impl::inject_event(&mut self.#field_n, peer_id, connection_id, ev) },
+            Some(ref i) => quote!{ #elem => #trait_to_impl::inject_event(&mut self.#i, peer_id, connection_id, ev) },
+            None => quote!{ #elem => #trait_to_impl::inject_event(&mut self.#field_n, peer_id, connection_id, ev) },
         })
     });
 

--- a/misc/core-derive/src/lib.rs
+++ b/misc/core-derive/src/lib.rs
@@ -293,8 +293,8 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
         }
 
         Some(match field.ident {
-            Some(ref i) => quote!{ #elem => ::libp2p::swarm::NetworkBehaviour::inject_event(&mut self.#i, peer_id, connection_id, ev) },
-            None => quote!{ #elem => ::libp2p::swarm::NetworkBehaviour::inject_event(&mut self.#field_n, peer_id, connection_id, ev) },
+            Some(ref i) => quote!{ #elem => $trait_to_impl::inject_event(&mut self.#i, peer_id, connection_id, ev) },
+            None => quote!{ #elem => $trait_to_impl::inject_event(&mut self.#field_n, peer_id, connection_id, ev) },
         })
     });
 

--- a/misc/core-derive/src/lib.rs
+++ b/misc/core-derive/src/lib.rs
@@ -293,8 +293,8 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
         }
 
         Some(match field.ident {
-            Some(ref i) => quote!{ #elem => self.#i.inject_event(peer_id, connection_id, ev) },
-            None => quote!{ #elem => self.#field_n.inject_event(peer_id, connection_id, ev) },
+            Some(ref i) => quote!{ #elem => ::libp2p::swarm::NetworkBehaviour::inject_event(&mut self.#i, peer_id, connection_id, ev) },
+            None => quote!{ #elem => ::libp2p::swarm::NetworkBehaviour::inject_event(&mut self.#field_n, peer_id, connection_id, ev) },
         })
     });
 

--- a/misc/core-derive/tests/test.rs
+++ b/misc/core-derive/tests/test.rs
@@ -204,3 +204,35 @@ fn where_clause() {
         bar: T,
     }
 }
+
+#[test]
+fn nested_derives_with_import() {
+    use libp2p::swarm::NetworkBehaviourEventProcess;
+
+    #[allow(dead_code)]
+    #[derive(NetworkBehaviour)]
+    struct Foo {
+        ping: libp2p::ping::Ping,
+    }
+
+    #[allow(dead_code)]
+    #[derive(NetworkBehaviour)]
+    struct Bar {
+        foo: Foo,
+    }
+
+    impl NetworkBehaviourEventProcess<libp2p::ping::PingEvent> for Foo {
+        fn inject_event(&mut self, _: libp2p::ping::PingEvent) {
+        }
+    }
+
+    impl NetworkBehaviourEventProcess<()> for Bar {
+        fn inject_event(&mut self, _: ()) {
+        }
+    }
+
+    #[allow(dead_code)]
+    fn bar() {
+        require_net_behaviour::<Bar>();
+    }
+}


### PR DESCRIPTION
There is a gnarly edge-case with the custom-derive where rustc cannot disambiguate the call if:

- The NetworkBehaviourEventProcess trait is imported
- We nest NetworkBehaviours that use the custom-derive

Without this patch, the test errors with:

```
error[E0034]: multiple applicable items in scope
   --> misc/core-derive/tests/test.rs:219:14
    |
219 |     #[derive(NetworkBehaviour)]
    |              ^^^^^^^^^^^^^^^^ multiple `inject_event` found
    |
note: candidate #1 is defined in an impl of the trait `libp2p_swarm::behaviour::NetworkBehaviourEventProcess` for the type `nested_derives_with_import::Foo`
   --> misc/core-derive/tests/test.rs:225:9
    |
225 |         fn inject_event(&mut self, _: libp2p::ping::PingEvent) {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: candidate #2 is defined in an impl of the trait `libp2p_swarm::behaviour::NetworkBehaviour` for the type `nested_derives_with_import::Foo`
   --> misc/core-derive/tests/test.rs:213:14
    |
213 |     #[derive(NetworkBehaviour)]
    |              ^^^^^^^^^^^^^^^^
help: disambiguate the method call for candidate #1
    |
219 |     #[derive(libp2p_swarm::behaviour::NetworkBehaviourEventProcess::inject_event(&mut NetworkBehaviour, NetworkBehaviour, NetworkBehaviour, NetworkBehaviour))]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: disambiguate the method call for candidate #2
    |
219 |     #[derive(libp2p_swarm::behaviour::NetworkBehaviour::inject_event(&mut NetworkBehaviour, NetworkBehaviour, NetworkBehaviour, NetworkBehaviour))]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```