### PR TITLE
kad: Avoid from/into `IteratorIndex`.

### DIFF
--- a/protocols/kad/src/query/peers/closest/disjoint.rs
+++ b/protocols/kad/src/query/peers/closest/disjoint.rs
@@ -24,7 +24,7 @@ use libp2p_core::PeerId;
 use std::{
     collections::HashMap,
     iter::{Cycle, Map, Peekable},
-    ops::{Add, Index, IndexMut, Range},
+    ops::{Index, IndexMut, Range},
 };
 use wasm_timer::Instant;
 
@@ -114,7 +114,7 @@ impl ClosestDisjointPeersIter {
             }
 
             for (i, iter) in &mut self.iters.iter_mut().enumerate() {
-                if i != (*initiated_by).into() {
+                if IteratorIndex(i) != *initiated_by {
                     // This iterator never triggered an actual request to the
                     // given peer - thus ignore the returned boolean.
                     iter.on_failure(peer);
@@ -162,7 +162,7 @@ impl ClosestDisjointPeersIter {
             }
 
             for (i, iter) in &mut self.iters.iter_mut().enumerate() {
-                if i != (*initiated_by).into() {
+                if IteratorIndex(i) != *initiated_by {
                     // Only report the success to all remaining not-first
                     // iterators. Do not pass the `closer_peers` in order to
                     // uphold the S/Kademlia disjoint paths guarantee.
@@ -322,26 +322,6 @@ impl ClosestDisjointPeersIter {
 /// Index into the [`ClosestDisjointPeersIter`] `iters` vector.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct IteratorIndex(usize);
-
-impl From<usize> for IteratorIndex {
-    fn from(i: usize) -> Self {
-        IteratorIndex(i)
-    }
-}
-
-impl From<IteratorIndex> for usize {
-    fn from(i: IteratorIndex) -> Self {
-        i.0
-    }
-}
-
-impl Add<usize> for IteratorIndex {
-    type Output = Self;
-
-    fn add(self, rhs: usize) -> Self::Output {
-        (self.0 + rhs).into()
-    }
-}
 
 impl Index<IteratorIndex> for Vec<ClosestPeersIter> {
     type Output = ClosestPeersIter;


### PR DESCRIPTION
[Type inference failed previously](https://gitlab.parity.io/parity/substrate/-/jobs/564937):

```
error[E0283]: type annotations needed for `(usize, &mut query::peers::closest::ClosestPeersIter)`
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/libp2p-kad-0.20.0/src/query/peers/closest/disjoint.rs:117:22
    |
116 |             for (i, iter) in &mut self.iters.iter_mut().enumerate() {
    |                              -------------------------------------- the element type for this iterator is not specified
117 |                 if i != (*initiated_by).into() {
    |                      ^^ cannot infer type for type `usize`
    |
    = note: cannot satisfy `usize: std::cmp::PartialEq<_>`
error[E0283]: type annotations needed for `(usize, &mut query::peers::closest::ClosestPeersIter)`
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/libp2p-kad-0.20.0/src/query/peers/closest/disjoint.rs:165:22
    |
164 |             for (i, iter) in &mut self.iters.iter_mut().enumerate() {
    |                              -------------------------------------- the element type for this iterator is not specified
165 |                 if i != (*initiated_by).into() {
    |                      ^^ cannot infer type for type `usize`
    |
    = note: cannot satisfy `usize: std::cmp::PartialEq<_>`

```