### PR TITLE
Expose TBehaviour in Toggle Struct

### DIFF
--- a/swarm/src/toggle.rs
+++ b/swarm/src/toggle.rs
@@ -51,6 +51,10 @@ impl<TBehaviour> Toggle<TBehaviour> {
     pub fn is_enabled(&self) -> bool {
         self.inner.is_some()
     }
+
+    pub fn get_behaviour(&self) -> &Option<TBehaviour>{
+        &self.inner
+    }
 }
 
 impl<TBehaviour> From<Option<TBehaviour>> for Toggle<TBehaviour> {


### PR DESCRIPTION
For my use case it is useful to access the TBheaviour. For instance when Mdns is wrapped in a Toggle struct, I still want the ability to call Mdns functions such as has_node(). However that is currently not possible because there is no way to expose TBehaviour