### PR TITLE
[request-response] Close substream after writing request/response.

### DIFF
--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.1
+
+- Always properly `close()` the substream after sending requests and
+responses in the `InboundUpgrade` and `OutboundUpgrade`. Otherwise this is
+left to `RequestResponseCodec::write_request` and `RequestResponseCodec::write_response`,
+which can be a pitfall and lead to subtle problems (see e.g.
+https://github.com/libp2p/rust-libp2p/pull/1606).
+
 # 0.1.0
 
 - Initial release.

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-request-response"
 edition = "2018"
 description = "Generic Request/Response Protocols"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/request-response/src/handler/protocol.rs
+++ b/protocols/request-response/src/handler/protocol.rs
@@ -111,9 +111,9 @@ where
                 if let Ok(response) = self.response_receiver.await {
                     let write = self.codec.write_response(&protocol, &mut io, response);
                     write.await?;
-                    io.close().await?;
                 }
             }
+            io.close().await?;
             Ok(())
         }.boxed()
     }
@@ -164,4 +164,3 @@ where
         }.boxed()
     }
 }
-

--- a/protocols/request-response/src/handler/protocol.rs
+++ b/protocols/request-response/src/handler/protocol.rs
@@ -111,6 +111,7 @@ where
                 if let Ok(response) = self.response_receiver.await {
                     let write = self.codec.write_response(&protocol, &mut io, response);
                     write.await?;
+                    io.close().await?;
                 }
             }
             Ok(())
@@ -156,6 +157,7 @@ where
         async move {
             let write = self.codec.write_request(&protocol, &mut io, self.request);
             write.await?;
+            io.close().await?;
             let read = self.codec.read_response(&protocol, &mut io);
             let response = read.await?;
             Ok(response)


### PR DESCRIPTION
Since forgetting to properly `close()` a substream may result in subtle problems that can be difficult to diagnose properly (see e.g. https://github.com/libp2p/rust-libp2p/pull/1606) it may be better to avoid this pitfall for implementations of `RequestResponseCodec` by always `close()`ing the substream in the `InboundUpgrade` and `OutboundUpgrade` explicitly.