### PR TITLE
Add as_ref and as_mut functions to Toggle

### DIFF
--- a/swarm/src/toggle.rs
+++ b/swarm/src/toggle.rs
@@ -51,6 +51,16 @@ impl<TBehaviour> Toggle<TBehaviour> {
     pub fn is_enabled(&self) -> bool {
         self.inner.is_some()
     }
+
+    /// Returns a reference to the inner `NetworkBehaviour`.
+    pub fn as_ref(&self) -> Option<&TBehaviour> {
+        self.inner.as_ref()
+    }
+
+    /// Returns a mutable reference to the inner `NetworkBehaviour`.
+    pub fn as_mut(&mut self) -> Option<&mut TBehaviour> {
+        self.inner.as_mut()
+    }
 }
 
 impl<TBehaviour> From<Option<TBehaviour>> for Toggle<TBehaviour> {


### PR DESCRIPTION
At present there is no way to get access to the inner `NetworkBehaviour`, which means you can't make any behaviours toggleable if you want to be able to call functions on them.