### PR TITLE
Fully qualified std::result::Result in macro

### DIFF
--- a/misc/core-derive/src/lib.rs
+++ b/misc/core-derive/src/lib.rs
@@ -469,7 +469,7 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
                 #(#inject_listener_error_stmts);*
             }
 
-            fn inject_listener_closed(&mut self, id: #listener_id, reason: Result<(), &std::io::Error>) {
+            fn inject_listener_closed(&mut self, id: #listener_id, reason: std::result::Result<(), &std::io::Error>) {
                 #(#inject_listener_closed_stmts);*
             }
 


### PR DESCRIPTION
Currently writing code where one defines a type alias named `Result` combined with a type that uses `#[derive(NetworkBehaviour)]` sometimes leads to [E0107](https://doc.rust-lang.org/error-index.html#E0107).

```rust
type Result<T> = std::result::Result<T, Error>;
struct Error {}

#[derive(NetworkBehaviour)]
struct Behaviour<TStore> {
    mdns: Mdns,
    kad: Kademlia<TStore>,
}

// NetworkBehaviourEventProcess implementations...
```

```texterror[E0107]: wrong number of type arguments: expected 1, found 2
   --> src/lib.rs:223:10
    |
223 | #[derive(NetworkBehaviour)]
    |          ^^^^^^^^^^^^^^^^ unexpected type argument
    |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

In my estimation this happens due to the use of `Result` in the definition of the `NetworkBehaviour` macro. Using the fully qualified name `std::result::Result` fixes this issue.