### PR TITLE
Display the identity hash of PeerIds when relevant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
   attempts per peer, with a configurable limit.
   [PR 1506](https://github.com/libp2p/rust-libp2p/pull/1506)
 
+- `libp2p-core`: `PeerId`s that use the identity hashing will now be properly
+  displayed using the string representation of an identity multihash, rather
+  than the canonical SHA 256 representation.
+  [PR 1576](https://github.com/libp2p/rust-libp2p/pull/1576)
+
 - `libp2p-noise`: Added the `X25519Spec` protocol suite which uses
   libp2p-noise-spec compliant signatures on static keys as well as the
   `/noise` protocol upgrade, hence providing a libp2p-noise-spec compliant

--- a/core/src/peer_id.rs
+++ b/core/src/peer_id.rs
@@ -147,7 +147,7 @@ impl PeerId {
 
     /// Returns a base-58 encoded string of this `PeerId`.
     pub fn to_base58(&self) -> String {
-        bs58::encode(self.borrow() as &[u8]).into_string()
+        bs58::encode(self.as_bytes()).into_string()
     }
 
     /// Checks whether the public key passed as parameter matches the public key of this `PeerId`.


### PR DESCRIPTION
The `Debug` and `Display` implementations call `to_base58()`.
This PR transitions `to_base58()` to the "proper" string representation of the `PeerId`.

In other words, identity `PeerId`s will now start with `1...` rather than `Qm...`