### PR TITLE
Treat connection limit errors as pending connection errors.

### DIFF
--- a/core/src/connection/error.rs
+++ b/core/src/connection/error.rs
@@ -29,10 +29,6 @@ pub enum ConnectionError<THandlerErr> {
     // TODO: Eventually this should also be a custom error?
     IO(io::Error),
 
-    /// The connection was dropped because the connection limit
-    /// for a peer has been reached.
-    ConnectionLimit(ConnectionLimit),
-
     /// The connection handler produced an error.
     Handler(THandlerErr),
 }
@@ -48,8 +44,6 @@ where
                 write!(f, "Connection error: I/O error: {}", err),
             ConnectionError::Handler(err) =>
                 write!(f, "Connection error: Handler error: {}", err),
-            ConnectionError::ConnectionLimit(l) =>
-                write!(f, "Connection error: Connection limit: {}.", l)
         }
     }
 }
@@ -63,7 +57,6 @@ where
         match self {
             ConnectionError::IO(err) => Some(err),
             ConnectionError::Handler(err) => Some(err),
-            ConnectionError::ConnectionLimit(..) => None,
         }
     }
 }
@@ -77,6 +70,10 @@ pub enum PendingConnectionError<TTransErr> {
     /// The peer identity obtained on the connection did not
     /// match the one that was expected or is otherwise invalid.
     InvalidPeerId,
+
+    /// The connection was dropped because the connection limit
+    /// for a peer has been reached.
+    ConnectionLimit(ConnectionLimit),
 
     /// An I/O error occurred on the connection.
     // TODO: Eventually this should also be a custom error?
@@ -96,6 +93,8 @@ where
                 write!(f, "Pending connection: Transport error: {}", err),
             PendingConnectionError::InvalidPeerId =>
                 write!(f, "Pending connection: Invalid peer ID."),
+            PendingConnectionError::ConnectionLimit(l) =>
+                write!(f, "Connection error: Connection limit: {}.", l),
         }
     }
 }
@@ -110,6 +109,7 @@ where
             PendingConnectionError::IO(err) => Some(err),
             PendingConnectionError::Transport(err) => Some(err),
             PendingConnectionError::InvalidPeerId => None,
+            PendingConnectionError::ConnectionLimit(..) => None,
         }
     }
 }

--- a/core/src/network.rs
+++ b/core/src/network.rs
@@ -567,7 +567,6 @@ where
                 (None, NetworkEvent::UnknownPeerDialError {
                     multiaddr: address,
                     error,
-                    handler,
                 }),
             ConnectedPoint::Listener { local_addr, send_back_addr } =>
                 (None, NetworkEvent::IncomingConnectionError {

--- a/core/src/network.rs
+++ b/core/src/network.rs
@@ -512,7 +512,7 @@ fn on_connection_failed<'a, TTrans, TInEvent, TOutEvent, THandler, TConnInfo, TP
     id: ConnectionId,
     endpoint: ConnectedPoint,
     error: PendingConnectionError<TTrans::Error>,
-    handler: THandler,
+    handler: Option<THandler>,
 ) -> (Option<DialingOpts<TPeerId, THandler>>, NetworkEvent<'a, TTrans, TInEvent, TOutEvent, THandler, TConnInfo, TPeerId>)
 where
     TTrans: Transport,
@@ -533,22 +533,29 @@ where
         let num_remain = u32::try_from(attempt.next.len()).unwrap();
         let failed_addr = attempt.current.clone();
 
-        let opts =
+        let (opts, attempts_remaining) =
             if num_remain > 0 {
-                let next_attempt = attempt.next.remove(0);
-                let opts = DialingOpts {
-                    peer: peer_id.clone(),
-                    handler,
-                    address: next_attempt,
-                    remaining: attempt.next
-                };
-                Some(opts)
+                if let Some(handler) = handler {
+                    let next_attempt = attempt.next.remove(0);
+                    let opts = DialingOpts {
+                        peer: peer_id.clone(),
+                        handler,
+                        address: next_attempt,
+                        remaining: attempt.next
+                    };
+                    (Some(opts), num_remain)
+                } else {
+                    // The error is "fatal" for the dialing attempt, since
+                    // the handler was already consumed. All potential
+                    // remaining connection attempts are thus void.
+                    (None, 0)
+                }
             } else {
-                None
+                (None, 0)
             };
 
         (opts, NetworkEvent::DialError {
-            attempts_remaining: num_remain,
+            attempts_remaining,
             peer_id,
             multiaddr: failed_addr,
             error,

--- a/core/src/network/event.rs
+++ b/core/src/network/event.rs
@@ -149,7 +149,7 @@ where
 
         /// The handler that was passed to `dial()`, if the
         /// connection failed before the handler was consumed.
-        handler: THandler,
+        handler: Option<THandler>,
     },
 
     /// An established connection produced an event.

--- a/core/src/network/event.rs
+++ b/core/src/network/event.rs
@@ -146,10 +146,6 @@ where
 
         /// The error that happened.
         error: PendingConnectionError<TTrans::Error>,
-
-        /// The handler that was passed to `dial()`, if the
-        /// connection failed before the handler was consumed.
-        handler: Option<THandler>,
     },
 
     /// An established connection produced an event.


### PR DESCRIPTION
Currently connection limit errors emitted by a `Pool` when the per-peer connection limit is reached are emitted as `ConnectionError`s as soon as background task reports the connection as established, i.e. there is never a `ConnectionEstablished` event emitted in these cases. This is problematic for two reasons:

  1. The `Network` code itself actually relies on an outgoing connection attempt to finish either with `PendingConnectionError` or `ConnectionEstablished`, otherwise there may even be a leak of entries in `self.dialing` which never get removed.

  2. It actually was the intention that `Network::ConnectionEstablished` events are always paired up 1-1 with `Network::ConnectionError` events (though the latter should probably be renamed to `ConnectionClosed`). The `Swarm` relies on this behaviour and maps `ConnectionError` to `SwarmEvent::ConnectionClosed`, as well as invoking `NetworkBehaviour::inject_connection_closed`, which may consequently be invoked for connections for which `inject_connection_established` was never called.

In summary, the per-peer connection limit is currently not safe to use. These problems are addressed here by having the `Pool` emit a `PendingConnectionError` instead when the limit of established connections of a peer is hit, thus moving the `ConnectionError::ConnectionLimit` to `PendingConnectionError::ConnectionLimit`.

This was supposedly observed via an underflowing counter in a network behaviour that tracks the number of established connections via `inject_connection_established` / `inject_connection_closed`.

I didn't get around yet to write a proper test case for this scenario, which I still intend to do, possibly in a follow-up PR, but since the patch is relatively simple and may want to be released relatively quickly, I'm already opening the PR as-is.