### PR TITLE
Add rust-ipfs to the list of notable users in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,4 @@ Where to ask questions?
 - https://github.com/sigp/lighthouse
 - https://github.com/golemfactory/golem-libp2p
 - https://github.com/comit-network/comit-rs
+- https://github.com/rs-ipfs/rust-ipfs


### PR DESCRIPTION
Not sure if it is notable enough, but it is open source and looking for contributors, so it would be cool to have it listed here.