### PR TITLE
Spec-compliant Noise Protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,22 @@
 # Version ???
 
+- `libp2p-noise`: Added the `X25519Spec` protocol suite which uses
+  libp2p-noise-spec compliant signatures on static keys as well as the
+  `/noise` protocol upgrade, hence providing a libp2p-noise-spec compliant
+  `XX` handshake. `IK` and `IX` are still supported with `X25519Spec`
+  though not guaranteed to be interoperable with other libp2p
+  implementations as these handshake patterns are not currently
+  included in the libp2p-noise-spec. The `X25519Spec` implementation
+  will eventually replace the current `X25519` implementation, with
+  the former being removed. To upgrade without interruptions, you may
+  temporarily include `NoiseConfig`s for both implementations as
+  alternatives in your transport upgrade pipeline.
+
 - `libp2p-kad`: Consider fixed (K_VALUE) amount of peers at closest query
   initialization. Unless `KademliaConfig::set_replication_factor` is used change
   has no effect.
   [PR 1536](https://github.com/libp2p/rust-libp2p/pull/1536)
+
 - `libp2p-tcp`: On listeners started with an IPv6 multi-address the socket
   option `IPV6_V6ONLY` is set to true. Instead of relying on IPv4-mapped IPv6
   address support, two listeners can be started if IPv4 and IPv6 should both

--- a/protocols/noise/src/io/handshake/payload.proto
+++ b/protocols/noise/src/io/handshake/payload.proto
@@ -4,8 +4,8 @@ package payload.proto;
 
 // Payloads for Noise handshake messages.
 
-message Identity {
-	bytes pubkey = 1;
-	bytes signature = 2;
+message NoiseHandshakePayload {
+    bytes identity_key = 1;
+    bytes identity_sig = 2;
+    bytes data         = 3;
 }
-

--- a/protocols/noise/src/lib.rs
+++ b/protocols/noise/src/lib.rs
@@ -60,7 +60,8 @@ pub use io::NoiseOutput;
 pub use io::handshake;
 pub use io::handshake::{Handshake, RemoteIdentity, IdentityExchange};
 pub use protocol::{Keypair, AuthenticKeypair, KeypairIdentity, PublicKey, SecretKey};
-pub use protocol::{Protocol, ProtocolParams, x25519::X25519, IX, IK, XX};
+pub use protocol::{Protocol, ProtocolParams, IX, IK, XX};
+pub use protocol::{x25519::X25519, x25519_spec::X25519Spec};
 
 use futures::prelude::*;
 use libp2p_core::{identity, PeerId, UpgradeInfo, InboundUpgrade, OutboundUpgrade};

--- a/protocols/noise/src/lib.rs
+++ b/protocols/noise/src/lib.rs
@@ -27,6 +27,9 @@
 //! implementations for various noise handshake patterns (currently `IK`, `IX`, and `XX`)
 //! over a particular choice of Diffie–Hellman key agreement (currently only X25519).
 //!
+//! > **Note**: Only the `XX` handshake pattern is currently guaranteed to provide
+//! >           interoperability with other libp2p implementations.
+//!
 //! All upgrades produce as output a pair, consisting of the remote's static public key
 //! and a `NoiseOutput` which represents the established cryptographic session with the
 //! remote, implementing `futures::io::AsyncRead` and `futures::io::AsyncWrite`.
@@ -38,11 +41,11 @@
 //! ```
 //! use libp2p_core::{identity, Transport, upgrade};
 //! use libp2p_tcp::TcpConfig;
-//! use libp2p_noise::{Keypair, X25519, NoiseConfig};
+//! use libp2p_noise::{Keypair, X25519Spec, NoiseConfig};
 //!
 //! # fn main() {
 //! let id_keys = identity::Keypair::generate_ed25519();
-//! let dh_keys = Keypair::<X25519>::new().into_authentic(&id_keys).unwrap();
+//! let dh_keys = Keypair::<X25519Spec>::new().into_authentic(&id_keys).unwrap();
 //! let noise = NoiseConfig::xx(dh_keys).into_authenticated();
 //! let builder = TcpConfig::new().upgrade(upgrade::Version::V1).authenticate(noise);
 //! // let transport = builder.multiplex(...);

--- a/protocols/noise/src/protocol.rs
+++ b/protocols/noise/src/protocol.rs
@@ -72,6 +72,7 @@ pub trait Protocol<C> {
     ///
     /// The trivial case is when the keys are byte for byte identical.
     #[allow(unused_variables)]
+    #[deprecated]
     fn linked(id_pk: &identity::PublicKey, dh_pk: &PublicKey<C>) -> bool {
         false
     }
@@ -88,6 +89,7 @@ pub trait Protocol<C> {
     /// without a signature, otherwise a signature over the static DH public key
     /// must be given and is verified with the public identity key, establishing
     /// the authenticity of the static DH public key w.r.t. the public identity key.
+    #[allow(deprecated)]
     fn verify(id_pk: &identity::PublicKey, dh_pk: &PublicKey<C>, sig: &Option<Vec<u8>>) -> bool
     where
         C: AsRef<[u8]>

--- a/protocols/noise/src/protocol/x25519.rs
+++ b/protocols/noise/src/protocol/x25519.rs
@@ -18,7 +18,10 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! Noise protocols based on X25519.
+//! Legacy Noise protocols based on X25519.
+//!
+//! **Note**: This set of protocols is not interoperable with other
+//! libp2p implementations.
 
 use crate::{NoiseConfig, NoiseError, Protocol, ProtocolParams};
 use curve25519_dalek::edwards::CompressedEdwardsY;
@@ -92,7 +95,11 @@ impl<R> UpgradeInfo for NoiseConfig<IK, X25519, R> {
     }
 }
 
-/// Noise protocols for X25519.
+/// Legacy Noise protocol for X25519.
+///
+/// **Note**: This `Protocol` provides no configuration that
+/// is interoperable  with other libp2p implementations.
+/// See [`crate::X25519Spec`] instead.
 impl Protocol<X25519> for X25519 {
     fn params_ik() -> ProtocolParams {
         PARAMS_IK.clone()

--- a/protocols/noise/src/protocol/x25519_spec.rs
+++ b/protocols/noise/src/protocol/x25519_spec.rs
@@ -1,0 +1,148 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! libp2p-spec compliant Noise protocols based on X25519.
+
+use crate::{NoiseConfig, NoiseError, Protocol, ProtocolParams};
+use libp2p_core::UpgradeInfo;
+use libp2p_core::identity;
+use rand::Rng;
+use x25519_dalek::{X25519_BASEPOINT_BYTES, x25519};
+use zeroize::Zeroize;
+
+use super::{*, x25519::X25519};
+
+const STATIC_KEY_DOMAIN: &str = "noise-libp2p-static-key:";
+
+/// A X25519 key.
+#[derive(Clone)]
+pub struct X25519Spec([u8; 32]);
+
+impl AsRef<[u8]> for X25519Spec {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl Zeroize for X25519Spec {
+    fn zeroize(&mut self) {
+        self.0.zeroize()
+    }
+}
+
+impl Keypair<X25519Spec> {
+    /// Create a new X25519 keypair.
+    pub fn new() -> Keypair<X25519Spec> {
+        let mut sk_bytes = [0u8; 32];
+        rand::thread_rng().fill(&mut sk_bytes);
+        let sk = SecretKey(X25519Spec(sk_bytes)); // Copy
+        sk_bytes.zeroize();
+        Self::from(sk)
+    }
+}
+
+/// Promote a X25519 secret key into a keypair.
+impl From<SecretKey<X25519Spec>> for Keypair<X25519Spec> {
+    fn from(secret: SecretKey<X25519Spec>) -> Keypair<X25519Spec> {
+        let public = PublicKey(X25519Spec(x25519((secret.0).0, X25519_BASEPOINT_BYTES)));
+        Keypair { secret, public }
+    }
+}
+
+impl UpgradeInfo for NoiseConfig<XX, X25519Spec> {
+    type Info = &'static [u8];
+    type InfoIter = std::iter::Once<Self::Info>;
+
+    fn protocol_info(&self) -> Self::InfoIter {
+        std::iter::once(b"/noise")
+    }
+}
+
+/// Noise protocols for libp2p spec-compliant X25519.
+impl Protocol<X25519Spec> for X25519Spec {
+    fn params_ik() -> ProtocolParams {
+        unimplemented!("libp2p noise spec does not support IK.")
+    }
+
+    fn params_ix() -> ProtocolParams {
+        unimplemented!("libp2p noise spec does not support IX.")
+    }
+
+    fn params_xx() -> ProtocolParams {
+        X25519::params_xx()
+    }
+
+    fn public_from_bytes(bytes: &[u8]) -> Result<PublicKey<X25519Spec>, NoiseError> {
+        if bytes.len() != 32 {
+            return Err(NoiseError::InvalidKey)
+        }
+        let mut pk = [0u8; 32];
+        pk.copy_from_slice(bytes);
+        Ok(PublicKey(X25519Spec(pk)))
+    }
+
+    fn linked(_: &identity::PublicKey, _: &PublicKey<X25519Spec>) -> bool {
+        unimplemented!("libp2p noise spec does not support linked keys.")
+    }
+
+    fn verify(id_pk: &identity::PublicKey, dh_pk: &PublicKey<X25519Spec>, sig: &Option<Vec<u8>>) -> bool
+    {
+        sig.as_ref().map_or(false, |s| {
+            id_pk.verify(&[STATIC_KEY_DOMAIN.as_bytes(), dh_pk.as_ref()].concat(), s)
+        })
+    }
+
+    fn sign(id_keys: &identity::Keypair, dh_pk: &PublicKey<X25519Spec>) -> Result<Vec<u8>, NoiseError> {
+        Ok(id_keys.sign(&[STATIC_KEY_DOMAIN.as_bytes(), dh_pk.as_ref()].concat())?)
+    }
+}
+
+#[doc(hidden)]
+impl snow::types::Dh for Keypair<X25519Spec> {
+    fn name(&self) -> &'static str { "25519" }
+    fn pub_len(&self) -> usize { 32 }
+    fn priv_len(&self) -> usize { 32 }
+    fn pubkey(&self) -> &[u8] { self.public.as_ref() }
+    fn privkey(&self) -> &[u8] { self.secret.as_ref() }
+
+    fn set(&mut self, sk: &[u8]) {
+        let mut secret = [0u8; 32];
+        secret.copy_from_slice(&sk[..]);
+        self.secret = SecretKey(X25519Spec(secret)); // Copy
+        self.public = PublicKey(X25519Spec(x25519(secret, X25519_BASEPOINT_BYTES)));
+        secret.zeroize();
+    }
+
+    fn generate(&mut self, rng: &mut dyn snow::types::Random) {
+        let mut secret = [0u8; 32];
+        rng.fill_bytes(&mut secret);
+        self.secret = SecretKey(X25519Spec(secret)); // Copy
+        self.public = PublicKey(X25519Spec(x25519(secret, X25519_BASEPOINT_BYTES)));
+        secret.zeroize();
+    }
+
+    fn dh(&self, pk: &[u8], shared_secret: &mut [u8]) -> Result<(), ()> {
+        let mut p = [0; 32];
+        p.copy_from_slice(&pk[.. 32]);
+        let ss = x25519((self.secret.0).0, p);
+        shared_secret[.. 32].copy_from_slice(&ss[..]);
+        Ok(())
+    }
+}

--- a/protocols/noise/src/protocol/x25519_spec.rs
+++ b/protocols/noise/src/protocol/x25519_spec.rs
@@ -18,7 +18,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! libp2p-spec compliant Noise protocols based on X25519.
+//! [libp2p-noise-spec] compliant Noise protocols based on X25519.
+//!
+//! [libp2p-noise-spec]: https://github.com/libp2p/specs/tree/master/noise
 
 use crate::{NoiseConfig, NoiseError, Protocol, ProtocolParams};
 use libp2p_core::UpgradeInfo;
@@ -29,6 +31,7 @@ use zeroize::Zeroize;
 
 use super::{*, x25519::X25519};
 
+/// Prefix of static key signatures for domain separation.
 const STATIC_KEY_DOMAIN: &str = "noise-libp2p-static-key:";
 
 /// A X25519 key.
@@ -75,14 +78,17 @@ impl UpgradeInfo for NoiseConfig<XX, X25519Spec> {
     }
 }
 
-/// Noise protocols for libp2p spec-compliant X25519.
+/// Noise protocols for X25519 with libp2p-spec compliant signatures.
+///
+/// **Note**: Only the XX handshake pattern is currently guaranteed to be
+/// interoperable with other libp2p implementations.
 impl Protocol<X25519Spec> for X25519Spec {
     fn params_ik() -> ProtocolParams {
-        unimplemented!("libp2p noise spec does not support IK.")
+        X25519::params_ik()
     }
 
     fn params_ix() -> ProtocolParams {
-        unimplemented!("libp2p noise spec does not support IX.")
+        X25519::params_ix()
     }
 
     fn params_xx() -> ProtocolParams {
@@ -96,10 +102,6 @@ impl Protocol<X25519Spec> for X25519Spec {
         let mut pk = [0u8; 32];
         pk.copy_from_slice(bytes);
         Ok(PublicKey(X25519Spec(pk)))
-    }
-
-    fn linked(_: &identity::PublicKey, _: &PublicKey<X25519Spec>) -> bool {
-        unimplemented!("libp2p noise spec does not support linked keys.")
     }
 
     fn verify(id_pk: &identity::PublicKey, dh_pk: &PublicKey<X25519Spec>, sig: &Option<Vec<u8>>) -> bool


### PR DESCRIPTION
This PR is a proposal for adding a [libp2p-spec compliant](https://github.com/libp2p/specs/pull/260) Noise `Protocol` implementation for `x25519`, called `X25519Spec`. The differences to the existing `X25519` protocol are:

  1. The spec-compliant protocol neither supports `IK` nor `IX`.
  2. The spec-compliant protocol adds the `noise-libp2p-static-key:` prefix for signing and verifying static DH keys, i.e. a domain separator.
  3. The spec-compliant protocol uses just `/noise` as the name for the protocol upgrade.

Please shout if I missed something required for spec compliance.

As an upgrade path, both a `NoiseConfig::xx` based on a `Keypair<X25519Spec>` as well as some other `NoiseConfig` based on a `Keypair<X25519>` could be used with a `SelectUpgrade`.

The protobuf changes are purely cosmetical, since luckily the same protobuf is used for both protocols.

If we eventually _only_ want to support the spec-compliant protocol, we could just replace `X25519Spec -> X25519` together with a few simplifications, like removing `IK` and `IX`.