### PR TITLE
memory: Do not return broken pipe error on EOF.

### DIFF
--- a/core/src/transport/memory.rs
+++ b/core/src/transport/memory.rs
@@ -243,7 +243,7 @@ impl<T> Stream for Chan<T> {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match Stream::poll_next(Pin::new(&mut self.incoming), cx) {
             Poll::Pending => Poll::Pending,
-            Poll::Ready(None) => Poll::Ready(Some(Err(io::ErrorKind::BrokenPipe.into()))),
+            Poll::Ready(None) => Poll::Ready(None),
             Poll::Ready(Some(v)) => Poll::Ready(Some(Ok(v))),
         }
     }


### PR DESCRIPTION
Signal the end of stream as `None` instead of producing a broken pipe error. This restores the behaviour prior to PR #1196. I could not find a motivation for this particular change in the PR and the previous implementation looks correct to me.