### PR TITLE
Allow gossipsub Topic construction from any string

### DIFF
--- a/examples/gossipsub-chat.rs
+++ b/examples/gossipsub-chat.rs
@@ -72,7 +72,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let transport = libp2p::build_development_transport(local_key)?;
 
     // Create a Gossipsub topic
-    let topic = Topic::new("test-net".into());
+    let topic = Topic::new("test-net");
 
     // Create a Swarm to manage peers and events
     let mut swarm = {

--- a/examples/ipfs-private.rs
+++ b/examples/ipfs-private.rs
@@ -168,7 +168,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let transport = build_transport(local_key.clone(), psk);
 
     // Create a Gosspipsub topic
-    let gossipsub_topic = gossipsub::Topic::new("chat".into());
+    let gossipsub_topic = gossipsub::Topic::new("chat");
 
     // We create a custom network behaviour that combines gossipsub, ping and identify.
     #[derive(NetworkBehaviour)]

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -562,7 +562,7 @@ mod tests {
         let mut gs: Gossipsub = Gossipsub::new(PeerId::random(), gs_config);
 
         // create a topic and fill it with some peers
-        let topic_hash = Topic::new("Test".into()).no_hash().clone();
+        let topic_hash = Topic::new("Test").no_hash().clone();
         let mut peers = vec![];
         for _ in 0..20 {
             peers.push(PeerId::random())

--- a/protocols/gossipsub/src/mcache.rs
+++ b/protocols/gossipsub/src/mcache.rs
@@ -166,8 +166,8 @@ mod tests {
     fn test_put_get_one() {
         let mut mc = MessageCache::new_default(10, 15);
 
-        let topic1_hash = Topic::new("topic1".into()).no_hash().clone();
-        let topic2_hash = Topic::new("topic2".into()).no_hash().clone();
+        let topic1_hash = Topic::new("topic1").no_hash().clone();
+        let topic2_hash = Topic::new("topic2").no_hash().clone();
 
         let m = gen_testm(10, vec![topic1_hash, topic2_hash]);
 
@@ -192,8 +192,8 @@ mod tests {
     fn test_get_wrong() {
         let mut mc = MessageCache::new_default(10, 15);
 
-        let topic1_hash = Topic::new("topic1".into()).no_hash().clone();
-        let topic2_hash = Topic::new("topic2".into()).no_hash().clone();
+        let topic1_hash = Topic::new("topic1").no_hash().clone();
+        let topic2_hash = Topic::new("topic2").no_hash().clone();
 
         let m = gen_testm(10, vec![topic1_hash, topic2_hash]);
 
@@ -239,8 +239,8 @@ mod tests {
     fn test_shift() {
         let mut mc = MessageCache::new_default(1, 5);
 
-        let topic1_hash = Topic::new("topic1".into()).no_hash().clone();
-        let topic2_hash = Topic::new("topic2".into()).no_hash().clone();
+        let topic1_hash = Topic::new("topic1").no_hash().clone();
+        let topic2_hash = Topic::new("topic2").no_hash().clone();
 
         // Build the message
         for i in 0..10 {
@@ -263,8 +263,8 @@ mod tests {
     fn test_empty_shift() {
         let mut mc = MessageCache::new_default(1, 5);
 
-        let topic1_hash = Topic::new("topic1".into()).no_hash().clone();
-        let topic2_hash = Topic::new("topic2".into()).no_hash().clone();
+        let topic1_hash = Topic::new("topic1").no_hash().clone();
+        let topic2_hash = Topic::new("topic2").no_hash().clone();
         // Build the message
         for i in 0..10 {
             let m = gen_testm(i, vec![topic1_hash.clone(), topic2_hash.clone()]);
@@ -289,8 +289,8 @@ mod tests {
     fn test_remove_last_from_shift() {
         let mut mc = MessageCache::new_default(4, 5);
 
-        let topic1_hash = Topic::new("topic1".into()).no_hash().clone();
-        let topic2_hash = Topic::new("topic2".into()).no_hash().clone();
+        let topic1_hash = Topic::new("topic1").no_hash().clone();
+        let topic2_hash = Topic::new("topic2").no_hash().clone();
         // Build the message
         for i in 0..10 {
             let m = gen_testm(i, vec![topic1_hash.clone(), topic2_hash.clone()]);

--- a/protocols/gossipsub/src/topic.rs
+++ b/protocols/gossipsub/src/topic.rs
@@ -51,8 +51,8 @@ pub struct Topic {
 }
 
 impl Topic {
-    pub fn new(topic: String) -> Self {
-        Topic { topic }
+    pub fn new(topic: impl Into<String>) -> Self {
+        Topic { topic: topic.into() }
     }
 
     /// Creates a `TopicHash` by SHA256 hashing the topic then base64 encoding the

--- a/protocols/gossipsub/tests/smoke.rs
+++ b/protocols/gossipsub/tests/smoke.rs
@@ -179,7 +179,7 @@ fn multi_hop_propagation() {
         let number_nodes = graph.nodes.len();
 
         // Subscribe each node to the same topic.
-        let topic = Topic::new("test-net".into());
+        let topic = Topic::new("test-net");
         for (_addr, node) in &mut graph.nodes {
             node.subscribe(topic.clone());
         }


### PR DESCRIPTION
Extend the constructor to allow any `Into<String>` input.
Unfortunately, this invalidates the current call sites with `"blah".into()`, so this should only be rolled into a new 0.x release.