### PR TITLE
[libp2p-ping] Properly close the substream in the InboundUpgrade.

### DIFF
--- a/protocols/ping/src/protocol.rs
+++ b/protocols/ping/src/protocol.rs
@@ -69,6 +69,7 @@ where
             while let Ok(_) = socket.read_exact(&mut payload).await {
                 socket.write_all(&payload).await?;
             }
+            socket.close().await?;
             Ok(())
         }.boxed()
     }
@@ -128,7 +129,7 @@ mod tests {
             } else {
                 panic!("MemoryTransport not listening on an address!");
             };
-        
+
         async_std::task::spawn(async move {
             let listener_event = listener.next().await.unwrap();
             let (listener_upgrade, _) = listener_event.unwrap().into_upgrade().unwrap();


### PR DESCRIPTION
Not doing so may result in FIN/RST frames being sent and received before earlier data frames. See https://github.com/paritytech/yamux/pull/81#issuecomment-643169973. This seems to be the cause for https://github.com/paritytech/substrate/issues/6311 as it creates a possible race whereby FIN/RST frames may be received before data frames, causing ping upgrade failures.