### PR TITLE
Upgrade async-std to 1.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ libp2p-tcp = { version = "0.19.1", path = "transports/tcp", optional = true }
 libp2p-websocket = { version = "0.19.0", path = "transports/websocket", optional = true }
 
 [dev-dependencies]
-async-std = "~1.5.0"
+async-std = "1.6.1"
 env_logger = "0.7.1"
 
 [workspace]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,7 +39,7 @@ zeroize = "1"
 ring = { version = "0.16.9", features = ["alloc", "std"], default-features = false }
 
 [dev-dependencies]
-async-std = "~1.5.0"
+async-std = "1.6.1"
 libp2p-mplex = { version = "0.19.0", path = "../muxers/mplex" }
 libp2p-secio = { version = "0.19.0", path = "../protocols/secio" }
 libp2p-tcp = { version = "0.19.0", path = "../transports/tcp" }

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -18,7 +18,7 @@ smallvec = "1.0"
 unsigned-varint = "0.3.2"
 
 [dev-dependencies]
-async-std = "~1.5.0"
+async-std = "1.6.1"
 quickcheck = "0.9.0"
 rand = "0.7.2"
 rw-stream-sink = "0.2.1"

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -20,5 +20,5 @@ parking_lot = "0.10"
 unsigned-varint = { version = "0.3", features = ["futures-codec"] }
 
 [dev-dependencies]
-async-std = "~1.5.0"
+async-std = "1.6.1"
 libp2p-tcp = { version = "0.19.0", path = "../../transports/tcp" }

--- a/protocols/deflate/Cargo.toml
+++ b/protocols/deflate/Cargo.toml
@@ -15,7 +15,7 @@ libp2p-core = { version = "0.19.0", path = "../../core" }
 flate2 = "1.0"
 
 [dev-dependencies]
-async-std = "~1.5.0"
+async-std = "1.6.1"
 libp2p-tcp = { version = "0.19.0", path = "../../transports/tcp" }
 rand = "0.7"
 quickcheck = "0.9"

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -28,7 +28,7 @@ smallvec = "1.1.0"
 prost = "0.6.1"
 
 [dev-dependencies]
-async-std = "~1.5.0"
+async-std = "1.6.1"
 env_logger = "0.7.1"
 libp2p-plaintext = { version = "0.19.0", path = "../plaintext" }
 libp2p-yamux = { version = "0.19.0", path = "../../muxers/yamux" }

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -19,7 +19,7 @@ smallvec = "1.0"
 wasm-timer = "0.2"
 
 [dev-dependencies]
-async-std = "~1.5.0"
+async-std = "1.6.1"
 libp2p-mplex = { version = "0.19.0", path = "../../muxers/mplex" }
 libp2p-secio = { version = "0.19.0", path = "../../protocols/secio" }
 libp2p-tcp = { version = "0.19.0", path = "../../transports/tcp" }

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-std = "~1.5.0"
+async-std = "1.6.1"
 data-encoding = "2.0"
 dns-parser = "0.8"
 either = "1.5.3"

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -31,6 +31,7 @@ env_logger = "0.7.1"
 libp2p-tcp = { version = "0.19.0", path = "../../transports/tcp", features = ["async-std"] }
 quickcheck = "0.9.0"
 sodiumoxide = "^0.2.5"
+async-std = { version = "1.6.1", features = ["attributes"] }
 
 [build-dependencies]
 prost-build = "0.6"

--- a/protocols/noise/tests/smoke.rs
+++ b/protocols/noise/tests/smoke.rs
@@ -18,11 +18,16 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures::{future::{self, Either}, prelude::*};
+use futures::{
+    future::{self, Either},
+    prelude::*,
+};
 use libp2p_core::identity;
-use libp2p_core::upgrade::{self, Negotiated, apply_inbound, apply_outbound};
-use libp2p_core::transport::{Transport, ListenerEvent};
-use libp2p_noise::{Keypair, X25519, X25519Spec, NoiseConfig, RemoteIdentity, NoiseError, NoiseOutput};
+use libp2p_core::transport::{ListenerEvent, Transport};
+use libp2p_core::upgrade::{self, apply_inbound, apply_outbound, Negotiated};
+use libp2p_noise::{
+    Keypair, NoiseConfig, NoiseError, NoiseOutput, RemoteIdentity, X25519Spec, X25519,
+};
 use libp2p_tcp::{TcpConfig, TcpTransStream};
 use log::info;
 use quickcheck::QuickCheck;
@@ -35,7 +40,9 @@ fn core_upgrade_compat() {
     let id_keys = identity::Keypair::generate_ed25519();
     let dh_keys = Keypair::<X25519>::new().into_authentic(&id_keys).unwrap();
     let noise = NoiseConfig::xx(dh_keys).into_authenticated();
-    let _ = TcpConfig::new().upgrade(upgrade::Version::V1).authenticate(noise);
+    let _ = TcpConfig::new()
+        .upgrade(upgrade::Version::V1)
+        .authenticate(noise);
 }
 
 #[test]
@@ -49,28 +56,88 @@ fn xx_spec() {
         let server_id_public = server_id.public();
         let client_id_public = client_id.public();
 
-        let server_dh = Keypair::<X25519Spec>::new().into_authentic(&server_id).unwrap();
+        let server_dh = Keypair::<X25519Spec>::new()
+            .into_authentic(&server_id)
+            .unwrap();
         let server_transport = TcpConfig::new()
             .and_then(move |output, endpoint| {
-                upgrade::apply(output, NoiseConfig::xx(server_dh), endpoint, upgrade::Version::V1)
+                upgrade::apply(
+                    output,
+                    NoiseConfig::xx(server_dh),
+                    endpoint,
+                    upgrade::Version::V1,
+                )
             })
             .and_then(move |out, _| expect_identity(out, &client_id_public));
 
-        let client_dh = Keypair::<X25519Spec>::new().into_authentic(&client_id).unwrap();
+        let client_dh = Keypair::<X25519Spec>::new()
+            .into_authentic(&client_id)
+            .unwrap();
         let client_transport = TcpConfig::new()
             .and_then(move |output, endpoint| {
-                upgrade::apply(output, NoiseConfig::xx(client_dh), endpoint, upgrade::Version::V1)
+                upgrade::apply(
+                    output,
+                    NoiseConfig::xx(client_dh),
+                    endpoint,
+                    upgrade::Version::V1,
+                )
             })
             .and_then(move |out, _| expect_identity(out, &server_id_public));
 
         run(server_transport, client_transport, messages);
         true
     }
-    QuickCheck::new().max_tests(30).quickcheck(prop as fn(Vec<Message>) -> bool)
+    QuickCheck::new()
+        .max_tests(30)
+        .quickcheck(prop as fn(Vec<Message>) -> bool)
 }
 
-#[test]
-fn xx() {
+#[async_std::test]
+async fn xx() {
+    let _ = env_logger::try_init();
+
+    fn prop(mut messages: Vec<Message>) -> bool {
+        messages.truncate(5);
+        let server_id = identity::Keypair::generate_ed25519();
+        let client_id = identity::Keypair::generate_ed25519();
+
+        let server_id_public = server_id.public();
+        let client_id_public = client_id.public();
+
+        let server_dh = Keypair::<X25519>::new().into_authentic(&server_id).unwrap();
+        let server_transport = TcpConfig::new()
+            .and_then(move |output, endpoint| {
+                upgrade::apply(
+                    output,
+                    NoiseConfig::xx(server_dh),
+                    endpoint,
+                    upgrade::Version::V1,
+                )
+            })
+            .and_then(move |out, _| expect_identity(out, &client_id_public));
+
+        let client_dh = Keypair::<X25519>::new().into_authentic(&client_id).unwrap();
+        let client_transport = TcpConfig::new()
+            .and_then(move |output, endpoint| {
+                upgrade::apply(
+                    output,
+                    NoiseConfig::xx(client_dh),
+                    endpoint,
+                    upgrade::Version::V1,
+                )
+            })
+            .and_then(move |out, _| expect_identity(out, &server_id_public));
+
+        run(server_transport, client_transport, messages);
+        true
+    }
+    QuickCheck::new()
+        .max_tests(30)
+        .quickcheck(prop as fn(Vec<Message>) -> bool)
+}
+
+#[async_std::test]
+async fn ix() {
     let _ = env_logger::try_init();
     fn prop(mut messages: Vec<Message>) -> bool {
         messages.truncate(5);
@@ -83,56 +150,37 @@ fn xx() {
         let server_dh = Keypair::<X25519>::new().into_authentic(&server_id).unwrap();
         let server_transport = TcpConfig::new()
             .and_then(move |output, endpoint| {
-                upgrade::apply(output, NoiseConfig::xx(server_dh), endpoint, upgrade::Version::V1)
+                upgrade::apply(
+                    output,
+                    NoiseConfig::ix(server_dh),
+                    endpoint,
+                    upgrade::Version::V1,
+                )
             })
             .and_then(move |out, _| expect_identity(out, &client_id_public));
 
         let client_dh = Keypair::<X25519>::new().into_authentic(&client_id).unwrap();
         let client_transport = TcpConfig::new()
             .and_then(move |output, endpoint| {
-                upgrade::apply(output, NoiseConfig::xx(client_dh), endpoint, upgrade::Version::V1)
+                upgrade::apply(
+                    output,
+                    NoiseConfig::ix(client_dh),
+                    endpoint,
+                    upgrade::Version::V1,
+                )
             })
             .and_then(move |out, _| expect_identity(out, &server_id_public));
 
         run(server_transport, client_transport, messages);
         true
     }
-    QuickCheck::new().max_tests(30).quickcheck(prop as fn(Vec<Message>) -> bool)
+    QuickCheck::new()
+        .max_tests(30)
+        .quickcheck(prop as fn(Vec<Message>) -> bool)
 }
 
-#[test]
-fn ix() {
-    let _ = env_logger::try_init();
-    fn prop(mut messages: Vec<Message>) -> bool {
-        messages.truncate(5);
-        let server_id = identity::Keypair::generate_ed25519();
-        let client_id = identity::Keypair::generate_ed25519();
-
-        let server_id_public = server_id.public();
-        let client_id_public = client_id.public();
-
-        let server_dh = Keypair::<X25519>::new().into_authentic(&server_id).unwrap();
-        let server_transport = TcpConfig::new()
-            .and_then(move |output, endpoint| {
-                upgrade::apply(output, NoiseConfig::ix(server_dh), endpoint, upgrade::Version::V1)
-            })
-            .and_then(move |out, _| expect_identity(out, &client_id_public));
-
-        let client_dh = Keypair::<X25519>::new().into_authentic(&client_id).unwrap();
-        let client_transport = TcpConfig::new()
-            .and_then(move |output, endpoint| {
-                upgrade::apply(output, NoiseConfig::ix(client_dh), endpoint, upgrade::Version::V1)
-            })
-            .and_then(move |out, _| expect_identity(out, &server_id_public));
-
-        run(server_transport, client_transport, messages);
-        true
-    }
-    QuickCheck::new().max_tests(30).quickcheck(prop as fn(Vec<Message>) -> bool)
-}
-
-#[test]
-fn ik_xx() {
+#[async_std::test]
+async fn ik_xx() {
     let _ = env_logger::try_init();
     fn prop(mut messages: Vec<Message>) -> bool {
         messages.truncate(5);
@@ -149,8 +197,11 @@ fn ik_xx() {
                 if endpoint.is_listener() {
                     Either::Left(apply_inbound(output, NoiseConfig::ik_listener(server_dh)))
                 } else {
-                    Either::Right(apply_outbound(output, NoiseConfig::xx(server_dh),
-                        upgrade::Version::V1))
+                    Either::Right(apply_outbound(
+                        output,
+                        NoiseConfig::xx(server_dh),
+                        upgrade::Version::V1,
+                    ))
                 }
             })
             .and_then(move |out, _| expect_identity(out, &client_id_public));
@@ -160,9 +211,11 @@ fn ik_xx() {
         let client_transport = TcpConfig::new()
             .and_then(move |output, endpoint| {
                 if endpoint.is_dialer() {
-                    Either::Left(apply_outbound(output,
+                    Either::Left(apply_outbound(
+                        output,
                         NoiseConfig::ik_dialer(client_dh, server_id_public, server_dh_public),
-                        upgrade::Version::V1))
+                        upgrade::Version::V1,
+                    ))
                 } else {
                     Either::Right(apply_inbound(output, NoiseConfig::xx(client_dh)))
                 }
@@ -172,7 +225,9 @@ fn ik_xx() {
         run(server_transport, client_transport, messages);
         true
     }
-    QuickCheck::new().max_tests(30).quickcheck(prop as fn(Vec<Message>) -> bool)
+    QuickCheck::new()
+        .max_tests(30)
+        .quickcheck(prop as fn(Vec<Message>) -> bool)
 }
 
 type Output<C> = (RemoteIdentity<C>, NoiseOutput<Negotiated<TcpTransStream>>);
@@ -187,14 +242,15 @@ where
     U::Dial: Send + 'static,
     U::Listener: Send + 'static,
     U::ListenerUpgrade: Send + 'static,
-    I: IntoIterator<Item = Message> + Clone
+    I: IntoIterator<Item = Message> + Clone,
 {
     futures::executor::block_on(async {
         let mut server: T::Listener = server_transport
             .listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap())
             .unwrap();
 
-        let server_address = server.try_next()
+        let server_address = server
+            .try_next()
             .await
             .expect("some event")
             .expect("no error")
@@ -203,7 +259,8 @@ where
 
         let outbound_msgs = messages.clone();
         let client_fut = async {
-            let mut client_session = client_transport.dial(server_address.clone())
+            let mut client_session = client_transport
+                .dial(server_address.clone())
                 .unwrap()
                 .await
                 .map(|(_, session)| session)
@@ -218,7 +275,8 @@ where
         };
 
         let server_fut = async {
-            let mut server_session = server.try_next()
+            let mut server_session = server
+                .try_next()
                 .await
                 .expect("some event")
                 .map(ListenerEvent::into_upgrade)
@@ -235,12 +293,15 @@ where
                     match server_session.read_exact(&mut n).await {
                         Ok(()) => u64::from_be_bytes(n),
                         Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => 0,
-                        Err(e) => panic!("error reading len: {}", e)
+                        Err(e) => panic!("error reading len: {}", e),
                     }
                 };
                 info!("server: reading message ({} bytes)", len);
                 let mut server_buffer = vec![0; len.try_into().unwrap()];
-                server_session.read_exact(&mut server_buffer).await.expect("no error");
+                server_session
+                    .read_exact(&mut server_buffer)
+                    .await
+                    .expect("no error");
                 assert_eq!(server_buffer, m.0)
             }
         };
@@ -249,12 +310,13 @@ where
     })
 }
 
-fn expect_identity<C>(output: Output<C>, pk: &identity::PublicKey)
-    -> impl Future<Output = Result<Output<C>, NoiseError>>
-{
+fn expect_identity<C>(
+    output: Output<C>,
+    pk: &identity::PublicKey,
+) -> impl Future<Output = Result<Output<C>, NoiseError>> {
     match output.0 {
         RemoteIdentity::IdentityKey(ref k) if k == pk => future::ok(output),
-        _ => panic!("Unexpected remote identity")
+        _ => panic!("Unexpected remote identity"),
     }
 }
 

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -19,7 +19,7 @@ void = "1.0"
 wasm-timer = "0.2"
 
 [dev-dependencies]
-async-std = "~1.5.0"
+async-std = "1.6.0"
 libp2p-tcp = { version = "0.19.0", path = "../../transports/tcp" }
 libp2p-secio = { version = "0.19.0", path = "../../protocols/secio" }
 libp2p-yamux = { version = "0.19.0", path = "../../muxers/yamux" }

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -46,7 +46,7 @@ secp256k1 = []
 aes-all = ["aesni"]
 
 [dev-dependencies]
-async-std = "~1.5.0"
+async-std = "1.6.1"
 criterion = "0.3"
 libp2p-mplex = { version = "0.19.0", path = "../../muxers/mplex" }
 libp2p-tcp = { version = "0.19.0", path = "../../transports/tcp" }

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-std = { version = "~1.5.0", optional = true }
+async-std = { version = "1.6.1", optional = true }
 futures = "0.3.1"
 futures-timer = "3.0"
 get_if_addrs = "0.5.3"

--- a/transports/uds/Cargo.toml
+++ b/transports/uds/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [target.'cfg(all(unix, not(any(target_os = "emscripten", target_os = "unknown"))))'.dependencies]
-async-std = { version = "~1.5.0", optional = true }
+async-std = { version = "1.6.1", optional = true }
 libp2p-core = { version = "0.19.0", path = "../../core" }
 log = "0.4.1"
 futures = "0.3.1"

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -25,3 +25,4 @@ webpki-roots = "0.18"
 
 [dev-dependencies]
 libp2p-tcp = { version = "0.19.0", path = "../tcp", features = ["async-std"] }
+async-std = { version = "1.6.1", features = ["attributes"] }

--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -26,20 +26,26 @@ pub mod tls;
 
 use error::Error;
 use framed::Connection;
-use futures::{future::BoxFuture, prelude::*, stream::BoxStream, ready};
+use futures::{future::BoxFuture, prelude::*, ready, stream::BoxStream};
 use libp2p_core::{
-    ConnectedPoint,
-    Transport,
     multiaddr::Multiaddr,
-    transport::{map::{MapFuture, MapStream}, ListenerEvent, TransportError}
+    transport::{
+        map::{MapFuture, MapStream},
+        ListenerEvent, TransportError,
+    },
+    ConnectedPoint, Transport,
 };
 use rw_stream_sink::RwStreamSink;
-use std::{io, pin::Pin, task::{Context, Poll}};
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 /// A Websocket transport.
 #[derive(Debug, Clone)]
 pub struct WsConfig<T> {
-    transport: framed::WsConfig<T>
+    transport: framed::WsConfig<T>,
 }
 
 impl<T> WsConfig<T> {
@@ -85,9 +91,7 @@ impl<T> WsConfig<T> {
 
 impl<T> From<framed::WsConfig<T>> for WsConfig<T> {
     fn from(framed: framed::WsConfig<T>) -> Self {
-        WsConfig {
-            transport: framed
-        }
+        WsConfig { transport: framed }
     }
 }
 
@@ -98,7 +102,7 @@ where
     T::Dial: Send + 'static,
     T::Listener: Send + 'static,
     T::ListenerUpgrade: Send + 'static,
-    T::Output: AsyncRead + AsyncWrite + Unpin + Send + 'static
+    T::Output: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     type Output = RwStreamSink<BytesConnection<T::Output>>;
     type Error = Error<T::Error>;
@@ -107,16 +111,21 @@ where
     type Dial = MapFuture<InnerFuture<T::Output, T::Error>, WrapperFn<T::Output>>;
 
     fn listen_on(self, addr: Multiaddr) -> Result<Self::Listener, TransportError<Self::Error>> {
-        self.transport.map(wrap_connection as WrapperFn<T::Output>).listen_on(addr)
+        self.transport
+            .map(wrap_connection as WrapperFn<T::Output>)
+            .listen_on(addr)
     }
 
     fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-        self.transport.map(wrap_connection as WrapperFn<T::Output>).dial(addr)
+        self.transport
+            .map(wrap_connection as WrapperFn<T::Output>)
+            .dial(addr)
     }
 }
 
 /// Type alias corresponding to `framed::WsConfig::Listener`.
-pub type InnerStream<T, E> = BoxStream<'static, Result<ListenerEvent<InnerFuture<T, E>, Error<E>>, Error<E>>>;
+pub type InnerStream<T, E> =
+    BoxStream<'static, Result<ListenerEvent<InnerFuture<T, E>, Error<E>>, Error<E>>>;
 
 /// Type alias corresponding to `framed::WsConfig::Dial` and `framed::WsConfig::ListenerUpgrade`.
 pub type InnerFuture<T, E> = BoxFuture<'static, Result<Connection<T>, Error<E>>>;
@@ -128,7 +137,7 @@ pub type WrapperFn<T> = fn(Connection<T>, ConnectedPoint) -> RwStreamSink<BytesC
 /// implementing `AsyncRead` + `AsyncWrite`.
 fn wrap_connection<T>(c: Connection<T>, _: ConnectedPoint) -> RwStreamSink<BytesConnection<T>>
 where
-    T: AsyncRead + AsyncWrite + Send + Unpin + 'static
+    T: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     RwStreamSink::new(BytesConnection(c))
 }
@@ -139,7 +148,7 @@ pub struct BytesConnection<T>(Connection<T>);
 
 impl<T> Stream for BytesConnection<T>
 where
-    T: AsyncRead + AsyncWrite + Send + Unpin + 'static
+    T: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     type Item = io::Result<Vec<u8>>;
 
@@ -147,10 +156,10 @@ where
         loop {
             if let Some(item) = ready!(self.0.try_poll_next_unpin(cx)?) {
                 if item.is_data() {
-                    return Poll::Ready(Some(Ok(item.into_bytes())))
+                    return Poll::Ready(Some(Ok(item.into_bytes())));
                 }
             } else {
-                return Poll::Ready(None)
+                return Poll::Ready(None);
             }
         }
     }
@@ -158,7 +167,7 @@ where
 
 impl<T> Sink<Vec<u8>> for BytesConnection<T>
 where
-    T: AsyncRead + AsyncWrite + Send + Unpin + 'static
+    T: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     type Error = io::Error;
 
@@ -183,20 +192,20 @@ where
 
 #[cfg(test)]
 mod tests {
-    use libp2p_core::Multiaddr;
-    use libp2p_tcp as tcp;
-    use futures::prelude::*;
-    use libp2p_core::{Transport, multiaddr::Protocol};
     use super::WsConfig;
+    use futures::prelude::*;
+    use libp2p_core::Multiaddr;
+    use libp2p_core::{multiaddr::Protocol, Transport};
+    use libp2p_tcp as tcp;
 
-    #[test]
-    fn dialer_connects_to_listener_ipv4() {
+    #[async_std::test]
+    async fn dialer_connects_to_listener_ipv4() {
         let a = "/ip4/127.0.0.1/tcp/0/ws".parse().unwrap();
         futures::executor::block_on(connect(a))
     }
 
-    #[test]
-    fn dialer_connects_to_listener_ipv6() {
+    #[async_std::test]
+    async fn dialer_connects_to_listener_ipv6() {
         let a = "/ip6/::1/tcp/0/ws".parse().unwrap();
         futures::executor::block_on(connect(a))
     }
@@ -204,11 +213,11 @@ mod tests {
     async fn connect(listen_addr: Multiaddr) {
         let ws_config = WsConfig::new(tcp::TcpConfig::new());
 
-        let mut listener = ws_config.clone()
-            .listen_on(listen_addr)
-            .expect("listener");
+        let mut listener = ws_config.clone().listen_on(listen_addr).expect("listener");
 
-        let addr = listener.try_next().await
+        let addr = listener
+            .try_next()
+            .await
             .expect("some event")
             .expect("no error")
             .into_new_address()
@@ -218,7 +227,8 @@ mod tests {
         assert_ne!(Some(Protocol::Tcp(0)), addr.iter().nth(1));
 
         let inbound = async move {
-            let (conn, _addr) = listener.try_filter_map(|e| future::ready(Ok(e.into_upgrade())))
+            let (conn, _addr) = listener
+                .try_filter_map(|e| future::ready(Ok(e.into_upgrade())))
                 .try_next()
                 .await
                 .unwrap()


### PR DESCRIPTION
Resolves #1588, and allows `libp2p` to be used in projects that rely on the latest version of `async-std`.