### PR TITLE
Keep consistency with Upgrade Inbound by using PING_SIZE

### DIFF
--- a/protocols/ping/src/protocol.rs
+++ b/protocols/ping/src/protocol.rs
@@ -83,7 +83,7 @@ where
     type Future = BoxFuture<'static, Result<Duration, io::Error>>;
 
     fn upgrade_outbound(self, mut socket: TSocket, _: Self::Info) -> Self::Future {
-        let payload: [u8; 32] = thread_rng().sample(distributions::Standard);
+        let payload: [u8; PING_SIZE] = thread_rng().sample(distributions::Standard);
         debug!("Preparing ping payload {:?}", payload);
         async move {
             socket.write_all(&payload).await?;


### PR DESCRIPTION
although 32 is prefect fine in our case, it would be consistent to use the const value PING_SIZE.