### PR TITLE
Publish 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 # Version ???
 
+
+# Version 0.18.0 (2020-04-09)
+
+- `libp2p-core`: Treat connection limit errors as pending connection errors.
+  [PR 1546](https://github.com/libp2p/rust-libp2p/pull/1546)
+
 - `libp2p-core-derive`: Disambiguate calls to `NetworkBehaviour::inject_event`.
   [PR 1543](https://github.com/libp2p/rust-libp2p/pull/1543)
 
 - `libp2p-floodsub`: Allow sent messages seen as subscribed.
   [PR 1520](https://github.com/libp2p/rust-libp2p/pull/1520)
+
+- `libp2p-kad`: Return peers independent of record existence.
+  [PR 1544](https://github.com/libp2p/rust-libp2p/pull/1544)
 
 - `libp2p-wasm-ext`: Fix "parsed is null" errors being thrown.
   [PR 1535](https://github.com/libp2p/rust-libp2p/pull/1535)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p"
 edition = "2018"
 description = "Peer-to-peer networking library"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -57,33 +57,33 @@ futures = "0.3.1"
 multiaddr = { package = "parity-multiaddr", version = "0.8.0", path = "misc/multiaddr" }
 multihash = "0.10"
 lazy_static = "1.2"
-libp2p-mplex = { version = "0.17.0", path = "muxers/mplex", optional = true }
-libp2p-identify = { version = "0.17.0", path = "protocols/identify", optional = true }
-libp2p-kad = { version = "0.17.0", path = "protocols/kad", optional = true }
-libp2p-floodsub = { version = "0.17.0", path = "protocols/floodsub", optional = true }
-libp2p-gossipsub = { version = "0.17.0", path = "./protocols/gossipsub", optional = true }
-libp2p-ping = { version = "0.17.0", path = "protocols/ping", optional = true }
-libp2p-plaintext = { version = "0.17.0", path = "protocols/plaintext", optional = true }
-libp2p-pnet = { version = "0.17.0", path = "protocols/pnet", optional = true }
-libp2p-core = { version = "0.17.1", path = "core" }
-libp2p-core-derive = { version = "0.17.0", path = "misc/core-derive" }
-libp2p-secio = { version = "0.17.0", path = "protocols/secio", default-features = false, optional = true }
-libp2p-swarm = { version = "0.17.0", path = "swarm" }
-libp2p-uds = { version = "0.17.0", path = "transports/uds", optional = true }
-libp2p-wasm-ext = { version = "0.17.0", path = "transports/wasm-ext", optional = true }
-libp2p-yamux = { version = "0.17.0", path = "muxers/yamux", optional = true }
-libp2p-noise = { version = "0.17.0", path = "protocols/noise", optional = true }
+libp2p-mplex = { version = "0.18.0", path = "muxers/mplex", optional = true }
+libp2p-identify = { version = "0.18.0", path = "protocols/identify", optional = true }
+libp2p-kad = { version = "0.18.0", path = "protocols/kad", optional = true }
+libp2p-floodsub = { version = "0.18.0", path = "protocols/floodsub", optional = true }
+libp2p-gossipsub = { version = "0.18.0", path = "./protocols/gossipsub", optional = true }
+libp2p-ping = { version = "0.18.0", path = "protocols/ping", optional = true }
+libp2p-plaintext = { version = "0.18.0", path = "protocols/plaintext", optional = true }
+libp2p-pnet = { version = "0.18.0", path = "protocols/pnet", optional = true }
+libp2p-core = { version = "0.18.0", path = "core" }
+libp2p-core-derive = { version = "0.18.0", path = "misc/core-derive" }
+libp2p-secio = { version = "0.18.0", path = "protocols/secio", default-features = false, optional = true }
+libp2p-swarm = { version = "0.18.0", path = "swarm" }
+libp2p-uds = { version = "0.18.0", path = "transports/uds", optional = true }
+libp2p-wasm-ext = { version = "0.18.0", path = "transports/wasm-ext", optional = true }
+libp2p-yamux = { version = "0.18.0", path = "muxers/yamux", optional = true }
+libp2p-noise = { version = "0.18.0", path = "protocols/noise", optional = true }
 parking_lot = "0.10.0"
 pin-project = "0.4.6"
 smallvec = "1.0"
 wasm-timer = "0.2.4"
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "unknown")))'.dependencies]
-libp2p-deflate = { version = "0.17.0", path = "protocols/deflate", optional = true }
-libp2p-dns = { version = "0.17.0", path = "transports/dns", optional = true }
-libp2p-mdns = { version = "0.17.0", path = "protocols/mdns", optional = true }
-libp2p-tcp = { version = "0.17.0", path = "transports/tcp", optional = true }
-libp2p-websocket = { version = "0.17.0", path = "transports/websocket", optional = true }
+libp2p-deflate = { version = "0.18.0", path = "protocols/deflate", optional = true }
+libp2p-dns = { version = "0.18.0", path = "transports/dns", optional = true }
+libp2p-mdns = { version = "0.18.0", path = "protocols/mdns", optional = true }
+libp2p-tcp = { version = "0.18.0", path = "transports/tcp", optional = true }
+libp2p-websocket = { version = "0.18.0", path = "transports/websocket", optional = true }
 
 [dev-dependencies]
 async-std = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-core"
 edition = "2018"
 description = "Core traits and structs of libp2p"
-version = "0.17.1"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -40,9 +40,9 @@ ring = { version = "0.16.9", features = ["alloc", "std"], default-features = fal
 
 [dev-dependencies]
 async-std = "1.0"
-libp2p-mplex = { version = "0.17.0", path = "../muxers/mplex" }
-libp2p-secio = { version = "0.17.0", path = "../protocols/secio" }
-libp2p-tcp = { version = "0.17.0", path = "../transports/tcp" }
+libp2p-mplex = { version = "0.18.0", path = "../muxers/mplex" }
+libp2p-secio = { version = "0.18.0", path = "../protocols/secio" }
+libp2p-tcp = { version = "0.18.0", path = "../transports/tcp" }
 quickcheck = "0.9.0"
 wasm-timer = "0.2"
 

--- a/misc/core-derive/Cargo.toml
+++ b/misc/core-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-core-derive"
 edition = "2018"
 description = "Procedural macros of libp2p-core"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -17,4 +17,4 @@ syn = { version = "1.0.8", default-features = false, features = ["clone-impls", 
 quote = "1.0"
 
 [dev-dependencies]
-libp2p = { version = "0.17.0", path = "../.." }
+libp2p = { version = "0.18.0", path = "../.." }

--- a/misc/peer-id-generator/Cargo.toml
+++ b/misc/peer-id-generator/Cargo.toml
@@ -11,5 +11,5 @@ categories = ["network-programming", "asynchronous"]
 publish = false
 
 [dependencies]
-libp2p-core = { version = "0.17.0", path = "../../core" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
 num_cpus = "1.8"

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-mplex"
 edition = "2018"
 description = "Mplex multiplexing protocol for libp2p"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -14,11 +14,11 @@ bytes = "0.5"
 fnv = "1.0"
 futures = "0.3.1"
 futures_codec = "0.3.4"
-libp2p-core = { version = "0.17.0", path = "../../core" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
 log = "0.4"
 parking_lot = "0.10"
 unsigned-varint = { version = "0.3", features = ["futures-codec"] }
 
 [dev-dependencies]
 async-std = "1.0"
-libp2p-tcp = { version = "0.17.0", path = "../../transports/tcp" }
+libp2p-tcp = { version = "0.18.0", path = "../../transports/tcp" }

--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-yamux"
 edition = "2018"
 description = "Yamux multiplexing protocol for libp2p"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.17.0", path = "../../core" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
 parking_lot = "0.10"
 thiserror = "1.0"
 yamux = "0.4.5"

--- a/protocols/deflate/Cargo.toml
+++ b/protocols/deflate/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-deflate"
 edition = "2018"
 description = "Deflate encryption protocol for libp2p"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,11 +11,11 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.17.0", path = "../../core" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
 flate2 = "1.0"
 
 [dev-dependencies]
 async-std = "1.0"
-libp2p-tcp = { version = "0.17.0", path = "../../transports/tcp" }
+libp2p-tcp = { version = "0.18.0", path = "../../transports/tcp" }
 rand = "0.7"
 quickcheck = "0.9"

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-floodsub"
 edition = "2018"
 description = "Floodsub protocol for libp2p"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -13,8 +13,8 @@ categories = ["network-programming", "asynchronous"]
 cuckoofilter = "0.3.2"
 fnv = "1.0"
 futures = "0.3.1"
-libp2p-core = { version = "0.17.0", path = "../../core" }
-libp2p-swarm = { version = "0.17.0", path = "../../swarm" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
+libp2p-swarm = { version = "0.18.0", path = "../../swarm" }
 prost = "0.6.1"
 rand = "0.7"
 smallvec = "1.0"

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-gossipsub"
 edition = "2018"
 description = "Gossipsub protocol for libp2p"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Age Manning <Age@AgeManning.com>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -10,8 +10,8 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-libp2p-swarm = { version = "0.17.0", path = "../../swarm" }
-libp2p-core = { version = "0.17.0", path = "../../core" }
+libp2p-swarm = { version = "0.18.0", path = "../../swarm" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
 bytes = "0.5.4"
 byteorder = "1.3.2"
 fnv = "1.0.6"
@@ -30,8 +30,8 @@ prost = "0.6.1"
 [dev-dependencies]
 async-std = "1.4.0"
 env_logger = "0.7.1"
-libp2p-plaintext = { version = "0.17.0", path = "../plaintext" }
-libp2p-yamux = { version = "0.17.0", path = "../../muxers/yamux" }
+libp2p-plaintext = { version = "0.18.0", path = "../plaintext" }
+libp2p-yamux = { version = "0.18.0", path = "../../muxers/yamux" }
 quickcheck = "0.9.2"
 
 [build-dependencies]

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-identify"
 edition = "2018"
 description = "Nodes identifcation protocol for libp2p"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,8 +11,8 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.17.0", path = "../../core" }
-libp2p-swarm = { version = "0.17.0", path = "../../swarm" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
+libp2p-swarm = { version = "0.18.0", path = "../../swarm" }
 log = "0.4.1"
 prost = "0.6.1"
 smallvec = "1.0"
@@ -20,9 +20,9 @@ wasm-timer = "0.2"
 
 [dev-dependencies]
 async-std = "1.0"
-libp2p-mplex = { version = "0.17.0", path = "../../muxers/mplex" }
-libp2p-secio = { version = "0.17.0", path = "../../protocols/secio" }
-libp2p-tcp = { version = "0.17.0", path = "../../transports/tcp" }
+libp2p-mplex = { version = "0.18.0", path = "../../muxers/mplex" }
+libp2p-secio = { version = "0.18.0", path = "../../protocols/secio" }
+libp2p-tcp = { version = "0.18.0", path = "../../transports/tcp" }
 
 [build-dependencies]
 prost-build = "0.6"

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-kad"
 edition = "2018"
 description = "Kademlia protocol for libp2p"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -17,8 +17,8 @@ fnv = "1.0"
 futures_codec = "0.3.4"
 futures = "0.3.1"
 log = "0.4"
-libp2p-core = { version = "0.17.0", path = "../../core" }
-libp2p-swarm = { version = "0.17.0", path = "../../swarm" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
+libp2p-swarm = { version = "0.18.0", path = "../../swarm" }
 multihash = "0.10"
 prost = "0.6.1"
 rand = "0.7.2"
@@ -30,8 +30,8 @@ unsigned-varint = { version = "0.3", features = ["futures-codec"] }
 void = "1.0"
 
 [dev-dependencies]
-libp2p-secio = { version = "0.17.0", path = "../secio" }
-libp2p-yamux = { version = "0.17.0", path = "../../muxers/yamux" }
+libp2p-secio = { version = "0.18.0", path = "../secio" }
+libp2p-yamux = { version = "0.18.0", path = "../../muxers/yamux" }
 quickcheck = "0.9.0"
 
 [build-dependencies]

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-mdns"
 edition = "2018"
-version = "0.17.0"
+version = "0.18.0"
 description = "Implementation of the libp2p mDNS discovery method"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
@@ -16,8 +16,8 @@ dns-parser = "0.8"
 either = "1.5.3"
 futures = "0.3.1"
 lazy_static = "1.2"
-libp2p-core = { version = "0.17.0", path = "../../core" }
-libp2p-swarm = { version = "0.17.0", path = "../../swarm" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
+libp2p-swarm = { version = "0.18.0", path = "../../swarm" }
 log = "0.4"
 net2 = "0.2"
 rand = "0.7"

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-noise"
 description = "Cryptographic handshake protocol using the noise framework."
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,7 +11,7 @@ edition = "2018"
 curve25519-dalek = "2.0.0"
 futures = "0.3.1"
 lazy_static = "1.2"
-libp2p-core = { version = "0.17.0", path = "../../core" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
 log = "0.4"
 prost = "0.6.1"
 rand = "0.7.2"
@@ -28,7 +28,7 @@ snow = { version = "0.6.1", features = ["default-resolver"], default-features = 
 
 [dev-dependencies]
 env_logger = "0.7.1"
-libp2p-tcp = { version = "0.17.0", path = "../../transports/tcp" }
+libp2p-tcp = { version = "0.18.0", path = "../../transports/tcp" }
 quickcheck = "0.9.0"
 sodiumoxide = "^0.2.5"
 

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-ping"
 edition = "2018"
 description = "Ping protocol for libp2p"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,8 +11,8 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.17.0", path = "../../core" }
-libp2p-swarm = { version = "0.17.0", path = "../../swarm" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
+libp2p-swarm = { version = "0.18.0", path = "../../swarm" }
 log = "0.4.1"
 rand = "0.7.2"
 void = "1.0"
@@ -20,7 +20,7 @@ wasm-timer = "0.2"
 
 [dev-dependencies]
 async-std = "1.0"
-libp2p-tcp = { version = "0.17.0", path = "../../transports/tcp" }
-libp2p-secio = { version = "0.17.0", path = "../../protocols/secio" }
-libp2p-yamux = { version = "0.17.0", path = "../../muxers/yamux" }
+libp2p-tcp = { version = "0.18.0", path = "../../transports/tcp" }
+libp2p-secio = { version = "0.18.0", path = "../../protocols/secio" }
+libp2p-yamux = { version = "0.18.0", path = "../../muxers/yamux" }
 quickcheck = "0.9.0"

--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-plaintext"
 edition = "2018"
 description = "Plaintext encryption dummy protocol for libp2p"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 bytes = "0.5"
 futures = "0.3.1"
 futures_codec = "0.3.4"
-libp2p-core = { version = "0.17.0", path = "../../core" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
 log = "0.4.8"
 prost = "0.6.1"
 rw-stream-sink = "0.2.0"

--- a/protocols/pnet/Cargo.toml
+++ b/protocols/pnet/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-pnet"
 edition = "2018"
 description = "Private swarm support for libp2p"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-secio"
 edition = "2018"
 description = "Secio encryption protocol for libp2p"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -16,7 +16,7 @@ ctr = "0.3"
 futures = "0.3.1"
 hmac = "0.7.0"
 lazy_static = "1.2.0"
-libp2p-core = { version = "0.17.0", path = "../../core" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
 log = "0.4.6"
 prost = "0.6.1"
 pin-project = "0.4.6"
@@ -48,8 +48,8 @@ aes-all = ["aesni"]
 [dev-dependencies]
 async-std = "1.0"
 criterion = "0.3"
-libp2p-mplex = { version = "0.17.0", path = "../../muxers/mplex" }
-libp2p-tcp = { version = "0.17.0", path = "../../transports/tcp" }
+libp2p-mplex = { version = "0.18.0", path = "../../muxers/mplex" }
+libp2p-tcp = { version = "0.18.0", path = "../../transports/tcp" }
 
 [[bench]]
 name = "bench"

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-swarm"
 edition = "2018"
 description = "The libp2p swarm"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.17.0", path = "../core" }
+libp2p-core = { version = "0.18.0", path = "../core" }
 log = "0.4"
 rand = "0.7"
 smallvec = "1.0"
@@ -19,6 +19,6 @@ wasm-timer = "0.2"
 void = "1"
 
 [dev-dependencies]
-libp2p-mplex = { version = "0.17.0", path = "../muxers/mplex" }
+libp2p-mplex = { version = "0.18.0", path = "../muxers/mplex" }
 quickcheck = "0.9.0"
 rand = "0.7.2"

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-dns"
 edition = "2018"
 description = "DNS transport implementation for libp2p"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -10,6 +10,6 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-libp2p-core = { version = "0.17.0", path = "../../core" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
 log = "0.4.1"
 futures = "0.3.1"

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-tcp"
 edition = "2018"
 description = "TCP/IP transport protocol for libp2p"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -15,7 +15,7 @@ futures = "0.3.1"
 futures-timer = "3.0"
 get_if_addrs = "0.5.3"
 ipnet = "2.0.0"
-libp2p-core = { version = "0.17.0", path = "../../core" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
 log = "0.4.1"
 tokio = { version = "0.2", default-features = false, features = ["tcp"], optional = true }
 

--- a/transports/uds/Cargo.toml
+++ b/transports/uds/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-uds"
 edition = "2018"
 description = "Unix domain sockets transport for libp2p"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [target.'cfg(all(unix, not(any(target_os = "emscripten", target_os = "unknown"))))'.dependencies]
 async-std = { version = "1.0", optional = true }
-libp2p-core = { version = "0.17.0", path = "../../core" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
 log = "0.4.1"
 futures = "0.3.1"
 tokio = { version = "0.2", default-features = false, features = ["uds"], optional = true }

--- a/transports/wasm-ext/Cargo.toml
+++ b/transports/wasm-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-wasm-ext"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 edition = "2018"
 description = "Allows passing in an external transport in a WASM environment"
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 futures = "0.3.1"
 js-sys = "0.3.19"
-libp2p-core = { version = "0.17.0", path = "../../core" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
 parity-send-wrapper = "0.1.0"
 wasm-bindgen = "0.2.42"
 wasm-bindgen-futures = "0.4.4"

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-websocket"
 edition = "2018"
 description = "WebSocket transport for libp2p"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -14,7 +14,7 @@ async-tls = "0.7.0"
 bytes = "0.5"
 either = "1.5.3"
 futures = "0.3.1"
-libp2p-core = { version = "0.17.0", path = "../../core" }
+libp2p-core = { version = "0.18.0", path = "../../core" }
 log = "0.4.8"
 quicksink = "0.1"
 rustls = "0.17.0"
@@ -25,4 +25,4 @@ webpki = "0.21"
 webpki-roots = "0.18"
 
 [dev-dependencies]
-libp2p-tcp = { version = "0.17.0", path = "../tcp" }
+libp2p-tcp = { version = "0.18.0", path = "../tcp" }


### PR DESCRIPTION
We're publishing 0.18.0 as it turns out that #1546 is a pretty important fix.

To be merged on top of https://github.com/libp2p/rust-libp2p/pull/1546
