### PR TITLE
Set SO_REUSEPORT and remove port translation.

### DIFF
--- a/core/src/connection.rs
+++ b/core/src/connection.rs
@@ -84,6 +84,8 @@ impl Endpoint {
 pub enum ConnectedPoint {
     /// We dialed the node.
     Dialer {
+        /// Local connection address.
+        local_addr: Option<Multiaddr>,
         /// Multiaddress that was successfully dialed.
         address: Multiaddr,
     },
@@ -138,7 +140,7 @@ impl ConnectedPoint {
     /// For `Dialer`, this modifies `address`. For `Listener`, this modifies `send_back_addr`.
     pub fn set_remote_address(&mut self, new_address: Multiaddr) {
         match self {
-            ConnectedPoint::Dialer { address } => *address = new_address,
+            ConnectedPoint::Dialer { address, .. } => *address = new_address,
             ConnectedPoint::Listener { send_back_addr, .. } => *send_back_addr = new_address,
         }
     }
@@ -322,6 +324,7 @@ impl<'a> IncomingInfo<'a> {
 /// Borrowed information about an outgoing connection currently being negotiated.
 #[derive(Debug, Copy, Clone)]
 pub struct OutgoingInfo<'a, TPeerId> {
+    pub local_addr: Option<&'a Multiaddr>,
     pub address: &'a Multiaddr,
     pub peer_id: Option<&'a TPeerId>,
 }
@@ -330,7 +333,8 @@ impl<'a, TPeerId> OutgoingInfo<'a, TPeerId> {
     /// Builds a `ConnectedPoint` corresponding to the outgoing connection.
     pub fn to_connected_point(&self) -> ConnectedPoint {
         ConnectedPoint::Dialer {
-            address: self.address.clone()
+            local_addr: self.local_addr.cloned(),
+            address: self.address.clone(),
         }
     }
 }

--- a/core/src/connection/pool.rs
+++ b/core/src/connection/pool.rs
@@ -527,8 +527,8 @@ where
             .filter_map(|(_, ref endpoint, ref peer_id)| {
                 match endpoint {
                     ConnectedPoint::Listener { .. } => None,
-                    ConnectedPoint::Dialer { address } =>
-                        Some(OutgoingInfo { address, peer_id: peer_id.as_ref() }),
+                    ConnectedPoint::Dialer { local_addr, address } =>
+                        Some(OutgoingInfo { local_addr: local_addr.as_ref(), address, peer_id: peer_id.as_ref() }),
                 }
             })
     }

--- a/core/src/either.rs
+++ b/core/src/either.rs
@@ -462,15 +462,15 @@ where
         }
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
         use TransportError::*;
         match self {
-            EitherTransport::Left(a) => match a.dial(addr) {
+            EitherTransport::Left(a) => match a.dial(local_addr, addr) {
                 Ok(connec) => Ok(EitherFuture::First(connec)),
                 Err(MultiaddrNotSupported(addr)) => Err(MultiaddrNotSupported(addr)),
                 Err(Other(err)) => Err(Other(EitherError::A(err))),
             },
-            EitherTransport::Right(b) => match b.dial(addr) {
+            EitherTransport::Right(b) => match b.dial(local_addr, addr) {
                 Ok(connec) => Ok(EitherFuture::Second(connec)),
                 Err(MultiaddrNotSupported(addr)) => Err(MultiaddrNotSupported(addr)),
                 Err(Other(err)) => Err(Other(EitherError::B(err))),

--- a/core/src/network/peer.rs
+++ b/core/src/network/peer.rs
@@ -232,9 +232,12 @@ where
             Peer::Local => return Err(ConnectionLimit { current: 0, limit: 0 })
         };
 
+        let local_addr = network.listeners.listener_for_port_reuse(&address).cloned();
+
         let id = network.dial_peer(DialingOpts {
             peer: peer_id.clone(),
             handler,
+            local_addr,
             address,
             remaining: remaining.into_iter().collect(),
         })?;
@@ -629,7 +632,7 @@ impl<'a, TInEvent, TConnInfo, TPeerId>
     /// Returns the remote address of the current connection attempt.
     pub fn address(&self) -> &Multiaddr {
         match self.inner.endpoint() {
-            ConnectedPoint::Dialer { address } => address,
+            ConnectedPoint::Dialer { address, .. } => address,
             ConnectedPoint::Listener { .. } => unreachable!("by definition of a `DialingAttempt`.")
         }
     }

--- a/core/src/transport.rs
+++ b/core/src/transport.rs
@@ -124,7 +124,7 @@ pub trait Transport {
     ///
     /// If [`TransportError::MultiaddrNotSupported`] is returned, it may be desirable to
     /// try an alternative [`Transport`], if available.
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>>
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>>
     where
         Self: Sized;
 

--- a/core/src/transport/and_then.rs
+++ b/core/src/transport/and_then.rs
@@ -60,11 +60,12 @@ where
         Ok(stream)
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-        let dialed_fut = self.transport.dial(addr.clone()).map_err(|err| err.map(EitherError::A))?;
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        let dialed_fut = self.transport.dial(local_addr.clone(), addr.clone())
+            .map_err(|err| err.map(EitherError::A))?;
         let future = AndThenFuture {
             inner: Either::Left(Box::pin(dialed_fut)),
-            args: Some((self.fun, ConnectedPoint::Dialer { address: addr })),
+            args: Some((self.fun, ConnectedPoint::Dialer { local_addr, address: addr })),
             marker: PhantomPinned,
         };
         Ok(future)

--- a/core/src/transport/boxed.rs
+++ b/core/src/transport/boxed.rs
@@ -43,7 +43,7 @@ pub type ListenerUpgrade<O, E> = Pin<Box<dyn Future<Output = Result<O, E>> + Sen
 
 trait Abstract<O, E> {
     fn listen_on(&self, addr: Multiaddr) -> Result<Listener<O, E>, TransportError<E>>;
-    fn dial(&self, addr: Multiaddr) -> Result<Dial<O, E>, TransportError<E>>;
+    fn dial(&self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Dial<O, E>, TransportError<E>>;
 }
 
 impl<T, O, E> Abstract<O, E> for T
@@ -62,8 +62,8 @@ where
         Ok(Box::pin(fut))
     }
 
-    fn dial(&self, addr: Multiaddr) -> Result<Dial<O, E>, TransportError<E>> {
-        let fut = Transport::dial(self.clone(), addr)?;
+    fn dial(&self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Dial<O, E>, TransportError<E>> {
+        let fut = Transport::dial(self.clone(), local_addr, addr)?;
         Ok(Box::pin(fut) as Dial<_, _>)
     }
 }
@@ -100,7 +100,7 @@ where E: error::Error,
         self.inner.listen_on(addr)
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-        self.inner.dial(addr)
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        self.inner.dial(local_addr, addr)
     }
 }

--- a/core/src/transport/choice.rs
+++ b/core/src/transport/choice.rs
@@ -59,14 +59,14 @@ where
         Err(TransportError::MultiaddrNotSupported(addr))
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-        let addr = match self.0.dial(addr) {
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        match self.0.dial(local_addr.clone(), addr.clone()) {
             Ok(connec) => return Ok(EitherFuture::First(connec)),
-            Err(TransportError::MultiaddrNotSupported(addr)) => addr,
+            Err(TransportError::MultiaddrNotSupported(_)) => {},
             Err(TransportError::Other(err)) => return Err(TransportError::Other(EitherError::A(err))),
         };
 
-        let addr = match self.1.dial(addr) {
+        let addr = match self.1.dial(local_addr, addr) {
             Ok(connec) => return Ok(EitherFuture::Second(connec)),
             Err(TransportError::MultiaddrNotSupported(addr)) => addr,
             Err(TransportError::Other(err)) => return Err(TransportError::Other(EitherError::B(err))),

--- a/core/src/transport/dummy.rs
+++ b/core/src/transport/dummy.rs
@@ -64,7 +64,7 @@ impl<TOut> Transport for DummyTransport<TOut> {
         Err(TransportError::MultiaddrNotSupported(addr))
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+    fn dial(self, _local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
         Err(TransportError::MultiaddrNotSupported(addr))
     }
 }

--- a/core/src/transport/map.rs
+++ b/core/src/transport/map.rs
@@ -52,9 +52,9 @@ where
         Ok(MapStream { stream, fun: self.fun })
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-        let future = self.transport.dial(addr.clone())?;
-        let p = ConnectedPoint::Dialer { address: addr };
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        let future = self.transport.dial(local_addr.clone(), addr.clone())?;
+        let p = ConnectedPoint::Dialer { local_addr, address: addr };
         Ok(MapFuture { inner: future, args: Some((self.fun, p)) })
     }
 }

--- a/core/src/transport/map_err.rs
+++ b/core/src/transport/map_err.rs
@@ -57,9 +57,9 @@ where
         }
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
         let map = self.map;
-        match self.transport.dial(addr) {
+        match self.transport.dial(local_addr, addr) {
             Ok(future) => Ok(MapErrDial { inner: future, map: Some(map) }),
             Err(err) => Err(err.map(map)),
         }

--- a/core/src/transport/memory.rs
+++ b/core/src/transport/memory.rs
@@ -113,7 +113,7 @@ impl Transport for MemoryTransport {
         Ok(listener)
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<DialFuture, TransportError<Self::Error>> {
+    fn dial(self, _local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<DialFuture, TransportError<Self::Error>> {
         let port = if let Ok(port) = parse_memory_addr(&addr) {
             if let Some(port) = NonZeroU64::new(port) {
                 port
@@ -306,9 +306,9 @@ mod tests {
     #[test]
     fn port_not_in_use() {
         let transport = MemoryTransport::default();
-        assert!(transport.dial("/memory/810172461024613".parse().unwrap()).is_err());
+        assert!(transport.dial(None, "/memory/810172461024613".parse().unwrap()).is_err());
         let _listener = transport.listen_on("/memory/810172461024613".parse().unwrap()).unwrap();
-        assert!(transport.dial("/memory/810172461024613".parse().unwrap()).is_ok());
+        assert!(transport.dial(None, "/memory/810172461024613".parse().unwrap()).is_ok());
     }
 
     #[test]
@@ -342,7 +342,7 @@ mod tests {
 
         let t2 = MemoryTransport::default();
         let dialer = async move {
-            let mut socket = t2.dial(cloned_t1_addr).unwrap().await.unwrap();
+            let mut socket = t2.dial(None, cloned_t1_addr).unwrap().await.unwrap();
             socket.write_all(&msg).await.unwrap();
         };
 

--- a/core/src/transport/optional.rs
+++ b/core/src/transport/optional.rs
@@ -67,9 +67,9 @@ where
         }
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
         if let Some(inner) = self.0 {
-            inner.dial(addr)
+            inner.dial(local_addr, addr)
         } else {
             Err(TransportError::MultiaddrNotSupported(addr))
         }

--- a/core/src/transport/timeout.rs
+++ b/core/src/transport/timeout.rs
@@ -93,8 +93,8 @@ where
         Ok(listener)
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-        let dial = self.inner.dial(addr)
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        let dial = self.inner.dial(local_addr, addr)
             .map_err(|err| err.map(TransportTimeoutError::Other))?;
         Ok(Timeout {
             inner: dial,

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -264,8 +264,8 @@ where
     type ListenerUpgrade = ListenerUpgradeFuture<T::ListenerUpgrade, U, I, C>;
     type Dial = DialUpgradeFuture<T::Dial, U, I, C>;
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-        let future = self.inner.dial(addr.clone())
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        let future = self.inner.dial(local_addr, addr.clone())
             .map_err(|err| err.map(TransportUpgradeError::Transport))?;
         Ok(DialUpgradeFuture {
             future: Box::pin(future),

--- a/core/tests/transport_upgrade.rs
+++ b/core/tests/transport_upgrade.rs
@@ -127,11 +127,10 @@ fn upgrade_pipeline() {
     };
 
     let client = async move {
-        let (peer, _mplex) = dialer_transport.dial(listen_addr2).unwrap().await.unwrap();
+        let (peer, _mplex) = dialer_transport.dial(None, listen_addr2).unwrap().await.unwrap();
         assert_eq!(peer, listener_id);
     };
 
     async_std::task::spawn(server);
     async_std::task::block_on(client);
 }
-

--- a/muxers/mplex/tests/async_write.rs
+++ b/muxers/mplex/tests/async_write.rs
@@ -65,7 +65,7 @@ fn async_write() {
         let transport = TcpConfig::new().and_then(move |c, e|
             upgrade::apply(c, mplex, e, upgrade::Version::V1));
 
-        let client = Arc::new(transport.dial(rx.await.unwrap()).unwrap().await.unwrap());
+        let client = Arc::new(transport.dial(None, rx.await.unwrap()).unwrap().await.unwrap());
         let mut inbound = loop {
             if let Some(s) = muxing::event_from_ref_and_wrap(client.clone()).await.unwrap()
                 .into_inbound_substream() {

--- a/muxers/mplex/tests/two_peers.rs
+++ b/muxers/mplex/tests/two_peers.rs
@@ -65,7 +65,7 @@ fn client_to_server_outbound() {
         let transport = TcpConfig::new().and_then(move |c, e|
             upgrade::apply(c, mplex, e, upgrade::Version::V1));
 
-        let client = Arc::new(transport.dial(rx.await.unwrap()).unwrap().await.unwrap());
+        let client = Arc::new(transport.dial(None, rx.await.unwrap()).unwrap().await.unwrap());
         let mut inbound = loop {
             if let Some(s) = muxing::event_from_ref_and_wrap(client.clone()).await.unwrap()
                 .into_inbound_substream() {
@@ -126,7 +126,7 @@ fn client_to_server_inbound() {
         let transport = TcpConfig::new().and_then(move |c, e|
             upgrade::apply(c, mplex, e, upgrade::Version::V1));
 
-        let client = transport.dial(rx.await.unwrap()).unwrap().await.unwrap();
+        let client = transport.dial(None, rx.await.unwrap()).unwrap().await.unwrap();
         let mut outbound = muxing::outbound_from_ref_and_wrap(Arc::new(client)).await.unwrap();
         outbound.write_all(b"hello world").await.unwrap();
         outbound.close().await.unwrap();

--- a/protocols/deflate/tests/test.rs
+++ b/protocols/deflate/tests/test.rs
@@ -82,7 +82,8 @@ async fn run(message1: Vec<u8>) {
         conn.close().await.expect("close")
     });
 
-    let mut conn = transport.dial(listen_addr).expect("dialer").await.expect("connection");
+    let mut conn = transport.dial(None, listen_addr)
+        .expect("dialer").await.expect("connection");
     conn.write_all(&message1).await.expect("write_all");
     conn.close().await.expect("close");
 

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -108,7 +108,7 @@ impl NetworkBehaviour for Identify {
 
     fn inject_connection_established(&mut self, peer_id: &PeerId, conn: &ConnectionId, endpoint: &ConnectedPoint) {
         let addr = match endpoint {
-            ConnectedPoint::Dialer { address } => address.clone(),
+            ConnectedPoint::Dialer { address, .. } => address.clone(),
             ConnectedPoint::Listener { send_back_addr, .. } => send_back_addr.clone(),
         };
 

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -258,7 +258,7 @@ mod tests {
         async_std::task::block_on(async move {
             let transport = TcpConfig::new();
 
-            let socket = transport.dial(rx.await.unwrap()).unwrap().await.unwrap();
+            let socket = transport.dial(None, rx.await.unwrap()).unwrap().await.unwrap();
             let RemoteInfo { info, observed_addr, .. } =
                 apply_outbound(socket, IdentifyProtocolConfig, upgrade::Version::V1).await.unwrap();
             assert_eq!(observed_addr, "/ip4/100.101.102.103/tcp/5000".parse().unwrap());

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -1426,7 +1426,7 @@ where
         // since the remote address on an inbound connection is specific to
         // that connection (e.g. typically the TCP port numbers).
         let address = match endpoint {
-            ConnectedPoint::Dialer { address } => Some(address.clone()),
+            ConnectedPoint::Dialer { address, .. } => Some(address.clone()),
             ConnectedPoint::Listener { .. } => None,
         };
 

--- a/protocols/noise/tests/smoke.rs
+++ b/protocols/noise/tests/smoke.rs
@@ -203,7 +203,7 @@ where
 
         let outbound_msgs = messages.clone();
         let client_fut = async {
-            let mut client_session = client_transport.dial(server_address.clone())
+            let mut client_session = client_transport.dial(None, server_address.clone())
                 .unwrap()
                 .await
                 .map(|(_, session)| session)

--- a/protocols/ping/src/protocol.rs
+++ b/protocols/ping/src/protocol.rs
@@ -138,7 +138,7 @@ mod tests {
         });
 
         async_std::task::block_on(async move {
-            let c = MemoryTransport.dial(listener_addr).unwrap().await.unwrap();
+            let c = MemoryTransport.dial(None, listener_addr).unwrap().await.unwrap();
             let rtt = upgrade::apply_outbound(c, Ping::default(), upgrade::Version::V1).await.unwrap();
             assert!(rtt > Duration::from_secs(0));
         });

--- a/protocols/plaintext/tests/smoke.rs
+++ b/protocols/plaintext/tests/smoke.rs
@@ -85,7 +85,10 @@ fn variable_msg_length() {
 
             let client_fut = async {
                 debug!("dialing {:?}", server_address);
-                let (received_server_id, mut client_channel) = client_transport.dial(server_address).unwrap().await.unwrap();
+                let (received_server_id, mut client_channel) = client_transport.dial(
+                    None,
+                    server_address,
+                ).unwrap().await.unwrap();
                 assert_eq!(received_server_id, server_id.public().into_peer_id());
 
                 debug!("Client: writing message.");

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -456,7 +456,7 @@ where
 
     fn inject_connection_established(&mut self, peer: &PeerId, conn: &ConnectionId, endpoint: &ConnectedPoint) {
         let address = match endpoint {
-            ConnectedPoint::Dialer { address } => Some(address.clone()),
+            ConnectedPoint::Dialer { address, .. } => Some(address.clone()),
             ConnectedPoint::Listener { .. } => None
         };
         let connections = self.connected.entry(peer.clone()).or_default();
@@ -604,4 +604,3 @@ struct Connection {
     id: ConnectionId,
     address: Option<Multiaddr>,
 }
-

--- a/src/bandwidth.rs
+++ b/src/bandwidth.rs
@@ -72,10 +72,10 @@ where
             .map(move |inner| BandwidthListener { inner, sinks })
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
         let sinks = self.sinks;
         self.inner
-            .dial(addr)
+            .dial(local_addr, addr)
             .map(move |fut| BandwidthFuture { inner: fut, sinks })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@
 //! use libp2p::{Multiaddr, Transport, tcp::TcpConfig};
 //! let tcp = TcpConfig::new();
 //! let addr: Multiaddr = "/ip4/98.97.96.95/tcp/20500".parse().expect("invalid multiaddr");
-//! let _conn = tcp.dial(addr);
+//! let _conn = tcp.dial(None, addr);
 //! ```
 //! In the above example, `_conn` is a [`Future`] that needs to be polled in order for
 //! the dialing to take place and eventually resolve to a connection. Polling

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -744,12 +744,10 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                     }
                 },
                 Poll::Ready(NetworkBehaviourAction::ReportObservedAddr { address }) => {
-                    for addr in this.network.address_translation(&address) {
-                        if this.external_addrs.iter().all(|a| *a != addr) {
-                            this.behaviour.inject_new_external_addr(&addr);
-                        }
-                        this.external_addrs.add(addr);
+                    if this.external_addrs.iter().find(|a| *a != &address).is_none() {
+                        this.behaviour.inject_new_external_addr(&address);
                     }
+                    this.external_addrs.add(address);
                 },
             }
         }

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -17,9 +17,8 @@ get_if_addrs = "0.5.3"
 ipnet = "2.0.0"
 libp2p-core = { version = "0.20.0", path = "../../core" }
 log = "0.4.1"
-socket2 = "0.3.12"
+socket2 = { version = "0.3.12", features = ["reuseport"] }
 tokio = { version = "0.2", default-features = false, features = ["tcp"], optional = true }
 
 [dev-dependencies]
 libp2p-tcp = { path = ".", features = ["async-std"] }
-

--- a/transports/uds/src/lib.rs
+++ b/transports/uds/src/lib.rs
@@ -101,7 +101,7 @@ impl Transport for $uds_config {
         }
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+    fn dial(self, _local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
         if let Ok(path) = multiaddr_to_path(&addr) {
             debug!("Dialing {}", addr);
             Ok(async move { <$unix_stream>::connect(&path).await }.boxed())
@@ -213,7 +213,7 @@ mod tests {
         async_std::task::block_on(async move {
             let uds = UdsConfig::new();
             let addr = rx.await.unwrap();
-            let mut socket = uds.dial(addr).unwrap().await.unwrap();
+            let mut socket = uds.dial(None, addr).unwrap().await.unwrap();
             socket.write(&[1, 2, 3]).await.unwrap();
         });
     }

--- a/transports/wasm-ext/src/lib.rs
+++ b/transports/wasm-ext/src/lib.rs
@@ -190,7 +190,7 @@ impl Transport for ExtTransport {
         })
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+    fn dial(self, _local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
         let promise = self
             .inner
             .dial(&addr.to_string())

--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -110,8 +110,8 @@ where
         self.transport.map(wrap_connection as WrapperFn<T::Output>).listen_on(addr)
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-        self.transport.map(wrap_connection as WrapperFn<T::Output>).dial(addr)
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        self.transport.map(wrap_connection as WrapperFn<T::Output>).dial(local_addr, addr)
     }
 }
 
@@ -226,7 +226,7 @@ mod tests {
             conn.await
         };
 
-        let outbound = ws_config.dial(addr).unwrap();
+        let outbound = ws_config.dial(None, addr).unwrap();
 
         let (a, b) = futures::join!(inbound, outbound);
         a.and(b).unwrap();


### PR DESCRIPTION
So with this patch I was able to get ipfs-embed to traverse the nat in netsim-embed [0]. ~The outgoing port is hard coded to 31333 which is the port used by ipfs-embed by default. Since there may be multiple listeners it's unclear which port should be used for outgoing connections.~ ~Note that the example only works sometimes, other times it deadlocks and times out.~

The first listener that works for the dialing address is used by the swarm when dialing. If no local_addr is provided the transport selects a suitable one.

- [0] https://github.com/ipfs-rust/netsim-embed/blob/master/examples/p2p.rs