### PR TITLE
Readd lost noise upgrades.

### DIFF
--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -28,7 +28,7 @@ snow = { version = "0.6.1", features = ["default-resolver"], default-features = 
 
 [dev-dependencies]
 env_logger = "0.7.1"
-libp2p-tcp = { version = "0.19.0", path = "../../transports/tcp" }
+libp2p-tcp = { version = "0.19.0", path = "../../transports/tcp", features = ["async-std"] }
 quickcheck = "0.9.0"
 sodiumoxide = "^0.2.5"
 

--- a/protocols/noise/src/protocol/x25519_spec.rs
+++ b/protocols/noise/src/protocol/x25519_spec.rs
@@ -78,6 +78,26 @@ impl UpgradeInfo for NoiseConfig<XX, X25519Spec> {
     }
 }
 
+/// **Note**: This is not currentlyy a standardised upgrade.
+impl UpgradeInfo for NoiseConfig<IX, X25519Spec> {
+    type Info = &'static [u8];
+    type InfoIter = std::iter::Once<Self::Info>;
+
+    fn protocol_info(&self) -> Self::InfoIter {
+        std::iter::once(b"/noise/ix/25519/chachapoly/sha256/0.1.0")
+    }
+}
+
+/// **Note**: This is not currently a standardised upgrade.
+impl<R> UpgradeInfo for NoiseConfig<IK, X25519Spec, R> {
+    type Info = &'static [u8];
+    type InfoIter = std::iter::Once<Self::Info>;
+
+    fn protocol_info(&self) -> Self::InfoIter {
+        std::iter::once(b"/noise/ik/25519/chachapoly/sha256/0.1.0")
+    }
+}
+
 /// Noise protocols for X25519 with libp2p-spec compliant signatures.
 ///
 /// **Note**: Only the XX handshake pattern is currently guaranteed to be


### PR DESCRIPTION
This readds the (non-standardised/specced) `UpgradeInfo` implementations for `IK` and `IX` to `X25519Spec` which got lost in the back-and-forth of https://github.com/libp2p/rust-libp2p/pull/1545. It also enables the `async-std` feature for the `libp2p-tcp` dependency in the tests, so that the `libp2p-noise` tests compile again on their own.