### PR TITLE
Align explanation with previously altered example code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,8 @@
 //! let transport = tcp.upgrade(upgrade::Version::V1).authenticate(secio).multiplex(yamux);
 //! # }
 //! ```
-//! In this example, `tcp_secio` is a new [`Transport`] that negotiates the secio protocol
+//! In this example, `transport` is a new [`Transport`] that negotiates the
+//! secio and yamux protocols
 //! on all connections.
 //!
 //! ## Network Behaviour


### PR DESCRIPTION
It looks like the code was changed at some point, but the explanation following it wasn't, leaving it inconsistent.

(I'm new to rust-libp2p, so maybe check that what I've altered it to actually does make sense, and is true.)