### PR TITLE
Bump rustls to 0.18.0

### DIFF
--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -10,13 +10,13 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-tls = "0.7.0"
+async-tls = "0.7.1"
 either = "1.5.3"
 futures = "0.3.1"
 libp2p-core = { version = "0.20.0", path = "../../core" }
 log = "0.4.8"
 quicksink = "0.1"
-rustls = "0.17.0"
+rustls = "0.18.0"
 rw-stream-sink = "0.2.0"
 soketto = { version = "0.4.1", features = ["deflate"] }
 url = "2.1"

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-tls = "0.7.1"
+async-tls = "0.8"
 either = "1.5.3"
 futures = "0.3.1"
 libp2p-core = { version = "0.20.0", path = "../../core" }


### PR DESCRIPTION
Fixes #1654.

Also update `async-tls` dependency to 0.7.1 as this is what brings the new `rustls` version into the dependency tree.