### PR TITLE
protocols/kad: Expose kbucket distance range

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.22.0 [unreleased]
+
+- Add `KBucketRef::range` exposing the minimum inclusive and maximum inclusive
+  `Distance` for the bucket
+  ([PR 1680](https://github.com/libp2p/rust-libp2p/pull/1680)).
+
 # 0.21.0 [2020-07-01]
 
 - Remove `KademliaEvent::Discovered`

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Next
+
+- Include empty buckets in `Kademlia::kbuckets`.
+
+
 # 0.21.0 [2020-07-01]
 
 - Remove `KademliaEvent::Discovered`

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,8 +1,3 @@
-# Next
-
-- Include empty buckets in `Kademlia::kbuckets`.
-
-
 # 0.21.0 [2020-07-01]
 
 - Remove `KademliaEvent::Discovered`

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -529,11 +529,11 @@ where
         }
     }
 
-    /// Returns an iterator over all non-empty buckets in the routing table.
+    /// Returns an iterator over all buckets in the routing table.
     pub fn kbuckets(&mut self)
         -> impl Iterator<Item = kbucket::KBucketRef<kbucket::Key<PeerId>, Addresses>>
     {
-        self.kbuckets.iter().filter(|b| !b.is_empty())
+        self.kbuckets.iter()
     }
 
     /// Returns the k-bucket for the distance to the given key.

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -529,11 +529,11 @@ where
         }
     }
 
-    /// Returns an iterator over all buckets in the routing table.
+    /// Returns an iterator over all non-empty buckets in the routing table.
     pub fn kbuckets(&mut self)
         -> impl Iterator<Item = kbucket::KBucketRef<kbucket::Key<PeerId>, Addresses>>
     {
-        self.kbuckets.iter()
+        self.kbuckets.iter().filter(|b| !b.is_empty())
     }
 
     /// Returns the k-bucket for the distance to the given key.

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -541,6 +541,23 @@ mod tests {
     }
 
     #[test]
+    fn buckets_are_non_overlapping_and_exhaustive() {
+        let local_key = Key::from(PeerId::random());
+        let timeout = Duration::from_secs(0);
+        let mut table = KBucketsTable::<KeyBytes, ()>::new(local_key.into(), timeout);
+
+        let mut prev_max = U256::from(0);
+
+        for bucket in table.iter() {
+            let (min, max) = bucket.range();
+            assert_eq!(Distance(prev_max + U256::from(1)), min);
+            prev_max = max.0;
+        }
+
+        assert_eq!(U256::MAX, prev_max);
+    }
+
+    #[test]
     fn bucket_contains_range() {
         fn prop(ix: u8) {
             let index = BucketIndex(ix as usize);

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -119,10 +119,13 @@ impl BucketIndex {
     /// Returns the minimum inclusive and maximum inclusive [`Distance`]
     /// included in the bucket for this index.
     fn range(&self) -> (Distance, Distance) {
-        (
-            Distance(U256::pow(U256::from(2), U256::from(self.0))),
-            Distance(U256::pow(U256::from(2), U256::from(self.0 + 1)) - 1),
-        )
+        let min = Distance(U256::pow(U256::from(2), U256::from(self.0)));
+        let max = match U256::overflowing_pow(U256::from(2), U256::from(self.0 + 1)) {
+            (exp, false) => Distance(exp - 1),
+            (_, true) => Distance(U256::MAX),
+        };
+
+        (min, max)
     }
 
     /// Generates a random distance that falls into the bucket for this index.

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -120,12 +120,12 @@ impl BucketIndex {
     /// included in the bucket for this index.
     fn range(&self) -> (Distance, Distance) {
         let min = Distance(U256::pow(U256::from(2), U256::from(self.0)));
-        let max = match U256::overflowing_pow(U256::from(2), U256::from(self.0 + 1)) {
-            (exp, false) => Distance(exp - 1),
-            (_, true) => Distance(U256::MAX),
-        };
-
-        (min, max)
+        if self.0 == u8::MAX.into() {
+            (min, Distance(U256::MAX))
+        } else {
+            let max = Distance(U256::pow(U256::from(2), U256::from(self.0 + 1)) - 1);
+            (min, max)
+        }
     }
 
     /// Generates a random distance that falls into the bucket for this index.


### PR DESCRIPTION
~~Instead of only returning non-empty kbuckets via `Kademlia::kbuckets`,
return empty ones as well.~~

~~Doing so enables consumers to (1) reason about each and every bucket and
(2) depend on a stable order of the buckets.~~


Add `KBucketRef::range` exposing the minimum inclusive and maximum
inclusive `Distance` for the bucket

More specifically within substrate I would like to expose the following metric:

```
HELP Number of nodes per protocol and Kademlia kbucket
substrate_sub_libp2p_kademlia_num_nodes_per_kbucket{protocol="sub", bucket="255"} 20
```