### PR TITLE
Release v0.20.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p"
 edition = "2018"
 description = "Peer-to-peer networking library"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -59,9 +59,9 @@ lazy_static = "1.2"
 libp2p-core = { version = "0.19.2", path = "core" }
 libp2p-core-derive = { version = "0.19.1", path = "misc/core-derive" }
 libp2p-floodsub = { version = "0.19.1", path = "protocols/floodsub", optional = true }
-libp2p-gossipsub = { version = "0.19.2", path = "./protocols/gossipsub", optional = true }
+libp2p-gossipsub = { version = "0.19.3", path = "./protocols/gossipsub", optional = true }
 libp2p-identify = { version = "0.19.2", path = "protocols/identify", optional = true }
-libp2p-kad = { version = "0.20.0", path = "protocols/kad", optional = true }
+libp2p-kad = { version = "0.20.1", path = "protocols/kad", optional = true }
 libp2p-mplex = { version = "0.19.2", path = "muxers/mplex", optional = true }
 libp2p-noise = { version = "0.19.1", path = "protocols/noise", optional = true }
 libp2p-ping = { version = "0.19.3", path = "protocols/ping", optional = true }

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.19.3 [2020-06-23]
+
+Maintenance release fixing linter warnings.
+
 # 0.19.2 [2020-06-22]
 
 Updated dependencies.

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-gossipsub"
 edition = "2018"
 description = "Gossipsub protocol for libp2p"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Age Manning <Age@AgeManning.com>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -363,7 +363,7 @@ impl Gossipsub {
                 &self.topic_peers,
                 topic_hash,
                 self.config.mesh_n - added_peers.len(),
-                { |_| true },
+                |_| true,
             );
             added_peers.extend_from_slice(&new_peers);
             // add them to the mesh

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -571,22 +571,22 @@ mod tests {
         gs.topic_peers.insert(topic_hash.clone(), peers.clone());
 
         let random_peers =
-            Gossipsub::get_random_peers(&gs.topic_peers, &topic_hash, 5, { |_| true });
+            Gossipsub::get_random_peers(&gs.topic_peers, &topic_hash, 5, |_| true);
         assert!(random_peers.len() == 5, "Expected 5 peers to be returned");
         let random_peers =
-            Gossipsub::get_random_peers(&gs.topic_peers, &topic_hash, 30, { |_| true });
+            Gossipsub::get_random_peers(&gs.topic_peers, &topic_hash, 30, |_| true);
         assert!(random_peers.len() == 20, "Expected 20 peers to be returned");
         assert!(random_peers == peers, "Expected no shuffling");
         let random_peers =
-            Gossipsub::get_random_peers(&gs.topic_peers, &topic_hash, 20, { |_| true });
+            Gossipsub::get_random_peers(&gs.topic_peers, &topic_hash, 20, |_| true);
         assert!(random_peers.len() == 20, "Expected 20 peers to be returned");
         assert!(random_peers == peers, "Expected no shuffling");
         let random_peers =
-            Gossipsub::get_random_peers(&gs.topic_peers, &topic_hash, 0, { |_| true });
+            Gossipsub::get_random_peers(&gs.topic_peers, &topic_hash, 0, |_| true);
         assert!(random_peers.len() == 0, "Expected 0 peers to be returned");
         // test the filter
         let random_peers =
-            Gossipsub::get_random_peers(&gs.topic_peers, &topic_hash, 5, { |_| false });
+            Gossipsub::get_random_peers(&gs.topic_peers, &topic_hash, 5, |_| false);
         assert!(random_peers.len() == 0, "Expected 0 peers to be returned");
         let random_peers =
             Gossipsub::get_random_peers(&gs.topic_peers, &topic_hash, 10, {

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.20.1 [2020-06-23]
+
+Maintenance release ([PR 1623](https://github.com/libp2p/rust-libp2p/pull/1623)).
+
 # 0.20.0 [2020-06-22]
 
 - Optionally require iterative queries to use disjoint paths based

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-kad"
 edition = "2018"
 description = "Kademlia protocol for libp2p"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
- Update `libp2p-kad` CHANGELOG and increment version to 0.20.1.
- Update `libp2p` version to 0.20.1.
- Fix some linter warning in `libp2p-gossipsub` and increment version to 0.19.3 and update CHANGELOG.