### PR TITLE
[libp2p-swarm] Ignore a node's own addresses on dialing.

### DIFF
--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 - Documentation updates.
 
+- Ignore addresses returned by `NetworkBehaviour::addresses_of_peer`
+that the `Swarm` considers to be listening addresses of the local node. This
+avoids futile dialing attempts of a node to itself, which can otherwise
+even happen in genuine situations, e.g. after the local node changed
+its network identity and a behaviour makes a dialing attempt to a
+former identity using the same addresses.
+
 # 0.20.0 [2020-07-01]
 
 - Updated the `libp2p-core` dependency.

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -382,13 +382,17 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
     /// dialing attempt or `addresses_of_peer` reports no addresses, `Ok(false)`
     /// is returned.
     pub fn dial(me: &mut Self, peer_id: &PeerId) -> Result<(), DialError> {
-        let mut addrs = me.behaviour.addresses_of_peer(peer_id).into_iter();
-        let peer = me.network.peer(peer_id.clone());
+        let self_ext_addrs = &me.external_addrs;
+        let self_lst_addrs = &me.listened_addrs;
+        let mut addrs = me.behaviour.addresses_of_peer(peer_id)
+            .into_iter()
+            .filter(|a| !self_ext_addrs.contains(a) && !self_lst_addrs.contains(a));
 
         let result =
             if let Some(first) = addrs.next() {
                 let handler = me.behaviour.new_handler().into_node_handler_builder();
-                peer.dial(first, addrs, handler)
+                me.network.peer(peer_id.clone())
+                    .dial(first, addrs, handler)
                     .map(|_| ())
                     .map_err(DialError::ConnectionLimit)
             } else {
@@ -696,11 +700,15 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                             // ongoing dialing attempt, if there is one.
                             log::trace!("Condition for new dialing attempt to {:?} not met: {:?}",
                                 peer_id, condition);
+                            let self_ext_addrs = &this.external_addrs;
+                            let self_lst_addrs = &this.listened_addrs;
                             if let Some(mut peer) = this.network.peer(peer_id.clone()).into_dialing() {
                                 let addrs = this.behaviour.addresses_of_peer(peer.id());
                                 let mut attempt = peer.some_attempt();
-                                for addr in addrs {
-                                    attempt.add_address(addr);
+                                for a in addrs {
+                                    if !self_ext_addrs.contains(&a) && !self_lst_addrs.contains(&a) {
+                                        attempt.add_address(a);
+                                    }
                                 }
                             }
                         }

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -382,11 +382,10 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
     /// dialing attempt or `addresses_of_peer` reports no addresses, `Ok(false)`
     /// is returned.
     pub fn dial(me: &mut Self, peer_id: &PeerId) -> Result<(), DialError> {
-        let self_ext_addrs = &me.external_addrs;
-        let self_lst_addrs = &me.listened_addrs;
+        let self_listening = &me.listened_addrs;
         let mut addrs = me.behaviour.addresses_of_peer(peer_id)
             .into_iter()
-            .filter(|a| !self_ext_addrs.contains(a) && !self_lst_addrs.contains(a));
+            .filter(|a| !self_listening.contains(a));
 
         let result =
             if let Some(first) = addrs.next() {
@@ -700,13 +699,12 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                             // ongoing dialing attempt, if there is one.
                             log::trace!("Condition for new dialing attempt to {:?} not met: {:?}",
                                 peer_id, condition);
-                            let self_ext_addrs = &this.external_addrs;
-                            let self_lst_addrs = &this.listened_addrs;
+                            let self_listening = &this.listened_addrs;
                             if let Some(mut peer) = this.network.peer(peer_id.clone()).into_dialing() {
                                 let addrs = this.behaviour.addresses_of_peer(peer.id());
                                 let mut attempt = peer.some_attempt();
                                 for a in addrs {
-                                    if !self_ext_addrs.contains(&a) && !self_lst_addrs.contains(&a) {
+                                    if !self_listening.contains(&a) {
                                         attempt.add_address(a);
                                     }
                                 }

--- a/swarm/src/registry.rs
+++ b/swarm/src/registry.rs
@@ -99,11 +99,6 @@ impl Addresses {
         self.registry.push(r)
     }
 
-    /// Checks whether an address is in the collection.
-    pub fn contains(&self, addr: &Multiaddr) -> bool {
-        self.registry.iter().any(|r| &r.addr == addr)
-    }
-
     /// Return an iterator over all [`Multiaddr`] values.
     ///
     /// The iteration is ordered by descending score.

--- a/swarm/src/registry.rs
+++ b/swarm/src/registry.rs
@@ -99,6 +99,11 @@ impl Addresses {
         self.registry.push(r)
     }
 
+    /// Checks whether an address is in the collection.
+    pub fn contains(&self, addr: &Multiaddr) -> bool {
+        self.registry.iter().any(|r| &r.addr == addr)
+    }
+
     /// Return an iterator over all [`Multiaddr`] values.
     ///
     /// The iteration is ordered by descending score.


### PR DESCRIPTION
Dialing attempts of a local node to one of its own addresses for what appears to be a different peer ID are futile and bound to fail with an `InvalidPeerId` error. To avoid such futile dialing attempts, filter out the node's own addresses from the addresses
reported by the `NetworkBehaviour` for any peer.

There can be a few reasons why a `NetworkBehaviour` may think an address belongs to a different peer, e.g.:

  1. In the context of e.g. `libp2p-kad`, the local node may have changed its network identity (e.g. key rotation)
     and "discovers" its former identity in the DHT, with the same address(es).
  2. Another peer may erroneously or intentionally, possibly even maliciously, report one of the local node's addresses as its own, making the node try to connect to itself.

Note: It is already the case (i.e. before this PR) that an attempt to dial the local peer ID is an error. This PR deals with the situation of trying to dial one of the local node's own addresses for what appears to be a different peer ID. Since many such situations are not necessarily programmer error, or it is at least unreasonably cumbersome to have each `NetworkBehaviour` track the local node's addresses, which the `Swarm` already does, just to avoid returning a local address for a different peer ID from `addresses_of_peer`, it seems sensible to just ignore such addresses directly in the `Swarm` which already keeps track of these.

Relates to https://github.com/paritytech/stakingops-issues/issues/18.