### PR TITLE
protocols/kad/src/lib: Expose  KademliaBucketInserts

### DIFF
--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -39,7 +39,7 @@ mod dht_proto {
 }
 
 pub use addresses::Addresses;
-pub use behaviour::{Kademlia, KademliaConfig, KademliaEvent, Quorum};
+pub use behaviour::{Kademlia, KademliaBucketInserts, KademliaConfig, KademliaEvent, Quorum};
 pub use behaviour::{
     QueryRef,
     QueryMut,


### PR DESCRIPTION
In order to call `KademliaConfig::set_kbucket_inserts` one needs to be able to instantiate a `KademliaBucketInserts`.