### PR TITLE
Updating github actions to use actions-rs/cargo for running cargo commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,15 @@ jobs:
         path: target
         key: cargo-build-target-${{ hashFiles('Cargo.toml') }}
     - name: Run tests, with no feature
-      run: cargo test --workspace --no-default-features
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace --no-default-features
     - name: Run tests, with all features
-      run: cargo test --workspace --all-features
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace --all-features
 
   test-wasm:
     name: Build on WASM


### PR DESCRIPTION
I noticed with the latest cargo (cargo 1.44.1) the latest version of libp2p (0.21.1) was not compiling due to this error:

<img width="1000" alt="Screen Shot 2020-07-08 at 2 25 10 PM" src="https://user-images.githubusercontent.com/2285160/86971907-de41e580-c126-11ea-81b3-30f3b236051b.png">

and yet the CI github action to run tests was not catching it (https://github.com/libp2p/rust-libp2p/actions) and gave a green checkmark to a bunch of commits that failed to compile locally. 

This PR isn't a fix for the compile error, but a fix to the github actions workflow so that these errors are caught in the future. 