### PR TITLE
Implement ProtocolsHandler methods in wrappers.

### DIFF
--- a/swarm/src/protocols_handler/dummy.rs
+++ b/swarm/src/protocols_handler/dummy.rs
@@ -26,7 +26,7 @@ use crate::protocols_handler::{
     ProtocolsHandlerEvent,
     ProtocolsHandlerUpgrErr
 };
-use libp2p_core::upgrade::{InboundUpgrade, OutboundUpgrade, DeniedUpgrade};
+use libp2p_core::{Multiaddr, upgrade::{InboundUpgrade, OutboundUpgrade, DeniedUpgrade}};
 use std::task::{Context, Poll};
 use void::Void;
 
@@ -71,7 +71,11 @@ impl ProtocolsHandler for DummyProtocolsHandler {
 
     fn inject_event(&mut self, _: Self::InEvent) {}
 
+    fn inject_address_change(&mut self, _: &Multiaddr) {}
+
     fn inject_dial_upgrade_error(&mut self, _: Self::OutboundOpenInfo, _: ProtocolsHandlerUpgrErr<<Self::OutboundProtocol as OutboundUpgrade<NegotiatedSubstream>>::Error>) {}
+
+    fn inject_listen_upgrade_error(&mut self, _: ProtocolsHandlerUpgrErr<<Self::InboundProtocol as InboundUpgrade<NegotiatedSubstream>>::Error>) {}
 
     fn connection_keep_alive(&self) -> KeepAlive {
         self.keep_alive

--- a/swarm/src/protocols_handler/map_in.rs
+++ b/swarm/src/protocols_handler/map_in.rs
@@ -26,7 +26,7 @@ use crate::protocols_handler::{
     ProtocolsHandlerEvent,
     ProtocolsHandlerUpgrErr
 };
-
+use libp2p_core::Multiaddr;
 use std::{marker::PhantomData, task::Context, task::Poll};
 
 /// Wrapper around a protocol handler that turns the input event into something else.
@@ -38,7 +38,6 @@ pub struct MapInEvent<TProtoHandler, TNewIn, TMap> {
 
 impl<TProtoHandler, TMap, TNewIn> MapInEvent<TProtoHandler, TNewIn, TMap> {
     /// Creates a `MapInEvent`.
-    #[inline]
     pub(crate) fn new(inner: TProtoHandler, map: TMap) -> Self {
         MapInEvent {
             inner,
@@ -62,12 +61,10 @@ where
     type OutboundProtocol = TProtoHandler::OutboundProtocol;
     type OutboundOpenInfo = TProtoHandler::OutboundOpenInfo;
 
-    #[inline]
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol> {
         self.inner.listen_protocol()
     }
 
-    #[inline]
     fn inject_fully_negotiated_inbound(
         &mut self,
         protocol: <Self::InboundProtocol as InboundUpgradeSend>::Output
@@ -75,7 +72,6 @@ where
         self.inner.inject_fully_negotiated_inbound(protocol)
     }
 
-    #[inline]
     fn inject_fully_negotiated_outbound(
         &mut self,
         protocol: <Self::OutboundProtocol as OutboundUpgradeSend>::Output,
@@ -84,24 +80,31 @@ where
         self.inner.inject_fully_negotiated_outbound(protocol, info)
     }
 
-    #[inline]
     fn inject_event(&mut self, event: TNewIn) {
         if let Some(event) = (self.map)(event) {
             self.inner.inject_event(event);
         }
     }
 
-    #[inline]
+    fn inject_address_change(&mut self, addr: &Multiaddr) {
+        self.inner.inject_address_change(addr)
+    }
+
     fn inject_dial_upgrade_error(&mut self, info: Self::OutboundOpenInfo, error: ProtocolsHandlerUpgrErr<<Self::OutboundProtocol as OutboundUpgradeSend>::Error>) {
         self.inner.inject_dial_upgrade_error(info, error)
     }
 
-    #[inline]
+    fn inject_listen_upgrade_error(
+        &mut self,
+        error: ProtocolsHandlerUpgrErr<<Self::InboundProtocol as InboundUpgradeSend>::Error>
+    ) {
+        self.inner.inject_listen_upgrade_error(error)
+    }
+
     fn connection_keep_alive(&self) -> KeepAlive {
         self.inner.connection_keep_alive()
     }
 
-    #[inline]
     fn poll(
         &mut self,
         cx: &mut Context<'_>,

--- a/swarm/src/protocols_handler/map_out.rs
+++ b/swarm/src/protocols_handler/map_out.rs
@@ -26,7 +26,7 @@ use crate::protocols_handler::{
     ProtocolsHandlerEvent,
     ProtocolsHandlerUpgrErr
 };
-
+use libp2p_core::Multiaddr;
 use std::task::{Context, Poll};
 
 /// Wrapper around a protocol handler that turns the output event into something else.
@@ -37,7 +37,6 @@ pub struct MapOutEvent<TProtoHandler, TMap> {
 
 impl<TProtoHandler, TMap> MapOutEvent<TProtoHandler, TMap> {
     /// Creates a `MapOutEvent`.
-    #[inline]
     pub(crate) fn new(inner: TProtoHandler, map: TMap) -> Self {
         MapOutEvent {
             inner,
@@ -60,12 +59,10 @@ where
     type OutboundProtocol = TProtoHandler::OutboundProtocol;
     type OutboundOpenInfo = TProtoHandler::OutboundOpenInfo;
 
-    #[inline]
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol> {
         self.inner.listen_protocol()
     }
 
-    #[inline]
     fn inject_fully_negotiated_inbound(
         &mut self,
         protocol: <Self::InboundProtocol as InboundUpgradeSend>::Output
@@ -73,7 +70,6 @@ where
         self.inner.inject_fully_negotiated_inbound(protocol)
     }
 
-    #[inline]
     fn inject_fully_negotiated_outbound(
         &mut self,
         protocol: <Self::OutboundProtocol as OutboundUpgradeSend>::Output,
@@ -82,22 +78,29 @@ where
         self.inner.inject_fully_negotiated_outbound(protocol, info)
     }
 
-    #[inline]
     fn inject_event(&mut self, event: Self::InEvent) {
         self.inner.inject_event(event)
     }
 
-    #[inline]
+    fn inject_address_change(&mut self, addr: &Multiaddr) {
+        self.inner.inject_address_change(addr)
+    }
+
     fn inject_dial_upgrade_error(&mut self, info: Self::OutboundOpenInfo, error: ProtocolsHandlerUpgrErr<<Self::OutboundProtocol as OutboundUpgradeSend>::Error>) {
         self.inner.inject_dial_upgrade_error(info, error)
     }
 
-    #[inline]
+    fn inject_listen_upgrade_error(
+        &mut self,
+        error: ProtocolsHandlerUpgrErr<<Self::InboundProtocol as InboundUpgradeSend>::Error>
+    ) {
+        self.inner.inject_listen_upgrade_error(error)
+    }
+
     fn connection_keep_alive(&self) -> KeepAlive {
         self.inner.connection_keep_alive()
     }
 
-    #[inline]
     fn poll(
         &mut self,
         cx: &mut Context<'_>,

--- a/swarm/src/protocols_handler/multi.rs
+++ b/swarm/src/protocols_handler/multi.rs
@@ -36,7 +36,7 @@ use crate::upgrade::{
     UpgradeInfoSend
 };
 use futures::{future::BoxFuture, prelude::*};
-use libp2p_core::{ConnectedPoint, PeerId, upgrade::ProtocolName};
+use libp2p_core::{ConnectedPoint, Multiaddr, PeerId, upgrade::ProtocolName};
 use rand::Rng;
 use std::{
     collections::{HashMap, HashSet},
@@ -135,6 +135,12 @@ where
         }
     }
 
+    fn inject_address_change(&mut self, addr: &Multiaddr) {
+        for h in self.handlers.values_mut() {
+            h.inject_address_change(addr)
+        }
+    }
+
     fn inject_dial_upgrade_error (
         &mut self,
         (key, arg): Self::OutboundOpenInfo,
@@ -145,6 +151,13 @@ where
         } else {
             log::error!("inject_dial_upgrade_error: no handler for protocol")
         }
+    }
+
+    fn inject_listen_upgrade_error(
+        &mut self,
+        _: ProtocolsHandlerUpgrErr<<Self::InboundProtocol as InboundUpgradeSend>::Error>
+    ) {
+        // TODO: ???
     }
 
     fn connection_keep_alive(&self) -> KeepAlive {


### PR DESCRIPTION
This PR forwards calls to some `ProtocolsHandler` methods that were previously not implemented in wrappers such as `MapInEvent`.

~~It is [unclear](https://github.com/twittner/rust-libp2p/blob/a8b990c5c11dee82477e243f77f0d9211b444228/swarm/src/protocols_handler/multi.rs#L160) though how this can be implemented in some handlers such as `MultiHandler` as the information at hand does not enable it to decide which handler to forward the call to.~~

NB that there is no guarantee at all that a `listen_protocol` call will eventually be followed by a call to either `inject_fully_negotiated_inbound` or `inject_listener_upgrade_err`.

For context see #1707.