### PR TITLE
Add ord for multiaddr

### DIFF
--- a/misc/multiaddr/src/lib.rs
+++ b/misc/multiaddr/src/lib.rs
@@ -36,7 +36,7 @@ static_assertions::const_assert! {
 }
 
 /// Representation of a Multiaddr.
-#[derive(PartialEq, Eq, Clone, Hash)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub struct Multiaddr { bytes: Arc<Vec<u8>> }
 
 impl Multiaddr {


### PR DESCRIPTION
So you can use it in ordering based containers like BTreeSet/BTreeMap etc. without a newtype wrapper.