### PR TITLE
Support /dns protocol in multiaddr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 - `libp2p-core`: Make the number of events buffered to/from tasks configurable.
   [PR 1574](https://github.com/libp2p/rust-libp2p/pull/1574)
 
+- `libp2p-dns`, `parity-multiaddr`: Added support for the `/dns` multiaddr
+  protocol. Additionally, the `multiaddr::from_url` function will now use
+  `/dns` instead of `/dns4`.
+  [PR 1575](https://github.com/libp2p/rust-libp2p/pull/1575)
+
 - `libp2p-noise`: Added the `X25519Spec` protocol suite which uses
   libp2p-noise-spec compliant signatures on static keys as well as the
   `/noise` protocol upgrade, hence providing a libp2p-noise-spec compliant

--- a/core/src/translation.rs
+++ b/core/src/translation.rs
@@ -37,9 +37,14 @@ use multiaddr::{Multiaddr, Protocol};
 /// If the first [`Protocol`]s are not IP addresses, `None` is returned instead.
 pub fn address_translation(original: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
     original.replace(0, move |proto| match proto {
-        Protocol::Ip4(_) | Protocol::Ip6(_) | Protocol::Dns4(_) | Protocol::Dns6(_) => match observed.iter().next() {
+        Protocol::Ip4(_)
+        | Protocol::Ip6(_)
+        | Protocol::Dns(_)
+        | Protocol::Dns4(_)
+        | Protocol::Dns6(_) => match observed.iter().next() {
             x @ Some(Protocol::Ip4(_)) => x,
             x @ Some(Protocol::Ip6(_)) => x,
+            x @ Some(Protocol::Dns(_)) => x,
             x @ Some(Protocol::Dns4(_)) => x,
             x @ Some(Protocol::Dns6(_)) => x,
             _ => None,

--- a/misc/multiaddr/src/from_url.rs
+++ b/misc/multiaddr/src/from_url.rs
@@ -70,7 +70,7 @@ fn from_url_inner_http_ws(url: url::Url, lossy: bool) -> std::result::Result<Mul
         if let Ok(ip) = hostname.parse::<IpAddr>() {
             Protocol::from(ip)
         } else {
-            Protocol::Dns4(hostname.into())
+            Protocol::Dns(hostname.into())
         }
     } else {
         return Err(FromUrlErr::BadUrl);
@@ -185,31 +185,31 @@ mod tests {
     #[test]
     fn dns_addr_ws() {
         let addr = from_url("ws://example.com").unwrap();
-        assert_eq!(addr, "/dns4/example.com/tcp/80/ws".parse().unwrap());
+        assert_eq!(addr, "/dns/example.com/tcp/80/ws".parse().unwrap());
     }
 
     #[test]
     fn dns_addr_http() {
         let addr = from_url("http://example.com").unwrap();
-        assert_eq!(addr, "/dns4/example.com/tcp/80/http".parse().unwrap());
+        assert_eq!(addr, "/dns/example.com/tcp/80/http".parse().unwrap());
     }
 
     #[test]
     fn dns_addr_wss() {
         let addr = from_url("wss://example.com").unwrap();
-        assert_eq!(addr, "/dns4/example.com/tcp/443/wss".parse().unwrap());
+        assert_eq!(addr, "/dns/example.com/tcp/443/wss".parse().unwrap());
     }
 
     #[test]
     fn dns_addr_https() {
         let addr = from_url("https://example.com").unwrap();
-        assert_eq!(addr, "/dns4/example.com/tcp/443/https".parse().unwrap());
+        assert_eq!(addr, "/dns/example.com/tcp/443/https".parse().unwrap());
     }
 
     #[test]
     fn bad_hostname() {
         let addr = from_url("wss://127.0.0.1x").unwrap();
-        assert_eq!(addr, "/dns4/127.0.0.1x/tcp/443/wss".parse().unwrap());
+        assert_eq!(addr, "/dns/127.0.0.1x/tcp/443/wss".parse().unwrap());
     }
 
     #[test]
@@ -223,7 +223,7 @@ mod tests {
     #[test]
     fn dns_and_port() {
         let addr = from_url("http://example.com:1000").unwrap();
-        assert_eq!(addr, "/dns4/example.com/tcp/1000/http".parse().unwrap());
+        assert_eq!(addr, "/dns/example.com/tcp/1000/http".parse().unwrap());
     }
 
     #[test]

--- a/misc/multiaddr/tests/lib.rs
+++ b/misc/multiaddr/tests/lib.rs
@@ -76,36 +76,37 @@ struct Proto(Protocol<'static>);
 impl Arbitrary for Proto {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         use Protocol::*;
-        match g.gen_range(0, 24) { // TODO: Add Protocol::Quic
+        match g.gen_range(0, 25) { // TODO: Add Protocol::Quic
              0 => Proto(Dccp(g.gen())),
-             1 => Proto(Dns4(Cow::Owned(SubString::arbitrary(g).0))),
-             2 => Proto(Dns6(Cow::Owned(SubString::arbitrary(g).0))),
-             3 => Proto(Http),
-             4 => Proto(Https),
-             5 => Proto(Ip4(Ipv4Addr::arbitrary(g))),
-             6 => Proto(Ip6(Ipv6Addr::arbitrary(g))),
-             7 => Proto(P2pWebRtcDirect),
-             8 => Proto(P2pWebRtcStar),
-             9 => Proto(P2pWebSocketStar),
-            10 => Proto(Memory(g.gen())),
+             1 => Proto(Dns(Cow::Owned(SubString::arbitrary(g).0))),
+             2 => Proto(Dns4(Cow::Owned(SubString::arbitrary(g).0))),
+             3 => Proto(Dns6(Cow::Owned(SubString::arbitrary(g).0))),
+             4 => Proto(Http),
+             5 => Proto(Https),
+             6 => Proto(Ip4(Ipv4Addr::arbitrary(g))),
+             7 => Proto(Ip6(Ipv6Addr::arbitrary(g))),
+             8 => Proto(P2pWebRtcDirect),
+             9 => Proto(P2pWebRtcStar),
+            10 => Proto(P2pWebSocketStar),
+            11 => Proto(Memory(g.gen())),
             // TODO: impl Arbitrary for Multihash:
-            11 => Proto(P2p(multihash("QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"))),
-            12 => Proto(P2pCircuit),
-            13 => Proto(Quic),
-            14 => Proto(Sctp(g.gen())),
-            15 => Proto(Tcp(g.gen())),
-            16 => Proto(Udp(g.gen())),
-            17 => Proto(Udt),
-            18 => Proto(Unix(Cow::Owned(SubString::arbitrary(g).0))),
-            19 => Proto(Utp),
-            20 => Proto(Ws("/".into())),
-            21 => Proto(Wss("/".into())),
-            22 => {
+            12 => Proto(P2p(multihash("QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"))),
+            13 => Proto(P2pCircuit),
+            14 => Proto(Quic),
+            15 => Proto(Sctp(g.gen())),
+            16 => Proto(Tcp(g.gen())),
+            17 => Proto(Udp(g.gen())),
+            18 => Proto(Udt),
+            19 => Proto(Unix(Cow::Owned(SubString::arbitrary(g).0))),
+            20 => Proto(Utp),
+            21 => Proto(Ws("/".into())),
+            22 => Proto(Wss("/".into())),
+            23 => {
                 let mut a = [0; 10];
                 g.fill(&mut a);
                 Proto(Onion(Cow::Owned(a), g.gen_range(1, std::u16::MAX)))
             },
-            23 => {
+            24 => {
                 let mut a = [0; 35];
                 g.fill_bytes(&mut a);
                 Proto(Onion3((a, g.gen_range(1, std::u16::MAX)).into()))

--- a/transports/websocket/src/framed.rs
+++ b/transports/websocket/src/framed.rs
@@ -373,7 +373,7 @@ fn location_to_multiaddr<T>(location: &str) -> Result<Multiaddr, Error<T>> {
             let mut a = Multiaddr::empty();
             match url.host() {
                 Some(url::Host::Domain(h)) => {
-                    a.push(Protocol::Dns4(h.into()))
+                    a.push(Protocol::Dns(h.into()))
                 }
                 Some(url::Host::Ipv4(ip)) => {
                     a.push(Protocol::Ip4(ip))

--- a/transports/websocket/src/framed.rs
+++ b/transports/websocket/src/framed.rs
@@ -353,6 +353,8 @@ fn host_and_dnsname<T>(addr: &Multiaddr) -> Result<(String, Option<webpki::DNSNa
             Ok((format!("{}:{}", ip, port), None)),
         (Some(Protocol::Ip6(ip)), Some(Protocol::Tcp(port))) =>
             Ok((format!("{}:{}", ip, port), None)),
+        (Some(Protocol::Dns(h)), Some(Protocol::Tcp(port))) =>
+            Ok((format!("{}:{}", &h, port), Some(tls::dns_name_ref(&h)?.to_owned()))),
         (Some(Protocol::Dns4(h)), Some(Protocol::Tcp(port))) =>
             Ok((format!("{}:{}", &h, port), Some(tls::dns_name_ref(&h)?.to_owned()))),
         (Some(Protocol::Dns6(h)), Some(Protocol::Tcp(port))) =>


### PR DESCRIPTION
The `/dns` protocol has been added to the spec and has had a de-facto meaning for years (citing https://github.com/multiformats/multiaddr/pull/100)

This adds address parsing and encoding support for `/dns` to the multiaddr library.