### PR TITLE
docs/release.md: Add release documentation

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -11,7 +11,8 @@ documentation will refer to `X.Y.Z` as _major_, _minor_ and _patch_ version.
   
   In case there is no `[unreleased]` section yet, create one with an increased
   major, minor or patch version depending on your change. In addition update the
-  corresponding entry of the crate in the root level `Cargo.toml`.
+  version in the crate's `Cargo.toml` as well as the corresponding entry of the
+  crate in the root level `Cargo.toml`.
 
 
 ## Releasing one or more crates

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,9 +1,9 @@
-# Release Process
+# Release process
 
 This project follows [semantic versioning](https://semver.org/). The following
 documentation will refer to `X.Y.Z` as _major_, _minor_ and _patch_ version.
 
-## Before the Release
+## Development between releases
 
 - Every substantial pull request should add an entry to the `[unreleased]`
   section of the corresponding crate `CHANGELOG.md` file. See
@@ -14,12 +14,13 @@ documentation will refer to `X.Y.Z` as _major_, _minor_ and _patch_ version.
   corresponding entry of the crate in the root level `Cargo.toml`.
 
 
-## Cutting a Release
+## Releasing one or more crates
 
-1. For each crate's `CHANGELOG.md` including the top level `libp2p` crate
-   replace `# X.Y.Z [unreleased]` with `# X.Y.Z [yyyy-mm-dd]` and create a
-   combined pull request against the rust-libp2p `master` branch.
-   
+1. Set the release date for each crate to be released in the respective
+   `CHANGELOG.md` by replacing `# X.Y.Z [unreleased]` with
+   `# X.Y.Z [yyyy-mm-dd]` and create a pull request against the rust-libp2p
+   `master` branch.
+
 2. Once merged, create and push a tag for each updated crate.
 
     ```
@@ -28,7 +29,8 @@ documentation will refer to `X.Y.Z` as _major_, _minor_ and _patch_ version.
     $ git push origin "${tag}"
     ```
     
-3. Create and push a tag for the top level `libp2p` crate.
+3. Create and push a tag for the top level `libp2p` crate, if it is being
+   released.
 
     ```
     # Note the additional `v` here.
@@ -37,7 +39,8 @@ documentation will refer to `X.Y.Z` as _major_, _minor_ and _patch_ version.
     $ git push origin "${tag}"
     ```
     
-4. Publish each crate including the top level `libp2p` crate to crates.io.
+4. Publish each tagged crate to crates.io. `cargo` assists in getting the order
+   of the releases correct.
 
     ```
     cd <CRATE-SUBDIRECTORY>

--- a/docs/release.md
+++ b/docs/release.md
@@ -17,10 +17,9 @@ documentation will refer to `X.Y.Z` as _major_, _minor_ and _patch_ version.
 
 ## Releasing one or more crates
 
-1. Set the release date for each crate to be released in the respective
-   `CHANGELOG.md` by replacing `# X.Y.Z [unreleased]` with
-   `# X.Y.Z [yyyy-mm-dd]` and create a pull request against the rust-libp2p
-   `master` branch.
+1. Remove the `[unreleased]` tag for each crate to be released in the respective
+   `CHANGELOG.md` and create a pull request against the rust-libp2p `master`
+   branch.
 
 2. Once merged, create and push a tag for each updated crate.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -25,6 +25,7 @@ documentation will refer to `X.Y.Z` as _major_, _minor_ and _patch_ version.
 
     ```
     $ tag="<CRATE-NAME>-X.Y.Z"
+    # Use `-s` for a GPG signed tag or `-a` for an annotated tag.
     $ git tag -s "${tag}" -m "${tag}"
     $ git push origin "${tag}"
     ```

--- a/docs/release.md
+++ b/docs/release.md
@@ -24,21 +24,23 @@ documentation will refer to `X.Y.Z` as _major_, _minor_ and _patch_ version.
 
 2. Once merged, create and push a tag for each updated crate.
 
-    ```
-    $ tag="<CRATE-NAME>-X.Y.Z"
+    ```bash
+    cd $CRATE-PATH
+    tag="$(sed -En 's/^name = \"(.*)\"$/\1/p' Cargo.toml)-$(sed -En 's/^version = \"(.*)\"$/\1/p' Cargo.toml)"
     # Use `-s` for a GPG signed tag or `-a` for an annotated tag.
-    $ git tag -s "${tag}" -m "${tag}"
-    $ git push origin "${tag}"
+    git tag -s "${tag}" -m "${tag}"
+    git push origin "${tag}"
     ```
     
 3. Create and push a tag for the top level `libp2p` crate, if it is being
    released.
 
-    ```
+    ```bash
+    cd $REPOSITORY-ROOT
     # Note the additional `v` here.
-    $ tag="vX.Y.Z"
-    $ git tag -s "${tag}" -m "${tag}"
-    $ git push origin "${tag}"
+    tag="v$(sed -En 's/^version = \"(.*)\"$/\1/p' Cargo.toml)"
+    git tag -s "${tag}" -m "${tag}"
+    git push origin "${tag}"
     ```
     
 4. Publish each tagged crate to crates.io. `cargo` assists in getting the order

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,45 @@
+# Release Process
+
+This project follows [semantic versioning](https://semver.org/). The following
+documentation will refer to `X.Y.Z` as _major_, _minor_ and _patch_ version.
+
+## Before the Release
+
+- Every substantial pull request should add an entry to the `[unreleased]`
+  section of the corresponding crate `CHANGELOG.md` file. See
+  [#1698](https://github.com/libp2p/rust-libp2p/pull/1698/files) as an example.
+  
+  In case there is no `[unreleased]` section yet, create one with an increased
+  major, minor or patch version depending on your change. In addition update the
+  corresponding entry of the crate in the root level `Cargo.toml`.
+
+
+## Cutting a Release
+
+1. For each crate's `CHANGELOG.md` including the top level `libp2p` crate
+   replace `# X.Y.Z [unreleased]` with `# X.Y.Z [yyyy-mm-dd]` and create a
+   combined pull request against the rust-libp2p `master` branch.
+   
+2. Once merged, create and push a tag for each updated crate.
+
+    ```
+    $ tag="<CRATE-NAME>-X.Y.Z"
+    $ git tag -s "${tag}" -m "${tag}"
+    $ git push origin "${tag}"
+    ```
+    
+3. Create and push a tag for the top level `libp2p` crate.
+
+    ```
+    # Note the additional `v` here.
+    $ tag="vX.Y.Z"
+    $ git tag -s "${tag}" -m "${tag}"
+    $ git push origin "${tag}"
+    ```
+    
+4. Publish each crate including the top level `libp2p` crate to crates.io.
+
+    ```
+    cd <CRATE-SUBDIRECTORY>
+    cargo publish
+    ```


### PR DESCRIPTION
In order to stay consistent across releases and also to enable possibly anyone with the correct access rights to release libp2p, this pull request adds a release documentation to the repository.

I have never cut a release of rust-libp2p. This documentation is based on past discussions and the git commit history. To reviewers: Please ensure this is in line with how you handled releasing for the last couple of versions.