### PR TITLE
Pin async-std in a different way

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ libp2p-tcp = { version = "0.19.1", path = "transports/tcp", optional = true }
 libp2p-websocket = { version = "0.19.0", path = "transports/websocket", optional = true }
 
 [dev-dependencies]
-async-std = "< 1.6"
+async-std = "~1.5.0"
 env_logger = "0.7.1"
 
 [workspace]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,7 +39,7 @@ zeroize = "1"
 ring = { version = "0.16.9", features = ["alloc", "std"], default-features = false }
 
 [dev-dependencies]
-async-std = "< 1.6"
+async-std = "~1.5.0"
 libp2p-mplex = { version = "0.19.0", path = "../muxers/mplex" }
 libp2p-secio = { version = "0.19.0", path = "../protocols/secio" }
 libp2p-tcp = { version = "0.19.0", path = "../transports/tcp" }

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -18,7 +18,7 @@ smallvec = "1.0"
 unsigned-varint = "0.3.2"
 
 [dev-dependencies]
-async-std = "< 1.6"
+async-std = "~1.5.0"
 quickcheck = "0.9.0"
 rand = "0.7.2"
 rw-stream-sink = "0.2.1"

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -20,5 +20,5 @@ parking_lot = "0.10"
 unsigned-varint = { version = "0.3", features = ["futures-codec"] }
 
 [dev-dependencies]
-async-std = "< 1.6"
+async-std = "~1.5.0"
 libp2p-tcp = { version = "0.19.0", path = "../../transports/tcp" }

--- a/protocols/deflate/Cargo.toml
+++ b/protocols/deflate/Cargo.toml
@@ -15,7 +15,7 @@ libp2p-core = { version = "0.19.0", path = "../../core" }
 flate2 = "1.0"
 
 [dev-dependencies]
-async-std = "< 1.6"
+async-std = "~1.5.0"
 libp2p-tcp = { version = "0.19.0", path = "../../transports/tcp" }
 rand = "0.7"
 quickcheck = "0.9"

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -28,7 +28,7 @@ smallvec = "1.1.0"
 prost = "0.6.1"
 
 [dev-dependencies]
-async-std = "< 1.6"
+async-std = "~1.5.0"
 env_logger = "0.7.1"
 libp2p-plaintext = { version = "0.19.0", path = "../plaintext" }
 libp2p-yamux = { version = "0.19.0", path = "../../muxers/yamux" }

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -19,7 +19,7 @@ smallvec = "1.0"
 wasm-timer = "0.2"
 
 [dev-dependencies]
-async-std = "< 1.6"
+async-std = "~1.5.0"
 libp2p-mplex = { version = "0.19.0", path = "../../muxers/mplex" }
 libp2p-secio = { version = "0.19.0", path = "../../protocols/secio" }
 libp2p-tcp = { version = "0.19.0", path = "../../transports/tcp" }

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-std = "< 1.6"
+async-std = "~1.5.0"
 data-encoding = "2.0"
 dns-parser = "0.8"
 either = "1.5.3"

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -19,7 +19,7 @@ void = "1.0"
 wasm-timer = "0.2"
 
 [dev-dependencies]
-async-std = "< 1.6"
+async-std = "~1.5.0"
 libp2p-tcp = { version = "0.19.0", path = "../../transports/tcp" }
 libp2p-secio = { version = "0.19.0", path = "../../protocols/secio" }
 libp2p-yamux = { version = "0.19.0", path = "../../muxers/yamux" }

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -46,7 +46,7 @@ secp256k1 = []
 aes-all = ["aesni"]
 
 [dev-dependencies]
-async-std = "< 1.6"
+async-std = "~1.5.0"
 criterion = "0.3"
 libp2p-mplex = { version = "0.19.0", path = "../../muxers/mplex" }
 libp2p-tcp = { version = "0.19.0", path = "../../transports/tcp" }

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-std = { version = "< 1.6", optional = true }
+async-std = { version = "~1.5.0", optional = true }
 futures = "0.3.1"
 futures-timer = "3.0"
 get_if_addrs = "0.5.3"

--- a/transports/uds/Cargo.toml
+++ b/transports/uds/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [target.'cfg(all(unix, not(any(target_os = "emscripten", target_os = "unknown"))))'.dependencies]
-async-std = { version = "< 1.6", optional = true }
+async-std = { version = "~1.5.0", optional = true }
 libp2p-core = { version = "0.19.0", path = "../../core" }
 log = "0.4.1"
 futures = "0.3.1"


### PR DESCRIPTION
It turns out that Cargo has some issues with our `<1.6` requirement. If you have a project with both `libp2p` and a dependency on `async-std 1.0` (such as, for example, Polkadot), then Cargo will resolve libp2p's requirements as `async-std 0.99`.

Let's instead go with using the `~`, documented here: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#tilde-requirements

It is equivalent to `>=1.5.0, <1.6.0`.
