### PR TITLE
Autonat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [features]
 default = [
+    "autonat",
     "deflate",
     "dns",
     "floodsub",
@@ -32,6 +33,7 @@ default = [
     "websocket",
     "yamux",
 ]
+autonat = ["libp2p-autonat"]
 deflate = ["libp2p-deflate"]
 dns = ["libp2p-dns"]
 floodsub = ["libp2p-floodsub"]
@@ -61,6 +63,7 @@ all-features = true
 bytes = "0.5"
 futures = "0.3.1"
 lazy_static = "1.2"
+libp2p-autonat = { version = "0.20.0", path = "protocols/autonat", optional = true }
 libp2p-core = { version = "0.20.0", path = "core" }
 libp2p-core-derive = { version = "0.20.0", path = "misc/core-derive" }
 libp2p-floodsub = { version = "0.20.0", path = "protocols/floodsub", optional = true }
@@ -105,6 +108,7 @@ members = [
     "misc/peer-id-generator",
     "muxers/mplex",
     "muxers/yamux",
+    "protocols/autonat",
     "protocols/floodsub",
     "protocols/gossipsub",
     "protocols/identify",

--- a/core/src/connection.rs
+++ b/core/src/connection.rs
@@ -84,6 +84,8 @@ impl Endpoint {
 pub enum ConnectedPoint {
     /// We dialed the node.
     Dialer {
+        /// Local connection address.
+        local_addr: Option<Multiaddr>,
         /// Multiaddress that was successfully dialed.
         address: Multiaddr,
     },
@@ -138,7 +140,7 @@ impl ConnectedPoint {
     /// For `Dialer`, this modifies `address`. For `Listener`, this modifies `send_back_addr`.
     pub fn set_remote_address(&mut self, new_address: Multiaddr) {
         match self {
-            ConnectedPoint::Dialer { address } => *address = new_address,
+            ConnectedPoint::Dialer { address, .. } => *address = new_address,
             ConnectedPoint::Listener { send_back_addr, .. } => *send_back_addr = new_address,
         }
     }
@@ -322,6 +324,7 @@ impl<'a> IncomingInfo<'a> {
 /// Borrowed information about an outgoing connection currently being negotiated.
 #[derive(Debug, Copy, Clone)]
 pub struct OutgoingInfo<'a, TPeerId> {
+    pub local_addr: Option<&'a Multiaddr>,
     pub address: &'a Multiaddr,
     pub peer_id: Option<&'a TPeerId>,
 }
@@ -330,7 +333,8 @@ impl<'a, TPeerId> OutgoingInfo<'a, TPeerId> {
     /// Builds a `ConnectedPoint` corresponding to the outgoing connection.
     pub fn to_connected_point(&self) -> ConnectedPoint {
         ConnectedPoint::Dialer {
-            address: self.address.clone()
+            local_addr: self.local_addr.cloned(),
+            address: self.address.clone(),
         }
     }
 }

--- a/core/src/connection/pool.rs
+++ b/core/src/connection/pool.rs
@@ -527,8 +527,8 @@ where
             .filter_map(|(_, ref endpoint, ref peer_id)| {
                 match endpoint {
                     ConnectedPoint::Listener { .. } => None,
-                    ConnectedPoint::Dialer { address } =>
-                        Some(OutgoingInfo { address, peer_id: peer_id.as_ref() }),
+                    ConnectedPoint::Dialer { local_addr, address } =>
+                        Some(OutgoingInfo { local_addr: local_addr.as_ref(), address, peer_id: peer_id.as_ref() }),
                 }
             })
     }

--- a/core/src/either.rs
+++ b/core/src/either.rs
@@ -462,15 +462,15 @@ where
         }
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
         use TransportError::*;
         match self {
-            EitherTransport::Left(a) => match a.dial(addr) {
+            EitherTransport::Left(a) => match a.dial(local_addr, addr) {
                 Ok(connec) => Ok(EitherFuture::First(connec)),
                 Err(MultiaddrNotSupported(addr)) => Err(MultiaddrNotSupported(addr)),
                 Err(Other(err)) => Err(Other(EitherError::A(err))),
             },
-            EitherTransport::Right(b) => match b.dial(addr) {
+            EitherTransport::Right(b) => match b.dial(local_addr, addr) {
                 Ok(connec) => Ok(EitherFuture::Second(connec)),
                 Err(MultiaddrNotSupported(addr)) => Err(MultiaddrNotSupported(addr)),
                 Err(Other(err)) => Err(Other(EitherError::B(err))),

--- a/core/src/network/peer.rs
+++ b/core/src/network/peer.rs
@@ -232,9 +232,12 @@ where
             Peer::Local => return Err(ConnectionLimit { current: 0, limit: 0 })
         };
 
+        let local_addr = network.listeners.listener_for_port_reuse(&address).cloned();
+
         let id = network.dial_peer(DialingOpts {
             peer: peer_id.clone(),
             handler,
+            local_addr,
             address,
             remaining: remaining.into_iter().collect(),
         })?;
@@ -629,7 +632,7 @@ impl<'a, TInEvent, TConnInfo, TPeerId>
     /// Returns the remote address of the current connection attempt.
     pub fn address(&self) -> &Multiaddr {
         match self.inner.endpoint() {
-            ConnectedPoint::Dialer { address } => address,
+            ConnectedPoint::Dialer { address, .. } => address,
             ConnectedPoint::Listener { .. } => unreachable!("by definition of a `DialingAttempt`.")
         }
     }

--- a/core/src/transport.rs
+++ b/core/src/transport.rs
@@ -124,7 +124,7 @@ pub trait Transport {
     ///
     /// If [`TransportError::MultiaddrNotSupported`] is returned, it may be desirable to
     /// try an alternative [`Transport`], if available.
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>>
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>>
     where
         Self: Sized;
 

--- a/core/src/transport/and_then.rs
+++ b/core/src/transport/and_then.rs
@@ -60,11 +60,12 @@ where
         Ok(stream)
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-        let dialed_fut = self.transport.dial(addr.clone()).map_err(|err| err.map(EitherError::A))?;
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        let dialed_fut = self.transport.dial(local_addr.clone(), addr.clone())
+            .map_err(|err| err.map(EitherError::A))?;
         let future = AndThenFuture {
             inner: Either::Left(Box::pin(dialed_fut)),
-            args: Some((self.fun, ConnectedPoint::Dialer { address: addr })),
+            args: Some((self.fun, ConnectedPoint::Dialer { local_addr, address: addr })),
             marker: PhantomPinned,
         };
         Ok(future)

--- a/core/src/transport/boxed.rs
+++ b/core/src/transport/boxed.rs
@@ -43,7 +43,7 @@ pub type ListenerUpgrade<O, E> = Pin<Box<dyn Future<Output = Result<O, E>> + Sen
 
 trait Abstract<O, E> {
     fn listen_on(&self, addr: Multiaddr) -> Result<Listener<O, E>, TransportError<E>>;
-    fn dial(&self, addr: Multiaddr) -> Result<Dial<O, E>, TransportError<E>>;
+    fn dial(&self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Dial<O, E>, TransportError<E>>;
 }
 
 impl<T, O, E> Abstract<O, E> for T
@@ -62,8 +62,8 @@ where
         Ok(Box::pin(fut))
     }
 
-    fn dial(&self, addr: Multiaddr) -> Result<Dial<O, E>, TransportError<E>> {
-        let fut = Transport::dial(self.clone(), addr)?;
+    fn dial(&self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Dial<O, E>, TransportError<E>> {
+        let fut = Transport::dial(self.clone(), local_addr, addr)?;
         Ok(Box::pin(fut) as Dial<_, _>)
     }
 }
@@ -100,7 +100,7 @@ where E: error::Error,
         self.inner.listen_on(addr)
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-        self.inner.dial(addr)
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        self.inner.dial(local_addr, addr)
     }
 }

--- a/core/src/transport/choice.rs
+++ b/core/src/transport/choice.rs
@@ -59,14 +59,14 @@ where
         Err(TransportError::MultiaddrNotSupported(addr))
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-        let addr = match self.0.dial(addr) {
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        match self.0.dial(local_addr.clone(), addr.clone()) {
             Ok(connec) => return Ok(EitherFuture::First(connec)),
-            Err(TransportError::MultiaddrNotSupported(addr)) => addr,
+            Err(TransportError::MultiaddrNotSupported(_)) => {},
             Err(TransportError::Other(err)) => return Err(TransportError::Other(EitherError::A(err))),
         };
 
-        let addr = match self.1.dial(addr) {
+        let addr = match self.1.dial(local_addr, addr) {
             Ok(connec) => return Ok(EitherFuture::Second(connec)),
             Err(TransportError::MultiaddrNotSupported(addr)) => addr,
             Err(TransportError::Other(err)) => return Err(TransportError::Other(EitherError::B(err))),

--- a/core/src/transport/dummy.rs
+++ b/core/src/transport/dummy.rs
@@ -64,7 +64,7 @@ impl<TOut> Transport for DummyTransport<TOut> {
         Err(TransportError::MultiaddrNotSupported(addr))
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+    fn dial(self, _local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
         Err(TransportError::MultiaddrNotSupported(addr))
     }
 }

--- a/core/src/transport/map.rs
+++ b/core/src/transport/map.rs
@@ -52,9 +52,9 @@ where
         Ok(MapStream { stream, fun: self.fun })
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-        let future = self.transport.dial(addr.clone())?;
-        let p = ConnectedPoint::Dialer { address: addr };
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        let future = self.transport.dial(local_addr.clone(), addr.clone())?;
+        let p = ConnectedPoint::Dialer { local_addr, address: addr };
         Ok(MapFuture { inner: future, args: Some((self.fun, p)) })
     }
 }

--- a/core/src/transport/map_err.rs
+++ b/core/src/transport/map_err.rs
@@ -57,9 +57,9 @@ where
         }
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
         let map = self.map;
-        match self.transport.dial(addr) {
+        match self.transport.dial(local_addr, addr) {
             Ok(future) => Ok(MapErrDial { inner: future, map: Some(map) }),
             Err(err) => Err(err.map(map)),
         }

--- a/core/src/transport/memory.rs
+++ b/core/src/transport/memory.rs
@@ -113,7 +113,7 @@ impl Transport for MemoryTransport {
         Ok(listener)
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<DialFuture, TransportError<Self::Error>> {
+    fn dial(self, _local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<DialFuture, TransportError<Self::Error>> {
         let port = if let Ok(port) = parse_memory_addr(&addr) {
             if let Some(port) = NonZeroU64::new(port) {
                 port
@@ -306,9 +306,9 @@ mod tests {
     #[test]
     fn port_not_in_use() {
         let transport = MemoryTransport::default();
-        assert!(transport.dial("/memory/810172461024613".parse().unwrap()).is_err());
+        assert!(transport.dial(None, "/memory/810172461024613".parse().unwrap()).is_err());
         let _listener = transport.listen_on("/memory/810172461024613".parse().unwrap()).unwrap();
-        assert!(transport.dial("/memory/810172461024613".parse().unwrap()).is_ok());
+        assert!(transport.dial(None, "/memory/810172461024613".parse().unwrap()).is_ok());
     }
 
     #[test]
@@ -342,7 +342,7 @@ mod tests {
 
         let t2 = MemoryTransport::default();
         let dialer = async move {
-            let mut socket = t2.dial(cloned_t1_addr).unwrap().await.unwrap();
+            let mut socket = t2.dial(None, cloned_t1_addr).unwrap().await.unwrap();
             socket.write_all(&msg).await.unwrap();
         };
 

--- a/core/src/transport/optional.rs
+++ b/core/src/transport/optional.rs
@@ -67,9 +67,9 @@ where
         }
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
         if let Some(inner) = self.0 {
-            inner.dial(addr)
+            inner.dial(local_addr, addr)
         } else {
             Err(TransportError::MultiaddrNotSupported(addr))
         }

--- a/core/src/transport/timeout.rs
+++ b/core/src/transport/timeout.rs
@@ -93,8 +93,8 @@ where
         Ok(listener)
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-        let dial = self.inner.dial(addr)
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        let dial = self.inner.dial(local_addr, addr)
             .map_err(|err| err.map(TransportTimeoutError::Other))?;
         Ok(Timeout {
             inner: dial,

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -264,8 +264,8 @@ where
     type ListenerUpgrade = ListenerUpgradeFuture<T::ListenerUpgrade, U, I, C>;
     type Dial = DialUpgradeFuture<T::Dial, U, I, C>;
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-        let future = self.inner.dial(addr.clone())
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        let future = self.inner.dial(local_addr, addr.clone())
             .map_err(|err| err.map(TransportUpgradeError::Transport))?;
         Ok(DialUpgradeFuture {
             future: Box::pin(future),

--- a/core/tests/transport_upgrade.rs
+++ b/core/tests/transport_upgrade.rs
@@ -127,11 +127,10 @@ fn upgrade_pipeline() {
     };
 
     let client = async move {
-        let (peer, _mplex) = dialer_transport.dial(listen_addr2).unwrap().await.unwrap();
+        let (peer, _mplex) = dialer_transport.dial(None, listen_addr2).unwrap().await.unwrap();
         assert_eq!(peer, listener_id);
     };
 
     async_std::task::spawn(server);
     async_std::task::block_on(client);
 }
-

--- a/muxers/mplex/tests/async_write.rs
+++ b/muxers/mplex/tests/async_write.rs
@@ -65,7 +65,7 @@ fn async_write() {
         let transport = TcpConfig::new().and_then(move |c, e|
             upgrade::apply(c, mplex, e, upgrade::Version::V1));
 
-        let client = Arc::new(transport.dial(rx.await.unwrap()).unwrap().await.unwrap());
+        let client = Arc::new(transport.dial(None, rx.await.unwrap()).unwrap().await.unwrap());
         let mut inbound = loop {
             if let Some(s) = muxing::event_from_ref_and_wrap(client.clone()).await.unwrap()
                 .into_inbound_substream() {

--- a/muxers/mplex/tests/two_peers.rs
+++ b/muxers/mplex/tests/two_peers.rs
@@ -65,7 +65,7 @@ fn client_to_server_outbound() {
         let transport = TcpConfig::new().and_then(move |c, e|
             upgrade::apply(c, mplex, e, upgrade::Version::V1));
 
-        let client = Arc::new(transport.dial(rx.await.unwrap()).unwrap().await.unwrap());
+        let client = Arc::new(transport.dial(None, rx.await.unwrap()).unwrap().await.unwrap());
         let mut inbound = loop {
             if let Some(s) = muxing::event_from_ref_and_wrap(client.clone()).await.unwrap()
                 .into_inbound_substream() {
@@ -126,7 +126,7 @@ fn client_to_server_inbound() {
         let transport = TcpConfig::new().and_then(move |c, e|
             upgrade::apply(c, mplex, e, upgrade::Version::V1));
 
-        let client = transport.dial(rx.await.unwrap()).unwrap().await.unwrap();
+        let client = transport.dial(None, rx.await.unwrap()).unwrap().await.unwrap();
         let mut outbound = muxing::outbound_from_ref_and_wrap(Arc::new(client)).await.unwrap();
         outbound.write_all(b"hello world").await.unwrap();
         outbound.close().await.unwrap();

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -18,3 +18,12 @@ libp2p-core = { version = "0.20.0", path = "../../core" }
 libp2p-swarm = { version = "0.20.0", path = "../../swarm" }
 libp2p-request-response = { version = "0.1.0", path = "../request-response" }
 prost = "0.6.1"
+
+[dev-dependencies]
+async-std = "1.6.2"
+netsim-embed = "0.1.0"
+
+[dev-dependencies.libp2p]
+default-features = false
+features = ["autonat", "noise", "tcp-async-std", "yamux"]
+path = "../.."

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "libp2p-autonat"
+version = "0.20.0"
+authors = ["David Craven <david@craven.ch>"]
+edition = "2018"
+license = "MIT"
+repository = "https://github.com/libp2p/rust-libp2p"
+keywords = ["peer-to-peer", "libp2p", "networking"]
+categories = ["network-programming", "asynchronous"]
+
+[build-dependencies]
+prost-build = "0.6"
+
+[dependencies]
+libp2p-core = { version = "0.20.0", path = "../../core" }
+libp2p-swarm = { version = "0.20.0", path = "../../swarm" }
+prost = "0.6.1"

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -19,6 +19,7 @@ libp2p-swarm = { version = "0.20.0", path = "../../swarm" }
 libp2p-request-response = { version = "0.1.0", path = "../request-response" }
 log = "0.4.11"
 prost = "0.6.1"
+wasm-timer = "0.2.4"
 
 [dev-dependencies]
 async-std = "1.6.2"

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -12,6 +12,9 @@ categories = ["network-programming", "asynchronous"]
 prost-build = "0.6"
 
 [dependencies]
+async-trait = "0.1.36"
+futures = "0.3.5"
 libp2p-core = { version = "0.20.0", path = "../../core" }
 libp2p-swarm = { version = "0.20.0", path = "../../swarm" }
+libp2p-request-response = { version = "0.1.0", path = "../request-response" }
 prost = "0.6.1"

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -17,6 +17,7 @@ futures = "0.3.5"
 libp2p-core = { version = "0.20.0", path = "../../core" }
 libp2p-swarm = { version = "0.20.0", path = "../../swarm" }
 libp2p-request-response = { version = "0.1.0", path = "../request-response" }
+log = "0.4.11"
 prost = "0.6.1"
 
 [dev-dependencies]

--- a/protocols/autonat/build.rs
+++ b/protocols/autonat/build.rs
@@ -1,0 +1,23 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+fn main() {
+    prost_build::compile_protos(&["src/structs.proto"], &["src"]).unwrap();
+}

--- a/protocols/autonat/src/autonat.rs
+++ b/protocols/autonat/src/autonat.rs
@@ -18,6 +18,149 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-pub struct AutoNat;
+pub use crate::protocol::DialResponse;
+use crate::protocol::{AutoNatCodec, AutoNatProtocol};
+use libp2p_core::{connection::ConnectionId, ConnectedPoint, Multiaddr, PeerId};
+use libp2p_request_response::{
+    handler::RequestProtocol, handler::RequestResponseHandlerEvent, ProtocolSupport,
+    RequestResponse, RequestResponseConfig, RequestResponseEvent, RequestResponseMessage,
+};
+use libp2p_swarm::{NetworkBehaviour, NetworkBehaviourAction, PollParameters};
+use std::{
+    iter,
+    task::{Context, Poll},
+};
 
-pub enum AutoNatEvent {}
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AutoNatEvent {
+    DialResponse(DialResponse),
+}
+
+pub struct AutoNat {
+    inner: RequestResponse<AutoNatCodec>,
+}
+
+impl AutoNat {
+    pub fn new() -> Self {
+        let protocols = iter::once((AutoNatProtocol, ProtocolSupport::Full));
+        let cfg = RequestResponseConfig::default();
+        let inner = RequestResponse::new(AutoNatCodec, protocols, cfg);
+        Self { inner }
+    }
+
+    pub fn add_address(&mut self, peer_id: &PeerId, addr: Multiaddr) {
+        self.inner.add_address(peer_id, addr)
+    }
+}
+
+impl NetworkBehaviour for AutoNat {
+    type ProtocolsHandler = <RequestResponse<AutoNatCodec> as NetworkBehaviour>::ProtocolsHandler;
+    type OutEvent = AutoNatEvent;
+
+    fn new_handler(&mut self) -> Self::ProtocolsHandler {
+        self.inner.new_handler()
+    }
+
+    fn addresses_of_peer(&mut self, peer: &PeerId) -> Vec<Multiaddr> {
+        self.inner.addresses_of_peer(peer)
+    }
+
+    fn inject_connected(&mut self, peer: &PeerId) {
+        self.inner.inject_connected(peer)
+    }
+
+    fn inject_connection_established(
+        &mut self,
+        peer: &PeerId,
+        conn: &ConnectionId,
+        endpoint: &ConnectedPoint,
+    ) {
+        self.inner
+            .inject_connection_established(peer, conn, endpoint)
+    }
+
+    fn inject_connection_closed(
+        &mut self,
+        peer: &PeerId,
+        conn: &ConnectionId,
+        endpoint: &ConnectedPoint,
+    ) {
+        self.inner.inject_connection_closed(peer, conn, endpoint)
+    }
+
+    fn inject_disconnected(&mut self, peer: &PeerId) {
+        self.inner.inject_disconnected(peer)
+    }
+
+    fn inject_dial_failure(&mut self, peer: &PeerId) {
+        self.inner.inject_dial_failure(peer)
+    }
+
+    fn inject_event(
+        &mut self,
+        peer: PeerId,
+        conn: ConnectionId,
+        event: RequestResponseHandlerEvent<AutoNatCodec>,
+    ) {
+        self.inner.inject_event(peer, conn, event)
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context,
+        pp: &mut impl PollParameters,
+    ) -> Poll<NetworkBehaviourAction<RequestProtocol<AutoNatCodec>, AutoNatEvent>> {
+        loop {
+            match self.inner.poll(cx, pp) {
+                Poll::Ready(NetworkBehaviourAction::GenerateEvent(
+                    RequestResponseEvent::Message { peer, message },
+                )) => match message {
+                    RequestResponseMessage::Request { request, channel } => {
+                        println!("{} {:?} {:?}", peer, request, channel);
+                    }
+                    RequestResponseMessage::Response {
+                        request_id,
+                        response,
+                    } => {
+                        println!("{} {:?} {:?}", peer, request_id, response);
+                    }
+                },
+                Poll::Ready(NetworkBehaviourAction::GenerateEvent(
+                    RequestResponseEvent::OutboundFailure {
+                        peer,
+                        request_id,
+                        error,
+                    },
+                )) => {
+                    println!("outbound failure {} {:?} {:?}", peer, request_id, error);
+                }
+                Poll::Ready(NetworkBehaviourAction::GenerateEvent(
+                    RequestResponseEvent::InboundFailure { peer, error },
+                )) => {
+                    println!("inbound failure {} {:?}", peer, error);
+                }
+                Poll::Ready(NetworkBehaviourAction::DialAddress { address }) => {
+                    return Poll::Ready(NetworkBehaviourAction::DialAddress { address })
+                }
+                Poll::Ready(NetworkBehaviourAction::DialPeer { peer_id, condition }) => {
+                    return Poll::Ready(NetworkBehaviourAction::DialPeer { peer_id, condition })
+                }
+                Poll::Ready(NetworkBehaviourAction::NotifyHandler {
+                    peer_id,
+                    handler,
+                    event,
+                }) => {
+                    return Poll::Ready(NetworkBehaviourAction::NotifyHandler {
+                        peer_id,
+                        handler,
+                        event,
+                    })
+                }
+                Poll::Ready(NetworkBehaviourAction::ReportObservedAddr { address }) => {
+                    return Poll::Ready(NetworkBehaviourAction::ReportObservedAddr { address })
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}

--- a/protocols/autonat/src/autonat.rs
+++ b/protocols/autonat/src/autonat.rs
@@ -1,0 +1,23 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+pub struct AutoNat;
+
+pub enum AutoNatEvent {}

--- a/protocols/autonat/src/autonat.rs
+++ b/protocols/autonat/src/autonat.rs
@@ -182,12 +182,12 @@ impl NetworkBehaviour for AutoNat {
                         error,
                     },
                 )) => {
-                    println!("outbound failure {} {:?} {:?}", peer, request_id, error);
+                    log::error!("autonat outbound failure {} {:?} {:?}", peer, request_id, error);
                 }
                 Poll::Ready(NetworkBehaviourAction::GenerateEvent(
                     RequestResponseEvent::InboundFailure { peer, error },
                 )) => {
-                    println!("inbound failure {} {:?}", peer, error);
+                    log::error!("autonat inbound failure {} {:?}", peer, error);
                 }
                 Poll::Ready(NetworkBehaviourAction::DialAddress { address }) => {
                     return Poll::Ready(NetworkBehaviourAction::DialAddress { address })

--- a/protocols/autonat/src/autonat.rs
+++ b/protocols/autonat/src/autonat.rs
@@ -120,7 +120,6 @@ impl NetworkBehaviour for AutoNat {
         endpoint: &ConnectedPoint,
     ) {
         self.inner.inject_connection_closed(peer, conn, endpoint);
-
         if let Some(addrs) = self.observed_addresses.get_mut(peer) {
             addrs.remove(conn);
         }
@@ -162,7 +161,6 @@ impl NetworkBehaviour for AutoNat {
                         request: _,
                         channel,
                     } => {
-                        println!("{:?}", self.addresses_of_peer(&peer));
                         self.requests.insert(peer.clone(), channel);
                         return Poll::Ready(NetworkBehaviourAction::DialPeer {
                             peer_id: peer,

--- a/protocols/autonat/src/lib.rs
+++ b/protocols/autonat/src/lib.rs
@@ -20,7 +20,7 @@
 
 //! Implementation of the [AutoNAT] protocol.
 
-pub use self::autonat::{AutoNat, AutoNatEvent};
+pub use self::autonat::{AutoNat, AutoNatEvent, DialResponse};
 
 mod autonat;
 mod protocol;

--- a/protocols/autonat/src/lib.rs
+++ b/protocols/autonat/src/lib.rs
@@ -1,0 +1,29 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Implementation of the [AutoNAT] protocol.
+
+pub use self::autonat::{AutoNat, AutoNatEvent};
+
+mod autonat;
+
+mod structs_proto {
+    include!(concat!(env!("OUT_DIR"), "/structs.rs"));
+}

--- a/protocols/autonat/src/lib.rs
+++ b/protocols/autonat/src/lib.rs
@@ -23,6 +23,7 @@
 pub use self::autonat::{AutoNat, AutoNatEvent};
 
 mod autonat;
+mod protocol;
 
 mod structs_proto {
     include!(concat!(env!("OUT_DIR"), "/structs.rs"));

--- a/protocols/autonat/src/protocol.rs
+++ b/protocols/autonat/src/protocol.rs
@@ -1,0 +1,275 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use crate::structs_proto;
+pub use crate::structs_proto::message::ResponseStatus;
+use async_trait::async_trait;
+use futures::io::{AsyncRead, AsyncWrite};
+use libp2p_core::{upgrade, Multiaddr, PeerId};
+use libp2p_request_response::{ProtocolName, RequestResponseCodec};
+use prost::Message;
+use std::{convert::TryFrom, io};
+
+#[derive(Clone, Debug)]
+pub struct AutoNatProtocol;
+
+impl ProtocolName for AutoNatProtocol {
+    fn protocol_name(&self) -> &[u8] {
+        b"/libp2p/autonat/1.0.0"
+    }
+}
+
+#[derive(Clone)]
+pub struct AutoNatCodec;
+
+#[async_trait]
+impl RequestResponseCodec for AutoNatCodec {
+    type Protocol = AutoNatProtocol;
+    type Request = DialRequest;
+    type Response = DialResponse;
+
+    async fn read_request<T>(
+        &mut self,
+        _: &AutoNatProtocol,
+        io: &mut T,
+    ) -> io::Result<Self::Request>
+    where
+        T: AsyncRead + Send + Unpin,
+    {
+        let bytes = upgrade::read_one(io, 1024)
+            .await
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let request = DialRequest::from_bytes(&bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(request)
+    }
+
+    async fn read_response<T>(
+        &mut self,
+        _: &AutoNatProtocol,
+        io: &mut T,
+    ) -> io::Result<Self::Response>
+    where
+        T: AsyncRead + Send + Unpin,
+    {
+        let bytes = upgrade::read_one(io, 1024)
+            .await
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let response = DialResponse::from_bytes(&bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(response)
+    }
+
+    async fn write_request<T>(
+        &mut self,
+        _: &AutoNatProtocol,
+        io: &mut T,
+        data: Self::Request,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Send + Unpin,
+    {
+        upgrade::write_one(io, data.to_bytes()).await
+    }
+
+    async fn write_response<T>(
+        &mut self,
+        _: &AutoNatProtocol,
+        io: &mut T,
+        data: Self::Response,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Send + Unpin,
+    {
+        upgrade::write_one(io, data.to_bytes()).await
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DialRequest {
+    pub peer_id: PeerId,
+    pub addrs: Vec<Multiaddr>,
+}
+
+impl DialRequest {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, io::Error> {
+        let msg = structs_proto::Message::decode(bytes)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        if msg.r#type != Some(structs_proto::message::MessageType::Dial as _) {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid type"));
+        }
+        let (peer_id, addrs) = if let Some(structs_proto::message::Dial {
+            peer:
+                Some(structs_proto::message::PeerInfo {
+                    id: Some(peer_id),
+                    addrs,
+                }),
+        }) = msg.dial
+        {
+            (peer_id, addrs)
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid dial message",
+            ));
+        };
+
+        let peer_id = {
+            PeerId::try_from(peer_id)
+                .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid peer id"))?
+        };
+        let addrs = {
+            let mut maddrs = vec![];
+            for addr in addrs.into_iter() {
+                let maddr = Multiaddr::try_from(addr)
+                    .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+                maddrs.push(maddr);
+            }
+            maddrs
+        };
+        Ok(Self { peer_id, addrs })
+    }
+
+    pub fn to_bytes(self) -> Vec<u8> {
+        let peer_id = self.peer_id.into_bytes();
+        let addrs = self.addrs.into_iter().map(|addr| addr.to_vec()).collect();
+
+        let msg = structs_proto::Message {
+            r#type: Some(structs_proto::message::MessageType::Dial as _),
+            dial: Some(structs_proto::message::Dial {
+                peer: Some(structs_proto::message::PeerInfo {
+                    id: Some(peer_id),
+                    addrs: addrs,
+                }),
+            }),
+            dial_response: None,
+        };
+
+        let mut bytes = Vec::with_capacity(msg.encoded_len());
+        msg.encode(&mut bytes)
+            .expect("Vec<u8> provides capacity as needed");
+        bytes
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DialResponse {
+    Ok(Multiaddr),
+    Err(ResponseStatus, String),
+}
+
+impl DialResponse {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, io::Error> {
+        let msg = structs_proto::Message::decode(bytes)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        if msg.r#type != Some(structs_proto::message::MessageType::DialResponse as _) {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid type"));
+        }
+
+        Ok(match msg.dial_response {
+            Some(structs_proto::message::DialResponse {
+                status: Some(0),
+                status_text: None,
+                addr: Some(addr),
+            }) => {
+                let addr = Multiaddr::try_from(addr)
+                    .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+                Self::Ok(addr)
+            }
+            Some(structs_proto::message::DialResponse {
+                status: Some(status),
+                status_text,
+                addr: None,
+            }) => {
+                let status = ResponseStatus::from_i32(status).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "invalid status code")
+                })?;
+                Self::Err(status, status_text.unwrap_or_default())
+            }
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid dial response message",
+                ));
+            }
+        })
+    }
+
+    pub fn to_bytes(self) -> Vec<u8> {
+        let dial_response = match self {
+            Self::Ok(addr) => structs_proto::message::DialResponse {
+                status: Some(0),
+                status_text: None,
+                addr: Some(addr.to_vec()),
+            },
+            Self::Err(status, status_text) => structs_proto::message::DialResponse {
+                status: Some(status as _),
+                status_text: Some(status_text),
+                addr: None,
+            },
+        };
+
+        let msg = structs_proto::Message {
+            r#type: Some(structs_proto::message::MessageType::DialResponse as _),
+            dial: None,
+            dial_response: Some(dial_response),
+        };
+
+        let mut bytes = Vec::with_capacity(msg.encoded_len());
+        msg.encode(&mut bytes)
+            .expect("Vec<u8> provides capacity as needed");
+        bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_request_encode_decode() {
+        let request = DialRequest {
+            peer_id: PeerId::random(),
+            addrs: vec![
+                "/ip4/8.8.8.8/tcp/30333".parse().unwrap(),
+                "/ip4/192.168.1.42/tcp/30333".parse().unwrap(),
+            ],
+        };
+        let bytes = request.clone().to_bytes();
+        let request2 = DialRequest::from_bytes(&bytes).unwrap();
+        assert_eq!(request, request2);
+    }
+
+    #[test]
+    fn test_response_ok_encode_decode() {
+        let response = DialResponse::Ok("/ip4/8.8.8.8/tcp/30333".parse().unwrap());
+        let bytes = response.clone().to_bytes();
+        let response2 = DialResponse::from_bytes(&bytes).unwrap();
+        assert_eq!(response, response2);
+    }
+
+    #[test]
+    fn test_response_err_encode_decode() {
+        let response = DialResponse::Err(ResponseStatus::EDialError, "failed to dial".into());
+        let bytes = response.clone().to_bytes();
+        let response2 = DialResponse::from_bytes(&bytes).unwrap();
+        assert_eq!(response, response2);
+    }
+}

--- a/protocols/autonat/src/structs.proto
+++ b/protocols/autonat/src/structs.proto
@@ -1,0 +1,37 @@
+syntax = "proto2";
+
+package structs;
+
+message Message {
+  enum MessageType {
+    DIAL          = 0;
+    DIAL_RESPONSE = 1;
+  }
+
+  enum ResponseStatus {
+    OK               = 0;
+    E_DIAL_ERROR     = 100;
+    E_DIAL_REFUSED   = 101;
+    E_BAD_REQUEST    = 200;
+    E_INTERNAL_ERROR = 300;
+  }
+
+  message PeerInfo {
+    optional bytes id = 1;
+    repeated bytes addrs = 2;
+  }
+
+  message Dial {
+    optional PeerInfo peer = 1;
+  }
+
+  message DialResponse {
+    optional ResponseStatus status = 1;
+    optional string statusText = 2;
+    optional bytes addr = 3;
+  }
+
+  optional MessageType type = 1;
+  optional Dial dial = 2;
+  optional DialResponse dialResponse = 3;
+}

--- a/protocols/autonat/tests/autonat.rs
+++ b/protocols/autonat/tests/autonat.rs
@@ -27,7 +27,7 @@ fn mk_swarm() -> (PeerId, Swarm<AutoNat>) {
         .map(|(peer, muxer), _| (peer, StreamMuxerBox::new(muxer)))
         .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
         .boxed();
-    let swarm = Swarm::new(transport, AutoNat::new(), peer_id.clone());
+    let swarm = Swarm::new(transport, AutoNat::default(), peer_id.clone());
     (peer_id, swarm)
 }
 

--- a/protocols/autonat/tests/autonat.rs
+++ b/protocols/autonat/tests/autonat.rs
@@ -1,0 +1,136 @@
+use async_std::task;
+use futures::channel::{mpsc, oneshot};
+use futures::future::{poll_fn, FutureExt};
+use futures::sink::SinkExt;
+use futures::stream::{Stream, StreamExt};
+use libp2p::autonat::{AutoNat, AutoNatEvent, DialResponse};
+use libp2p::core::{
+    identity, muxing::StreamMuxerBox, transport::Transport, upgrade, Multiaddr, PeerId,
+};
+use libp2p::noise::{Keypair, NoiseConfig, X25519Spec};
+use libp2p::swarm::Swarm;
+use libp2p::tcp::TcpConfig;
+use netsim_embed::{Ipv4Range, NatConfig, NetworkBuilder};
+use std::{io, pin::Pin, task::Poll};
+
+fn mk_swarm() -> (PeerId, Swarm<AutoNat>) {
+    let id_keys = identity::Keypair::generate_ed25519();
+    let peer_id = id_keys.public().into_peer_id();
+    let noise_keys = Keypair::<X25519Spec>::new()
+        .into_authentic(&id_keys)
+        .expect("invalid noise keys");
+    let transport = TcpConfig::new()
+        .nodelay(true)
+        .upgrade(upgrade::Version::V1)
+        .authenticate(NoiseConfig::xx(noise_keys).into_authenticated())
+        .multiplex(libp2p::yamux::Config::default())
+        .map(|(peer, muxer), _| (peer, StreamMuxerBox::new(muxer)))
+        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
+        .boxed();
+    let swarm = Swarm::new(transport, AutoNat::new(), peer_id.clone());
+    (peer_id, swarm)
+}
+
+enum Command {
+    DialRequest(PeerId, Multiaddr),
+}
+
+enum Event {
+    Ready(PeerId, Multiaddr),
+    Result(AutoNatEvent),
+}
+
+fn autonat_netsim_setup(natconfig: NatConfig) -> oneshot::Receiver<AutoNatEvent> {
+    let (tx, rx) = oneshot::channel();
+    netsim_embed::run(async move {
+        let mut global = NetworkBuilder::new(Ipv4Range::global());
+        global.spawn_machine(
+            |mut cmd: mpsc::Receiver<Command>, mut event: mpsc::Sender<Event>| async move {
+                let (peer_id, mut swarm) = mk_swarm();
+                let addr = "/ip4/0.0.0.0/tcp/0".parse().expect("Invalid addr");
+                Swarm::listen_on(&mut swarm, addr).expect("listen_on failed");
+                while let Some(_) = swarm.next().now_or_never() {}
+                let listener = Swarm::listeners(&swarm).next().expect("no listeners");
+                event
+                    .send(Event::Ready(peer_id, listener.clone()))
+                    .await
+                    .expect("failed to send ready event");
+
+                poll_fn(move |cx| loop {
+                    if let Poll::Ready(None) = Pin::new(&mut cmd).poll_next(cx) {
+                        return Poll::Ready(());
+                    }
+                    if let Poll::Pending = Pin::new(&mut swarm).poll_next(cx) {
+                        return Poll::Pending;
+                    }
+                })
+                .await
+            },
+        );
+
+        let mut local = NetworkBuilder::new(Ipv4Range::random_local_subnet());
+        local.spawn_machine(
+            |mut cmd: mpsc::Receiver<Command>, mut event: mpsc::Sender<Event>| async move {
+                let (_peer_id, mut swarm) = mk_swarm();
+                if let Some(Command::DialRequest(peer_id, addr)) = cmd.next().await {
+                    swarm.add_address(&peer_id, addr);
+                    Swarm::dial(&mut swarm, &peer_id).expect("dial failed");
+                } else {
+                    unreachable!();
+                }
+                let result = swarm.next().await;
+                event
+                    .send(Event::Result(result))
+                    .await
+                    .expect("sending result failed");
+            },
+        );
+
+        global.spawn_network(Some(natconfig), local);
+
+        let mut net = global.spawn();
+        let (peer_id, addr) = if let Event::Ready(peer_id, addr) =
+            net.machine(0).recv().await.expect("recv ready failed")
+        {
+            (peer_id, addr)
+        } else {
+            unreachable!()
+        };
+
+        let m = net.subnet(0).machine(0);
+        m.send(Command::DialRequest(peer_id, addr)).await;
+        if let Event::Result(event) = m.recv().await.expect("recv result failed") {
+            tx.send(event).expect("sending result failed 2");
+        }
+    });
+    rx
+}
+
+#[test]
+#[ignore]
+fn autonat_with_traversable_nat() {
+    let natconfig = NatConfig::default();
+    let rx = autonat_netsim_setup(natconfig);
+    task::block_on(async move {
+        let event = rx.await.expect("recv result failed 2");
+        if let AutoNatEvent::DialResponse(DialResponse::Ok(_)) = event {
+        } else {
+            panic!();
+        }
+    });
+}
+
+#[test]
+#[ignore]
+fn autonat_with_untraversable_nat() {
+    let mut natconfig = NatConfig::default();
+    natconfig.symmetric = true;
+    let rx = autonat_netsim_setup(natconfig);
+    task::block_on(async move {
+        let event = rx.await.expect("recv result failed 2");
+        if let AutoNatEvent::DialResponse(DialResponse::Err(_, _)) = event {
+        } else {
+            panic!();
+        }
+    });
+}

--- a/protocols/autonat/tests/autonat.rs
+++ b/protocols/autonat/tests/autonat.rs
@@ -72,6 +72,10 @@ fn autonat_netsim_setup(natconfig: NatConfig) -> oneshot::Receiver<AutoNatEvent>
         local.spawn_machine(
             |mut cmd: mpsc::Receiver<Command>, mut event: mpsc::Sender<Event>| async move {
                 let (_peer_id, mut swarm) = mk_swarm();
+                let addr = "/ip4/0.0.0.0/tcp/0".parse().expect("Invalid addr");
+                Swarm::listen_on(&mut swarm, addr).expect("listen_on failed");
+                while let Some(_) = swarm.next().now_or_never() {}
+
                 if let Some(Command::DialRequest(peer_id, addr)) = cmd.next().await {
                     swarm.add_address(&peer_id, addr);
                     swarm.dial_request(&peer_id);

--- a/protocols/autonat/tests/autonat.rs
+++ b/protocols/autonat/tests/autonat.rs
@@ -74,7 +74,7 @@ fn autonat_netsim_setup(natconfig: NatConfig) -> oneshot::Receiver<AutoNatEvent>
                 let (_peer_id, mut swarm) = mk_swarm();
                 if let Some(Command::DialRequest(peer_id, addr)) = cmd.next().await {
                     swarm.add_address(&peer_id, addr);
-                    Swarm::dial(&mut swarm, &peer_id).expect("dial failed");
+                    swarm.dial_request(&peer_id);
                 } else {
                     unreachable!();
                 }

--- a/protocols/deflate/tests/test.rs
+++ b/protocols/deflate/tests/test.rs
@@ -82,7 +82,8 @@ async fn run(message1: Vec<u8>) {
         conn.close().await.expect("close")
     });
 
-    let mut conn = transport.dial(listen_addr).expect("dialer").await.expect("connection");
+    let mut conn = transport.dial(None, listen_addr)
+        .expect("dialer").await.expect("connection");
     conn.write_all(&message1).await.expect("write_all");
     conn.close().await.expect("close");
 

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -108,7 +108,7 @@ impl NetworkBehaviour for Identify {
 
     fn inject_connection_established(&mut self, peer_id: &PeerId, conn: &ConnectionId, endpoint: &ConnectedPoint) {
         let addr = match endpoint {
-            ConnectedPoint::Dialer { address } => address.clone(),
+            ConnectedPoint::Dialer { address, .. } => address.clone(),
             ConnectedPoint::Listener { send_back_addr, .. } => send_back_addr.clone(),
         };
 

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -258,7 +258,7 @@ mod tests {
         async_std::task::block_on(async move {
             let transport = TcpConfig::new();
 
-            let socket = transport.dial(rx.await.unwrap()).unwrap().await.unwrap();
+            let socket = transport.dial(None, rx.await.unwrap()).unwrap().await.unwrap();
             let RemoteInfo { info, observed_addr, .. } =
                 apply_outbound(socket, IdentifyProtocolConfig, upgrade::Version::V1).await.unwrap();
             assert_eq!(observed_addr, "/ip4/100.101.102.103/tcp/5000".parse().unwrap());

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -1426,7 +1426,7 @@ where
         // since the remote address on an inbound connection is specific to
         // that connection (e.g. typically the TCP port numbers).
         let address = match endpoint {
-            ConnectedPoint::Dialer { address } => Some(address.clone()),
+            ConnectedPoint::Dialer { address, .. } => Some(address.clone()),
             ConnectedPoint::Listener { .. } => None,
         };
 

--- a/protocols/noise/tests/smoke.rs
+++ b/protocols/noise/tests/smoke.rs
@@ -203,7 +203,7 @@ where
 
         let outbound_msgs = messages.clone();
         let client_fut = async {
-            let mut client_session = client_transport.dial(server_address.clone())
+            let mut client_session = client_transport.dial(None, server_address.clone())
                 .unwrap()
                 .await
                 .map(|(_, session)| session)

--- a/protocols/ping/src/protocol.rs
+++ b/protocols/ping/src/protocol.rs
@@ -138,7 +138,7 @@ mod tests {
         });
 
         async_std::task::block_on(async move {
-            let c = MemoryTransport.dial(listener_addr).unwrap().await.unwrap();
+            let c = MemoryTransport.dial(None, listener_addr).unwrap().await.unwrap();
             let rtt = upgrade::apply_outbound(c, Ping::default(), upgrade::Version::V1).await.unwrap();
             assert!(rtt > Duration::from_secs(0));
         });

--- a/protocols/plaintext/tests/smoke.rs
+++ b/protocols/plaintext/tests/smoke.rs
@@ -85,7 +85,10 @@ fn variable_msg_length() {
 
             let client_fut = async {
                 debug!("dialing {:?}", server_address);
-                let (received_server_id, mut client_channel) = client_transport.dial(server_address).unwrap().await.unwrap();
+                let (received_server_id, mut client_channel) = client_transport.dial(
+                    None,
+                    server_address,
+                ).unwrap().await.unwrap();
                 assert_eq!(received_server_id, server_id.public().into_peer_id());
 
                 debug!("Client: writing message.");

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -456,7 +456,7 @@ where
 
     fn inject_connection_established(&mut self, peer: &PeerId, conn: &ConnectionId, endpoint: &ConnectedPoint) {
         let address = match endpoint {
-            ConnectedPoint::Dialer { address } => Some(address.clone()),
+            ConnectedPoint::Dialer { address, .. } => Some(address.clone()),
             ConnectedPoint::Listener { .. } => None
         };
         let connections = self.connected.entry(peer.clone()).or_default();
@@ -604,4 +604,3 @@ struct Connection {
     id: ConnectionId,
     address: Option<Multiaddr>,
 }
-

--- a/src/bandwidth.rs
+++ b/src/bandwidth.rs
@@ -72,10 +72,10 @@ where
             .map(move |inner| BandwidthListener { inner, sinks })
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
         let sinks = self.sinks;
         self.inner
-            .dial(addr)
+            .dial(local_addr, addr)
             .map(move |fut| BandwidthFuture { inner: fut, sinks })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@
 //! use libp2p::{Multiaddr, Transport, tcp::TcpConfig};
 //! let tcp = TcpConfig::new();
 //! let addr: Multiaddr = "/ip4/98.97.96.95/tcp/20500".parse().expect("invalid multiaddr");
-//! let _conn = tcp.dial(addr);
+//! let _conn = tcp.dial(None, addr);
 //! ```
 //! In the above example, `_conn` is a [`Future`] that needs to be polled in order for
 //! the dialing to take place and eventually resolve to a connection. Polling

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,10 @@ pub use multiaddr;
 #[doc(inline)]
 pub use multihash;
 
+#[cfg(feature = "autonat")]
+#[cfg_attr(docsrs, doc(cfg(feature = "autonat")))]
+#[doc(inline)]
+pub use libp2p_autonat as autonat;
 #[doc(inline)]
 pub use libp2p_core as core;
 #[cfg(feature = "deflate")]

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -744,12 +744,10 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                     }
                 },
                 Poll::Ready(NetworkBehaviourAction::ReportObservedAddr { address }) => {
-                    for addr in this.network.address_translation(&address) {
-                        if this.external_addrs.iter().all(|a| *a != addr) {
-                            this.behaviour.inject_new_external_addr(&addr);
-                        }
-                        this.external_addrs.add(addr);
+                    if this.external_addrs.iter().find(|a| *a != &address).is_none() {
+                        this.behaviour.inject_new_external_addr(&address);
                     }
+                    this.external_addrs.add(address);
                 },
             }
         }

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -17,9 +17,8 @@ get_if_addrs = "0.5.3"
 ipnet = "2.0.0"
 libp2p-core = { version = "0.20.0", path = "../../core" }
 log = "0.4.1"
-socket2 = "0.3.12"
+socket2 = { version = "0.3.12", features = ["reuseport"] }
 tokio = { version = "0.2", default-features = false, features = ["tcp"], optional = true }
 
 [dev-dependencies]
 libp2p-tcp = { path = ".", features = ["async-std"] }
-

--- a/transports/uds/src/lib.rs
+++ b/transports/uds/src/lib.rs
@@ -101,7 +101,7 @@ impl Transport for $uds_config {
         }
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+    fn dial(self, _local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
         if let Ok(path) = multiaddr_to_path(&addr) {
             debug!("Dialing {}", addr);
             Ok(async move { <$unix_stream>::connect(&path).await }.boxed())
@@ -213,7 +213,7 @@ mod tests {
         async_std::task::block_on(async move {
             let uds = UdsConfig::new();
             let addr = rx.await.unwrap();
-            let mut socket = uds.dial(addr).unwrap().await.unwrap();
+            let mut socket = uds.dial(None, addr).unwrap().await.unwrap();
             socket.write(&[1, 2, 3]).await.unwrap();
         });
     }

--- a/transports/wasm-ext/src/lib.rs
+++ b/transports/wasm-ext/src/lib.rs
@@ -190,7 +190,7 @@ impl Transport for ExtTransport {
         })
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+    fn dial(self, _local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
         let promise = self
             .inner
             .dial(&addr.to_string())

--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -110,8 +110,8 @@ where
         self.transport.map(wrap_connection as WrapperFn<T::Output>).listen_on(addr)
     }
 
-    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-        self.transport.map(wrap_connection as WrapperFn<T::Output>).dial(addr)
+    fn dial(self, local_addr: Option<Multiaddr>, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        self.transport.map(wrap_connection as WrapperFn<T::Output>).dial(local_addr, addr)
     }
 }
 
@@ -226,7 +226,7 @@ mod tests {
             conn.await
         };
 
-        let outbound = ws_config.dial(addr).unwrap();
+        let outbound = ws_config.dial(None, addr).unwrap();
 
         let (a, b) = futures::join!(inbound, outbound);
         a.and(b).unwrap();


### PR DESCRIPTION
Builds on top of #1667 to add a dial back protocol with unit tests. The wire format is the same as the libp2p autonat protocol, but not tested if it's compatible, as there isn't a published spec for it. Uses netsim-embed to simulate a traversable and an untraversable nat.