### PR TITLE
Fix some libp2p-kad types not being reexported

### DIFF
--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -41,6 +41,9 @@ mod dht_proto {
 pub use addresses::Addresses;
 pub use behaviour::{Kademlia, KademliaConfig, KademliaEvent, Quorum};
 pub use behaviour::{
+    QueryRef,
+    QueryMut,
+
     QueryResult,
     QueryInfo,
     QueryStats,

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -56,6 +56,8 @@ pub use behaviour::{
     GetRecordOk,
     GetRecordError,
 
+    PutRecordPhase,
+    PutRecordContext,
     PutRecordResult,
     PutRecordOk,
     PutRecordError,
@@ -64,6 +66,8 @@ pub use behaviour::{
     GetClosestPeersOk,
     GetClosestPeersError,
 
+    AddProviderPhase,
+    AddProviderContext,
     AddProviderResult,
     AddProviderOk,
     AddProviderError,


### PR DESCRIPTION
You can't see their documentation on `docs.rs` at the moment.