### PR TITLE
Update rustls dependency.

### DIFF
--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,6 +1,6 @@
-# ?.?.? [????-??-??]
+# 0.21.1 [2020-07-09]
 
-- Update `rustls` dependency to `0.18`.
+- Update `async-tls` and `rustls` dependency.
 
 # 0.21.0 [2020-07-02]
 

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,3 +1,7 @@
+# ?.?.? [????-??-??]
+
+- Update `rustls` dependency to `0.18`.
+
 # 0.21.0 [2020-07-02]
 
 - Update `libp2p-core`.

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-tls = "0.7.0"
+async-tls = "0.7.1"
 either = "1.5.3"
 futures = "0.3.1"
 libp2p-core = { version = "0.20.0", path = "../../core" }

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-websocket"
 edition = "2018"
 description = "WebSocket transport for libp2p"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -10,7 +10,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-tls = "0.7.1"
+async-tls = "0.8.0"
 either = "1.5.3"
 futures = "0.3.1"
 libp2p-core = { version = "0.20.0", path = "../../core" }

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3.1"
 libp2p-core = { version = "0.20.0", path = "../../core" }
 log = "0.4.8"
 quicksink = "0.1"
-rustls = "0.17.0"
+rustls = "0.18.0"
 rw-stream-sink = "0.2.0"
 soketto = { version = "0.4.1", features = ["deflate"] }
 url = "2.1"


### PR DESCRIPTION
The `async-tls` patch release `0.7.1` bumped its `rustls` dependency from `0.17` to `0.18`. `libp2p-websocket` has an explicit dependency on `rustls-0.17`, thus both versions get be pulled in resulting in problems like
```rust
error[E0277]: the trait bound `async_tls::connector::TlsConnector: std::convert::From<std::sync::Arc<rustls::client::ClientConfig>>` is not satisfied
  --> transports/websocket/src/tls.rs:73:47
   |
73 |             client: Arc::new(client_config()).into(),
   |                                               ^^^^ the trait `std::convert::From<std::sync::Arc<rustls::client::ClientConfig>>` is not implemented for `async_tls::connector::TlsConnector`
   |
   = help: the following implementations were found:
             <async_tls::connector::TlsConnector as std::convert::From<std::sync::Arc<rustls::client::ClientConfig>>>
   = note: required because of the requirements on the impl of `std::convert::Into<async_tls::connector::TlsConnector>` for `std::sync::Arc<rustls::client::ClientConfig>`
```
See e.g. [this build](https://github.com/libp2p/rust-libp2p/pull/1651/checks?check_run_id=851012006). To fix this, this PR updates `rustls` to `0.18` for `libp2p-websocket` as well. Given that `rustls`-types are at least in part exposed on the `async-tls` API (as witnessed above), it may have been more appropriate for the minor `rustls` version bump to be released as `async-tls-0.8` :man_shrugging: 