### PR TITLE
protocols/kad/src/kbuckets: Explicitly convert u8 to usize

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.22.1 [2020-08-19]
+
+- Explicitly convert from u8 to usize in `BucketIndex::range` to prevent type
+  inference issues ([PR 1716](https://github.com/libp2p/rust-libp2p/pull/1716)).
+
 # 0.22.0 [2020-08-18]
 
 - Store addresses in provider records.

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-kad"
 edition = "2018"
 description = "Kademlia protocol for libp2p"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -120,7 +120,7 @@ impl BucketIndex {
     /// included in the bucket for this index.
     fn range(&self) -> (Distance, Distance) {
         let min = Distance(U256::pow(U256::from(2), U256::from(self.0)));
-        if self.0 == u8::MAX.into() {
+        if self.0 == Into::<usize>::into(u8::MAX) {
             (min, Distance(U256::MAX))
         } else {
             let max = Distance(U256::pow(U256::from(2), U256::from(self.0 + 1)) - 1);

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -120,7 +120,7 @@ impl BucketIndex {
     /// included in the bucket for this index.
     fn range(&self) -> (Distance, Distance) {
         let min = Distance(U256::pow(U256::from(2), U256::from(self.0)));
-        if self.0 == Into::<usize>::into(u8::MAX) {
+        if self.0 == usize::from(u8::MAX) {
             (min, Distance(U256::MAX))
         } else {
             let max = Distance(U256::pow(U256::from(2), U256::from(self.0 + 1)) - 1);


### PR DESCRIPTION
Compiling libp2p-kad for `--target wasm32-unknown-unknown` fails with
the cryptic error message `cannot infer type for type usize`.
Explicitly converting to `usize` solves the issue.

```
961error[E0283]: type annotations needed
962   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/libp2p-kad-0.22.0/src/kbucket.rs:123:19
963    |
964123 |         if self.0 == u8::MAX.into() {
965    |                   ^^ cannot infer type for type `usize`
966    |
967    = note: cannot satisfy `usize: std::cmp::PartialEq<_>`
```

I am not familiar enough with `wasm32-unknown-unknown` to know the exact cause. In case you deem it to be worth the effort, I am happy to dig deeper into this.

Likely related to https://github.com/rust-lang/rust/issues/71584 and https://github.com/rust-lang/rust/issues/71538.

Needed for https://github.com/paritytech/substrate/pull/6891.