### PR TITLE
Tor transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ env_logger = "0.7.1"
 [workspace]
 members = [
     "core",
+    "examples/tor",
     "misc/core-derive",
     "misc/multiaddr",
     "misc/multistream-select",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ request-response = ["libp2p-request-response"]
 secio = ["libp2p-secio"]
 tcp-async-std = ["libp2p-tcp", "libp2p-tcp/async-std"]
 tcp-tokio = ["libp2p-tcp", "libp2p-tcp/tokio"]
+tor =  ["libp2p-tor",]
 uds = ["libp2p-uds"]
 wasm-ext = ["libp2p-wasm-ext"]
 websocket = ["libp2p-websocket"]
@@ -90,6 +91,7 @@ libp2p-deflate = { version = "0.20.0", path = "protocols/deflate", optional = tr
 libp2p-dns = { version = "0.20.0", path = "transports/dns", optional = true }
 libp2p-mdns = { version = "0.20.0", path = "protocols/mdns", optional = true }
 libp2p-tcp = { version = "0.20.0", path = "transports/tcp", optional = true }
+libp2p-tor = { version = "0.20.0", path = "transports/tor", optional = true }
 libp2p-websocket = { version = "0.21.0", path = "transports/websocket", optional = true }
 
 [dev-dependencies]
@@ -118,6 +120,7 @@ members = [
     "swarm",
     "transports/dns",
     "transports/tcp",
+    "transports/tor",
     "transports/uds",
     "transports/websocket",
     "transports/wasm-ext"

--- a/examples/tor/Cargo.toml
+++ b/examples/tor/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "ping-pong"
+version = "0.2.0"
+authors = ["Tobin C. Harding <tobin@coblox.tech>"]
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+clap = "2.32"
+data-encoding = "2.2"
+futures = "0.3"
+futures-timer = "3.0"
+get_if_addrs = "0.5"
+ipnet = "2.3"
+libp2p = { version = "0.20", default-features = false, features = [ "secio", "yamux", "mplex", "dns", "tcp-tokio", "ping"] }
+log = "0.4"
+simple_logger = "1.6"
+socket2 = "0.3"
+structopt = "0.3"
+tokio = { version = "0.2", features = ["rt-threaded", "macros", "tcp"] }
+tokio-socks = "0.2"

--- a/examples/tor/README.md
+++ b/examples/tor/README.md
@@ -1,0 +1,25 @@
+# libp2p over Tor - Ping-Pong
+
+Basic TCP peer to peer connectivity using libp2p over the Tor network.
+
+## Usage
+
+0. Install Tor
+1. Configure an onion service using the Tor run file. You can use
+`./torrc` and run `tor` using `sudo /usr/bin/tor --defaults-torrc tor-service-defaults-torrc -f torrc --RunAsDaemon 0`
+2. Once you have run `tor` for the first time get the onion address
+   from the `hostname` file (if you used the `tor` invocation above
+   this will be in `/var/lib/tor/hidden_service/hostname`). Set the
+   onion address `const ONION` in `main.rs`.
+3. Set the log level in `main.rs` if you wish.
+
+Now to run this demo application run tor in one terminal, the listener
+in another terminal, and the dialer in a third terminal.
+
+- Run the listener with: `ping-pong --listener`.
+- Run the dialer with: `ping-pong --dialer`.
+
+See `ping-pong --help` for more information.
+
+
+Tested on Ubuntu LTS 18 using Tor version 0.4.3.5

--- a/examples/tor/src/cli.rs
+++ b/examples/tor/src/cli.rs
@@ -1,0 +1,17 @@
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "ping-pong", about = "libp2p ping-pong application over Tor.")]
+pub struct Opt {
+    /// Run as the dialer i.e., do the ping
+    #[structopt(short, long)]
+    pub dialer: bool,
+
+    /// Run as the listener i.e., do the pong (default)
+    #[structopt(short, long)]
+    pub listener: bool,
+
+    /// Onion mulitaddr to use (only required for dialer)
+    #[structopt(long)]
+    pub onion: Option<String>,
+}

--- a/examples/tor/src/lib.rs
+++ b/examples/tor/src/lib.rs
@@ -1,0 +1,151 @@
+mod cli;
+pub mod transport;
+
+pub use cli::Opt;
+
+use std::{
+    io,
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+    collections::HashMap,
+};
+
+use anyhow::{Result};
+use futures::{future, prelude::*};
+use libp2p::{
+    core::{
+        either::EitherError,
+        muxing::StreamMuxerBox,
+        transport::{boxed::Boxed, timeout::TransportTimeoutError},
+        upgrade::{SelectUpgrade, Version},
+        UpgradeError,
+    },
+    dns::{DnsConfig, DnsErr},
+    identity,
+    mplex::MplexConfig,
+    ping::{Ping, PingConfig},
+    secio::{SecioConfig, SecioError},
+    swarm::SwarmBuilder,
+    yamux, Multiaddr, PeerId, Swarm, Transport,
+};
+use tokio::net::TcpStream;
+use tokio_socks::{tcp::Socks5Stream, IntoTargetAddr};
+
+use crate::transport::TorTokioTcpConfig;
+
+/// Entry point to run the ping-pong application as a dialer.
+pub async fn run_dialer(addr: Multiaddr) -> Result<()> {
+    let map = HashMap::new();
+    let config = PingConfig::new()
+        .with_keep_alive(true)
+        .with_interval(Duration::from_secs(1));
+    let mut swarm = crate::build_swarm(config, map)?;
+
+    Swarm::dial_addr(&mut swarm, addr).unwrap();
+
+    future::poll_fn(move |cx: &mut Context| loop {
+        match swarm.poll_next_unpin(cx) {
+            Poll::Ready(Some(event)) => println!("{:?}", event),
+            Poll::Ready(None) => return Poll::Ready(()),
+            Poll::Pending => return Poll::Pending,
+        }
+    })
+    .await;
+
+    Ok(())
+}
+
+/// Entry point to run the ping-pong application as a listener.
+pub async fn run_listener(onion: Multiaddr) -> Result<()> {
+    let map = onion_port_map(onion.clone());
+    println!("Onion service: {}", onion);
+
+    let config = PingConfig::new().with_keep_alive(true);
+    let mut swarm = crate::build_swarm(config, map)?;
+
+    Swarm::listen_on(&mut swarm, onion.clone())?;
+
+    future::poll_fn(move |cx: &mut Context| loop {
+        match swarm.poll_next_unpin(cx) {
+            Poll::Ready(Some(event)) => println!("{:?}", event),
+            Poll::Ready(None) => return Poll::Ready(()),
+            Poll::Pending => return Poll::Pending,
+        }
+    })
+    .await;
+
+    Ok(())
+}
+
+/// Build a libp2p swarm (also called a switch).
+pub fn build_swarm(config: PingConfig, map: HashMap<Multiaddr, u16>) -> Result<Swarm<Ping>> {
+    let id_keys = identity::Keypair::generate_ed25519();
+    let peer_id = PeerId::from(id_keys.public());
+
+    let transport = crate::build_transport(id_keys, map)?;
+    let behaviour = Ping::new(config);
+
+    let swarm = SwarmBuilder::new(transport, behaviour, peer_id)
+        .executor(Box::new(TokioExecutor))
+        .build();
+
+    Ok(swarm)
+}
+
+fn onion_port_map(onion: Multiaddr) -> HashMap<Multiaddr, u16> {
+    let mut map = HashMap::new();
+    // FIMXE: This shouldn't be hard coded.
+    map.insert(onion, 7777);
+    map
+}
+
+struct TokioExecutor;
+
+impl libp2p::core::Executor for TokioExecutor {
+    fn exec(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>) {
+        tokio::spawn(future);
+    }
+}
+
+/// Builds a libp2p transport with the following features:
+/// - TCp connectivity
+/// - DNS name resolution
+/// - Authentication via secio
+/// - Multiplexing via yamux or mplex
+pub fn build_transport(keypair: identity::Keypair, map: HashMap<Multiaddr, u16>) -> anyhow::Result<PingPongTransport> {
+    let transport = TorTokioTcpConfig::new().nodelay(true).onion_map(map);
+    let transport = DnsConfig::new(transport)?;
+
+    let transport = transport
+        .upgrade(Version::V1)
+        .authenticate(SecioConfig::new(keypair))
+        .multiplex(SelectUpgrade::new(
+            yamux::Config::default(),
+            MplexConfig::new(),
+        ))
+        .map(|(peer, muxer), _| (peer, StreamMuxerBox::new(muxer)))
+        .timeout(Duration::from_secs(20))
+        .boxed();
+
+    Ok(transport)
+}
+
+/// libp2p `Transport` for the ping-pong application.
+pub type PingPongTransport = Boxed<
+    (PeerId, StreamMuxerBox),
+    TransportTimeoutError<
+        EitherError<
+            EitherError<DnsErr<io::Error>, UpgradeError<SecioError>>,
+            UpgradeError<EitherError<io::Error, io::Error>>,
+        >,
+    >,
+>;
+
+/// Connect to the Tor socks5 proxy socket.
+pub async fn connect_tor_socks_proxy<'a>(dest: impl IntoTargetAddr<'a>, port: u16) -> Result<TcpStream> {
+    let tor_sock = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port));
+    let stream = Socks5Stream::connect(tor_sock, dest).await?;
+    Ok(stream.into_inner())
+}

--- a/examples/tor/src/main.rs
+++ b/examples/tor/src/main.rs
@@ -1,0 +1,42 @@
+#![warn(rust_2018_idioms)]
+#![forbid(unsafe_code)]
+use anyhow::{Context, Result};
+use log::{warn, Level};
+use structopt::StructOpt;
+
+use ping_pong::{run_dialer, run_listener, Opt};
+
+/// The ping-pong onion service address.
+const ONION: &str = "/onion3/r4nttccifklkruvrztwxuhk2iy4xx7cnnex2sgogbo4zw6rnx3cq2bid:7";
+
+/// Tor should be started with a hidden service configured. Must be
+/// re-started for each execution of the listener.
+///
+/// See torrc for an example, if using that file Tor can be started with:
+///
+///   sudo /usr/bin/tor --defaults-torrc tor-service-defaults-torrc -f torrc --RunAsDaemon 0
+///
+/// After the first execution of Tor the onion address can be found in
+///
+///   /var/lib/tor/hidden_service/hostname
+///
+/// Update ONION above before running the listener.
+#[tokio::main]
+async fn main() -> Result<()> {
+    simple_logger::init_with_level(Level::Debug).unwrap();
+
+    let opt = Opt::from_args();
+
+    let addr = opt.onion.unwrap_or_else(|| ONION.to_string());
+    let addr = addr
+        .parse()
+        .with_context(|| format!("failed to parse multiaddr: {}", addr))?;
+
+    if opt.dialer {
+        run_dialer(addr).await?;
+    } else {
+        run_listener(addr).await?;
+    }
+
+    Ok(())
+}

--- a/examples/tor/src/transport.rs
+++ b/examples/tor/src/transport.rs
@@ -1,0 +1,544 @@
+// Copyright 2017 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+// Copyright 2020 CoBloX Pty Ltd.
+
+//! Implementation of the libp2p `Transport` trait for TCP/IP.
+//!
+//! Copied from github.com/libp2p/rust-libp2p/transports/tcp/lib.rs
+//! Modified by Tobin C. Harding <tobin@coblox.tech>
+
+use anyhow::Result;
+use data_encoding::BASE32;
+use futures::{
+    future::{self, Ready},
+    prelude::*,
+};
+use futures_timer::Delay;
+use get_if_addrs::{get_if_addrs, IfAddr};
+use ipnet::{IpNet, Ipv4Net, Ipv6Net};
+use libp2p::core::{
+    multiaddr::{Multiaddr, Protocol},
+    transport::{ListenerEvent, TransportError},
+    Transport,
+};
+use log::{debug, info, trace};
+use socket2::{Domain, Socket, Type};
+use std::{
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4, IpAddr},
+    collections::{HashMap, VecDeque},
+    convert::TryFrom,
+    io,
+    iter::{self, FromIterator},
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Default port for the Tor SOCKS5 proxy.
+const DEFAULT_SOCKS_PORT: u16 = 9050;
+
+/// Represents the configuration for a TCP/IP transport capability for libp2p.
+///
+/// The TCP sockets created by libp2p will need to be progressed by running the futures and streams
+/// obtained by libp2p through the tokio reactor.
+#[cfg_attr(docsrs, doc(cfg(feature = $feature_name)))]
+#[derive(Debug, Clone, Default)]
+pub struct TorTokioTcpConfig {
+    /// How long a listener should sleep after receiving an error, before trying again.
+    sleep_on_error: Duration,
+    /// TTL to set for opened sockets, or `None` to keep default.
+    ttl: Option<u32>,
+    /// `TCP_NODELAY` to set for opened sockets, or `None` to keep default.
+    nodelay: Option<bool>,
+    /// Map of Multiaddr to port number for local socket.
+    onion_map: HashMap<Multiaddr, u16>,
+    /// Tor SOCKS5 proxy port number.
+    socks_port: u16,
+}
+
+impl TorTokioTcpConfig {
+    /// Creates a new configuration object for TCP/IP.
+    pub fn new() -> TorTokioTcpConfig {
+        TorTokioTcpConfig {
+            sleep_on_error: Duration::from_millis(100),
+            ttl: None,
+            nodelay: None,
+            onion_map: HashMap::new(),
+            socks_port: DEFAULT_SOCKS_PORT,
+        }
+    }
+
+    /// Sets the TTL to set for opened sockets.
+    pub fn ttl(mut self, value: u32) -> Self {
+        self.ttl = Some(value);
+        self
+    }
+
+    /// Sets the `TCP_NODELAY` to set for opened sockets.
+    pub fn nodelay(mut self, value: bool) -> Self {
+        self.nodelay = Some(value);
+        self
+    }
+
+    /// Sets the map for onion address -> local socket port number.
+    pub fn onion_map(mut self, value: HashMap<Multiaddr, u16>) -> Self {
+        self.onion_map = value;
+        self
+    }
+
+    /// Sets the Tor SOCKS5 proxy port number.
+    pub fn socks_port(mut self, port: u16) -> Self {
+        self.socks_port = port;
+        self
+    }
+}
+
+type Listener<TUpgrade, TError> =
+    Pin<Box<dyn Stream<Item = Result<ListenerEvent<TUpgrade, TError>, TError>> + Send>>;
+
+impl Transport for TorTokioTcpConfig {
+    type Output = TokioTcpTransStream;
+    type Error = io::Error;
+    type Listener = Listener<Self::ListenerUpgrade, Self::Error>;
+    type ListenerUpgrade = Ready<Result<Self::Output, Self::Error>>;
+    type Dial = Pin<Box<dyn Future<Output = Result<TokioTcpTransStream, io::Error>> + Send>>;
+
+    fn listen_on(self, addr: Multiaddr) -> Result<Self::Listener, TransportError<Self::Error>> {
+        let port = match self.onion_map.get(&addr) {
+            Some(port) => port,
+            None => return Err(TransportError::MultiaddrNotSupported(addr)),
+        };
+        let socket_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, *port));
+
+        async fn do_listen(
+            cfg: TorTokioTcpConfig,
+            socket_addr: SocketAddr,
+        ) -> Result<
+            impl Stream<
+                Item = Result<
+                    ListenerEvent<Ready<Result<TokioTcpTransStream, io::Error>>, io::Error>,
+                    io::Error,
+                >,
+            >,
+            io::Error,
+        > {
+            let socket = if socket_addr.is_ipv4() {
+                Socket::new(
+                    Domain::ipv4(),
+                    Type::stream(),
+                    Some(socket2::Protocol::tcp()),
+                )?
+            } else {
+                let s = Socket::new(
+                    Domain::ipv6(),
+                    Type::stream(),
+                    Some(socket2::Protocol::tcp()),
+                )?;
+                s.set_only_v6(true)?;
+                s
+            };
+            if cfg!(target_family = "unix") {
+                socket.set_reuse_address(true)?;
+            }
+            socket.bind(&socket_addr.into())?;
+            socket.listen(1024)?; // we may want to make this configurable
+
+            let listener = <TcpListener>::try_from(socket.into_tcp_listener())
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+            let local_addr = listener.local_addr()?;
+            let port = local_addr.port();
+
+            // Determine all our listen addresses which is either a single local IP address
+            // or (if a wildcard IP address was used) the addresses of all our interfaces,
+            // as reported by `get_if_addrs`.
+            let addrs = if socket_addr.ip().is_unspecified() {
+                let addrs = host_addresses(port)?;
+                debug!(
+                    "Listening on {:?}",
+                    addrs.iter().map(|(_, _, ma)| ma).collect::<Vec<_>>()
+                );
+                Addresses::Many(addrs)
+            } else {
+                let ma = ip_to_multiaddr(local_addr.ip(), port);
+                debug!("Listening on {:?}", ma);
+                Addresses::One(ma)
+            };
+
+            // Generate `NewAddress` events for each new `Multiaddr`.
+            let pending = match addrs {
+                Addresses::One(ref ma) => {
+                    let event = ListenerEvent::NewAddress(ma.clone());
+                    let mut list = VecDeque::new();
+                    list.push_back(Ok(event));
+                    list
+                }
+                Addresses::Many(ref aa) => aa
+                    .iter()
+                    .map(|(_, _, ma)| ma)
+                    .cloned()
+                    .map(ListenerEvent::NewAddress)
+                    .map(Result::Ok)
+                    .collect::<VecDeque<_>>(),
+            };
+
+            let listen_stream = TokioTcpListenStream {
+                stream: listener,
+                pause: None,
+                pause_duration: cfg.sleep_on_error,
+                port,
+                addrs,
+                pending,
+                config: cfg,
+            };
+
+            Ok(stream::unfold(listen_stream, |s| s.next().map(Some)))
+        }
+
+        Ok(Box::pin(do_listen(self, socket_addr).try_flatten_stream()))
+    }
+
+    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        let dest = tor_address_string(addr.clone())
+            .ok_or_else(|| TransportError::MultiaddrNotSupported(addr))?;
+        debug!("dest: {}", dest);
+
+        async fn do_dial(
+            cfg: TorTokioTcpConfig,
+            dest: String,
+        ) -> Result<TokioTcpTransStream, io::Error> {
+            info!("connecting to Tor proxy ...");
+            let stream = crate::connect_tor_socks_proxy(dest, cfg.socks_port)
+                .await
+                .map_err(|e| io::Error::new(io::ErrorKind::ConnectionRefused, e))?;
+            info!("connection established");
+
+            apply_config(&cfg, &stream)?;
+
+            Ok(TokioTcpTransStream { inner: stream })
+        }
+
+        Ok(Box::pin(do_dial(self, dest)))
+    }
+}
+
+// Tor expects address in form: ADDR.onion:PORT
+fn tor_address_string(mut multi: Multiaddr) -> Option<String> {
+    let (encoded, port) = match multi.pop()? {
+        Protocol::Onion(addr, port) => {
+            (BASE32.encode(addr.as_ref()), port)
+        }
+        Protocol::Onion3(addr) => {
+            (BASE32.encode(addr.hash()), addr.port())
+        }
+        _ => return None,
+    };
+    let addr = format!("{}.onion:{}", encoded.to_lowercase(), port);
+    Some(addr)
+}
+
+/// Stream that listens on an TCP/IP address.
+#[cfg_attr(docsrs, doc(cfg(feature = $feature_name)))]
+pub struct TokioTcpListenStream {
+    /// The incoming connections.
+    stream: TcpListener,
+    /// The current pause if any.
+    pause: Option<Delay>,
+    /// How long to pause after an error.
+    pause_duration: Duration,
+    /// The port which we use as our listen port in listener event addresses.
+    port: u16,
+    /// The set of known addresses.
+    addrs: Addresses,
+    /// Temporary buffer of listener events.
+    pending: Buffer<TokioTcpTransStream>,
+    /// Original configuration.
+    config: TorTokioTcpConfig,
+}
+
+impl TokioTcpListenStream {
+    /// Takes ownership of the listener, and returns the next incoming event and the listener.
+    async fn next(
+        mut self,
+    ) -> (
+        Result<ListenerEvent<Ready<Result<TokioTcpTransStream, io::Error>>, io::Error>, io::Error>,
+        Self,
+    ) {
+        loop {
+            if let Some(event) = self.pending.pop_front() {
+                return (event, self);
+            }
+
+            if let Some(pause) = self.pause.take() {
+                let _ = pause.await;
+            }
+
+            // TODO: do we get the peer_addr at the same time?
+            let (sock, _) = match self.stream.accept().await {
+                Ok(s) => s,
+                Err(e) => {
+                    debug!("error accepting incoming connection: {}", e);
+                    self.pause = Some(Delay::new(self.pause_duration));
+                    return (Ok(ListenerEvent::Error(e)), self);
+                }
+            };
+
+            let sock_addr = match sock.peer_addr() {
+                Ok(addr) => addr,
+                Err(err) => {
+                    debug!("Failed to get peer address: {:?}", err);
+                    continue;
+                }
+            };
+
+            let local_addr = match sock.local_addr() {
+                Ok(sock_addr) => {
+                    if let Addresses::Many(ref mut addrs) = self.addrs {
+                        if let Err(err) = check_for_interface_changes(
+                            &sock_addr,
+                            self.port,
+                            addrs,
+                            &mut self.pending,
+                        ) {
+                            return (Ok(ListenerEvent::Error(err)), self);
+                        }
+                    }
+                    ip_to_multiaddr(sock_addr.ip(), sock_addr.port())
+                }
+                Err(err) => {
+                    debug!("Failed to get local address of incoming socket: {:?}", err);
+                    continue;
+                }
+            };
+
+            let remote_addr = ip_to_multiaddr(sock_addr.ip(), sock_addr.port());
+
+            match apply_config(&self.config, &sock) {
+                Ok(()) => {
+                    trace!("Incoming connection from {} at {}", remote_addr, local_addr);
+                    self.pending.push_back(Ok(ListenerEvent::Upgrade {
+                        upgrade: future::ok(TokioTcpTransStream { inner: sock }),
+                        local_addr,
+                        remote_addr,
+                    }))
+                }
+                Err(err) => {
+                    debug!(
+                        "Error upgrading incoming connection from {}: {:?}",
+                        remote_addr, err
+                    );
+                    self.pending.push_back(Ok(ListenerEvent::Upgrade {
+                        upgrade: future::err(err),
+                        local_addr,
+                        remote_addr,
+                    }))
+                }
+            }
+        }
+    }
+}
+
+/// Wraps around a `TcpStream` and adds logging for important events.
+#[cfg_attr(docsrs, doc(cfg(feature = $feature_name)))]
+#[derive(Debug)]
+pub struct TokioTcpTransStream {
+    inner: TcpStream,
+}
+
+impl Drop for TokioTcpTransStream {
+    fn drop(&mut self) {
+        if let Ok(addr) = self.inner.peer_addr() {
+            debug!("Dropped TCP connection to {:?}", addr);
+        } else {
+            debug!("Dropped TCP connection to undeterminate peer");
+        }
+    }
+}
+
+/// Applies the socket configuration parameters to a socket.
+fn apply_config(config: &TorTokioTcpConfig, socket: &TcpStream) -> Result<(), io::Error> {
+    if let Some(ttl) = config.ttl {
+        socket.set_ttl(ttl)?;
+    }
+
+    if let Some(nodelay) = config.nodelay {
+        socket.set_nodelay(nodelay)?;
+    }
+
+    Ok(())
+}
+
+impl AsyncRead for TokioTcpTransStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        tokio::io::AsyncRead::poll_read(Pin::new(&mut self.inner), cx, buf)
+    }
+}
+
+impl AsyncWrite for TokioTcpTransStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        tokio::io::AsyncWrite::poll_write(Pin::new(&mut self.inner), cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), io::Error>> {
+        tokio::io::AsyncWrite::poll_flush(Pin::new(&mut self.inner), cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), io::Error>> {
+        tokio::io::AsyncWrite::poll_shutdown(Pin::new(&mut self.inner), cx)
+    }
+}
+
+// Create a [`Multiaddr`] from the given IP address and port number.
+fn ip_to_multiaddr(ip: IpAddr, port: u16) -> Multiaddr {
+    let proto = match ip {
+        IpAddr::V4(ip) => Protocol::Ip4(ip),
+        IpAddr::V6(ip) => Protocol::Ip6(ip),
+    };
+    let it = iter::once(proto).chain(iter::once(Protocol::Tcp(port)));
+    Multiaddr::from_iter(it)
+}
+
+// Collect all local host addresses and use the provided port number as listen port.
+fn host_addresses(port: u16) -> io::Result<Vec<(IpAddr, IpNet, Multiaddr)>> {
+    let mut addrs = Vec::new();
+    for iface in get_if_addrs()? {
+        let ip = iface.ip();
+        let ma = ip_to_multiaddr(ip, port);
+        let ipn = match iface.addr {
+            IfAddr::V4(ip4) => {
+                let prefix_len = (!u32::from_be_bytes(ip4.netmask.octets())).leading_zeros();
+                let ipnet = Ipv4Net::new(ip4.ip, prefix_len as u8)
+                    .expect("prefix_len is the number of bits in a u32, so can not exceed 32");
+                IpNet::V4(ipnet)
+            }
+            IfAddr::V6(ip6) => {
+                let prefix_len = (!u128::from_be_bytes(ip6.netmask.octets())).leading_zeros();
+                let ipnet = Ipv6Net::new(ip6.ip, prefix_len as u8)
+                    .expect("prefix_len is the number of bits in a u128, so can not exceed 128");
+                IpNet::V6(ipnet)
+            }
+        };
+        addrs.push((ip, ipn, ma))
+    }
+    Ok(addrs)
+}
+
+/// Listen address information.
+#[derive(Debug)]
+enum Addresses {
+    /// A specific address is used to listen.
+    One(Multiaddr),
+    /// A set of addresses is used to listen.
+    Many(Vec<(IpAddr, IpNet, Multiaddr)>),
+}
+
+type Buffer<T> = VecDeque<Result<ListenerEvent<Ready<Result<T, io::Error>>, io::Error>, io::Error>>;
+
+// If we listen on all interfaces, find out to which interface the given
+// socket address belongs. In case we think the address is new, check
+// all host interfaces again and report new and expired listen addresses.
+fn check_for_interface_changes<T>(
+    socket_addr: &SocketAddr,
+    listen_port: u16,
+    listen_addrs: &mut Vec<(IpAddr, IpNet, Multiaddr)>,
+    pending: &mut Buffer<T>,
+) -> Result<(), io::Error> {
+    // Check for exact match:
+    if listen_addrs.iter().any(|(ip, ..)| ip == &socket_addr.ip()) {
+        return Ok(());
+    }
+
+    // No exact match => check netmask
+    if listen_addrs
+        .iter()
+        .any(|(_, net, _)| net.contains(&socket_addr.ip()))
+    {
+        return Ok(());
+    }
+
+    // The local IP address of this socket is new to us.
+    // We check for changes in the set of host addresses and report new
+    // and expired addresses.
+    //
+    // TODO: We do not detect expired addresses unless there is a new address.
+    let old_listen_addrs = std::mem::replace(listen_addrs, host_addresses(listen_port)?);
+
+    // Check for addresses no longer in use.
+    for (ip, _, ma) in old_listen_addrs.iter() {
+        if listen_addrs.iter().find(|(i, ..)| i == ip).is_none() {
+            debug!("Expired listen address: {}", ma);
+            pending.push_back(Ok(ListenerEvent::AddressExpired(ma.clone())));
+        }
+    }
+
+    // Check for new addresses.
+    for (ip, _, ma) in listen_addrs.iter() {
+        if old_listen_addrs.iter().find(|(i, ..)| i == ip).is_none() {
+            debug!("New listen address: {}", ma);
+            pending.push_back(Ok(ListenerEvent::NewAddress(ma.clone())));
+        }
+    }
+
+    // We should now be able to find the local address, if not something
+    // is seriously wrong and we report an error.
+    if listen_addrs
+        .iter()
+        .find(|(ip, net, _)| ip == &socket_addr.ip() || net.contains(&socket_addr.ip()))
+        .is_none()
+    {
+        let msg = format!("{} does not match any listen address", socket_addr.ip());
+        return Err(io::Error::new(io::ErrorKind::Other, msg));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tor_address_string;
+
+    #[test]
+    fn can_format_tor_address_v3() {
+        let multi = "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234".parse().expect("failed to parse multiaddr");
+        let want = "vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd.onion:1234";
+        let got = tor_address_string(multi).expect("failed to stringify");
+
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn can_format_tor_address_v2() {
+        let multi = "/onion/aaimaq4ygg2iegci:80".parse().expect("failed to parse multiaddr");
+        let want = "aaimaq4ygg2iegci.onion:80";
+        let got = tor_address_string(multi).expect("failed to stringify");
+
+        assert_eq!(got, want);
+    }
+}

--- a/examples/tor/tor-service-defaults-torrc
+++ b/examples/tor/tor-service-defaults-torrc
@@ -1,0 +1,15 @@
+DataDirectory /var/lib/tor
+PidFile /run/tor/tor.pid
+RunAsDaemon 1
+User debian-tor
+
+ControlSocket /run/tor/control GroupWritable RelaxDirModeCheck
+ControlSocketsGroupWritable 1
+SocksPort unix:/run/tor/socks WorldWritable
+SocksPort 9050
+
+CookieAuthentication 1
+CookieAuthFileGroupReadable 1
+CookieAuthFile /run/tor/control.authcookie
+
+Log notice syslog

--- a/examples/tor/torrc
+++ b/examples/tor/torrc
@@ -1,0 +1,192 @@
+## Configuration file for a typical Tor user
+## Last updated 9 October 2013 for Tor 0.2.5.2-alpha.
+## (may or may not work for much older or much newer versions of Tor.)
+##
+## Lines that begin with "## " try to explain what's going on. Lines
+## that begin with just "#" are disabled commands: you can enable them
+## by removing the "#" symbol.
+##
+## See 'man tor', or https://www.torproject.org/docs/tor-manual.html,
+## for more options you can use in this file.
+##
+## Tor will look for this file in various places based on your platform:
+## https://www.torproject.org/docs/faq#torrc
+
+## Tor opens a socks proxy on port 9050 by default -- even if you don't
+## configure one below. Set "SocksPort 0" if you plan to run Tor only
+## as a relay, and not make any local application connections yourself.
+#SocksPort 9050 # Default: Bind to localhost:9050 for local connections.
+#SocksPort 192.168.0.1:9100 # Bind to this address:port too.
+
+## Entry policies to allow/deny SOCKS requests based on IP address.
+## First entry that matches wins. If no SocksPolicy is set, we accept
+## all (and only) requests that reach a SocksPort. Untrusted users who
+## can access your SocksPort may be able to learn about the connections
+## you make.
+#SocksPolicy accept 192.168.0.0/16
+#SocksPolicy reject *
+
+## Logs go to stdout at level "notice" unless redirected by something
+## else, like one of the below lines. You can have as many Log lines as
+## you want.
+##
+## We advise using "notice" in most cases, since anything more verbose
+## may provide sensitive information to an attacker who obtains the logs.
+##
+## Send all messages of level 'notice' or higher to /var/log/tor/notices.log
+#Log notice file /var/log/tor/notices.log
+## Send every possible message to /var/log/tor/debug.log
+#Log debug file /var/log/tor/debug.log
+## Use the system log instead of Tor's logfiles
+#Log notice syslog
+## To send all messages to stderr:
+Log debug stderr
+
+## Uncomment this to start the process in the background... or use
+## --runasdaemon 1 on the command line. This is ignored on Windows;
+## see the FAQ entry if you want Tor to run as an NT service.
+#RunAsDaemon 1
+
+## The directory for keeping all the keys/etc. By default, we store
+## things in $HOME/.tor on Unix, and in Application Data\tor on Windows.
+#DataDirectory /var/lib/tor
+
+## The port on which Tor will listen for local connections from Tor
+## controller applications, as documented in control-spec.txt.
+#ControlPort 9051
+
+## If you enable the controlport, be sure to enable one of these
+## authentication methods, to prevent attackers from accessing it.
+#HashedControlPassword 16:872860B76453A77D60CA2BB8C1A7042072093276A3D701AD684053EC4C
+#CookieAuthentication 1
+
+############### This section is just for location-hidden services ###
+
+## Once you have configured a hidden service, you can look at the
+## contents of the file ".../hidden_service/hostname" for the address
+## to tell people.
+##
+## HiddenServicePort x y:z says to redirect requests on port x to the
+## address y:z.
+
+HiddenServiceDir /var/lib/tor/hidden_service/
+HiddenServicePort 7 127.0.0.1:7777
+
+#HiddenServiceDir /var/lib/tor/other_hidden_service/
+#HiddenServicePort 80 127.0.0.1:80
+#HiddenServicePort 22 127.0.0.1:22
+
+################ This section is just for relays #####################
+#
+## See https://www.torproject.org/docs/tor-doc-relay for details.
+
+## Required: what port to advertise for incoming Tor connections.
+#ORPort 9001
+## If you want to listen on a port other than the one advertised in
+## ORPort (e.g. to advertise 443 but bind to 9090), you can do it as
+## follows.  You'll need to do ipchains or other port forwarding
+## yourself to make this work.
+#ORPort 443 NoListen
+#ORPort 127.0.0.1:9090 NoAdvertise
+
+## The IP address or full DNS name for incoming connections to your
+## relay. Leave commented out and Tor will guess.
+#Address noname.example.com
+
+## If you have multiple network interfaces, you can specify one for
+## outgoing traffic to use.
+# OutboundBindAddress 10.0.0.5
+
+## A handle for your relay, so people don't have to refer to it by key.
+#Nickname ididnteditheconfig
+
+## Define these to limit how much relayed traffic you will allow. Your
+## own traffic is still unthrottled. Note that RelayBandwidthRate must
+## be at least 20 KB.
+## Note that units for these config options are bytes per second, not bits
+## per second, and that prefixes are binary prefixes, i.e. 2^10, 2^20, etc.
+#RelayBandwidthRate 100 KB  # Throttle traffic to 100KB/s (800Kbps)
+#RelayBandwidthBurst 200 KB # But allow bursts up to 200KB/s (1600Kbps)
+
+## Use these to restrict the maximum traffic per day, week, or month.
+## Note that this threshold applies separately to sent and received bytes,
+## not to their sum: setting "4 GB" may allow up to 8 GB total before
+## hibernating.
+##
+## Set a maximum of 4 gigabytes each way per period.
+#AccountingMax 4 GB
+## Each period starts daily at midnight (AccountingMax is per day)
+#AccountingStart day 00:00
+## Each period starts on the 3rd of the month at 15:00 (AccountingMax
+## is per month)
+#AccountingStart month 3 15:00
+
+## Administrative contact information for this relay or bridge. This line
+## can be used to contact you if your relay or bridge is misconfigured or
+## something else goes wrong. Note that we archive and publish all
+## descriptors containing these lines and that Google indexes them, so
+## spammers might also collect them. You may want to obscure the fact that
+## it's an email address and/or generate a new address for this purpose.
+#ContactInfo Random Person <nobody AT example dot com>
+## You might also include your PGP or GPG fingerprint if you have one:
+#ContactInfo 0xFFFFFFFF Random Person <nobody AT example dot com>
+
+## Uncomment this to mirror directory information for others. Please do
+## if you have enough bandwidth.
+#DirPort 9030 # what port to advertise for directory connections
+## If you want to listen on a port other than the one advertised in
+## DirPort (e.g. to advertise 80 but bind to 9091), you can do it as
+## follows.  below too. You'll need to do ipchains or other port
+## forwarding yourself to make this work.
+#DirPort 80 NoListen
+#DirPort 127.0.0.1:9091 NoAdvertise
+## Uncomment to return an arbitrary blob of html on your DirPort. Now you
+## can explain what Tor is if anybody wonders why your IP address is
+## contacting them. See contrib/tor-exit-notice.html in Tor's source
+## distribution for a sample.
+#DirPortFrontPage /etc/tor/tor-exit-notice.html
+
+## Uncomment this if you run more than one Tor relay, and add the identity
+## key fingerprint of each Tor relay you control, even if they're on
+## different networks. You declare it here so Tor clients can avoid
+## using more than one of your relays in a single circuit. See
+## https://www.torproject.org/docs/faq#MultipleRelays
+## However, you should never include a bridge's fingerprint here, as it would
+## break its concealability and potentionally reveal its IP/TCP address.
+#MyFamily $keyid,$keyid,...
+
+## A comma-separated list of exit policies. They're considered first
+## to last, and the first match wins. If you want to _replace_
+## the default exit policy, end this with either a reject *:* or an
+## accept *:*. Otherwise, you're _augmenting_ (prepending to) the
+## default exit policy. Leave commented to just use the default, which is
+## described in the man page or at
+## https://www.torproject.org/documentation.html
+##
+## Look at https://www.torproject.org/faq-abuse.html#TypicalAbuses
+## for issues you might encounter if you use the default exit policy.
+##
+## If certain IPs and ports are blocked externally, e.g. by your firewall,
+## you should update your exit policy to reflect this -- otherwise Tor
+## users will be told that those destinations are down.
+##
+## For security, by default Tor rejects connections to private (local)
+## networks, including to your public IP address. See the man page entry
+## for ExitPolicyRejectPrivate if you want to allow "exit enclaving".
+##
+#ExitPolicy accept *:6660-6667,reject *:* # allow irc ports but no more
+#ExitPolicy accept *:119 # accept nntp as well as default exit policy
+#ExitPolicy reject *:* # no exits allowed
+
+## Bridge relays (or "bridges") are Tor relays that aren't listed in the
+## main directory. Since there is no complete public list of them, even an
+## ISP that filters connections to all the known Tor relays probably
+## won't be able to block all the bridges. Also, websites won't treat you
+## differently because they won't know you're running Tor. If you can
+## be a real relay, please do; but if not, be a bridge!
+#BridgeRelay 1
+## By default, Tor will advertise your bridge to users through various
+## mechanisms like https://bridges.torproject.org/. If you want to run
+## a private bridge, for example because you'll give out your bridge
+## address manually to your friends, uncomment this line:
+#PublishServerDescriptor 0

--- a/transports/tor/Cargo.toml
+++ b/transports/tor/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "libp2p-tor"
+edition = "2018"
+description = "TCP/IP transport protocol for libp2p over the Tor network"
+version = "0.20.0"
+authors = ["Tobin C. Harding <tobin@coblox.tech>"]
+license = "MIT"
+repository = "https://github.com/libp2p/rust-libp2p"
+keywords = ["peer-to-peer", "libp2p", "networking", "tor"]
+categories = ["network-programming", "asynchronous"]
+
+[dependencies]
+data-encoding = "2.2"
+futures = "0.3.1"
+futures-timer = "3.0"
+get_if_addrs = "0.5.3"
+ipnet = "2.0.0"
+libp2p-core = { version = "0.20.0", path = "../../core" }
+log = "0.4.1"
+socket2 = "0.3.12"
+tokio = { version = "0.2", default-features = false, features = ["tcp"] }
+tokio-socks = "0.2"

--- a/transports/tor/src/lib.rs
+++ b/transports/tor/src/lib.rs
@@ -1,0 +1,552 @@
+// Copyright 2017 Parity Technologies (UK) Ltd.
+// Copyright 2020 CoBloX Pty Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Implementation of the libp2p `Transport` trait for TCP/IP over Tor.
+//!
+//! Based on code for the Tokio TCP Transport.
+
+use data_encoding::BASE32;
+use futures::{
+    future::{self, Ready},
+    prelude::*,
+};
+use futures_timer::Delay;
+use get_if_addrs::{get_if_addrs, IfAddr};
+use ipnet::{IpNet, Ipv4Net, Ipv6Net};
+use libp2p_core::{
+    multiaddr::{Multiaddr, Protocol},
+    transport::{ListenerEvent, TransportError},
+    Transport,
+};
+use log::{warn, debug, info, trace};
+use socket2::{Domain, Socket, Type};
+use std::{
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4, IpAddr},
+    collections::{HashMap, VecDeque},
+    convert::TryFrom,
+    io,
+    iter::{self, FromIterator},
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_socks::{tcp::Socks5Stream, IntoTargetAddr};
+
+/// Default port for the Tor SOCKS5 proxy.
+const DEFAULT_SOCKS_PORT: u16 = 9050;
+
+/// Represents the configuration for a TCP/IP transport capability for libp2p.
+///
+/// The TCP sockets created by libp2p will need to be progressed by running the futures and streams
+/// obtained by libp2p through the tokio reactor.
+#[cfg_attr(docsrs, doc(cfg(feature = $feature_name)))]
+#[derive(Debug, Clone, Default)]
+pub struct TorTokioTcpConfig {
+    /// How long a listener should sleep after receiving an error, before trying again.
+    sleep_on_error: Duration,
+    /// TTL to set for opened sockets, or `None` to keep default.
+    ttl: Option<u32>,
+    /// `TCP_NODELAY` to set for opened sockets, or `None` to keep default.
+    nodelay: Option<bool>,
+    /// Map of Multiaddr to port number for local socket.
+    onion_map: HashMap<Multiaddr, u16>,
+    /// Tor SOCKS5 proxy port number.
+    socks_port: u16,
+}
+
+impl TorTokioTcpConfig {
+    /// Creates a new configuration object for TCP/IP.
+    pub fn new() -> TorTokioTcpConfig {
+        TorTokioTcpConfig {
+            sleep_on_error: Duration::from_millis(100),
+            ttl: None,
+            nodelay: None,
+            onion_map: HashMap::new(),
+            socks_port: DEFAULT_SOCKS_PORT,
+        }
+    }
+
+    /// Sets the TTL to set for opened sockets.
+    pub fn ttl(mut self, value: u32) -> Self {
+        self.ttl = Some(value);
+        self
+    }
+
+    /// Sets the `TCP_NODELAY` to set for opened sockets.
+    pub fn nodelay(mut self, value: bool) -> Self {
+        self.nodelay = Some(value);
+        self
+    }
+
+    /// Sets the map for onion address -> local socket port number.
+    pub fn onion_map(mut self, value: HashMap<Multiaddr, u16>) -> Self {
+        self.onion_map = value;
+        self
+    }
+
+    /// Sets the Tor SOCKS5 proxy port number.
+    pub fn socks_port(mut self, port: u16) -> Self {
+        self.socks_port = port;
+        self
+    }
+}
+
+type Listener<TUpgrade, TError> =
+    Pin<Box<dyn Stream<Item = Result<ListenerEvent<TUpgrade, TError>, TError>> + Send>>;
+
+impl Transport for TorTokioTcpConfig {
+    type Output = TokioTcpTransStream;
+    type Error = io::Error;
+    type Listener = Listener<Self::ListenerUpgrade, Self::Error>;
+    type ListenerUpgrade = Ready<Result<Self::Output, Self::Error>>;
+    type Dial = Pin<Box<dyn Future<Output = Result<TokioTcpTransStream, io::Error>> + Send>>;
+
+    fn listen_on(self, addr: Multiaddr) -> Result<Self::Listener, TransportError<Self::Error>> {
+        if self.onion_map.is_empty() {
+            warn!("Mapping of onion address to local port number is required to use Tor");
+        }
+        let port = match self.onion_map.get(&addr) {
+            Some(port) => port,
+            None => return Err(TransportError::MultiaddrNotSupported(addr)),
+        };
+        let socket_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, *port));
+
+        async fn do_listen(
+            cfg: TorTokioTcpConfig,
+            socket_addr: SocketAddr,
+        ) -> Result<
+            impl Stream<
+                Item = Result<
+                    ListenerEvent<Ready<Result<TokioTcpTransStream, io::Error>>, io::Error>,
+                    io::Error,
+                >,
+            >,
+            io::Error,
+        > {
+            let socket = if socket_addr.is_ipv4() {
+                Socket::new(
+                    Domain::ipv4(),
+                    Type::stream(),
+                    Some(socket2::Protocol::tcp()),
+                )?
+            } else {
+                let s = Socket::new(
+                    Domain::ipv6(),
+                    Type::stream(),
+                    Some(socket2::Protocol::tcp()),
+                )?;
+                s.set_only_v6(true)?;
+                s
+            };
+            if cfg!(target_family = "unix") {
+                socket.set_reuse_address(true)?;
+            }
+            socket.bind(&socket_addr.into())?;
+            socket.listen(1024)?; // we may want to make this configurable
+
+            let listener = <TcpListener>::try_from(socket.into_tcp_listener())
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+            let local_addr = listener.local_addr()?;
+            let port = local_addr.port();
+
+            // Determine all our listen addresses which is either a single local IP address
+            // or (if a wildcard IP address was used) the addresses of all our interfaces,
+            // as reported by `get_if_addrs`.
+            let addrs = if socket_addr.ip().is_unspecified() {
+                let addrs = host_addresses(port)?;
+                debug!(
+                    "Listening on {:?}",
+                    addrs.iter().map(|(_, _, ma)| ma).collect::<Vec<_>>()
+                );
+                Addresses::Many(addrs)
+            } else {
+                let ma = ip_to_multiaddr(local_addr.ip(), port);
+                debug!("Listening on {:?}", ma);
+                Addresses::One(ma)
+            };
+
+            // Generate `NewAddress` events for each new `Multiaddr`.
+            let pending = match addrs {
+                Addresses::One(ref ma) => {
+                    let event = ListenerEvent::NewAddress(ma.clone());
+                    let mut list = VecDeque::new();
+                    list.push_back(Ok(event));
+                    list
+                }
+                Addresses::Many(ref aa) => aa
+                    .iter()
+                    .map(|(_, _, ma)| ma)
+                    .cloned()
+                    .map(ListenerEvent::NewAddress)
+                    .map(Result::Ok)
+                    .collect::<VecDeque<_>>(),
+            };
+
+            let listen_stream = TokioTcpListenStream {
+                stream: listener,
+                pause: None,
+                pause_duration: cfg.sleep_on_error,
+                port,
+                addrs,
+                pending,
+                config: cfg,
+            };
+
+            Ok(stream::unfold(listen_stream, |s| s.next().map(Some)))
+        }
+
+        Ok(Box::pin(do_listen(self, socket_addr).try_flatten_stream()))
+    }
+
+    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        let dest = tor_address_string(addr.clone())
+            .ok_or_else(|| TransportError::MultiaddrNotSupported(addr))?;
+        debug!("dest: {}", dest);
+
+        async fn do_dial(
+            cfg: TorTokioTcpConfig,
+            dest: String,
+        ) -> Result<TokioTcpTransStream, io::Error> {
+            info!("connecting to Tor proxy ...");
+            let stream = crate::connect_tor_socks_proxy(dest, cfg.socks_port)
+                .await
+                .map_err(|e| io::Error::new(io::ErrorKind::ConnectionRefused, e))?;
+            info!("connection established");
+
+            apply_config(&cfg, &stream)?;
+
+            Ok(TokioTcpTransStream { inner: stream })
+        }
+
+        Ok(Box::pin(do_dial(self, dest)))
+    }
+}
+
+// Tor expects address in form: ADDR.onion:PORT
+fn tor_address_string(mut multi: Multiaddr) -> Option<String> {
+    let (encoded, port) = match multi.pop()? {
+        Protocol::Onion(addr, port) => {
+            (BASE32.encode(addr.as_ref()), port)
+        }
+        Protocol::Onion3(addr) => {
+            (BASE32.encode(addr.hash()), addr.port())
+        }
+        _ => return None,
+    };
+    let addr = format!("{}.onion:{}", encoded.to_lowercase(), port);
+    Some(addr)
+}
+
+/// Connect to the Tor SOCKS5 proxy socket.
+async fn connect_tor_socks_proxy<'a>(dest: impl IntoTargetAddr<'a>, port: u16) -> Result<TcpStream, tokio_socks::Error> {
+    let tor_sock = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port));
+    let stream = Socks5Stream::connect(tor_sock, dest).await?;
+    Ok(stream.into_inner())
+}
+
+/// Stream that listens on an TCP/IP address.
+#[cfg_attr(docsrs, doc(cfg(feature = $feature_name)))]
+pub struct TokioTcpListenStream {
+    /// The incoming connections.
+    stream: TcpListener,
+    /// The current pause if any.
+    pause: Option<Delay>,
+    /// How long to pause after an error.
+    pause_duration: Duration,
+    /// The port which we use as our listen port in listener event addresses.
+    port: u16,
+    /// The set of known addresses.
+    addrs: Addresses,
+    /// Temporary buffer of listener events.
+    pending: Buffer<TokioTcpTransStream>,
+    /// Original configuration.
+    config: TorTokioTcpConfig,
+}
+
+impl TokioTcpListenStream {
+    /// Takes ownership of the listener, and returns the next incoming event and the listener.
+    async fn next(
+        mut self,
+    ) -> (
+        Result<ListenerEvent<Ready<Result<TokioTcpTransStream, io::Error>>, io::Error>, io::Error>,
+        Self,
+    ) {
+        loop {
+            if let Some(event) = self.pending.pop_front() {
+                return (event, self);
+            }
+
+            if let Some(pause) = self.pause.take() {
+                let _ = pause.await;
+            }
+
+            // TODO: do we get the peer_addr at the same time?
+            let (sock, _) = match self.stream.accept().await {
+                Ok(s) => s,
+                Err(e) => {
+                    debug!("error accepting incoming connection: {}", e);
+                    self.pause = Some(Delay::new(self.pause_duration));
+                    return (Ok(ListenerEvent::Error(e)), self);
+                }
+            };
+
+            let sock_addr = match sock.peer_addr() {
+                Ok(addr) => addr,
+                Err(err) => {
+                    debug!("Failed to get peer address: {:?}", err);
+                    continue;
+                }
+            };
+
+            let local_addr = match sock.local_addr() {
+                Ok(sock_addr) => {
+                    if let Addresses::Many(ref mut addrs) = self.addrs {
+                        if let Err(err) = check_for_interface_changes(
+                            &sock_addr,
+                            self.port,
+                            addrs,
+                            &mut self.pending,
+                        ) {
+                            return (Ok(ListenerEvent::Error(err)), self);
+                        }
+                    }
+                    ip_to_multiaddr(sock_addr.ip(), sock_addr.port())
+                }
+                Err(err) => {
+                    debug!("Failed to get local address of incoming socket: {:?}", err);
+                    continue;
+                }
+            };
+
+            let remote_addr = ip_to_multiaddr(sock_addr.ip(), sock_addr.port());
+
+            match apply_config(&self.config, &sock) {
+                Ok(()) => {
+                    trace!("Incoming connection from {} at {}", remote_addr, local_addr);
+                    self.pending.push_back(Ok(ListenerEvent::Upgrade {
+                        upgrade: future::ok(TokioTcpTransStream { inner: sock }),
+                        local_addr,
+                        remote_addr,
+                    }))
+                }
+                Err(err) => {
+                    debug!(
+                        "Error upgrading incoming connection from {}: {:?}",
+                        remote_addr, err
+                    );
+                    self.pending.push_back(Ok(ListenerEvent::Upgrade {
+                        upgrade: future::err(err),
+                        local_addr,
+                        remote_addr,
+                    }))
+                }
+            }
+        }
+    }
+}
+
+/// Wraps around a `TcpStream` and adds logging for important events.
+#[cfg_attr(docsrs, doc(cfg(feature = $feature_name)))]
+#[derive(Debug)]
+pub struct TokioTcpTransStream {
+    inner: TcpStream,
+}
+
+impl Drop for TokioTcpTransStream {
+    fn drop(&mut self) {
+        if let Ok(addr) = self.inner.peer_addr() {
+            debug!("Dropped TCP connection to {:?}", addr);
+        } else {
+            debug!("Dropped TCP connection to undeterminate peer");
+        }
+    }
+}
+
+/// Applies the socket configuration parameters to a socket.
+fn apply_config(config: &TorTokioTcpConfig, socket: &TcpStream) -> Result<(), io::Error> {
+    if let Some(ttl) = config.ttl {
+        socket.set_ttl(ttl)?;
+    }
+
+    if let Some(nodelay) = config.nodelay {
+        socket.set_nodelay(nodelay)?;
+    }
+
+    Ok(())
+}
+
+impl AsyncRead for TokioTcpTransStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        tokio::io::AsyncRead::poll_read(Pin::new(&mut self.inner), cx, buf)
+    }
+}
+
+impl AsyncWrite for TokioTcpTransStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        tokio::io::AsyncWrite::poll_write(Pin::new(&mut self.inner), cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), io::Error>> {
+        tokio::io::AsyncWrite::poll_flush(Pin::new(&mut self.inner), cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), io::Error>> {
+        tokio::io::AsyncWrite::poll_shutdown(Pin::new(&mut self.inner), cx)
+    }
+}
+
+// Create a [`Multiaddr`] from the given IP address and port number.
+fn ip_to_multiaddr(ip: IpAddr, port: u16) -> Multiaddr {
+    let proto = match ip {
+        IpAddr::V4(ip) => Protocol::Ip4(ip),
+        IpAddr::V6(ip) => Protocol::Ip6(ip),
+    };
+    let it = iter::once(proto).chain(iter::once(Protocol::Tcp(port)));
+    Multiaddr::from_iter(it)
+}
+
+// Collect all local host addresses and use the provided port number as listen port.
+fn host_addresses(port: u16) -> io::Result<Vec<(IpAddr, IpNet, Multiaddr)>> {
+    let mut addrs = Vec::new();
+    for iface in get_if_addrs()? {
+        let ip = iface.ip();
+        let ma = ip_to_multiaddr(ip, port);
+        let ipn = match iface.addr {
+            IfAddr::V4(ip4) => {
+                let prefix_len = (!u32::from_be_bytes(ip4.netmask.octets())).leading_zeros();
+                let ipnet = Ipv4Net::new(ip4.ip, prefix_len as u8)
+                    .expect("prefix_len is the number of bits in a u32, so can not exceed 32");
+                IpNet::V4(ipnet)
+            }
+            IfAddr::V6(ip6) => {
+                let prefix_len = (!u128::from_be_bytes(ip6.netmask.octets())).leading_zeros();
+                let ipnet = Ipv6Net::new(ip6.ip, prefix_len as u8)
+                    .expect("prefix_len is the number of bits in a u128, so can not exceed 128");
+                IpNet::V6(ipnet)
+            }
+        };
+        addrs.push((ip, ipn, ma))
+    }
+    Ok(addrs)
+}
+
+/// Listen address information.
+#[derive(Debug)]
+enum Addresses {
+    /// A specific address is used to listen.
+    One(Multiaddr),
+    /// A set of addresses is used to listen.
+    Many(Vec<(IpAddr, IpNet, Multiaddr)>),
+}
+
+type Buffer<T> = VecDeque<Result<ListenerEvent<Ready<Result<T, io::Error>>, io::Error>, io::Error>>;
+
+// If we listen on all interfaces, find out to which interface the given
+// socket address belongs. In case we think the address is new, check
+// all host interfaces again and report new and expired listen addresses.
+fn check_for_interface_changes<T>(
+    socket_addr: &SocketAddr,
+    listen_port: u16,
+    listen_addrs: &mut Vec<(IpAddr, IpNet, Multiaddr)>,
+    pending: &mut Buffer<T>,
+) -> Result<(), io::Error> {
+    // Check for exact match:
+    if listen_addrs.iter().any(|(ip, ..)| ip == &socket_addr.ip()) {
+        return Ok(());
+    }
+
+    // No exact match => check netmask
+    if listen_addrs
+        .iter()
+        .any(|(_, net, _)| net.contains(&socket_addr.ip()))
+    {
+        return Ok(());
+    }
+
+    // The local IP address of this socket is new to us.
+    // We check for changes in the set of host addresses and report new
+    // and expired addresses.
+    //
+    // TODO: We do not detect expired addresses unless there is a new address.
+    let old_listen_addrs = std::mem::replace(listen_addrs, host_addresses(listen_port)?);
+
+    // Check for addresses no longer in use.
+    for (ip, _, ma) in old_listen_addrs.iter() {
+        if listen_addrs.iter().find(|(i, ..)| i == ip).is_none() {
+            debug!("Expired listen address: {}", ma);
+            pending.push_back(Ok(ListenerEvent::AddressExpired(ma.clone())));
+        }
+    }
+
+    // Check for new addresses.
+    for (ip, _, ma) in listen_addrs.iter() {
+        if old_listen_addrs.iter().find(|(i, ..)| i == ip).is_none() {
+            debug!("New listen address: {}", ma);
+            pending.push_back(Ok(ListenerEvent::NewAddress(ma.clone())));
+        }
+    }
+
+    // We should now be able to find the local address, if not something
+    // is seriously wrong and we report an error.
+    if listen_addrs
+        .iter()
+        .find(|(ip, net, _)| ip == &socket_addr.ip() || net.contains(&socket_addr.ip()))
+        .is_none()
+    {
+        let msg = format!("{} does not match any listen address", socket_addr.ip());
+        return Err(io::Error::new(io::ErrorKind::Other, msg));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tor_address_string;
+
+    #[test]
+    fn can_format_tor_address_v3() {
+        let multi = "/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234".parse().expect("failed to parse multiaddr");
+        let want = "vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd.onion:1234";
+        let got = tor_address_string(multi).expect("failed to stringify");
+
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn can_format_tor_address_v2() {
+        let multi = "/onion/aaimaq4ygg2iegci:80".parse().expect("failed to parse multiaddr");
+        let want = "aaimaq4ygg2iegci.onion:80";
+        let got = tor_address_string(multi).expect("failed to stringify");
+
+        assert_eq!(got, want);
+    }
+}


### PR DESCRIPTION
Add a Tor transport based on the Tokio TCP Transport. This Transport allows users of libp2p to run all TCP traffic over the Tor network.

For the listener side of the application, using this transport, one can pass an onion address to the application. libp2p will pass this address down to the transport via the call to `listen_on`. In order to create a listening socket to redirect the onion service to we must be able to map from the onion `Multiaddr` to the port number to use. In order to do this we add a `HashMap` to the `TorTokioTcpConfig`, the user must set up this map when building the transport.

For the dialer side things are considerably more simple. When the `dial` method is called we set up an IPv4 TCP connection to the locally running Tor instance's SOCKS5 proxy. We then simply return the `TcpStream` that was created.

This works with upgrades and is tested with multiplexing via yamux and authentication via secio.

Patch 1 adds the new Transport. Patch 2 adds an example application to show how the new transport can be used.

Creating as a draft because this PR introduces a lot of duplicate code copied from the TCP transport. I have some ideas how to reduce this but would like to see I'm on the right track first.

Thanks