### PR TITLE
[libp2p-noise] Disable sending of legacy handshake payloads (by default).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
+# Version 0.23.0 (2020-??-??)
+
+**NOTE**: For a smooth upgrade path from `0.21` to `> 0.22`
+on an existing deployment, this version must not be skipped
+or the provided feature flags used!
+
+- Bump `libp2p-noise` dependency to `0.22`. See the `libp2p-noise`
+changelog for details. The corresponding feature flag `noise-send-legacy-handshake`
+is provided through the `libp2p` crate.
+
 # Version 0.22.0 (2020-07-17)
 
 **NOTE**: For a smooth upgrade path from `0.21` to `> 0.22`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,10 @@
 
 **NOTE**: For a smooth upgrade path from `0.21` to `> 0.22`
 on an existing deployment, this version must not be skipped
-or the provided feature flags used!
+or the provided legacy configuration for `libp2p-noise` used!
 
 - Bump `libp2p-noise` dependency to `0.22`. See the `libp2p-noise`
-changelog for details. The corresponding feature flag `noise-send-legacy-handshake`
-is provided through the `libp2p` crate.
+changelog for details about the `LegacyConfig`.
 
 - Refactored bandwidth logging ([PR 1670](https://github.com/libp2p/rust-libp2p/pull/1670)).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,6 @@ wasm-ext = ["libp2p-wasm-ext"]
 websocket = ["libp2p-websocket"]
 yamux = ["libp2p-yamux"]
 secp256k1 = ["libp2p-core/secp256k1", "libp2p-secio/secp256k1"]
-noise-send-legacy-handshake = ["libp2p-noise/send-legacy-handshake"]
-
 [package.metadata.docs.rs]
 all-features = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ wasm-ext = ["libp2p-wasm-ext"]
 websocket = ["libp2p-websocket"]
 yamux = ["libp2p-yamux"]
 secp256k1 = ["libp2p-core/secp256k1", "libp2p-secio/secp256k1"]
+
 [package.metadata.docs.rs]
 all-features = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ wasm-ext = ["libp2p-wasm-ext"]
 websocket = ["libp2p-websocket"]
 yamux = ["libp2p-yamux"]
 secp256k1 = ["libp2p-core/secp256k1", "libp2p-secio/secp256k1"]
+noise-send-legacy-handshake = ["libp2p-noise/send-legacy-handshake"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -68,7 +69,7 @@ libp2p-gossipsub = { version = "0.20.0", path = "./protocols/gossipsub", optiona
 libp2p-identify = { version = "0.20.0", path = "protocols/identify", optional = true }
 libp2p-kad = { version = "0.21.0", path = "protocols/kad", optional = true }
 libp2p-mplex = { version = "0.20.0", path = "muxers/mplex", optional = true }
-libp2p-noise = { version = "0.21.0", path = "protocols/noise", optional = true }
+libp2p-noise = { version = "0.22.0", path = "protocols/noise", optional = true }
 libp2p-ping = { version = "0.20.0", path = "protocols/ping", optional = true }
 libp2p-plaintext = { version = "0.20.0", path = "protocols/plaintext", optional = true }
 libp2p-pnet = { version = "0.19.1", path = "protocols/pnet", optional = true }

--- a/protocols/noise/CHANGELOG.md
+++ b/protocols/noise/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 0.22.0 [2020-??-??]
+
+**NOTE**: For a smooth upgrade path from `0.20` to `> 0.21`
+on an existing deployment, this version must not be skipped
+or the provided feature flags used!
+
+- Stop sending length-prefixed protobuf frames in handshake
+payloads by default. See [issue 1631](https://github.com/libp2p/rust-libp2p/issues/1631).
+The new feature `send-legacy-handshake` is provided to optionally
+continue sending the legacy handshake. Note: This release
+always supports receiving legacy handshake payloads. A future
+release will also move receiving legacy handshake payloads
+behind a feature flag, before support for legacy handshakes
+is eventually removed altogether. In this way the feature
+flags allow to delay the handshake upgrade without having to freeze
+the version of `libp2p-noise` altogether.
+
 # 0.21.0 [2020-07-17]
 
 **NOTE**: For a smooth upgrade path from `0.20` to `> 0.21`

--- a/protocols/noise/CHANGELOG.md
+++ b/protocols/noise/CHANGELOG.md
@@ -9,13 +9,12 @@ payloads by default. See [issue 1631](https://github.com/libp2p/rust-libp2p/issu
 The new `LegacyConfig` is provided to optionally
 configure sending the legacy handshake. Note: This release
 always supports receiving legacy handshake payloads. A future
-release will also move receiving legacy handshake payloads,
-allowing to enable it through the `LegacyConfig`. However,
-all legacy configuration options will eventually be removed,
-so this is primarily to allow delaying the handshake upgrade
-or keeping compatibility with a network whose peers are slow
-to upgrade, without having to freeze the version of `libp2p-noise`
-altogether in these projects.
+release will also move receiving legacy handshake payloads
+into a `LegacyConfig` option. However, all legacy configuration
+options will eventually be removed, so this is primarily to allow
+delaying the handshake upgrade or keeping compatibility with a network
+whose peers are slow to upgrade, without having to freeze the
+version of `libp2p-noise` altogether in these projects.
 
 # 0.21.0 [2020-07-17]
 

--- a/protocols/noise/CHANGELOG.md
+++ b/protocols/noise/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **NOTE**: For a smooth upgrade path from `0.20` to `> 0.21`
 on an existing deployment, this version must not be skipped
-or the provided feature flags used!
+or the provided `LegacyConfig` used!
 
 - Stop sending length-prefixed protobuf frames in handshake
 payloads by default. See [issue 1631](https://github.com/libp2p/rust-libp2p/issues/1631).

--- a/protocols/noise/CHANGELOG.md
+++ b/protocols/noise/CHANGELOG.md
@@ -6,14 +6,16 @@ or the provided feature flags used!
 
 - Stop sending length-prefixed protobuf frames in handshake
 payloads by default. See [issue 1631](https://github.com/libp2p/rust-libp2p/issues/1631).
-The new feature `send-legacy-handshake` is provided to optionally
-continue sending the legacy handshake. Note: This release
+The new `LegacyConfig` is provided to optionally
+configure sending the legacy handshake. Note: This release
 always supports receiving legacy handshake payloads. A future
-release will also move receiving legacy handshake payloads
-behind a feature flag, before support for legacy handshakes
-is eventually removed altogether. In this way the feature
-flags allow to delay the handshake upgrade without having to freeze
-the version of `libp2p-noise` altogether.
+release will also move receiving legacy handshake payloads,
+allowing to enable it through the `LegacyConfig`. However,
+all legacy configuration options will eventually be removed,
+so this is primarily to allow delaying the handshake upgrade
+or keeping compatibility with a network whose peers are slow
+to upgrade, without having to freeze the version of `libp2p-noise`
+altogether in these projects.
 
 # 0.21.0 [2020-07-17]
 

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-noise"
 description = "Cryptographic handshake protocol using the noise framework."
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -35,4 +35,8 @@ sodiumoxide = "0.2.5"
 
 [build-dependencies]
 prost-build = "0.6"
+
+[features]
+default = []
+send-legacy-handshake = []
 

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -36,7 +36,3 @@ sodiumoxide = "0.2.5"
 [build-dependencies]
 prost-build = "0.6"
 
-[features]
-default = []
-send-legacy-handshake = []
-

--- a/protocols/noise/src/io/handshake.rs
+++ b/protocols/noise/src/io/handshake.rs
@@ -25,6 +25,7 @@ mod payload_proto {
 }
 
 use bytes::Bytes;
+use crate::LegacyConfig;
 use crate::error::NoiseError;
 use crate::protocol::{Protocol, PublicKey, KeypairIdentity};
 use crate::io::{NoiseOutput, framed::NoiseFramed};
@@ -125,14 +126,15 @@ pub fn rt1_initiator<T, C>(
     io: T,
     session: Result<snow::HandshakeState, NoiseError>,
     identity: KeypairIdentity,
-    identity_x: IdentityExchange
+    identity_x: IdentityExchange,
+    legacy: LegacyConfig,
 ) -> Handshake<T, C>
 where
     T: AsyncWrite + AsyncRead + Send + Unpin + 'static,
     C: Protocol<C> + AsRef<[u8]>
 {
     Handshake(Box::pin(async move {
-        let mut state = State::new(io, session, identity, identity_x)?;
+        let mut state = State::new(io, session, identity, identity_x, legacy)?;
         send_identity(&mut state).await?;
         recv_identity(&mut state).await?;
         state.finish()
@@ -160,13 +162,14 @@ pub fn rt1_responder<T, C>(
     session: Result<snow::HandshakeState, NoiseError>,
     identity: KeypairIdentity,
     identity_x: IdentityExchange,
+    legacy: LegacyConfig,
 ) -> Handshake<T, C>
 where
     T: AsyncWrite + AsyncRead + Send + Unpin + 'static,
     C: Protocol<C> + AsRef<[u8]>
 {
     Handshake(Box::pin(async move {
-        let mut state = State::new(io, session, identity, identity_x)?;
+        let mut state = State::new(io, session, identity, identity_x, legacy)?;
         recv_identity(&mut state).await?;
         send_identity(&mut state).await?;
         state.finish()
@@ -195,14 +198,15 @@ pub fn rt15_initiator<T, C>(
     io: T,
     session: Result<snow::HandshakeState, NoiseError>,
     identity: KeypairIdentity,
-    identity_x: IdentityExchange
+    identity_x: IdentityExchange,
+    legacy: LegacyConfig,
 ) -> Handshake<T, C>
 where
     T: AsyncWrite + AsyncRead + Unpin + Send + 'static,
     C: Protocol<C> + AsRef<[u8]>
 {
     Handshake(Box::pin(async move {
-        let mut state = State::new(io, session, identity, identity_x)?;
+        let mut state = State::new(io, session, identity, identity_x, legacy)?;
         send_empty(&mut state).await?;
         recv_identity(&mut state).await?;
         send_identity(&mut state).await?;
@@ -232,14 +236,15 @@ pub fn rt15_responder<T, C>(
     io: T,
     session: Result<snow::HandshakeState, NoiseError>,
     identity: KeypairIdentity,
-    identity_x: IdentityExchange
+    identity_x: IdentityExchange,
+    legacy: LegacyConfig,
 ) -> Handshake<T, C>
 where
     T: AsyncWrite + AsyncRead + Unpin + Send + 'static,
     C: Protocol<C> + AsRef<[u8]>
 {
     Handshake(Box::pin(async move {
-        let mut state = State::new(io, session, identity, identity_x)?;
+        let mut state = State::new(io, session, identity, identity_x, legacy)?;
         recv_empty(&mut state).await?;
         send_identity(&mut state).await?;
         recv_identity(&mut state).await?;
@@ -263,6 +268,8 @@ struct State<T> {
     id_remote_pubkey: Option<identity::PublicKey>,
     /// Whether to send the public identity key of the local node to the remote.
     send_identity: bool,
+    /// Legacy configuration parameters.
+    legacy: LegacyConfig,
 }
 
 impl<T> State<T> {
@@ -275,7 +282,8 @@ impl<T> State<T> {
         io: T,
         session: Result<snow::HandshakeState, NoiseError>,
         identity: KeypairIdentity,
-        identity_x: IdentityExchange
+        identity_x: IdentityExchange,
+        legacy: LegacyConfig,
     ) -> Result<Self, NoiseError> {
         let (id_remote_pubkey, send_identity) = match identity_x {
             IdentityExchange::Mutual => (None, true),
@@ -289,7 +297,8 @@ impl<T> State<T> {
                 io: NoiseFramed::new(io, s),
                 dh_remote_pubkey_sig: None,
                 id_remote_pubkey,
-                send_identity
+                send_identity,
+                legacy,
             }
         )
     }
@@ -434,7 +443,7 @@ where
     }
 
     let mut msg =
-        if cfg!(feature = "send-legacy-handshake") {
+        if state.legacy.send_legacy_handshake {
             let mut msg = Vec::with_capacity(2 + pb.encoded_len());
             msg.extend_from_slice(&(pb.encoded_len() as u16).to_be_bytes());
             msg

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,7 +272,7 @@ pub use self::transport_ext::TransportExt;
 /// > **Note**: This `Transport` is not suitable for production usage, as its implementation
 /// >           reserves the right to support additional protocols or remove deprecated protocols.
 #[cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "secio", feature = "mplex", feature = "yamux"))]
-#[cfg_attr(docsrs, doc(cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "secio", feature = "mplex", feature = "yamux"))))]
+#[cfg_attr(docsrs, doc(cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "noise", feature = "mplex", feature = "yamux"))))]
 pub fn build_development_transport(keypair: identity::Keypair)
     -> std::io::Result<impl Transport<Output = (PeerId, impl core::muxing::StreamMuxer<OutboundSubstream = impl Send, Substream = impl Send, Error = impl Into<std::io::Error>> + Send + Sync), Error = impl std::error::Error + Send, Listener = impl Send, Dial = impl Send, ListenerUpgrade = impl Send> + Clone>
 {
@@ -284,7 +284,7 @@ pub fn build_development_transport(keypair: identity::Keypair)
 /// The implementation supports TCP/IP, WebSockets over TCP/IP, noise as the encryption layer,
 /// and mplex or yamux as the multiplexing layer.
 #[cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "secio", feature = "mplex", feature = "yamux"))]
-#[cfg_attr(docsrs, doc(cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "secio", feature = "mplex", feature = "yamux"))))]
+#[cfg_attr(docsrs, doc(cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "noise", feature = "mplex", feature = "yamux"))))]
 pub fn build_tcp_ws_noise_mplex_yamux(keypair: identity::Keypair)
     -> std::io::Result<impl Transport<Output = (PeerId, impl core::muxing::StreamMuxer<OutboundSubstream = impl Send, Substream = impl Send, Error = impl Into<std::io::Error>> + Send + Sync), Error = impl std::error::Error + Send, Listener = impl Send, Dial = impl Send, ListenerUpgrade = impl Send> + Clone>
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,15 +276,45 @@ pub use self::transport_ext::TransportExt;
 pub fn build_development_transport(keypair: identity::Keypair)
     -> std::io::Result<impl Transport<Output = (PeerId, impl core::muxing::StreamMuxer<OutboundSubstream = impl Send, Substream = impl Send, Error = impl Into<std::io::Error>> + Send + Sync), Error = impl std::error::Error + Send, Listener = impl Send, Dial = impl Send, ListenerUpgrade = impl Send> + Clone>
 {
-     build_tcp_ws_secio_mplex_yamux(keypair)
+     build_tcp_ws_noise_mplex_yamux(keypair)
 }
+
+/// Builds an implementation of `Transport` that is suitable for usage with the `Swarm`.
+///
+/// The implementation supports TCP/IP, WebSockets over TCP/IP, noise as the encryption layer,
+/// and mplex or yamux as the multiplexing layer.
+#[cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "secio", feature = "mplex", feature = "yamux"))]
+#[cfg_attr(docsrs, doc(cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "secio", feature = "mplex", feature = "yamux"))))]
+pub fn build_tcp_ws_noise_mplex_yamux(keypair: identity::Keypair)
+    -> std::io::Result<impl Transport<Output = (PeerId, impl core::muxing::StreamMuxer<OutboundSubstream = impl Send, Substream = impl Send, Error = impl Into<std::io::Error>> + Send + Sync), Error = impl std::error::Error + Send, Listener = impl Send, Dial = impl Send, ListenerUpgrade = impl Send> + Clone>
+{
+    let transport = {
+        #[cfg(feature = "tcp-async-std")]
+        let tcp = tcp::TcpConfig::new().nodelay(true);
+        #[cfg(feature = "tcp-tokio")]
+        let tcp = tcp::TokioTcpConfig::new().nodelay(true);
+        let transport = dns::DnsConfig::new(tcp)?;
+        let trans_clone = transport.clone();
+        transport.or_transport(websocket::WsConfig::new(trans_clone))
+    };
+
+    let noise_keys = noise::Keypair::<noise::X25519Spec>::new()
+        .into_authentic(&keypair)
+        .expect("Signing libp2p-noise static DH keypair failed.");
+
+    Ok(transport
+        .upgrade(core::upgrade::Version::V1)
+        .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
+        .multiplex(core::upgrade::SelectUpgrade::new(yamux::Config::default(), mplex::MplexConfig::new()))
+        .map(|(peer, muxer), _| (peer, core::muxing::StreamMuxerBox::new(muxer)))
+        .timeout(std::time::Duration::from_secs(20)))
+}
+
 
 /// Builds an implementation of `Transport` that is suitable for usage with the `Swarm`.
 ///
 /// The implementation supports TCP/IP, WebSockets over TCP/IP, secio as the encryption layer,
 /// and mplex or yamux as the multiplexing layer.
-///
-/// > **Note**: If you ever need to express the type of this `Transport`.
 #[cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "secio", feature = "mplex", feature = "yamux"))]
 #[cfg_attr(docsrs, doc(cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "secio", feature = "mplex", feature = "yamux"))))]
 pub fn build_tcp_ws_secio_mplex_yamux(keypair: identity::Keypair)


### PR DESCRIPTION
This is step 2 in resolving https://github.com/libp2p/rust-libp2p/issues/1631. With this PR, `rust-libp2p` is now compatible with the other `libp2p-noise` implementations. As a conservative option, if one does not wish to migrate to the spec-compliant handshakes with this release, a feature flag `send-legacy-handshake` is provided by `libp2p-noise`. The plan is to provide an analogous flag `recv-legacy-handshake` with a future release that removes support for receiving legacy handshakes _by default_. In this way the two feature flags allow delaying this transition in downstream projects, if necessary. Of course, eventually these flags should be removed.

As evidence and test that this release of `libp2p-noise` provides interoperability, the `build_development_transport` used by all examples now uses `libp2p-noise`, which includes the `ipfs-kad` example that connects to IPFS nodes.