### PR TITLE
Allow any closure to be passed as an executor

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -78,20 +78,8 @@ pub trait Executor {
     fn exec(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>);
 }
 
-impl<'a, T: ?Sized + Executor> Executor for &'a T {
+impl<F: Fn(Pin<Box<dyn Future<Output = ()> + Send>>)> Executor for F {
     fn exec(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) {
-        T::exec(&**self, f)
-    }
-}
-
-impl<'a, T: ?Sized + Executor> Executor for &'a mut T {
-    fn exec(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) {
-        T::exec(&**self, f)
-    }
-}
-
-impl<T: ?Sized + Executor> Executor for Box<T> {
-    fn exec(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) {
-        T::exec(&**self, f)
+        self(f)
     }
 }

--- a/core/src/network.rs
+++ b/core/src/network.rs
@@ -625,18 +625,6 @@ impl NetworkConfig {
         self
     }
 
-    /// Shortcut for calling `executor` with an object that calls the given closure.
-    pub fn set_executor_fn(mut self, f: impl Fn(Pin<Box<dyn Future<Output = ()> + Send>>) + Send + 'static) -> Self {
-        struct SpawnImpl<F>(F);
-        impl<F: Fn(Pin<Box<dyn Future<Output = ()> + Send>>)> Executor for SpawnImpl<F> {
-            fn exec(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) {
-                (self.0)(f)
-            }
-        }
-        self.set_executor(Box::new(SpawnImpl(f)));
-        self
-    }
-
     pub fn executor(&self) -> Option<&Box<dyn Executor + Send>> {
         self.manager_config.executor.as_ref()
     }
@@ -683,4 +671,25 @@ impl NetworkConfig {
         self.pool_limits.max_outgoing_per_peer = Some(n);
         self
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Dummy;
+
+    impl Executor for Dummy {
+        fn exec(&self, _: Pin<Box<dyn Future<Output=()> + Send>>) { }
+    }
+
+    #[test]
+    fn set_executor() {
+        NetworkConfig::default()
+            .set_executor(Box::new(Dummy))
+            .set_executor(Box::new(|f| {
+                async_std::task::spawn(f);
+            }));
+    }
+
 }

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -87,7 +87,7 @@ use protocols_handler::{
 };
 use futures::{
     prelude::*,
-    executor::{ThreadPool, ThreadPoolBuilder},
+    executor::ThreadPoolBuilder,
     stream::FusedStream,
 };
 use libp2p_core::{
@@ -1090,19 +1090,13 @@ where TBehaviour: NetworkBehaviour,
 
         // If no executor has been explicitly configured, try to set up a thread pool.
         if network_cfg.executor().is_none() {
-            struct PoolWrapper(ThreadPool);
-            impl Executor for PoolWrapper {
-                fn exec(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) {
-                    self.0.spawn_ok(f)
-                }
-            }
-
             match ThreadPoolBuilder::new()
                 .name_prefix("libp2p-swarm-task-")
                 .create()
-                .map(|tp| Box::new(PoolWrapper(tp)) as Box<_>)
             {
-                Ok(executor) => { network_cfg.set_executor(Box::new(executor)); },
+                Ok(tp) => {
+                    network_cfg.set_executor(Box::new(move |f| tp.spawn_ok(f)));
+                },
                 Err(err) => log::warn!("Failed to create executor thread pool: {:?}", err)
             }
         }


### PR DESCRIPTION
Previously, only dedicated implementations of `Executor` could be passed to `set_executor` of `NetworkConfig`. To pass a closure, one had to use `executor_fn`. Unfortunately, that function isn't exposed on the `SwarmBuilder` and hence cannot be used from the outside.

With this patch, any closure that takes a future can be passed as an executor.

This allows us to:

- simplify the `build` function of `NetworkConfig` by removing the `SpawnImpl`
- use functions like `tokio::spawn` or `async_std::task::spawn` as the executor on the `SwarmBuilder` because they share the same interface

I believe this is a breaking change because we have to remove certain `impl` blocks from `libp2p-core`.