### PR TITLE
Fix ping test in request-response.

### DIFF
--- a/protocols/request-response/tests/ping.rs
+++ b/protocols/request-response/tests/ping.rs
@@ -356,8 +356,11 @@ impl RequestResponseCodec for PingCodec {
         T: AsyncRead + Unpin + Send
     {
         read_one(io, 1024)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
-            .map_ok(Ping)
+            .map(|res| match res {
+                Err(e) => Err(io::Error::new(io::ErrorKind::InvalidData, e)),
+                Ok(vec) if vec.is_empty() => Err(io::ErrorKind::UnexpectedEof.into()),
+                Ok(vec) => Ok(Ping(vec))
+            })
             .await
     }
 
@@ -367,8 +370,11 @@ impl RequestResponseCodec for PingCodec {
         T: AsyncRead + Unpin + Send
     {
         read_one(io, 1024)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
-            .map_ok(Pong)
+            .map(|res| match res {
+                Err(e) => Err(io::Error::new(io::ErrorKind::InvalidData, e)),
+                Ok(vec) if vec.is_empty() => Err(io::ErrorKind::UnexpectedEof.into()),
+                Ok(vec) => Ok(Pong(vec))
+            })
             .await
     }
 


### PR DESCRIPTION
The codec impl did not check that it actually read any bytes in `read_request` and `read_response`. The used `read_one` function does not error on EOF either, so instead of signalling connection loss the codec could produce empty `Ping` or `Pong` messages.