### PR TITLE
Remove uses of pin_project::project attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ libp2p-wasm-ext = { version = "0.19.0", path = "transports/wasm-ext", optional =
 libp2p-yamux = { version = "0.19.0", path = "muxers/yamux", optional = true }
 libp2p-noise = { version = "0.19.0", path = "protocols/noise", optional = true }
 parking_lot = "0.10.0"
-pin-project = "0.4.6"
+pin-project = "0.4.17"
 smallvec = "1.0"
 wasm-timer = "0.2.4"
 
@@ -115,4 +115,3 @@ members = [
     "transports/websocket",
     "transports/wasm-ext"
 ]
-

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ multiaddr = { package = "parity-multiaddr", version = "0.9.0", path = "../misc/m
 multihash = "0.11.0"
 multistream-select = { version = "0.8.1", path = "../misc/multistream-select" }
 parking_lot = "0.10.0"
-pin-project = "0.4.6"
+pin-project = "0.4.17"
 prost = "0.6.1"
 rand = "0.7"
 rw-stream-sink = "0.2.0"

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 bytes = "0.5"
 futures = "0.3"
 log = "0.4"
-pin-project = "0.4.8"
+pin-project = "0.4.17"
 smallvec = "1.0"
 unsigned-varint = "0.3.2"
 

--- a/protocols/pnet/Cargo.toml
+++ b/protocols/pnet/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4.8"
 salsa20 = "0.3.0"
 sha3 = "0.8"
 rand = "0.7"
-pin-project = "0.4.6"
+pin-project = "0.4.17"
 
 [dev-dependencies]
 quickcheck = "0.9.0"

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -19,7 +19,7 @@ lazy_static = "1.2.0"
 libp2p-core = { version = "0.19.0", path = "../../core" }
 log = "0.4.6"
 prost = "0.6.1"
-pin-project = "0.4.6"
+pin-project = "0.4.17"
 quicksink = "0.1"
 rand = "0.7"
 rw-stream-sink = "0.2.0"


### PR DESCRIPTION
pin-project will deprecate the project attribute due to some unfixable
limitations.

Refs: https://github.com/taiki-e/pin-project/issues/225

*Although the deprecation of the project attribute has not been released yet, this PR is submitted in advance to avoid the CI from being broken by deprecated warnings.*