### PR TITLE
protocols/kad/behaviour: Return peers independent of record existence

### DIFF
--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -1278,13 +1278,7 @@ where
                     None => None
                 };
 
-                // If no record is found, at least report known closer peers.
-                let closer_peers =
-                    if record.is_none() {
-                        self.find_closest(&kbucket::Key::new(key), &source)
-                    } else {
-                        Vec::new()
-                    };
+                let closer_peers = self.find_closest(&kbucket::Key::new(key), &source);
 
                 self.queued_events.push_back(NetworkBehaviourAction::NotifyHandler {
                     peer_id: source,


### PR DESCRIPTION
A node receiving a `GetRecord` request first checks whether it has the given record. If it does have the record it does not return closer nodes. (See https://github.com/libp2p/rust-libp2p/blob/master/protocols/kad/src/behaviour.rs#L1268-L1287)

A node that knows the record for the given key is likely within a neighborhood of nodes that know the record as well. In addition the node likely knows its neighboorhood well.

When querying for a key with a quorum of 1 the above behavior of only returning the record but not any close peers is fine. Once one queries with a higher quorum having a node respond with the record as well as close nodes is likely going to speed up the query, given that the returned peers probably know the record as well.

This patch aligns the behavior of the `GetRecord` request with the [`GetProviderReq`](https://github.com/libp2p/rust-libp2p/blob/master/protocols/kad/src/behaviour.rs#L1218) behavior.

As far as I can tell the [Golang implementation](https://github.com/libp2p/go-libp2p-kad-dht/blob/master/handlers.go#L54-L90) follows the same suggested behavior.

What do you think @romanb 
