### PR TITLE
Add a method to create a pre shared key when you have the raw bytes

### DIFF
--- a/protocols/pnet/src/lib.rs
+++ b/protocols/pnet/src/lib.rs
@@ -55,6 +55,11 @@ const FINGERPRINT_SIZE: usize = 16;
 pub struct PreSharedKey([u8; KEY_SIZE]);
 
 impl PreSharedKey {
+    /// Create a new pre shared key from raw bytes
+    pub fn new(data: [u8; KEY_SIZE]) -> Self {
+        Self(data)
+    }
+
     /// Compute PreSharedKey fingerprint identical to the go-libp2p fingerprint.
     /// The computation of the fingerprint is not specified in the spec.
     ///


### PR DESCRIPTION
This was an oversight of the original impl. Currently the only way to make a PSK is by parsing a PSK file. But sometimes you already have the raw bytes.

The raw bytes are just random data, so there is no harm in having a method to create a PreSharedKey
from the raw bytes.