### PR TITLE
Change the gossipsub rpc protocol to use bytes for message ids

### DIFF
--- a/examples/gossipsub-chat.rs
+++ b/examples/gossipsub-chat.rs
@@ -83,7 +83,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let message_id_fn = |message: &GossipsubMessage| {
             let mut s = DefaultHasher::new();
             message.data.hash(&mut s);
-            MessageId(s.finish().to_string())
+            MessageId::from(s.finish().to_string())
         };
 
         // set custom gossipsub

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -26,6 +26,7 @@ base64 = "0.11.0"
 lru = "0.4.3"
 smallvec = "1.1.0"
 prost = "0.6.1"
+hex_fmt = "0.3.0"
 
 [dev-dependencies]
 async-std = "1.6.2"

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -314,7 +314,7 @@ impl Gossipsub {
             None => {
                 warn!(
                     "Message not in cache. Ignoring forwarding. Message Id: {}",
-                    message_id.0
+                    message_id
                 );
                 return false;
             }

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -683,7 +683,7 @@ mod tests {
         let (mut gs, peers, _) = build_and_inject_nodes(20, Vec::new(), true);
 
         let events_before = gs.events.len();
-        gs.handle_iwant(&peers[7], vec![MessageId(String::from("unknown id"))]);
+        gs.handle_iwant(&peers[7], vec![MessageId::new(b"unknown id")]);
         let events_after = gs.events.len();
 
         assert_eq!(
@@ -700,10 +700,7 @@ mod tests {
 
         gs.handle_ihave(
             &peers[7],
-            vec![(
-                topic_hashes[0].clone(),
-                vec![MessageId(String::from("unknown id"))],
-            )],
+            vec![(topic_hashes[0].clone(), vec![MessageId::new(b"unknown id")])],
         );
 
         // check that we sent an IWANT request for `unknown id`
@@ -711,7 +708,7 @@ mod tests {
             Some(controls) => controls.iter().any(|c| match c {
                 GossipsubControlAction::IWant { message_ids } => message_ids
                     .iter()
-                    .any(|m| *m.0 == String::from("unknown id")),
+                    .any(|m| *m == MessageId::new(b"unknown id")),
                 _ => false,
             }),
             _ => false,
@@ -730,7 +727,7 @@ mod tests {
         let (mut gs, peers, topic_hashes) =
             build_and_inject_nodes(20, vec![String::from("topic1")], true);
 
-        let msg_id = MessageId(String::from("known id"));
+        let msg_id = MessageId::new(b"known id");
         gs.received.put(msg_id.clone(), ());
 
         let events_before = gs.events.len();
@@ -754,7 +751,7 @@ mod tests {
             &peers[7],
             vec![(
                 TopicHash::from_raw(String::from("unsubscribed topic")),
-                vec![MessageId(String::from("irrelevant id"))],
+                vec![MessageId::new(b"irrelevant id")],
             )],
         );
         let events_after = gs.events.len();

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -108,7 +108,7 @@ impl Default for GossipsubConfig {
                 // default message id is: source + sequence number
                 let mut source_string = message.source.to_base58();
                 source_string.push_str(&message.sequence_number.to_string());
-                MessageId(source_string)
+                MessageId::from(source_string)
             },
         }
     }

--- a/protocols/gossipsub/src/mcache.rs
+++ b/protocols/gossipsub/src/mcache.rs
@@ -62,7 +62,7 @@ impl MessageCache {
             // default message id is: source + sequence number
             let mut source_string = message.source.to_base58();
             source_string.push_str(&message.sequence_number.to_string());
-            MessageId(source_string)
+            MessageId::from(source_string)
         };
         MessageCache {
             gossip,
@@ -153,7 +153,7 @@ mod tests {
             // default message id is: source + sequence number
             let mut source_string = message.source.to_base58();
             source_string.push_str(&message.sequence_number.to_string());
-            MessageId(source_string)
+            MessageId::from(source_string)
         };
         let x: usize = 3;
         let mc = MessageCache::new(x, 5, default_id);
@@ -200,7 +200,7 @@ mod tests {
         mc.put(m.clone());
 
         // Try to get an incorrect ID
-        let wrong_id = MessageId(String::from("wrongid"));
+        let wrong_id = MessageId::new(b"wrongid");
         let fetched = mc.get(&wrong_id);
         assert_eq!(fetched.is_none(), true);
     }
@@ -211,7 +211,7 @@ mod tests {
         let mc = MessageCache::new_default(10, 15);
 
         // Try to get an incorrect ID
-        let wrong_string = MessageId(String::from("imempty"));
+        let wrong_string = MessageId::new(b"imempty");
         let fetched = mc.get(&wrong_string);
         assert_eq!(fetched.is_none(), true);
     }

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -261,7 +261,7 @@ impl Decoder for GossipsubCodec {
                     message_ids: ihave
                         .message_ids
                         .into_iter()
-                        .map(|x| MessageId(x))
+                        .map(MessageId::from)
                         .collect::<Vec<_>>(),
                 })
                 .collect();
@@ -273,7 +273,7 @@ impl Decoder for GossipsubCodec {
                     message_ids: iwant
                         .message_ids
                         .into_iter()
-                        .map(|x| MessageId(x))
+                        .map(MessageId::from)
                         .collect::<Vec<_>>(),
                 })
                 .collect();
@@ -320,18 +320,30 @@ impl Decoder for GossipsubCodec {
 }
 
 /// A type for gossipsub message ids.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct MessageId(pub String);
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct MessageId(Vec<u8>);
 
-impl std::fmt::Display for MessageId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+impl MessageId {
+    pub fn new(value: &[u8]) -> Self {
+        Self(value.to_vec())
     }
 }
 
-impl Into<String> for MessageId {
-    fn into(self) -> String {
-        self.0.into()
+impl<T: Into<Vec<u8>>> From<T> for MessageId {
+    fn from(value: T) -> Self {
+        Self(value.into())
+    }
+}
+
+impl std::fmt::Display for MessageId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex_fmt::HexFmt(&self.0))
+    }
+}
+
+impl std::fmt::Debug for MessageId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MessageId({})", hex_fmt::HexFmt(&self.0))
     }
 }
 

--- a/protocols/gossipsub/src/rpc.proto
+++ b/protocols/gossipsub/src/rpc.proto
@@ -30,11 +30,11 @@ message ControlMessage {
 
 message ControlIHave {
 	optional string topic_id = 1;
-	repeated string message_ids = 2;
+	repeated bytes message_ids = 2;
 }
 
 message ControlIWant {
-	repeated string message_ids= 1;
+	repeated bytes message_ids= 1;
 }
 
 message ControlGraft {


### PR DESCRIPTION
And do the corresponding changes to make this work.

This aligns gossipsub with the changes in the spec https://github.com/libp2p/specs/commit/8e5da407893d6e340b7ec68d849cb57b19449671

Note that this is already included in https://github.com/libp2p/rust-libp2p/pull/1583 , but since the message signing PR might take some time to be merged, this is just the format change as an independent PR.