### PR TITLE
Fix connection keep-alive for request-response.

### DIFF
--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.2.0 // unreleased
 
+- Fixed connection keep-alive, permitting connections to close due
+  to inactivity.
 - Added `RequestResponse::throttled` to wrap the behaviour into one that
   enforces limits on inbound and outbound requests per peer. The limits
   have to be known upfront by all nodes.

--- a/protocols/request-response/src/handler.rs
+++ b/protocols/request-response/src/handler.rs
@@ -313,7 +313,7 @@ where
             self.outbound.shrink_to_fit();
         }
 
-        if self.inbound.is_empty() {
+        if self.inbound.is_empty() && self.keep_alive.is_yes() {
             // No new inbound or outbound requests. However, we may just have
             // started the latest inbound or outbound upgrade(s), so make sure
             // the keep-alive timeout is preceded by the substream timeout.


### PR DESCRIPTION
Upon reviewing https://github.com/libp2p/rust-libp2p/pull/1698 I double-checked the analogous handling in `request-response` which seemed to lack a condition, resulting in an indefinite keep-alive. More generally and judging from prior experience from other handlers where the keep-alive handling has been tricky to get right, it seems this keep-alive handling may better be done in a more general manner in `libp2p-core`, for all connection handlers. Not sure yet how realistic that is though.