### PR TITLE
protocols/kad/query/fixed: Decrease num_waiting on failure

### DIFF
--- a/protocols/kad/src/query/peers/fixed.rs
+++ b/protocols/kad/src/query/peers/fixed.rs
@@ -76,9 +76,10 @@ impl FixedPeersIter {
     }
 
     pub fn on_failure(&mut self, peer: &PeerId) {
-        if let State::Waiting { .. } = &self.state {
+        if let State::Waiting { num_waiting } = &mut self.state {
             if let Some(state @ PeerState::Waiting) = self.peers.get_mut(peer) {
                 *state = PeerState::Failed;
+                *num_waiting -= 1;
             }
         }
     }
@@ -133,3 +134,30 @@ impl FixedPeersIter {
     }
 }
 
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn decrease_num_waiting_on_failure() {
+        let mut iter = FixedPeersIter::new(vec![PeerId::random(), PeerId::random()], 1);
+
+        match iter.next() {
+            PeersIterState::Waiting(Some(peer)) => {
+                let peer = peer.into_owned();
+                iter.on_failure(&peer);
+            },
+            _ => panic!("Expected iterator to yield peer."),
+        }
+
+        match iter.next() {
+            PeersIterState::Waiting(Some(_)) => {},
+            PeersIterState::WaitingAtCapacity => panic!(
+                "Expected iterator to return another peer given that the \
+                 previous `on_failure` call should have allowed another peer \
+                 to be queried.",
+            ),
+            _ => panic!("Expected iterator to yield peer."),
+        }
+    }
+}


### PR DESCRIPTION
Make sure to decrease `num_waiting` when being notified of a peer
failure to allow an additional peer to be queried.

Given that `FixedPeersIter` is initialized with `replication_factor` by
`QueryPool` this bug will not surface today.