### PR TITLE
Spec-compliant noise handshake payloads (Step 1, Take 2).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
+# Version 0.22.0 (????-??-??)
+
+**NOTE**: For a smooth upgrade path from `0.21` to `> 0.22`
+on an existing deployment using `libp2p-noise`, this version
+must not be skipped!
+
+- Bump `libp2p-noise` dependency to `0.21`.
+
 # Version 0.21.1 (2020-07-02)
 
 - Bump `libp2p-websockets` lower bound.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ libp2p-gossipsub = { version = "0.20.0", path = "./protocols/gossipsub", optiona
 libp2p-identify = { version = "0.20.0", path = "protocols/identify", optional = true }
 libp2p-kad = { version = "0.21.0", path = "protocols/kad", optional = true }
 libp2p-mplex = { version = "0.20.0", path = "muxers/mplex", optional = true }
-libp2p-noise = { version = "0.20.0", path = "protocols/noise", optional = true }
+libp2p-noise = { version = "0.21.0", path = "protocols/noise", optional = true }
 libp2p-ping = { version = "0.20.0", path = "protocols/ping", optional = true }
 libp2p-plaintext = { version = "0.20.0", path = "protocols/plaintext", optional = true }
 libp2p-pnet = { version = "0.19.1", path = "protocols/pnet", optional = true }

--- a/protocols/noise/CHANGELOG.md
+++ b/protocols/noise/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.21.0 [????-??-??]
+
+**NOTE**: For a smooth upgrade path from `0.20` to `> 0.21`
+on an existing deployment, this version must not be skipped!
+
+- Add support for reading handshake protobuf frames without
+length prefixes in preparation for no longer sending them.
+See [issue 1631](https://github.com/libp2p/rust-libp2p/issues/1631).
+
+- Update the `snow` dependency to the latest patch version.
 # 0.20.0 [2020-07-01]
 
 - Updated dependencies.

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-noise"
 description = "Cryptographic handshake protocol using the noise framework."
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -21,10 +21,10 @@ x25519-dalek = "0.6.0"
 zeroize = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-snow = { version = "0.7.0", features = ["ring-resolver"], default-features = false }
+snow = { version = "0.7.1", features = ["ring-resolver"], default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-snow = { version = "0.7.0", features = ["default-resolver"], default-features = false }
+snow = { version = "0.7.1", features = ["default-resolver"], default-features = false }
 
 [dev-dependencies]
 env_logger = "0.7.1"

--- a/protocols/noise/src/io.rs
+++ b/protocols/noise/src/io.rs
@@ -347,6 +347,9 @@ impl<T: AsyncWrite + Unpin> AsyncWrite for NoiseOutput<T> {
 }
 
 impl<T: AsyncRead + Unpin> NoiseOutput<T> {
+    /// Reads the next frame if called in state `ReadLen`, otherwise
+    /// completes reading of the current frame, in either case returning
+    /// the frame length or `None` on reading EOF.
     fn read_frame(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<Option<usize>>> {
         loop {
             match self.read_state {


### PR DESCRIPTION
This is an alternative for https://github.com/libp2p/rust-libp2p/pull/1658 with a simpler implementation strategy, based on a proposal by @twittner. See the previous PR for further details. The upgrade strategy remains the same.