### PR TITLE
Upgrade ed25519-dalek to pre.4

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.20.1 [2020-17-17]
+
+- Update ed25519-dalek dependency.
+
 # 0.20.0 [2020-07-01]
 
 - Conditional compilation fixes for the `wasm32-wasi` target

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-core"
 edition = "2018"
 description = "Core traits and structs of libp2p"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 asn1_der = "0.6.1"
 bs58 = "0.3.0"
-ed25519-dalek = "1.0.0-pre.3"
+ed25519-dalek = "1.0.0-pre.4"
 either = "1.5"
 fnv = "1.0"
 futures = { version = "0.3.1", features = ["executor", "thread-pool"] }

--- a/core/src/identity/ed25519.rs
+++ b/core/src/identity/ed25519.rs
@@ -20,8 +20,9 @@
 
 //! Ed25519 keys.
 
-use ed25519_dalek as ed25519;
+use ed25519_dalek::{self as ed25519, Signer, Verifier};
 use rand::RngCore;
+use std::convert::TryFrom;
 use super::error::DecodingError;
 use zeroize::Zeroize;
 use core::fmt;
@@ -107,7 +108,7 @@ pub struct PublicKey(ed25519::PublicKey);
 impl PublicKey {
     /// Verify the Ed25519 signature on a message using the public key.
     pub fn verify(&self, msg: &[u8], sig: &[u8]) -> bool {
-        ed25519::Signature::from_bytes(sig).and_then(|s| self.0.verify(msg, &s)).is_ok()
+        ed25519::Signature::try_from(sig).and_then(|s| self.0.verify(msg, &s)).is_ok()
     }
 
     /// Encode the public key into a byte array in compressed form, i.e.

--- a/core/src/identity/ed25519.rs
+++ b/core/src/identity/ed25519.rs
@@ -20,7 +20,7 @@
 
 //! Ed25519 keys.
 
-use ed25519_dalek::{self as ed25519, Signer, Verifier};
+use ed25519_dalek::{self as ed25519, Signer as _, Verifier as _};
 use rand::RngCore;
 use std::convert::TryFrom;
 use super::error::DecodingError;


### PR DESCRIPTION
This PR upgrades `ed25519-dalek` to `1.0.0-pre.4` to address recent build errors (see [here](https://github.com/libp2p/rust-libp2p/pull/1658/checks?check_run_id=880828051)). Since a) the changes seem to be uncritical, i.e. primarily https://github.com/dalek-cryptography/ed25519-dalek/commit/6e0667d4298fdf9cb0d3c3cd65c39ba52f0ec702 as far as changes to the public API are concerned, and `libp2p-core` fully encapsulates its use of `ed25519-dalek` I propose a simple patch release here. For a full changelog of `ed25519-dalek` from `pre.3` to `pre.4` see [here](https://github.com/dalek-cryptography/ed25519-dalek/compare/1.0.0-pre.3...1.0.0-pre.4).