### PR TITLE
core: remove duplicates when performing address translation

### DIFF
--- a/core/src/network.rs
+++ b/core/src/network.rs
@@ -206,7 +206,7 @@ where
         THandler: 'a,
     {
         let mut addrs: Vec<_> = self.listen_addrs()
-            .flat_map(move |server| address_translation(server, observed_addr))
+            .filter_map(move |server| address_translation(server, observed_addr))
             .collect();
 
         // remove duplicates

--- a/core/src/network.rs
+++ b/core/src/network.rs
@@ -205,7 +205,15 @@ where
         TMuxer: 'a,
         THandler: 'a,
     {
-        self.listen_addrs().flat_map(move |server| address_translation(server, observed_addr))
+        let mut addrs: Vec<_> = self.listen_addrs()
+            .flat_map(move |server| address_translation(server, observed_addr))
+            .collect();
+
+        // remove duplicates
+        addrs.sort_unstable();
+        addrs.dedup();
+
+        addrs.into_iter()
     }
 
     /// Returns the peer id of the local node.


### PR DESCRIPTION
When doing address translation we want to keep the discovered external address but keep the local port. If we are listening on multiple addresses (with the same port) we end up with a bunch of duplicates.