### PR TITLE
Make the number of events buffered to/from tasks configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
   attempts per peer, with a configurable limit.
   [PR 1506](https://github.com/libp2p/rust-libp2p/pull/1506)
 
+- `libp2p-core`: Updated to multihash 0.11.0.
+  [PR 1566](https://github.com/libp2p/rust-libp2p/pull/1566)
+
+- `libp2p-core`: Make the number of events buffered to/from tasks configurable.
+
 - `libp2p-noise`: Added the `X25519Spec` protocol suite which uses
   libp2p-noise-spec compliant signatures on static keys as well as the
   `/noise` protocol upgrade, hence providing a libp2p-noise-spec compliant
@@ -26,8 +31,6 @@
   address support, two listeners can be started if IPv4 and IPv6 should both
   be supported. IPv4 listener addresses are not affected by this change.
   [PR 1555](https://github.com/libp2p/rust-libp2p/pull/1555)
-
-- `libp2p-core`: Updated to multihash 0.11.0.
 
 # Version 0.18.1 (2020-04-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   [PR 1566](https://github.com/libp2p/rust-libp2p/pull/1566)
 
 - `libp2p-core`: Make the number of events buffered to/from tasks configurable.
+  [PR 1574](https://github.com/libp2p/rust-libp2p/pull/1574)
 
 - `libp2p-noise`: Added the `X25519Spec` protocol suite which uses
   libp2p-noise-spec compliant signatures on static keys as well as the

--- a/core/src/connection/manager.rs
+++ b/core/src/connection/manager.rs
@@ -133,7 +133,7 @@ where
 /// Configuration options when creating a [`Manager`].
 ///
 /// The default configuration specifies no dedicated task executor, a
-/// "from task" channel size of 32, and a "to task" channel size of 7.
+/// task event buffer size of 32, and a task command buffer size of 7.
 #[non_exhaustive]
 pub struct ManagerConfig {
     /// Executor to use to spawn tasks.

--- a/core/src/connection/manager.rs
+++ b/core/src/connection/manager.rs
@@ -99,8 +99,7 @@ pub struct Manager<I, O, H, E, HE, C> {
     /// Next available identifier for a new connection / task.
     next_task_id: TaskId,
 
-    /// Configuration for the size of the channel from the manager to
-    /// newly-created tasks.
+    /// Size of the task command buffer (per task).
     to_task_channel_size: usize,
 
     /// The executor to use for running the background tasks. If `None`,
@@ -140,10 +139,10 @@ pub struct ManagerConfig {
     /// Executor to use to spawn tasks.
     pub executor: Option<Box<dyn Executor + Send>>,
 
-    /// Size of the channel from the manager to newly-created tasks.
+    /// Size of the task command buffer (per task).
     pub to_task_channel_size: usize,
 
-    /// Size of the channel from background tasks to the manager.
+    /// Size of the task event buffer (for all tasks).
     pub from_task_channel_size: usize,
 }
 

--- a/core/src/connection/pool.rs
+++ b/core/src/connection/pool.rs
@@ -19,7 +19,6 @@
 // DEALINGS IN THE SOFTWARE.
 
 use crate::{
-    Executor,
     ConnectedPoint,
     PeerId,
     connection::{
@@ -36,7 +35,7 @@ use crate::{
         OutgoingInfo,
         Substream,
         PendingConnectionError,
-        manager::{self, Manager},
+        manager::{self, Manager, ManagerConfig},
     },
     muxing::StreamMuxer,
 };
@@ -175,13 +174,13 @@ where
     /// Creates a new empty `Pool`.
     pub fn new(
         local_id: TPeerId,
-        executor: Option<Box<dyn Executor + Send>>,
+        manager_config: ManagerConfig,
         limits: PoolLimits
     ) -> Self {
         Pool {
             local_id,
             limits,
-            manager: Manager::new(executor),
+            manager: Manager::new(manager_config),
             established: Default::default(),
             pending: Default::default(),
         }

--- a/core/src/network.rs
+++ b/core/src/network.rs
@@ -644,7 +644,7 @@ impl NetworkConfig {
     /// longer be able to deliver events to the associated `ConnectionHandler`,
     /// thus exerting back-pressure on the connection and peer API.
     pub fn set_notify_handler_buffer_size(&mut self, n: NonZeroUsize) -> &mut Self {
-        self.manager_config.to_task_channel_size = n.get() - 1;
+        self.manager_config.task_command_buffer_size = n.get() - 1;
         self
     }
 
@@ -653,9 +653,9 @@ impl NetworkConfig {
     ///
     /// When the buffer is full, the background tasks of all connections will stall.
     /// In this way, the consumers of network events exert back-pressure on
-    /// the network connection I/O. 
+    /// the network connection I/O.
     pub fn set_connection_event_buffer_size(&mut self, n: usize) -> &mut Self {
-        self.manager_config.from_task_channel_size = n;
+        self.manager_config.task_event_buffer_size = n;
         self
     }
 

--- a/core/src/network.rs
+++ b/core/src/network.rs
@@ -605,11 +605,9 @@ pub struct NetworkInfo {
 /// `notify_handler` buffer size of 8.
 #[derive(Default)]
 pub struct NetworkConfig {
-    /// Note that `ManagerConfig` doesn't contain the number of buffered
-    /// events, but rather the size of the channel (which is an
-    /// implementation detail). When it comes to the "to task buffer events"
-    /// configuration option, the size of the channel is the number of
-    /// buffered events minus one.
+    /// Note that the `ManagerConfig`s task command buffer always provides
+    /// one "free" slot per task. Thus the given total `notify_handler_buffer_size`
+    /// exposed for configuration on the `Network` is reduced by one.
     manager_config: ManagerConfig,
     pool_limits: PoolLimits,
 }

--- a/core/src/network.rs
+++ b/core/src/network.rs
@@ -601,8 +601,8 @@ pub struct NetworkInfo {
 /// The (optional) configuration for a [`Network`].
 ///
 /// The default configuration specifies no dedicated task executor, no
-/// connection limits, a "from task" extra buffer size of 1, and a
-/// "to task" buffer size of 5.
+/// connection limits, a "from task" extra buffer size of 32, and a
+/// "to task" buffer size of 8.
 #[derive(Default)]
 pub struct NetworkConfig {
     /// Note that `ManagerConfig` doesn't contain the number of buffered

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -123,7 +123,7 @@ use registry::{Addresses, AddressIntoIter};
 use smallvec::SmallVec;
 use std::{error, fmt, hash::Hash, io, ops::{Deref, DerefMut}, pin::Pin, task::{Context, Poll}};
 use std::collections::HashSet;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 use upgrade::UpgradeInfoSend as _;
 
 /// Contains the state of the network, plus the way it should behave.
@@ -999,6 +999,48 @@ where TBehaviour: NetworkBehaviour,
     /// [`SwarmBuilder::build`] will try to set up a `ThreadPool`.
     pub fn executor(mut self, e: Box<dyn Executor + Send>) -> Self {
         self.network_config.set_executor(e);
+        self
+    }
+
+    /// Configures the number of events from the [`NetworkBehaviour`] in
+    /// destination to the [`ProtocolsHandler`] that can be buffered before
+    /// the [`Swarm`] has to wait. An individual buffer with this number of
+    /// events exists for each individual connection.
+    ///
+    /// The ideal value depends on the executor used, the CPU speed, and the
+    /// volume of events. If this value is too low, then the [`Swarm`] will
+    /// be sleeping more often than necessary. Increasing this value increases
+    /// the overall memory usage.
+    pub fn to_task_buffered_events(mut self, n: NonZeroUsize) -> Self {
+        self.network_config.set_to_task_buffered_events(n);
+        self
+    }
+
+    /// Configures the number of extra events from the [`ProtocolsHandler`] in
+    /// destination to the [`NetworkBehaviour`] that can be buffered before
+    /// the [`ProtocolsHandler`] has to go to sleep.
+    ///
+    /// There exists a buffer of events received from [`ProtocolsHandler`]s
+    /// that the [`NetworkBehaviour`] has yet to process. This buffer is
+    /// shared between all instances of [`ProtocolsHandler`]. Each instance of
+    /// [`ProtocolsHandler`] is guaranteed one slot in this buffer, meaning
+    /// that delivering an event for the first time is guaranteed to be
+    /// instantaneous. Any extra event delivery, however, must wait for that
+    /// first event to be delivered or for an "extra slot" to be available.
+    ///
+    /// This option configures the number of such "extra slots" in this
+    /// shared buffer. These extra slots are assigned in a first-come,
+    /// first-served basis.
+    ///
+    /// The ideal value depends on the executor used, the CPU speed, the
+    /// average number of connections, and the volume of events. If this value
+    /// is too low, then the [`ProtocolsHandler`]s will be sleeping more often
+    /// than necessary. Increasing this value increases the overall memory
+    /// usage, and more importantly the latency between the moment when an
+    /// event is emitted and the moment when it is received by the
+    /// [`NetworkBehaviour`].
+    pub fn from_task_extra_buffered_events(mut self, n: usize) -> Self {
+        self.network_config.set_from_task_extra_buffered_events(n);
         self
     }
 

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1012,7 +1012,7 @@ where TBehaviour: NetworkBehaviour,
     /// be sleeping more often than necessary. Increasing this value increases
     /// the overall memory usage.
     pub fn notify_handler_buffer_size(mut self, n: NonZeroUsize) -> Self {
-        self.network_config.set_to_task_buffered_events(n);
+        self.network_config.set_notify_handler_buffer_size(n);
         self
     }
 
@@ -1040,7 +1040,7 @@ where TBehaviour: NetworkBehaviour,
     /// event is emitted and the moment when it is received by the
     /// [`NetworkBehaviour`].
     pub fn connection_event_buffer_size(mut self, n: usize) -> Self {
-        self.network_config.set_from_task_extra_buffered_events(n);
+        self.network_config.set_connection_event_buffer_size(n);
         self
     }
 

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1011,7 +1011,7 @@ where TBehaviour: NetworkBehaviour,
     /// volume of events. If this value is too low, then the [`Swarm`] will
     /// be sleeping more often than necessary. Increasing this value increases
     /// the overall memory usage.
-    pub fn to_task_buffered_events(mut self, n: NonZeroUsize) -> Self {
+    pub fn notify_handler_buffer_size(mut self, n: NonZeroUsize) -> Self {
         self.network_config.set_to_task_buffered_events(n);
         self
     }
@@ -1039,7 +1039,7 @@ where TBehaviour: NetworkBehaviour,
     /// usage, and more importantly the latency between the moment when an
     /// event is emitted and the moment when it is received by the
     /// [`NetworkBehaviour`].
-    pub fn from_task_extra_buffered_events(mut self, n: usize) -> Self {
+    pub fn connection_event_buffer_size(mut self, n: usize) -> Self {
         self.network_config.set_from_task_extra_buffered_events(n);
         self
     }


### PR DESCRIPTION
cc https://github.com/paritytech/substrate/issues/6009

Hints seem to indicate that we have some CPU issues in Substrate from the low number of events that can be buffered. This PR makes this limit configurable.

Additionally, this PR increases these values: the channel size from tasks to the swarm is now 32 (instead of 1!), and the channel size from the swarm to each task is now 7 (so 8 in practice).

When reviewing, keep in mind that channels reserve an extra element for each active sender, as documented: https://docs.rs/futures/0.3.5/futures/channel/mpsc/fn.channel.html


(I also slightly fixed the CHANGELOG to be alphabetically-ordered)

