### PR TITLE
Improve the code of the WebSocket browser binding

### DIFF
--- a/transports/wasm-ext/CHANGELOG.md
+++ b/transports/wasm-ext/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.20.1 [????-??-??]
+# 0.20.1 [2020-07-06]
 
 - Improve the code quality of the `websockets.js` binding with the browser's `WebSocket` API.
 

--- a/transports/wasm-ext/CHANGELOG.md
+++ b/transports/wasm-ext/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.20.1 [????-??-??]
+
+- Improve the code quality of the `websockets.js` binding with the browser's `WebSocket` API.
+
 # 0.20.0 [2020-07-01]
 
 - Updated dependencies.

--- a/transports/wasm-ext/Cargo.toml
+++ b/transports/wasm-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-wasm-ext"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 edition = "2018"
 description = "Allows passing in an external transport in a WASM environment"

--- a/transports/wasm-ext/src/lib.rs
+++ b/transports/wasm-ext/src/lib.rs
@@ -72,14 +72,17 @@ pub mod ffi {
         #[wasm_bindgen(method, catch)]
         pub fn listen_on(this: &Transport, multiaddr: &str) -> Result<js_sys::Iterator, JsValue>;
 
-        /// Returns a `Readable​Stream​`.
+        /// Returns an iterator of JavaScript `Promise`s that resolve to `ArrayBuffer` objects
+        /// (or resolve to null, see below). These `ArrayBuffer` objects contain the data that the
+        /// remote has sent to us. If the remote closes the connection, the iterator must produce
+        /// a `Promise` that resolves to `null`.
         #[wasm_bindgen(method, getter)]
         pub fn read(this: &Connection) -> js_sys::Iterator;
 
         /// Writes data to the connection. Returns a `Promise` that resolves when the connection is
         /// ready for writing again.
         ///
-        /// If the `Promise` returns an error, the writing side of the connection is considered
+        /// If the `Promise` produces an error, the writing side of the connection is considered
         /// unrecoverable and the connection should be closed as soon as possible.
         ///
         /// Guaranteed to only be called after the previous write promise has resolved.
@@ -95,7 +98,8 @@ pub mod ffi {
         #[wasm_bindgen(method)]
         pub fn close(this: &Connection);
 
-        /// List of addresses we have started listening on. Must be an array of strings of multiaddrs.
+        /// List of addresses we have started listening on. Must be an array of strings of
+        /// multiaddrs.
         #[wasm_bindgen(method, getter)]
         pub fn new_addrs(this: &ListenEvent) -> Option<Box<[JsValue]>>;
 


### PR DESCRIPTION
Reworks a bit the binding between `libp2p-wasm-ext` and the browser's `WebSocket` object.

I've used https://html.spec.whatwg.org/multipage/web-sockets.html to review the current code and make it more robust.

Notably:

- We now directly ask the browser to produce `ArrayBuffer` objects rather than obtaining `Blob` objects and converting them manually into `ArrayBuffer`.
- The threshold for sending more data is now 8kiB. In other words, as long as the out buffer (the one handled by the browser and whose length is accessed through `bufferedAmount`) is smaller than 8kiB, we report to the upper layers that we are ready to accept more data.
- `onclose` and `onerror` now unconditionally irreversibly shut down both the opening attempt and the incoming stream of bytes, without checking the state of the connection.
- Sending now returns a `Promise` that repeatedly checks `WebSocket.readyState` and returns an error if it's no longer open.

The changes in `lib.rs` are only documentation clarifications, no change to the API itself has been made.
