### PR TITLE
Try revert to nightly-2020-05-20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,9 @@ jobs:
     - name: Install nightly Rust
       # TODO: intra-doc links are available on nightly only
       # see https://doc.rust-lang.org/nightly/rustdoc/lints.html#intra_doc_link_resolution_failure
-      run: rustup default nightly
+      run: rustup default nightly-2020-05-20
     - name: Check rustdoc links
-      run: RUSTDOCFLAGS="--deny intra_doc_link_resolution_failure" cargo +nightly doc --verbose --workspace --no-deps --document-private-items
+      run: RUSTDOCFLAGS="--deny intra_doc_link_resolution_failure" cargo doc --verbose --workspace --no-deps --document-private-items
 
   integration-test:
     name: Integration tests


### PR DESCRIPTION
Try to fix the intra-link doc tests by pinning to an earlier nightly.

Note that the `Build and test` check will not pass because of #1588. I'm only testing `Check rustdoc intra-doc links`.