### PR TITLE
Debug instance for the gossipsub behaviour

### DIFF
--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -26,7 +26,7 @@ base64 = "0.11.0"
 lru = "0.4.3"
 smallvec = "1.1.0"
 prost = "0.6.1"
-hex = "0.4.2"
+hex_fmt = "0.3.0"
 
 [dev-dependencies]
 async-std = "1.6.2"

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -26,6 +26,7 @@ base64 = "0.11.0"
 lru = "0.4.3"
 smallvec = "1.1.0"
 prost = "0.6.1"
+hex = "0.4.2"
 
 [dev-dependencies]
 async-std = "1.6.2"

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -51,6 +51,7 @@ use wasm_timer::{Instant, Interval};
 
 mod tests;
 
+#[derive(Debug)]
 /// Network behaviour that handles the gossipsub protocol.
 pub struct Gossipsub {
     /// Configuration providing gossipsub performance parameters.

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -231,8 +231,19 @@ impl GossipsubConfigBuilder {
 
 impl std::fmt::Debug for GossipsubConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        struct StringOrBytes<'a>(&'a [u8]);
+
+        impl<'a> std::fmt::Debug for StringOrBytes<'a> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                if let Ok(text) = std::str::from_utf8(self.0) {
+                    write!(f, "\"{}\"", text)
+                } else {
+                    write!(f, "{}", hex::encode(self.0))
+                }
+            }
+        }
         let mut builder = f.debug_struct("GossipsubConfig");
-        let _ = builder.field("protocol_id", &self.protocol_id);
+        let _ = builder.field("protocol_id", &StringOrBytes(&self.protocol_id));
         let _ = builder.field("history_length", &self.history_length);
         let _ = builder.field("history_gossip", &self.history_gossip);
         let _ = builder.field("mesh_n", &self.mesh_n);

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -238,7 +238,7 @@ impl std::fmt::Debug for GossipsubConfig {
                 if let Ok(text) = std::str::from_utf8(self.0) {
                     write!(f, "\"{}\"", text)
                 } else {
-                    write!(f, "{}", hex::encode(self.0))
+                    write!(f, "{}", hex_fmt::HexFmt(self.0))
                 }
             }
         }

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -231,19 +231,12 @@ impl GossipsubConfigBuilder {
 
 impl std::fmt::Debug for GossipsubConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        struct StringOrBytes<'a>(&'a [u8]);
-
-        impl<'a> std::fmt::Debug for StringOrBytes<'a> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                if let Ok(text) = std::str::from_utf8(self.0) {
-                    write!(f, "\"{}\"", text)
-                } else {
-                    write!(f, "{}", hex_fmt::HexFmt(self.0))
-                }
-            }
-        }
         let mut builder = f.debug_struct("GossipsubConfig");
-        let _ = builder.field("protocol_id", &StringOrBytes(&self.protocol_id));
+        let _ = if let Ok(text) = std::str::from_utf8(&self.protocol_id) {
+            builder.field("protocol_id", &text)
+        } else {
+            builder.field("protocol_id", &hex_fmt::HexFmt(&self.protocol_id))
+        };
         let _ = builder.field("history_length", &self.history_length);
         let _ = builder.field("history_gossip", &self.history_gossip);
         let _ = builder.field("mesh_n", &self.mesh_n);

--- a/protocols/gossipsub/src/mcache.rs
+++ b/protocols/gossipsub/src/mcache.rs
@@ -22,7 +22,7 @@ extern crate fnv;
 
 use crate::protocol::{GossipsubMessage, MessageId};
 use crate::topic::TopicHash;
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt};
 
 /// CacheEntry stored in the history.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -38,6 +38,16 @@ pub struct MessageCache {
     history: Vec<Vec<CacheEntry>>,
     gossip: usize,
     msg_id: fn(&GossipsubMessage) -> MessageId,
+}
+
+impl fmt::Debug for MessageCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MessageCache")
+            .field("msgs", &self.msgs)
+            .field("history", &self.history)
+            .field("gossip", &self.gossip)
+            .finish()
+    }
 }
 
 /// Implementation of the MessageCache.

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -29,7 +29,7 @@ use futures::prelude::*;
 use futures_codec::{Decoder, Encoder, Framed};
 use libp2p_core::{InboundUpgrade, OutboundUpgrade, PeerId, UpgradeInfo};
 use prost::Message as ProtobufMessage;
-use std::{borrow::Cow, io, iter, pin::Pin};
+use std::{borrow::Cow, fmt, io, iter, pin::Pin};
 use unsigned_varint::codec;
 
 /// Implementation of the `ConnectionUpgrade` for the Gossipsub protocol.
@@ -336,7 +336,7 @@ impl Into<String> for MessageId {
 }
 
 /// A message received by the gossipsub system.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct GossipsubMessage {
     /// Id of the peer that published this message.
     pub source: PeerId,
@@ -351,6 +351,18 @@ pub struct GossipsubMessage {
     ///
     /// Each message can belong to multiple topics at once.
     pub topics: Vec<TopicHash>,
+}
+
+impl fmt::Debug for GossipsubMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GossipsubMessage")
+            .field("data", &hex::encode(&self.data))
+            .field("source", &self.source)
+            .field("sequence_number", &self.sequence_number)
+            .field("topics", &self.topics)
+            .finish()
+    }
+
 }
 
 /// A subscription received by the gossipsub system.

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -356,7 +356,7 @@ pub struct GossipsubMessage {
 impl fmt::Debug for GossipsubMessage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GossipsubMessage")
-            .field("data", &hex::encode(&self.data))
+            .field("data.len", &self.data.len())
             .field("source", &self.source)
             .field("sequence_number", &self.sequence_number)
             .field("topics", &self.topics)

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -356,13 +356,12 @@ pub struct GossipsubMessage {
 impl fmt::Debug for GossipsubMessage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GossipsubMessage")
-            .field("data.len", &self.data.len())
+            .field("data", &hex_fmt::HexFmt(&self.data))
             .field("source", &self.source)
             .field("sequence_number", &self.sequence_number)
             .field("topics", &self.topics)
             .finish()
     }
-
 }
 
 /// A subscription received by the gossipsub system.

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -356,7 +356,7 @@ pub struct GossipsubMessage {
 impl fmt::Debug for GossipsubMessage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GossipsubMessage")
-            .field("data", &hex_fmt::HexFmt(&self.data))
+            .field("data",&format_args!("{:<20}", &hex_fmt::HexFmt(&self.data)))
             .field("source", &self.source)
             .field("sequence_number", &self.sequence_number)
             .field("topics", &self.topics)


### PR DESCRIPTION
To assist looking into https://github.com/libp2p/rust-libp2p/issues/1671

Not sure if the nicer debug output is worth the extra dependency. For me it is, but YMMV. I can remove this if you see this differently.

Edit: I added truncation of the message bytes to ensure that the debug output for a gossipsub msg is not too big.