### PR TITLE
Public gossipsub api

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.21.0 [unreleased]
 
+- public API to list topics and peers. [PR 1677](https://github.com/libp2p/rust-libp2p/pull/1677).
+
 - `Debug` instance for `Gossipsub`. [PR 1673](https://github.com/libp2p/rust-libp2p/pull/1673).
 
 - Bump `libp2p-core` and `libp2p-swarm` dependency.

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.21.0 [unreleased]
 
-- public API to list topics and peers. [PR 1677](https://github.com/libp2p/rust-libp2p/pull/1677).
+- Add public API to list topics and peers. [PR 1677](https://github.com/libp2p/rust-libp2p/pull/1677).
 
 - `Debug` instance for `Gossipsub`. [PR 1673](https://github.com/libp2p/rust-libp2p/pull/1673).
 

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -221,7 +221,7 @@ impl Gossipsub {
         }
     }
 
-    /// lists the hashes of the topics we are currently subscribed to
+    /// Lists the hashes of the topics we are currently subscribed to.
     pub fn topics(&self) -> impl Iterator<Item = &TopicHash> {
         self.mesh.keys()
     }
@@ -234,7 +234,7 @@ impl Gossipsub {
     /// lists all peers for any topic
     pub fn all_peers(&self) -> impl Iterator<Item = &PeerId> {
         let mut res = BTreeSet::new();
-        for (_, peers) in self.mesh.iter() {
+        for peers in self.mesh.values() {
             res.extend(peers);
         }
         res.into_iter()

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -221,6 +221,25 @@ impl Gossipsub {
         }
     }
 
+    /// lists the hashes of the topics we are currently subscribed to
+    pub fn topics(&self) -> impl Iterator<Item = &TopicHash> {
+        self.mesh.keys()
+    }
+
+    /// lists peers for a certain topic hash
+    pub fn peers(&self, topic_hash: &TopicHash) -> impl Iterator<Item = &PeerId> {
+        self.mesh.get(topic_hash).into_iter().map(|x| x.into_iter()).flatten()
+    }
+
+    /// lists all peers for any topic
+    pub fn all_peers(&self) -> impl Iterator<Item = &PeerId> {
+        let mut res = BTreeSet::new();
+        for (_, peers) in self.mesh.iter() {
+            res.extend(peers);
+        }
+        res.into_iter()
+    }
+
     /// Subscribe to a topic.
     ///
     /// Returns true if the subscription worked. Returns false if we were already subscribed.
@@ -1508,10 +1527,10 @@ impl fmt::Debug for Gossipsub {
 impl fmt::Debug for PublishConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            PublishConfig::Signing { author, .. } => f.write_fmt(format_args!("PublishConfig::Signing({})", author)), 
-            PublishConfig::Author(author) => f.write_fmt(format_args!("PublishConfig::Author({})", author)), 
-            PublishConfig::RandomAuthor => f.write_fmt(format_args!("PublishConfig::RandomAuthor")), 
-            PublishConfig::Anonymous => f.write_fmt(format_args!("PublishConfig::Anonymous")), 
+            PublishConfig::Signing { author, .. } => f.write_fmt(format_args!("PublishConfig::Signing({})", author)),
+            PublishConfig::Author(author) => f.write_fmt(format_args!("PublishConfig::Author({})", author)),
+            PublishConfig::RandomAuthor => f.write_fmt(format_args!("PublishConfig::RandomAuthor")),
+            PublishConfig::Anonymous => f.write_fmt(format_args!("PublishConfig::Anonymous")),
         }
     }
 }

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -226,12 +226,12 @@ impl Gossipsub {
         self.mesh.keys()
     }
 
-    /// lists peers for a certain topic hash
+    /// Lists peers for a certain topic hash.
     pub fn peers(&self, topic_hash: &TopicHash) -> impl Iterator<Item = &PeerId> {
         self.mesh.get(topic_hash).into_iter().map(|x| x.into_iter()).flatten()
     }
 
-    /// lists all peers for any topic
+    /// Lists all peers for any topic.
     pub fn all_peers(&self) -> impl Iterator<Item = &PeerId> {
         let mut res = BTreeSet::new();
         for peers in self.mesh.values() {

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -904,17 +904,17 @@ mod tests {
 
         assert_eq!(
             gs.topics().cloned().collect::<Vec<_>>(), topic_hashes,
-            "Expected topics to contain registred topic"
+            "Expected topics to match registered topic."
         );
 
         assert_eq!(
             gs.peers(&TopicHash::from_raw("topic1")).cloned().collect::<Vec<_>>(), peers,
-            "Expected peers for a registered topic to contain all peers"
+            "Expected peers for a registered topic to contain all peers."
         );
 
         assert_eq!(
             gs.all_peers().cloned().collect::<BTreeSet<_>>(), peers.into_iter().collect::<BTreeSet<_>>(),
-            "Expected all_peers to contain all peers"
+            "Expected all_peers to contain all peers."
         );
     }
 }

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -901,6 +901,7 @@ mod tests {
     fn test_public_api() {
         let (gs, peers, topic_hashes) =
             build_and_inject_nodes(4, vec![String::from("topic1")], true);
+        let peers = peers.into_iter().collect::<BTreeSet<_>>();
 
         assert_eq!(
             gs.topics().cloned().collect::<Vec<_>>(), topic_hashes,
@@ -908,12 +909,12 @@ mod tests {
         );
 
         assert_eq!(
-            gs.peers(&TopicHash::from_raw("topic1")).cloned().collect::<Vec<_>>(), peers,
+            gs.peers(&TopicHash::from_raw("topic1")).cloned().collect::<BTreeSet<_>>(), peers,
             "Expected peers for a registered topic to contain all peers."
         );
 
         assert_eq!(
-            gs.all_peers().cloned().collect::<BTreeSet<_>>(), peers.into_iter().collect::<BTreeSet<_>>(),
+            gs.all_peers().cloned().collect::<BTreeSet<_>>(), peers,
             "Expected all_peers to contain all peers."
         );
     }

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -896,7 +896,7 @@ mod tests {
         assert_eq!(gs.mesh.get(&topics[0]).unwrap().len(), config.mesh_n);
     }
 
-    // some very basic test of public api methods
+    // Some very basic test of public api methods.
     #[test]
     fn test_public_api() {
         let (gs, peers, topic_hashes) =

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -895,4 +895,26 @@ mod tests {
         // Peers should be removed to reach mesh_n
         assert_eq!(gs.mesh.get(&topics[0]).unwrap().len(), config.mesh_n);
     }
+
+    // some very basic test of public api methods
+    #[test]
+    fn test_public_api() {
+        let (gs, peers, topic_hashes) =
+            build_and_inject_nodes(4, vec![String::from("topic1")], true);
+
+        assert_eq!(
+            gs.topics().cloned().collect::<Vec<_>>(), topic_hashes,
+            "Expected topics to contain registred topic"
+        );
+
+        assert_eq!(
+            gs.peers(&TopicHash::from_raw("topic1")).cloned().collect::<Vec<_>>(), peers,
+            "Expected peers for a registered topic to contain all peers"
+        );
+
+        assert_eq!(
+            gs.all_peers().cloned().collect::<BTreeSet<_>>(), peers.into_iter().collect::<BTreeSet<_>>(),
+            "Expected all_peers to contain all peers"
+        );
+    }
 }


### PR DESCRIPTION
Add some public api to allow implementing the ipfs pubsub api

Basically
-pubsub ls https://docs.ipfs.io/reference/http/api/#api-v0-pubsub-ls
 lists topics that we are currently listening to
-pubsub peers https://docs.ipfs.io/reference/http/api/#api-v0-pubsub-peers
 lists peers we are peered to for a single topic, or overall