### PR TITLE
Deprecate StreamMuxer::is_remote_acknowledged

### DIFF
--- a/core/src/connection.rs
+++ b/core/src/connection.rs
@@ -230,14 +230,6 @@ where
         self.handler.inject_event(event);
     }
 
-    /// Returns `true` if the remote has shown any sign of activity
-    /// since the connection has been established.
-    ///
-    /// See also [`StreamMuxer::is_remote_acknowledged`].
-    pub fn is_remote_acknowledged(&self) -> bool {
-        self.muxing.is_remote_acknowledged()
-    }
-
     /// Begins an orderly shutdown of the connection, returning a
     /// `Future` that resolves when connection shutdown is complete.
     pub fn close(self) -> Close<TMuxer> {

--- a/core/src/connection/substream.rs
+++ b/core/src/connection/substream.rs
@@ -123,13 +123,6 @@ where
         self.outbound_substreams.push((user_data, raw));
     }
 
-    /// Returns `true` if the remote has shown any sign of activity after the muxer has been open.
-    ///
-    /// See `StreamMuxer::is_remote_acknowledged`.
-    pub fn is_remote_acknowledged(&self) -> bool {
-        self.inner.is_remote_acknowledged()
-    }
-
     /// Destroys the node stream and returns all the pending outbound substreams, plus an object
     /// that signals the remote that we shut down the connection.
     #[must_use]

--- a/core/src/either.rs
+++ b/core/src/either.rs
@@ -297,13 +297,6 @@ where
         }
     }
 
-    fn is_remote_acknowledged(&self) -> bool {
-        match self {
-            EitherOutput::First(inner) => inner.is_remote_acknowledged(),
-            EitherOutput::Second(inner) => inner.is_remote_acknowledged()
-        }
-    }
-
     fn close(&self, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
         match self {
             EitherOutput::First(inner) => inner.close(cx).map_err(|e| e.into()),

--- a/core/src/muxing.rs
+++ b/core/src/muxing.rs
@@ -64,8 +64,7 @@ mod singleton;
 ///
 /// The state of a muxer, as exposed by this API, is the following:
 ///
-/// - A connection to the remote. The `is_remote_acknowledged`, `flush_all` and `close` methods
-///   operate on this.
+/// - A connection to the remote. The `flush_all` and `close` methods operate on this.
 /// - A list of substreams that are open. The `poll_inbound`, `poll_outbound`, `read_substream`,
 ///   `write_substream`, `flush_substream`, `shutdown_substream` and `destroy_substream` methods
 ///   allow controlling these entries.
@@ -180,7 +179,10 @@ pub trait StreamMuxer {
     /// allowed to assume that the handshake has succeeded when it didn't in fact succeed. This
     /// method can be called in order to determine whether the remote has accepted our handshake or
     /// has potentially not received it yet.
-    fn is_remote_acknowledged(&self) -> bool;
+    #[deprecated(note = "This method is unused and will be removed in the future")]
+    fn is_remote_acknowledged(&self) -> bool {
+        true
+    }
 
     /// Closes this `StreamMuxer`.
     ///
@@ -526,11 +528,6 @@ impl StreamMuxer for StreamMuxerBox {
     }
 
     #[inline]
-    fn is_remote_acknowledged(&self) -> bool {
-        self.inner.is_remote_acknowledged()
-    }
-
-    #[inline]
     fn flush_all(&self, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
         self.inner.flush_all(cx)
     }
@@ -629,11 +626,6 @@ where
     #[inline]
     fn close(&self, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
         self.inner.close(cx).map_err(|e| e.into())
-    }
-
-    #[inline]
-    fn is_remote_acknowledged(&self) -> bool {
-        self.inner.is_remote_acknowledged()
     }
 
     #[inline]


### PR DESCRIPTION
This method was only used for the "simultaneous dialing system" in case two nodes were dialing each other at the same time.

This system has been removed a long time ago (#1440) and we can thus deprecate the corresponding method.
