### PR TITLE
core-derive: use full qualified name when polling NetworkBehaviour

### DIFF
--- a/misc/core-derive/CHANGELOG.md
+++ b/misc/core-derive/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.20.2 [2020-07-28]
+
+- Generate fully-qualified method name for `poll` to avoid
+ambiguity. [PR 1681](https://github.com/libp2p/rust-libp2p/pull/1681).
+
 # 0.20.1 [2020-07-08]
 
 - Allow users to opt out of the `NetworkBehaviourEventProcess`

--- a/misc/core-derive/Cargo.toml
+++ b/misc/core-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-core-derive"
 edition = "2018"
 description = "Procedural macros of libp2p-core"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/misc/core-derive/src/lib.rs
+++ b/misc/core-derive/src/lib.rs
@@ -435,7 +435,7 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
 
         Some(quote!{
             loop {
-                match #field_name.poll(cx, poll_params) {
+                match #trait_to_impl::poll(&mut #field_name, cx, poll_params) {
                     #generate_event_match_arm
                     std::task::Poll::Ready(#network_behaviour_action::DialAddress { address }) => {
                         return std::task::Poll::Ready(#network_behaviour_action::DialAddress { address });


### PR DESCRIPTION
If the users define a custom poll method also named in `poll` like
`#[behaviour(poll_method = "poll")`, it will cause issues as the wrong
`poll` method being called.

So use full qualified name to avoid ambiguity.

Fixes #1679.