### PR TITLE
Restore `RequestResponse::throttled`.

### DIFF
--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -15,7 +15,6 @@ futures = "0.3.1"
 libp2p-core = { version = "0.21.0", path = "../../core" }
 libp2p-swarm = { version = "0.22.0", path = "../../swarm" }
 log = "0.4.11"
-lru = "0.6"
 rand = "0.7"
 smallvec = "1.4"
 wasm-timer = "0.2"

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -17,6 +17,7 @@ libp2p-swarm = { version = "0.22.0", path = "../../swarm" }
 log = "0.4.11"
 rand = "0.7"
 smallvec = "1.4"
+thiserror = "1.0.20"
 wasm-timer = "0.2"
 
 [dev-dependencies]

--- a/protocols/request-response/src/handler.rs
+++ b/protocols/request-response/src/handler.rs
@@ -47,6 +47,7 @@ use smallvec::SmallVec;
 use std::{
     collections::VecDeque,
     io,
+    sync::{atomic::{AtomicU64, Ordering}, Arc},
     time::Duration,
     task::{Context, Poll}
 };
@@ -79,9 +80,10 @@ where
     /// Inbound upgrades waiting for the incoming request.
     inbound: FuturesUnordered<BoxFuture<'static,
         Result<
-            (TCodec::Request, oneshot::Sender<TCodec::Response>),
+            ((RequestId, TCodec::Request), oneshot::Sender<TCodec::Response>),
             oneshot::Canceled
         >>>,
+    inbound_request_id: Arc<AtomicU64>
 }
 
 impl<TCodec> RequestResponseHandler<TCodec>
@@ -93,6 +95,7 @@ where
         codec: TCodec,
         keep_alive_timeout: Duration,
         substream_timeout: Duration,
+        inbound_request_id: Arc<AtomicU64>
     ) -> Self {
         Self {
             inbound_protocols,
@@ -104,6 +107,7 @@ where
             inbound: FuturesUnordered::new(),
             pending_events: VecDeque::new(),
             pending_error: None,
+            inbound_request_id
         }
     }
 }
@@ -117,6 +121,7 @@ where
 {
     /// An inbound request.
     Request {
+        request_id: RequestId,
         request: TCodec::Request,
         sender: oneshot::Sender<TCodec::Response>
     },
@@ -130,9 +135,9 @@ where
     /// An outbound request failed to negotiate a mutually supported protocol.
     OutboundUnsupportedProtocols(RequestId),
     /// An inbound request timed out.
-    InboundTimeout,
+    InboundTimeout(RequestId),
     /// An inbound request failed to negotiate a mutually supported protocol.
-    InboundUnsupportedProtocols,
+    InboundUnsupportedProtocols(RequestId),
 }
 
 impl<TCodec> ProtocolsHandler for RequestResponseHandler<TCodec>
@@ -145,7 +150,7 @@ where
     type InboundProtocol = ResponseProtocol<TCodec>;
     type OutboundProtocol = RequestProtocol<TCodec>;
     type OutboundOpenInfo = RequestId;
-    type InboundOpenInfo = ();
+    type InboundOpenInfo = RequestId;
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
         // A channel for notifying the handler when the inbound
@@ -155,6 +160,8 @@ where
         // A channel for notifying the inbound upgrade when the
         // response is sent.
         let (rs_send, rs_recv) = oneshot::channel();
+
+        let request_id = RequestId(self.inbound_request_id.fetch_add(1, Ordering::Relaxed));
 
         // By keeping all I/O inside the `ResponseProtocol` and thus the
         // inbound substream upgrade via above channels, we ensure that it
@@ -167,6 +174,7 @@ where
             codec: self.codec.clone(),
             request_sender: rq_send,
             response_receiver: rs_recv,
+            request_id
         };
 
         // The handler waits for the request to come in. It then emits
@@ -174,13 +182,13 @@ where
         // `ResponseChannel`.
         self.inbound.push(rq_recv.map_ok(move |rq| (rq, rs_send)).boxed());
 
-        SubstreamProtocol::new(proto, ()).with_timeout(self.substream_timeout)
+        SubstreamProtocol::new(proto, request_id).with_timeout(self.substream_timeout)
     }
 
     fn inject_fully_negotiated_inbound(
         &mut self,
         (): (),
-        (): ()
+        _id: RequestId
     ) {
         // Nothing to do, as the response has already been sent
         // as part of the upgrade.
@@ -231,13 +239,12 @@ where
 
     fn inject_listen_upgrade_error(
         &mut self,
-        (): Self::InboundOpenInfo,
+        info: RequestId,
         error: ProtocolsHandlerUpgrErr<io::Error>
     ) {
         match error {
             ProtocolsHandlerUpgrErr::Timeout => {
-                self.pending_events.push_back(
-                    RequestResponseHandlerEvent::InboundTimeout);
+                self.pending_events.push_back(RequestResponseHandlerEvent::InboundTimeout(info))
             }
             ProtocolsHandlerUpgrErr::Upgrade(UpgradeError::Select(NegotiationError::Failed)) => {
                 // The local peer merely doesn't support the protocol(s) requested.
@@ -246,7 +253,7 @@ where
                 // An event is reported to permit user code to react to the fact that
                 // the local peer does not support the requested protocol(s).
                 self.pending_events.push_back(
-                    RequestResponseHandlerEvent::InboundUnsupportedProtocols);
+                    RequestResponseHandlerEvent::InboundUnsupportedProtocols(info));
             }
             _ => {
                 // Anything else is considered a fatal error or misbehaviour of
@@ -282,12 +289,12 @@ where
         // Check for inbound requests.
         while let Poll::Ready(Some(result)) = self.inbound.poll_next_unpin(cx) {
             match result {
-                Ok((rq, rs_sender)) => {
+                Ok(((id, rq), rs_sender)) => {
                     // We received an inbound request.
                     self.keep_alive = KeepAlive::Yes;
                     return Poll::Ready(ProtocolsHandlerEvent::Custom(
                         RequestResponseHandlerEvent::Request {
-                            request: rq, sender: rs_sender
+                            request_id: id, request: rq, sender: rs_sender
                         }))
                 }
                 Err(oneshot::Canceled) => {

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -221,9 +221,7 @@ impl<TResponse> ResponseChannel<TResponse> {
     }
 }
 
-/// The (local) ID of an outgoing request.
-///
-/// See [`RequestResponse::send_request`].
+/// The ID of an inbound or outbound request.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct RequestId(u64);
 

--- a/protocols/request-response/src/throttled.rs
+++ b/protocols/request-response/src/throttled.rs
@@ -192,9 +192,16 @@ impl<C: RequestResponseCodec + Clone> Throttled<C> {
 
     /// Are we waiting for a response to the given request?
     ///
-    /// See [`RequestResponse::is_pending`] for details.
-    pub fn is_pending(&self, id: &RequestId) -> bool {
-        self.behaviour.is_pending(id)
+    /// See [`RequestResponse::is_pending_outbound`] for details.
+    pub fn is_pending_outbound(&self, id: &RequestId) -> bool {
+        self.behaviour.is_pending_outbound(id)
+    }
+
+    /// Are we still processing and inbound request?
+    ///
+    /// See [`RequestResponse::is_pending_inbound`] for details.
+    pub fn is_pending_inbound(&self, id: &RequestId) -> bool {
+        self.behaviour.is_pending_inbound(id)
     }
 
     /// Update the limits when a request resolved.

--- a/protocols/request-response/tests/ping.rs
+++ b/protocols/request-response/tests/ping.rs
@@ -36,7 +36,7 @@ use libp2p_tcp::TcpConfig;
 use futures::{prelude::*, channel::mpsc};
 use rand::{self, Rng};
 use std::{io, iter};
-// use std::{collections::HashSet, num::NonZeroU16}; // Disabled until #1706 is fixed.
+use std::{collections::HashSet, num::NonZeroU16};
 
 /// Exercises a simple ping protocol.
 #[test]
@@ -73,7 +73,7 @@ fn ping_protocol() {
             match swarm1.next().await {
                 RequestResponseEvent::Message {
                     peer,
-                    message: RequestResponseMessage::Request { request, channel }
+                    message: RequestResponseMessage::Request { request, channel, .. }
                 } => {
                     assert_eq!(&request, &expected_ping);
                     assert_eq!(&peer, &peer2_id);
@@ -117,202 +117,201 @@ fn ping_protocol() {
     let () = async_std::task::block_on(peer2);
 }
 
-// Disabled until #1706 is fixed.
-///// Like `ping_protocol`, but throttling concurrent requests.
-//#[test]
-//fn ping_protocol_throttled() {
-//    let ping = Ping("ping".to_string().into_bytes());
-//    let pong = Pong("pong".to_string().into_bytes());
-//
-//    let protocols = iter::once((PingProtocol(), ProtocolSupport::Full));
-//    let cfg = RequestResponseConfig::default();
-//
-//    let (peer1_id, trans) = mk_transport();
-//    let ping_proto1 = RequestResponse::new(PingCodec(), protocols.clone(), cfg.clone()).throttled();
-//    let mut swarm1 = Swarm::new(trans, ping_proto1, peer1_id.clone());
-//
-//    let (peer2_id, trans) = mk_transport();
-//    let ping_proto2 = RequestResponse::new(PingCodec(), protocols, cfg).throttled();
-//    let mut swarm2 = Swarm::new(trans, ping_proto2, peer2_id.clone());
-//
-//    let (mut tx, mut rx) = mpsc::channel::<Multiaddr>(1);
-//
-//    let addr = "/ip4/127.0.0.1/tcp/0".parse().unwrap();
-//    Swarm::listen_on(&mut swarm1, addr).unwrap();
-//
-//    let expected_ping = ping.clone();
-//    let expected_pong = pong.clone();
-//
-//    let limit: u16 = rand::thread_rng().gen_range(1, 10);
-//    swarm1.set_default_limit(NonZeroU16::new(limit).unwrap());
-//    swarm2.set_default_limit(NonZeroU16::new(limit).unwrap());
-//
-//    let peer1 = async move {
-//        while let Some(_) = swarm1.next().now_or_never() {}
-//
-//        let l = Swarm::listeners(&swarm1).next().unwrap();
-//        tx.send(l.clone()).await.unwrap();
-//
-//        loop {
-//            match swarm1.next().await {
-//                throttled::Event::Event(RequestResponseEvent::Message {
-//                    peer,
-//                    message: RequestResponseMessage::Request { request, channel }
-//                }) => {
-//                    assert_eq!(&request, &expected_ping);
-//                    assert_eq!(&peer, &peer2_id);
-//                    swarm1.send_response(channel, pong.clone());
-//                },
-//                e => panic!("Peer1: Unexpected event: {:?}", e)
-//            }
-//        }
-//    };
-//
-//    let num_pings: u8 = rand::thread_rng().gen_range(1, 100);
-//
-//    let peer2 = async move {
-//        let mut count = 0;
-//        let addr = rx.next().await.unwrap();
-//        swarm2.add_address(&peer1_id, addr.clone());
-//        let mut blocked = false;
-//        let mut req_ids = HashSet::new();
-//
-//        loop {
-//            if !blocked {
-//                while let Some(id) = swarm2.send_request(&peer1_id, ping.clone()).ok() {
-//                    req_ids.insert(id);
-//                }
-//                blocked = true;
-//            }
-//            match swarm2.next().await {
-//                throttled::Event::ResumeSending(peer) => {
-//                    assert_eq!(peer, peer1_id);
-//                    blocked = false
-//                }
-//                throttled::Event::Event(RequestResponseEvent::Message {
-//                    peer,
-//                    message: RequestResponseMessage::Response { request_id, response }
-//                }) => {
-//                    count += 1;
-//                    assert_eq!(&response, &expected_pong);
-//                    assert_eq!(&peer, &peer1_id);
-//                    assert!(req_ids.remove(&request_id));
-//                    if count >= num_pings {
-//                        break
-//                    }
-//                }
-//                e => panic!("Peer2: Unexpected event: {:?}", e)
-//            }
-//        }
-//    };
-//
-//    async_std::task::spawn(Box::pin(peer1));
-//    let () = async_std::task::block_on(peer2);
-//}
-//
-//#[test]
-//fn ping_protocol_limit_violation() {
-//    let ping = Ping("ping".to_string().into_bytes());
-//    let pong = Pong("pong".to_string().into_bytes());
-//
-//    let protocols = iter::once((PingProtocol(), ProtocolSupport::Full));
-//    let cfg = RequestResponseConfig::default();
-//
-//    let (peer1_id, trans) = mk_transport();
-//    let ping_proto1 = RequestResponse::new(PingCodec(), protocols.clone(), cfg.clone()).throttled();
-//    let mut swarm1 = Swarm::new(trans, ping_proto1, peer1_id.clone());
-//
-//    let (peer2_id, trans) = mk_transport();
-//    let ping_proto2 = RequestResponse::new(PingCodec(), protocols, cfg).throttled();
-//    let mut swarm2 = Swarm::new(trans, ping_proto2, peer2_id.clone());
-//
-//    let (mut tx, mut rx) = mpsc::channel::<Multiaddr>(1);
-//
-//    let addr = "/ip4/127.0.0.1/tcp/0".parse().unwrap();
-//    Swarm::listen_on(&mut swarm1, addr).unwrap();
-//
-//    let expected_ping = ping.clone();
-//    let expected_pong = pong.clone();
-//
-//    swarm2.set_default_limit(NonZeroU16::new(2).unwrap());
-//
-//    let peer1 = async move {
-//        while let Some(_) = swarm1.next().now_or_never() {}
-//
-//        let l = Swarm::listeners(&swarm1).next().unwrap();
-//        tx.send(l.clone()).await.unwrap();
-//
-//        let mut pending_responses = Vec::new();
-//
-//        loop {
-//            match swarm1.next().await {
-//                throttled::Event::Event(RequestResponseEvent::Message {
-//                    peer,
-//                    message: RequestResponseMessage::Request { request, channel }
-//                }) => {
-//                    assert_eq!(&request, &expected_ping);
-//                    assert_eq!(&peer, &peer2_id);
-//                    pending_responses.push((channel, pong.clone()));
-//                },
-//                throttled::Event::TooManyInboundRequests(p) => {
-//                    assert_eq!(p, peer2_id);
-//                    break
-//                }
-//                e => panic!("Peer1: Unexpected event: {:?}", e)
-//            }
-//            if pending_responses.len() >= 2 {
-//                for (channel, pong) in pending_responses.drain(..) {
-//                    swarm1.send_response(channel, pong)
-//                }
-//            }
-//        }
-//    };
-//
-//    let num_pings: u8 = rand::thread_rng().gen_range(1, 100);
-//
-//    let peer2 = async move {
-//        let mut count = 0;
-//        let addr = rx.next().await.unwrap();
-//        swarm2.add_address(&peer1_id, addr.clone());
-//        let mut blocked = false;
-//        let mut req_ids = HashSet::new();
-//
-//        loop {
-//            if !blocked {
-//                while let Some(id) = swarm2.send_request(&peer1_id, ping.clone()).ok() {
-//                    req_ids.insert(id);
-//                }
-//                blocked = true;
-//            }
-//            match swarm2.next().await {
-//                throttled::Event::ResumeSending(peer) => {
-//                    assert_eq!(peer, peer1_id);
-//                    blocked = false
-//                }
-//                throttled::Event::Event(RequestResponseEvent::Message {
-//                    peer,
-//                    message: RequestResponseMessage::Response { request_id, response }
-//                }) => {
-//                    count += 1;
-//                    assert_eq!(&response, &expected_pong);
-//                    assert_eq!(&peer, &peer1_id);
-//                    assert!(req_ids.remove(&request_id));
-//                    if count >= num_pings {
-//                        break
-//                    }
-//                }
-//                throttled::Event::Event(RequestResponseEvent::OutboundFailure { error, .. }) => {
-//                    assert!(matches!(error, OutboundFailure::ConnectionClosed));
-//                    break
-//                }
-//                e => panic!("Peer2: Unexpected event: {:?}", e)
-//            }
-//        }
-//    };
-//
-//    async_std::task::spawn(Box::pin(peer1));
-//    let () = async_std::task::block_on(peer2);
-//}
+/// Like `ping_protocol`, but throttling concurrent requests.
+#[test]
+fn ping_protocol_throttled() {
+    let ping = Ping("ping".to_string().into_bytes());
+    let pong = Pong("pong".to_string().into_bytes());
+
+    let protocols = iter::once((PingProtocol(), ProtocolSupport::Full));
+    let cfg = RequestResponseConfig::default();
+
+    let (peer1_id, trans) = mk_transport();
+    let ping_proto1 = RequestResponse::new(PingCodec(), protocols.clone(), cfg.clone()).throttled();
+    let mut swarm1 = Swarm::new(trans, ping_proto1, peer1_id.clone());
+
+    let (peer2_id, trans) = mk_transport();
+    let ping_proto2 = RequestResponse::new(PingCodec(), protocols, cfg).throttled();
+    let mut swarm2 = Swarm::new(trans, ping_proto2, peer2_id.clone());
+
+    let (mut tx, mut rx) = mpsc::channel::<Multiaddr>(1);
+
+    let addr = "/ip4/127.0.0.1/tcp/0".parse().unwrap();
+    Swarm::listen_on(&mut swarm1, addr).unwrap();
+
+    let expected_ping = ping.clone();
+    let expected_pong = pong.clone();
+
+    let limit: u16 = rand::thread_rng().gen_range(1, 10);
+    swarm1.set_default_limit(NonZeroU16::new(limit).unwrap());
+    swarm2.set_default_limit(NonZeroU16::new(limit).unwrap());
+
+    let peer1 = async move {
+        while let Some(_) = swarm1.next().now_or_never() {}
+
+        let l = Swarm::listeners(&swarm1).next().unwrap();
+        tx.send(l.clone()).await.unwrap();
+
+        loop {
+            match swarm1.next().await {
+                throttled::Event::Event(RequestResponseEvent::Message {
+                    peer,
+                    message: RequestResponseMessage::Request { request, channel, .. },
+                }) => {
+                    assert_eq!(&request, &expected_ping);
+                    assert_eq!(&peer, &peer2_id);
+                    swarm1.send_response(channel, pong.clone());
+                },
+                e => panic!("Peer1: Unexpected event: {:?}", e)
+            }
+        }
+    };
+
+    let num_pings: u8 = rand::thread_rng().gen_range(1, 100);
+
+    let peer2 = async move {
+        let mut count = 0;
+        let addr = rx.next().await.unwrap();
+        swarm2.add_address(&peer1_id, addr.clone());
+        let mut blocked = false;
+        let mut req_ids = HashSet::new();
+
+        loop {
+            if !blocked {
+                while let Some(id) = swarm2.send_request(&peer1_id, ping.clone()).ok() {
+                    req_ids.insert(id);
+                }
+                blocked = true;
+            }
+            match swarm2.next().await {
+                throttled::Event::ResumeSending(peer) => {
+                    assert_eq!(peer, peer1_id);
+                    blocked = false
+                }
+                throttled::Event::Event(RequestResponseEvent::Message {
+                    peer,
+                    message: RequestResponseMessage::Response { request_id, response }
+                }) => {
+                    count += 1;
+                    assert_eq!(&response, &expected_pong);
+                    assert_eq!(&peer, &peer1_id);
+                    assert!(req_ids.remove(&request_id));
+                    if count >= num_pings {
+                        break
+                    }
+                }
+                e => panic!("Peer2: Unexpected event: {:?}", e)
+            }
+        }
+    };
+
+    async_std::task::spawn(Box::pin(peer1));
+    let () = async_std::task::block_on(peer2);
+}
+
+#[test]
+fn ping_protocol_limit_violation() {
+    let ping = Ping("ping".to_string().into_bytes());
+    let pong = Pong("pong".to_string().into_bytes());
+
+    let protocols = iter::once((PingProtocol(), ProtocolSupport::Full));
+    let cfg = RequestResponseConfig::default();
+
+    let (peer1_id, trans) = mk_transport();
+    let ping_proto1 = RequestResponse::new(PingCodec(), protocols.clone(), cfg.clone()).throttled();
+    let mut swarm1 = Swarm::new(trans, ping_proto1, peer1_id.clone());
+
+    let (peer2_id, trans) = mk_transport();
+    let ping_proto2 = RequestResponse::new(PingCodec(), protocols, cfg).throttled();
+    let mut swarm2 = Swarm::new(trans, ping_proto2, peer2_id.clone());
+
+    let (mut tx, mut rx) = mpsc::channel::<Multiaddr>(1);
+
+    let addr = "/ip4/127.0.0.1/tcp/0".parse().unwrap();
+    Swarm::listen_on(&mut swarm1, addr).unwrap();
+
+    let expected_ping = ping.clone();
+    let expected_pong = pong.clone();
+
+    swarm2.set_default_limit(NonZeroU16::new(2).unwrap());
+
+    let peer1 = async move {
+        while let Some(_) = swarm1.next().now_or_never() {}
+
+        let l = Swarm::listeners(&swarm1).next().unwrap();
+        tx.send(l.clone()).await.unwrap();
+
+        let mut pending_responses = Vec::new();
+
+        loop {
+            match swarm1.next().await {
+                throttled::Event::Event(RequestResponseEvent::Message {
+                    peer,
+                    message: RequestResponseMessage::Request { request, channel, .. }
+                }) => {
+                    assert_eq!(&request, &expected_ping);
+                    assert_eq!(&peer, &peer2_id);
+                    pending_responses.push((channel, pong.clone()));
+                },
+                throttled::Event::TooManyInboundRequests(p) => {
+                    assert_eq!(p, peer2_id);
+                    break
+                }
+                e => panic!("Peer1: Unexpected event: {:?}", e)
+            }
+            if pending_responses.len() >= 2 {
+                for (channel, pong) in pending_responses.drain(..) {
+                    swarm1.send_response(channel, pong)
+                }
+            }
+        }
+    };
+
+    let num_pings: u8 = rand::thread_rng().gen_range(1, 100);
+
+    let peer2 = async move {
+        let mut count = 0;
+        let addr = rx.next().await.unwrap();
+        swarm2.add_address(&peer1_id, addr.clone());
+        let mut blocked = false;
+        let mut req_ids = HashSet::new();
+
+        loop {
+            if !blocked {
+                while let Some(id) = swarm2.send_request(&peer1_id, ping.clone()).ok() {
+                    req_ids.insert(id);
+                }
+                blocked = true;
+            }
+            match swarm2.next().await {
+                throttled::Event::ResumeSending(peer) => {
+                    assert_eq!(peer, peer1_id);
+                    blocked = false
+                }
+                throttled::Event::Event(RequestResponseEvent::Message {
+                    peer,
+                    message: RequestResponseMessage::Response { request_id, response }
+                }) => {
+                    count += 1;
+                    assert_eq!(&response, &expected_pong);
+                    assert_eq!(&peer, &peer1_id);
+                    assert!(req_ids.remove(&request_id));
+                    if count >= num_pings {
+                        break
+                    }
+                }
+                throttled::Event::Event(RequestResponseEvent::OutboundFailure { error, .. }) => {
+                    assert!(matches!(error, OutboundFailure::ConnectionClosed));
+                    break
+                }
+                e => panic!("Peer2: Unexpected event: {:?}", e)
+            }
+        }
+    };
+
+    async_std::task::spawn(Box::pin(peer1));
+    let () = async_std::task::block_on(peer2);
+}
 
 fn mk_transport() -> (PeerId, Boxed<(PeerId, StreamMuxerBox), io::Error>) {
     let id_keys = identity::Keypair::generate_ed25519();


### PR DESCRIPTION
Fixes #1706.
Continuation of #1714.