### PR TITLE
[RFC][libp2p-swarm] Let network I/O run ahead of NetworkBehaviour polling.

### DIFF
--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -639,15 +639,16 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
             // the swarm are consumed, i.e. back-pressure on the network
             // I/O can only be triggered by the code consuming swarm events.
             //
-            // 3. All connections can continue to receive data and send the data
-            // they already have. All received data can be continuously fed into
-            // `NetworkBehaviour::inject_event`.
+            // 3. All connections can continue to receive data and send data
+            // in the form of events to the `NetworkBehaviour`. All received data
+            // can be continuously fed into `NetworkBehaviour::inject_event`. It
+            // may be desirable in the future to allow `inject_event` to signal
+            // back-pressure via a return value.
             //
             // 4. As a direct consequence of (3.), `NetworkBehaviour::inject_event` can
             // be called any number of times before `NetworkBehaviour::poll` is
-            // called again, so behaviours need to be aware that they may need
-            // to buffer more data and propagate back-pressure on their own API
-            // if necessary.
+            // called again (in the absence of a means for `inject_event` to signal
+            // back-pressure).
             if let Some((peer_id, handler, event)) = this.pending_event.take() {
                 if let Some(mut peer) = this.network.peer(peer_id.clone()).into_connected() {
                     match handler {


### PR DESCRIPTION
The design of `libp2p-swarm` is currently such that it tries to progress the underlying `Network` and the associated `NetworkBehaviour` in tandem, that is, to poll both with roughly equal frequency. In particular, if the `Network` has more events (is `Ready`) but a connection handler is not ready to receive an event emitted by the behaviour, the swarm waits until notified of the handler being ready to make progress again. This PR is a proposal for letting the `Network` make progress arbitrarily far ahead of the `NetworkBehaviour`, only subject to back-pressure from the consumer of the swarm events. This is done by `continue`ing the swarm loop instead of returning `Poll::Pending` in all the cases where a connection handler is currently busy. To be more precise (from the code comments):
```rust
// If the pending event cannot be delivered because the connection
// is busy, continue to poll the network. That means the following
// if a single connection (handler) is slow (i.e. does not accept the pending
// event):
//
// 1. All connections are temporarily unable to get new data to send
// from the behaviour (since we only buffer a single pending event).
// This is a problem that still needs to be resolved by providing
// a means for the swarm to exercise connection-specific back-pressure
// on the `NetworkBehaviour`.
//
// 2. New connections continue to get accepted and in general
// network I/O progresses as long as the events emitted by
// the swarm are consumed, i.e. back-pressure on the network
// I/O can only be achieved by the code consuming swarm events.
//
// 3. All connections can continue to receive data and send data
// in the form of events to the `NetworkBehaviour`. All received data
// can be continuously fed into `NetworkBehaviour::inject_event`. It
// may be desirable in the future to allow `inject_event` to signal
// back-pressure via a return value.
//
// 4. As a direct consequence of (3.), `NetworkBehaviour::inject_event` can
// be called any number of times before `NetworkBehaviour::poll` is
// called again (in the absence of a means for `inject_event` to signal
// back-pressure).
```
Point (3.) implies that instead of letting the connection event buffers in `libp2p-core` be filled just because a single connection (handler) is slow, the buffering, if there is any, is left to the behaviour (with no direct means for back-pressure, for now). That seems like the better choice because it allows the behaviour and network I/O to make progress (albeit not being `poll()`ed again until the slow connection handler consumes the pending event).

This obviously has a few consequences on how one writes robust `NetworkBehaviour`s and as mentioned in points (1.) and (3.) is still not free of problems, but may be a step in the right direction.