### PR TITLE
fix: NetworkBehaviour crash if ignoring a non-last struct field

### DIFF
--- a/misc/core-derive/src/lib.rs
+++ b/misc/core-derive/src/lib.rs
@@ -288,7 +288,7 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
             quote!{ ev }
         };
 
-        for _ in 0 .. data_struct.fields.iter().filter(|f| !is_ignored(f)).count() - 1 - field_n {
+        for _ in 0 .. data_struct.fields.iter().filter(|f| !is_ignored(f)).count() - 1 - enum_n {
             elem = quote!{ #either_ident::First(#elem) };
         }
 
@@ -378,7 +378,7 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
         } else {
             quote!{ event }
         };
-        for _ in 0 .. data_struct.fields.iter().filter(|f| !is_ignored(f)).count() - 1 - field_n {
+        for _ in 0 .. data_struct.fields.iter().filter(|f| !is_ignored(f)).count() - 1 - enum_n {
             wrapped_event = quote!{ #either_ident::First(#wrapped_event) };
         }
 

--- a/misc/core-derive/tests/test.rs
+++ b/misc/core-derive/tests/test.rs
@@ -110,6 +110,33 @@ fn three_fields() {
 }
 
 #[test]
+fn three_fields_non_last_ignored() {
+    #[allow(dead_code)]
+    #[derive(NetworkBehaviour)]
+    struct Foo {
+        ping: libp2p::ping::Ping,
+        #[behaviour(ignore)]
+        identify: String,
+        kad: libp2p::kad::Kademlia<libp2p::kad::record::store::MemoryStore>,
+    }
+
+    impl libp2p::swarm::NetworkBehaviourEventProcess<libp2p::ping::PingEvent> for Foo {
+        fn inject_event(&mut self, _: libp2p::ping::PingEvent) {
+        }
+    }
+
+    impl libp2p::swarm::NetworkBehaviourEventProcess<libp2p::kad::KademliaEvent> for Foo {
+        fn inject_event(&mut self, _: libp2p::kad::KademliaEvent) {
+        }
+    }
+
+    #[allow(dead_code)]
+    fn foo() {
+        require_net_behaviour::<Foo>();
+    }
+}
+
+#[test]
 fn custom_polling() {
     #[allow(dead_code)]
     #[derive(NetworkBehaviour)]


### PR DESCRIPTION
Macro was using field_n (field index including ignored fields) for calculations instad of
enum_n (field index excluding ignored fields). When calculating the nesting the calculation
was made between the number of non-ignored fields and a field_n that lead to integer overflow.

Fixes #1553 