### PR TITLE
Add CHANGELOG and increment version to 0.19.2

### DIFF
--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.19.2
+# 0.19.2 [2020-06-18]
 
 - Close substream in inbound upgrade
   [PR 1606](https://github.com/libp2p/rust-libp2p/pull/1606).

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 0.19.2
+
+- Close substream in inbound upgrade
+  [PR 1606](https://github.com/libp2p/rust-libp2p/pull/1606).
+

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-ping"
 edition = "2018"
 description = "Ping protocol for libp2p"
-version = "0.19.1"
+version = "0.19.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
Prepare bugfix release of `libp2p-ping`.