### PR TITLE
Gossipsub: Use sets instead of vectors inside behaviour state

### DIFF
--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -374,7 +374,7 @@ impl Gossipsub {
             let mesh_peers = self
                 .mesh
                 .entry(topic_hash.clone())
-                .or_insert_with(|| Default::default());
+                .or_insert_with(Default::default);
             mesh_peers.extend(new_peers);
         }
 
@@ -695,7 +695,7 @@ impl Gossipsub {
                         |peer| !peers.contains(peer)
                     });
                 for peer in &peer_list {
-                    let current_topic = to_graft.entry(peer.clone()).or_insert_with(|| vec![]);
+                    let current_topic = to_graft.entry(peer.clone()).or_insert_with(Vec::new);
                     current_topic.push(topic_hash.clone());
                 }
                 // update the mesh
@@ -721,7 +721,7 @@ impl Gossipsub {
                     let peer = shuffled
                         .pop()
                         .expect("There should always be enough peers to remove");
-                    let current_topic = to_prune.entry(peer).or_insert_with(|| vec![]);
+                    let current_topic = to_prune.entry(peer).or_insert_with(Vec::new);
                     current_topic.push(topic_hash.clone());
                 }
             }

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -768,7 +768,7 @@ impl Gossipsub {
             }
             for to_remove in to_remove_peers {
                 peers.remove(&to_remove);
-            }            
+            }
 
             // not enough peers
             if peers.len() < self.config.mesh_n {

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -254,11 +254,11 @@ mod tests {
 
         // verify fanout nodes
         // add 3 random peers to the fanout[topic1]
-        gs.fanout.insert(topic_hashes[1].clone(), vec![]);
+        gs.fanout.insert(topic_hashes[1].clone(), Default::default());
         let new_peers = vec![];
         for _ in 0..3 {
             let fanout_peers = gs.fanout.get_mut(&topic_hashes[1]).unwrap();
-            fanout_peers.push(PeerId::random());
+            fanout_peers.insert(PeerId::random());
         }
 
         // subscribe to topic1

--- a/protocols/gossipsub/src/topic.rs
+++ b/protocols/gossipsub/src/topic.rs
@@ -24,7 +24,7 @@ use prost::Message;
 use sha2::{Digest, Sha256};
 use std::fmt;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TopicHash {
     /// The topic hash. Stored as a string to align with the protobuf API.
     hash: String,
@@ -45,7 +45,7 @@ impl TopicHash {
 }
 
 /// A gossipsub topic.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Topic {
     topic: String,
 }


### PR DESCRIPTION
To completely eliminate the possibility of having duplicate peers in these sets