### PR TITLE
swarm/one_shot: Initialize handler with KeepAlive::Until

### DIFF
--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -13,6 +13,9 @@ callback.
 
 - Update the `libp2p-core` dependency to `0.21`, fixing [1584](https://github.com/libp2p/rust-libp2p/issues/1584).
 
+- Fix connections being kept alive by `OneShotHandler` when not handling any
+  requests [PR 1698](https://github.com/libp2p/rust-libp2p/pull/1698).
+
 # 0.20.1 [2020-07-08]
 
 - Documentation updates.

--- a/swarm/src/protocols_handler/one_shot.rs
+++ b/swarm/src/protocols_handler/one_shot.rs
@@ -72,7 +72,7 @@ where
             dial_queue: SmallVec::new(),
             dial_negotiated: 0,
             max_dial_negotiated: 8,
-            keep_alive: KeepAlive::Yes,
+            keep_alive: KeepAlive::Until(Instant::now() + config.keep_alive_timeout),
             config,
         }
     }

--- a/swarm/src/protocols_handler/one_shot.rs
+++ b/swarm/src/protocols_handler/one_shot.rs
@@ -245,3 +245,30 @@ impl Default for OneShotHandlerConfig {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use futures::executor::block_on;
+    use futures::future::poll_fn;
+    use libp2p_core::upgrade::DeniedUpgrade;
+    use void::Void;
+
+    #[test]
+    fn do_not_keep_idle_connection_alive() {
+        let mut handler: OneShotHandler<_, DeniedUpgrade, Void> = OneShotHandler::new(
+            SubstreamProtocol::new(DeniedUpgrade{}),
+            Default::default(),
+        );
+
+        block_on(poll_fn(|cx| {
+            loop {
+                if let Poll::Pending = handler.poll(cx) {
+                    return Poll::Ready(())
+                }
+            }
+        }));
+
+        assert!(matches!(handler.connection_keep_alive(), KeepAlive::Until(_)));
+    }
+}


### PR DESCRIPTION
The `OneShotHandler` `keep_alive` property is altered on incoming and
outgoing reqeusts. By default it is initialized in `KeepAlive::Yes`. In
case there are no incoming or outgoing requests happening, this state is
never changed and thus the handler keeps the underlying connection alive
indefinitely.

With this commit the handler is initialized with `KeepAlive::Until`. As
before the `keep_alive` timer is updated on incoming requests and set to
`KeepAlive::Yes` on outgoing requests.

---

Related to https://github.com/paritytech/polkadot/issues/1544.