### PR TITLE
[noise] Remove (by default) support for receiving legacy handshakes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 
 # Version 0.25.0 [unreleased]
 
+- Bump `libp2p-noise` to `0.24`. See the `libp2p-noise`
+changelog for details about the `LegacyConfig`.
+
 - The `ProtocolsHandler` in `libp2p-swarm` has a new associated type
   `InboundOpenInfo` ([PR 1714]).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ libp2p-gossipsub = { version = "0.22.0", path = "./protocols/gossipsub", optiona
 libp2p-identify = { version = "0.22.0", path = "protocols/identify", optional = true }
 libp2p-kad = { version = "0.23.0", path = "protocols/kad", optional = true }
 libp2p-mplex = { version = "0.21.0", path = "muxers/mplex", optional = true }
-libp2p-noise = { version = "0.23.0", path = "protocols/noise", optional = true }
+libp2p-noise = { version = "0.24.0", path = "protocols/noise", optional = true }
 libp2p-ping = { version = "0.22.0", path = "protocols/ping", optional = true }
 libp2p-plaintext = { version = "0.21.0", path = "protocols/plaintext", optional = true }
 libp2p-pnet = { version = "0.19.1", path = "protocols/pnet", optional = true }

--- a/protocols/noise/CHANGELOG.md
+++ b/protocols/noise/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.24.0 [unreleased]
+
+- Remove fallback legacy handshake payload decoding by default.
+To continue supporting inbound legacy handshake payloads,
+`recv_legacy_handshake` must be configured on the `LegacyConfig`.
+
 # 0.23.0 [2020-08-18]
 
 - Bump `libp2p-core` dependency.

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-noise"
 description = "Cryptographic handshake protocol using the noise framework."
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/noise/src/lib.rs
+++ b/protocols/noise/src/lib.rs
@@ -391,12 +391,18 @@ pub struct LegacyConfig {
     /// noise frame. These payloads are not interoperable with other
     /// libp2p implementations.
     pub send_legacy_handshake: bool,
+    /// Whether to support receiving legacy handshake payloads,
+    /// i.e. length-prefixed protobuf payloads inside a length-prefixed
+    /// noise frame. These payloads are not interoperable with other
+    /// libp2p implementations.
+    pub recv_legacy_handshake: bool,
 }
 
 impl Default for LegacyConfig {
     fn default() -> Self {
         Self {
             send_legacy_handshake: false,
+            recv_legacy_handshake: false,
         }
     }
 }


### PR DESCRIPTION
This is the final step for the migration, except for removing the legacy configuration options eventually in the distant future. There is no rush with this PR - indeed some time should pass since the latest release (`0.23`) before this is considered for merge and release.