### PR TITLE
protocols/kad: Remove unnecessary PeerId conversion for fixed iter

### DIFF
--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -761,7 +761,6 @@ where
             }
 
             QueryInfo::PrepareAddProvider { key, context } => {
-                let closest_peers = result.peers.map(kbucket::Key::from);
                 let provider_id = params.local_peer_id().clone();
                 let external_addresses = params.external_addresses().collect();
                 let inner = QueryInner::new(QueryInfo::AddProvider {
@@ -770,7 +769,7 @@ where
                     external_addresses,
                     context,
                 });
-                self.queries.add_fixed(closest_peers, inner);
+                self.queries.add_fixed(result.peers, inner);
                 None
             }
 
@@ -799,7 +798,7 @@ where
                         let context = PutRecordContext::Cache;
                         let info = QueryInfo::PutRecord { record, quorum, context, num_results: 0 };
                         let inner = QueryInner::new(info);
-                        self.queries.add_fixed(iter::once(cache_key), inner);
+                        self.queries.add_fixed(iter::once(cache_key.into_preimage()), inner);
                     }
                     Ok(GetRecordOk { records })
                 } else if records.is_empty() {
@@ -814,10 +813,9 @@ where
             }
 
             QueryInfo::PreparePutRecord { record, quorum, context } => {
-                let closest_peers = result.peers.map(kbucket::Key::from);
                 let info = QueryInfo::PutRecord { record, quorum, context, num_results: 0 };
                 let inner = QueryInner::new(info);
-                self.queries.add_fixed(closest_peers, inner);
+                self.queries.add_fixed(result.peers, inner);
                 None
             }
 

--- a/protocols/kad/src/query.rs
+++ b/protocols/kad/src/query.rs
@@ -89,9 +89,8 @@ impl<TInner> QueryPool<TInner> {
     /// Adds a query to the pool that contacts a fixed set of peers.
     pub fn add_fixed<I>(&mut self, peers: I, inner: TInner) -> QueryId
     where
-        I: IntoIterator<Item = Key<PeerId>>
+        I: IntoIterator<Item = PeerId>
     {
-        let peers = peers.into_iter().map(|k| k.into_preimage()).collect::<Vec<_>>();
         let parallelism = self.config.replication_factor.get();
         let peer_iter = QueryPeerIter::Fixed(FixedPeersIter::new(peers, parallelism));
         self.add(peer_iter, inner)
@@ -295,4 +294,3 @@ pub struct QueryResult<TInner, TPeers> {
     /// The successfully contacted peers.
     pub peers: TPeers
 }
-

--- a/protocols/kad/src/query/peers/fixed.rs
+++ b/protocols/kad/src/query/peers/fixed.rs
@@ -57,7 +57,12 @@ enum PeerState {
 }
 
 impl FixedPeersIter {
-    pub fn new(peers: Vec<PeerId>, parallelism: usize) -> Self {
+    pub fn new<I>(peers: I, parallelism: usize) -> Self
+    where
+        I: IntoIterator<Item = PeerId>
+    {
+        let peers = peers.into_iter().collect::<Vec<_>>();
+
         Self {
             parallelism,
             peers: FnvHashMap::default(),


### PR DESCRIPTION
`FixedPeersIter` requires the initial set of peers to be passed as
`PeerId`s and not as `Key<PeerId>`s. This commit removes the unnecessary
conversion.

(*I would expect rustc or llvm to optimize this away anyways. I find it still worth
 it to reduce complexity.*)