### PR TITLE
Make sure inject_dial_failure is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Version ???
 
+
+# Version 0.18.1 (2020-04-17)
+
 - `libp2p-swarm`: Make sure inject_dial_failure is called in all situations.
   [PR 1549](https://github.com/libp2p/rust-libp2p/pull/1549)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Version ???
 
+- `libp2p-swarm`: Make sure inject_dial_failure is called in all situations.
+  [PR 1549](https://github.com/libp2p/rust-libp2p/pull/1549)
 
 # Version 0.18.0 (2020-04-09)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p"
 edition = "2018"
 description = "Peer-to-peer networking library"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ libp2p-pnet = { version = "0.18.0", path = "protocols/pnet", optional = true }
 libp2p-core = { version = "0.18.0", path = "core" }
 libp2p-core-derive = { version = "0.18.0", path = "misc/core-derive" }
 libp2p-secio = { version = "0.18.0", path = "protocols/secio", default-features = false, optional = true }
-libp2p-swarm = { version = "0.18.0", path = "swarm" }
+libp2p-swarm = { version = "0.18.1", path = "swarm" }
 libp2p-uds = { version = "0.18.0", path = "transports/uds", optional = true }
 libp2p-wasm-ext = { version = "0.18.0", path = "transports/wasm-ext", optional = true }
 libp2p-yamux = { version = "0.18.0", path = "muxers/yamux", optional = true }

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-swarm"
 edition = "2018"
 description = "The libp2p swarm"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -740,7 +740,7 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                                     this.behaviour.inject_dial_failure(&peer_id);
                                 }
                             }
-                        };
+                        }
                     }
                 },
                 Poll::Ready(NetworkBehaviourAction::NotifyHandler { peer_id, handler, event }) => {

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -733,8 +733,6 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                             if let Some(mut peer) = this.network.peer(peer_id.clone()).into_dialing() {
                                 let addrs = this.behaviour.addresses_of_peer(peer.id());
                                 peer.connection().add_addresses(addrs);
-                            } else {
-                                this.behaviour.inject_dial_failure(&peer_id);
                             }
                         };
                     }

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -730,9 +730,15 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                         } else {
                             log::trace!("Condition for new dialing attempt to {:?} not met: {:?}",
                                 peer_id, condition);
-                            if let Some(mut peer) = this.network.peer(peer_id.clone()).into_dialing() {
-                                let addrs = this.behaviour.addresses_of_peer(peer.id());
-                                peer.connection().add_addresses(addrs);
+                            match this.network.peer(peer_id.clone()) {
+                                Peer::Dialing(mut peer) => {
+                                    let addrs = this.behaviour.addresses_of_peer(peer.id());
+                                    peer.connection().add_addresses(addrs);
+                                },
+                                Peer::Connected(_) => {},
+                                Peer::Disconnected(..) | Peer::Local => {
+                                    this.behaviour.inject_dial_failure(&peer_id);
+                                }
                             }
                         };
                     }

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -730,15 +730,9 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                         } else {
                             log::trace!("Condition for new dialing attempt to {:?} not met: {:?}",
                                 peer_id, condition);
-                            match this.network.peer(peer_id.clone()) {
-                                Peer::Dialing(mut peer) => {
-                                    let addrs = this.behaviour.addresses_of_peer(peer.id());
-                                    peer.connection().add_addresses(addrs);
-                                },
-                                Peer::Connected(_) => {},
-                                Peer::Disconnected(..) | Peer::Local => {
-                                    this.behaviour.inject_dial_failure(&peer_id);
-                                }
+                            if let Some(mut peer) = this.network.peer(peer_id.clone()).into_dialing() {
+                                let addrs = this.behaviour.addresses_of_peer(peer.id());
+                                peer.connection().add_addresses(addrs);
                             }
                         }
                     }

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -403,6 +403,12 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                             return Err(error)
                         }
                     }
+                } else {
+                    log::debug!(
+                        "New dialing attempt to disconnected peer {:?} failed: no address.",
+                        peer_id
+                    );
+                    me.behaviour.inject_dial_failure(&peer_id);
                 }
                 Ok(false)
             },
@@ -419,6 +425,12 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                             return Err(error)
                         }
                     }
+                } else {
+                    log::debug!(
+                        "New dialing attempt to disconnected peer {:?} failed: no address.",
+                        peer_id
+                    );
+                    me.behaviour.inject_dial_failure(&peer_id);
                 }
                 Ok(false)
             }
@@ -427,6 +439,7 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                 Ok(false)
             },
             Peer::Local => {
+                me.behaviour.inject_dial_failure(&peer_id);
                 Err(ConnectionLimit { current: 0, limit: 0 })
             }
         }
@@ -701,36 +714,29 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                     if this.banned_peers.contains(&peer_id) {
                         this.behaviour.inject_dial_failure(&peer_id);
                     } else {
-                        let result = match condition {
+                        let condition_matched = match condition {
                             DialPeerCondition::Disconnected
-                                if this.network.is_disconnected(&peer_id) =>
-                            {
-                                ExpandedSwarm::dial(this, &peer_id)
-                            }
+                                if this.network.is_disconnected(&peer_id) => true,
                             DialPeerCondition::NotDialing
-                                if !this.network.is_dialing(&peer_id) =>
-                            {
-                                ExpandedSwarm::dial(this, &peer_id)
-                            }
-                            _ => {
-                                log::trace!("Condition for new dialing attempt to {:?} not met: {:?}",
-                                    peer_id, condition);
-                                if let Some(mut peer) = this.network.peer(peer_id.clone()).into_dialing() {
-                                    let addrs = this.behaviour.addresses_of_peer(peer.id());
-                                    peer.connection().add_addresses(addrs);
-                                }
-                                Ok(false)
-                            }
+                                if !this.network.is_dialing(&peer_id) => true,
+                            _ => false
                         };
-                        match result {
-                            Ok(false) => {},
-                            Ok(true) => return Poll::Ready(SwarmEvent::Dialing(peer_id)),
-                            Err(err) => {
-                                log::debug!("Initiating dialing attempt to {:?} failed: {:?}",
-                                    &peer_id, err);
+
+                        if condition_matched {
+                            if let Ok(true) = ExpandedSwarm::dial(this, &peer_id) {
+                                return Poll::Ready(SwarmEvent::Dialing(peer_id));
+                            }
+
+                        } else {
+                            log::trace!("Condition for new dialing attempt to {:?} not met: {:?}",
+                                peer_id, condition);
+                            if let Some(mut peer) = this.network.peer(peer_id.clone()).into_dialing() {
+                                let addrs = this.behaviour.addresses_of_peer(peer.id());
+                                peer.connection().add_addresses(addrs);
+                            } else {
                                 this.behaviour.inject_dial_failure(&peer_id);
                             }
-                        }
+                        };
                     }
                 },
                 Poll::Ready(NetworkBehaviourAction::NotifyHandler { peer_id, handler, event }) => {


### PR DESCRIPTION
Context: https://github.com/paritytech/substrate/issues/5684

There is an assumption right now in Substrate's code (and probably other) that, after we call `dial` or emit a `DialPeer`, the `inject_dial_failure` method is called if we know that we won't be able to reach the given node.

This is not the case right now in the situation where `addresses_of_peer` returns an empty list. In that situation, we ask the `Swarm` to connect to a node, and don't get any event whatsoever about that node ever again.

This PR modifies `dial` to emit the event if necessary, and simplifies the handling of `DialPeer` to rely more on the behaviour of `dial`.

In generally, I wish it was precisely documented and explained what happens in which situation, and that it is possible in any situation to track the state of each connection attempt, but that's a later change.
While I think it's be reasonable to ask @romanb to handle and review that, he's unfortunately on vacation right now.
