### PR TITLE
Deprecate SECIO.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ default = [
     "plaintext",
     "pnet",
     "request-response",
-    "secio",
     "secp256k1",
     "tcp-async-std",
     "uds",
@@ -46,7 +45,6 @@ ping = ["libp2p-ping"]
 plaintext = ["libp2p-plaintext"]
 pnet = ["libp2p-pnet"]
 request-response = ["libp2p-request-response"]
-secio = ["libp2p-secio"]
 tcp-async-std = ["libp2p-tcp", "libp2p-tcp/async-std"]
 tcp-tokio = ["libp2p-tcp", "libp2p-tcp/tokio"]
 uds = ["libp2p-uds"]
@@ -54,7 +52,7 @@ wasm-ext = ["libp2p-wasm-ext"]
 wasm-ext-websocket = ["wasm-ext", "libp2p-wasm-ext/websocket"]
 websocket = ["libp2p-websocket"]
 yamux = ["libp2p-yamux"]
-secp256k1 = ["libp2p-core/secp256k1", "libp2p-secio/secp256k1"]
+secp256k1 = ["libp2p-core/secp256k1"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -76,7 +74,6 @@ libp2p-ping = { version = "0.22.0", path = "protocols/ping", optional = true }
 libp2p-plaintext = { version = "0.22.0", path = "protocols/plaintext", optional = true }
 libp2p-pnet = { version = "0.19.1", path = "protocols/pnet", optional = true }
 libp2p-request-response = { version = "0.3.0", path = "protocols/request-response", optional = true }
-libp2p-secio = { version = "0.22.0", path = "protocols/secio", default-features = false, optional = true }
 libp2p-swarm = { version = "0.22.0", path = "swarm" }
 libp2p-uds = { version = "0.22.0", path = "transports/uds", optional = true }
 libp2p-wasm-ext = { version = "0.22.0", path = "transports/wasm-ext", optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -41,7 +41,7 @@ ring = { version = "0.16.9", features = ["alloc", "std"], default-features = fal
 [dev-dependencies]
 async-std = "1.6.2"
 libp2p-mplex = { path = "../muxers/mplex" }
-libp2p-secio = { path = "../protocols/secio" }
+libp2p-noise = { path = "../protocols/noise" }
 libp2p-tcp = { path = "../transports/tcp", features = ["async-std"] }
 quickcheck = "0.9.0"
 wasm-timer = "0.2"

--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -103,11 +103,11 @@
 //! #extern crate futures;
 //! #extern crate tokio;
 //! #use libp2p::gossipsub::GossipsubEvent;
-//! #use libp2p::{gossipsub, secio,
+//! #use libp2p::{identity, gossipsub,
 //! #    tokio_codec::{FramedRead, LinesCodec},
 //! #};
-//! let local_key = secio::SecioKeyPair::ed25519_generated().unwrap();
-//! let local_pub_key = local_key.to_public_key();
+//! let local_key = identity::Keypair::generate_ed25519();
+//! let local_pub_key = local_key.public();
 //!
 //! // Set up an encrypted TCP Transport over the Mplex and Yamux protocols
 //! let transport = libp2p::build_development_transport(local_key);

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -21,7 +21,7 @@ wasm-timer = "0.2"
 [dev-dependencies]
 async-std = "1.6.2"
 libp2p-mplex = { path = "../../muxers/mplex" }
-libp2p-secio = { path = "../../protocols/secio" }
+libp2p-noise = { path = "../../protocols/noise" }
 libp2p-tcp = { path = "../../transports/tcp", features = ["async-std"] }
 
 [build-dependencies]

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -277,8 +277,8 @@ mod tests {
         Transport,
         upgrade
     };
+    use libp2p_noise as noise;
     use libp2p_tcp::TcpConfig;
-    use libp2p_secio::SecioConfig;
     use libp2p_swarm::{Swarm, SwarmEvent};
     use libp2p_mplex::MplexConfig;
     use std::{fmt, io};
@@ -291,11 +291,12 @@ mod tests {
         Error = impl fmt::Debug
     > + Clone) {
         let id_keys = identity::Keypair::generate_ed25519();
+        let noise_keys = noise::Keypair::<noise::X25519Spec>::new().into_authentic(&id_keys).unwrap();
         let pubkey = id_keys.public();
         let transport = TcpConfig::new()
             .nodelay(true)
             .upgrade(upgrade::Version::V1)
-            .authenticate(SecioConfig::new(id_keys))
+            .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
             .multiplex(MplexConfig::new());
         (pubkey, transport)
     }

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -31,7 +31,7 @@ void = "1.0"
 
 [dev-dependencies]
 futures-timer = "3.0"
-libp2p-secio = { path = "../secio" }
+libp2p-noise = { path = "../noise" }
 libp2p-yamux = { path = "../../muxers/yamux" }
 quickcheck = "0.9.0"
 

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -21,6 +21,6 @@ wasm-timer = "0.2"
 [dev-dependencies]
 async-std = "1.6.2"
 libp2p-tcp = { path = "../../transports/tcp", features = ["async-std"] }
-libp2p-secio = { path = "../../protocols/secio" }
+libp2p-noise = { path = "../../protocols/noise" }
 libp2p-yamux = { path = "../../muxers/yamux" }
 quickcheck = "0.9.0"

--- a/protocols/secio/CHANGELOG.md
+++ b/protocols/secio/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 0.22.0 [unreleased]
 
+- As of this release, SECIO is deprecated. Please use `libp2p-noise` instead.
+  For some more context, [see here](https://blog.ipfs.io/2020-08-07-deprecating-secio/).
+
 - Bump `libp2p-core` dependency.
 
 # 0.21.0 [2020-08-18]

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/libp2p/rust-libp2p"
 keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
+[badges]
+maintenance = { status = "deprecated" }
+
 [dependencies]
 aes-ctr = "0.3"
 aesni = { version = "0.6", features = ["nocheck"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,20 +82,21 @@
 //! *upgraded*. Upgrading a transport is the process of negotiating an additional protocol
 //! with the remote, mediated through a negotiation protocol called [`multistream-select`].
 //!
-//! Example ([`secio`] + [`yamux`] Protocol Upgrade):
+//! Example ([`noise`] + [`yamux`] Protocol Upgrade):
 //!
 //! ```rust
-//! # #[cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), feature = "tcp-async-std", feature = "secio", feature = "yamux"))] {
-//! use libp2p::{Transport, core::upgrade, tcp::TcpConfig, secio::SecioConfig, identity::Keypair, yamux};
+//! # #[cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), feature = "tcp-async-std", feature = "noise", feature = "yamux"))] {
+//! use libp2p::{Transport, core::upgrade, tcp::TcpConfig, noise, identity::Keypair, yamux};
 //! let tcp = TcpConfig::new();
-//! let secio = SecioConfig::new(Keypair::generate_ed25519());
+//! let id_keys = Keypair::generate_ed25519();
+//! let noise_keys = noise::Keypair::<noise::X25519Spec>::new().into_authentic(&id_keys).unwrap();
+//! let noise = noise::NoiseConfig::xx(noise_keys).into_authenticated();
 //! let yamux = yamux::Config::default();
-//! let transport = tcp.upgrade(upgrade::Version::V1).authenticate(secio).multiplex(yamux);
+//! let transport = tcp.upgrade(upgrade::Version::V1).authenticate(noise).multiplex(yamux);
 //! # }
 //! ```
 //! In this example, `transport` is a new [`Transport`] that negotiates the
-//! secio and yamux protocols
-//! on all connections.
+//! noise and yamux protocols on all connections.
 //!
 //! ## Network Behaviour
 //!
@@ -128,7 +129,7 @@
 //!      implements [`StreamMuxer`] (e.g. [`Yamux`]). The peer ID must be the
 //!      identity of the remote peer of the established connection, which is
 //!      usually obtained through a transport encryption protocol such as
-//!      [`secio`] that authenticates the peer. See the implementation of
+//!      [`noise`] that authenticates the peer. See the implementation of
 //!      [`build_development_transport`] for an example.
 //!   3. Creating a struct that implements the [`NetworkBehaviour`] trait and combines all the
 //!      desired network behaviours, implementing the event handlers as per the
@@ -136,7 +137,7 @@
 //!   4. Instantiating a [`Swarm`] with the transport, the network behaviour and the
 //!      local peer ID from the previous steps.
 //!
-//! The swarm instance can then be polled with the [tokio] library, in order to
+//! The swarm instance can then be polled e.g. with the [tokio] library, in order to
 //! continuously drive the network activity of the program.
 //!
 //! [`Keypair`]: identity::Keypair
@@ -212,10 +213,6 @@ pub use libp2p_ping as ping;
 #[cfg_attr(docsrs, doc(cfg(feature = "plaintext")))]
 #[doc(inline)]
 pub use libp2p_plaintext as plaintext;
-#[cfg(feature = "secio")]
-#[cfg_attr(docsrs, doc(cfg(feature = "secio")))]
-#[doc(inline)]
-pub use libp2p_secio as secio;
 #[doc(inline)]
 pub use libp2p_swarm as swarm;
 #[cfg(any(feature = "tcp-async-std", feature = "tcp-tokio"))]
@@ -310,14 +307,13 @@ pub fn build_tcp_ws_noise_mplex_yamux(keypair: identity::Keypair)
         .timeout(std::time::Duration::from_secs(20)))
 }
 
-
 /// Builds an implementation of `Transport` that is suitable for usage with the `Swarm`.
 ///
-/// The implementation supports TCP/IP, WebSockets over TCP/IP, secio as the encryption layer,
+/// The implementation supports TCP/IP, WebSockets over TCP/IP, noise as the encryption layer,
 /// and mplex or yamux as the multiplexing layer.
-#[cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "secio", feature = "mplex", feature = "yamux"))]
-#[cfg_attr(docsrs, doc(cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "secio", feature = "mplex", feature = "yamux"))))]
-pub fn build_tcp_ws_secio_mplex_yamux(keypair: identity::Keypair)
+#[cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "noise", feature = "mplex", feature = "yamux", feature = "pnet"))]
+#[cfg_attr(docsrs, doc(cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "noise", feature = "mplex", feature = "yamux", feature = "pnet"))))]
+pub fn build_tcp_ws_pnet_noise_mplex_yamux(keypair: identity::Keypair, psk: PreSharedKey)
     -> std::io::Result<impl Transport<Output = (PeerId, impl core::muxing::StreamMuxer<OutboundSubstream = impl Send, Substream = impl Send, Error = impl Into<std::io::Error>> + Send + Sync), Error = impl std::error::Error + Send, Listener = impl Send, Dial = impl Send, ListenerUpgrade = impl Send> + Clone>
 {
     let transport = {
@@ -330,39 +326,14 @@ pub fn build_tcp_ws_secio_mplex_yamux(keypair: identity::Keypair)
         transport.or_transport(websocket::WsConfig::new(trans_clone))
     };
 
-    Ok(transport
-        .upgrade(core::upgrade::Version::V1)
-        .authenticate(secio::SecioConfig::new(keypair))
-        .multiplex(core::upgrade::SelectUpgrade::new(yamux::Config::default(), mplex::MplexConfig::new()))
-        .map(|(peer, muxer), _| (peer, core::muxing::StreamMuxerBox::new(muxer)))
-        .timeout(std::time::Duration::from_secs(20)))
-}
-
-/// Builds an implementation of `Transport` that is suitable for usage with the `Swarm`.
-///
-/// The implementation supports TCP/IP, WebSockets over TCP/IP, secio as the encryption layer,
-/// and mplex or yamux as the multiplexing layer.
-///
-/// > **Note**: If you ever need to express the type of this `Transport`.
-#[cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "secio", feature = "mplex", feature = "yamux", feature = "pnet"))]
-#[cfg_attr(docsrs, doc(cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "secio", feature = "mplex", feature = "yamux", feature = "pnet"))))]
-pub fn build_tcp_ws_pnet_secio_mplex_yamux(keypair: identity::Keypair, psk: PreSharedKey)
-    -> std::io::Result<impl Transport<Output = (PeerId, impl core::muxing::StreamMuxer<OutboundSubstream = impl Send, Substream = impl Send, Error = impl Into<std::io::Error>> + Send + Sync), Error = impl std::error::Error + Send, Listener = impl Send, Dial = impl Send, ListenerUpgrade = impl Send> + Clone>
-{
-    let transport = {
-        #[cfg(feature = "tcp-async-std")]
-        let tcp = tcp::TcpConfig::new().nodelay(true);
-        #[cfg(feature = "tcp-tokio")]
-        let tcp = tcp::TokioTcpConfig::new().nodelay(true);
-        let transport = dns::DnsConfig::new(tcp)?;
-        let trans_clone = transport.clone();
-        transport.or_transport(websocket::WsConfig::new(trans_clone))
-    };
+    let noise_keys = noise::Keypair::<noise::X25519Spec>::new()
+        .into_authentic(&keypair)
+        .expect("Signing libp2p-noise static DH keypair failed.");
 
     Ok(transport
         .and_then(move |socket, _| PnetConfig::new(psk).handshake(socket))
         .upgrade(core::upgrade::Version::V1)
-        .authenticate(secio::SecioConfig::new(keypair))
+        .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
         .multiplex(core::upgrade::SelectUpgrade::new(yamux::Config::default(), mplex::MplexConfig::new()))
         .map(|(peer, muxer), _| (peer, core::muxing::StreamMuxerBox::new(muxer)))
         .timeout(std::time::Duration::from_secs(20)))

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -21,6 +21,6 @@ void = "1"
 
 [dev-dependencies]
 libp2p-mplex = { path = "../muxers/mplex" }
-libp2p-secio = { path = "../protocols/secio" }
+libp2p-noise = { path = "../protocols/noise" }
 quickcheck = "0.9.0"
 rand = "0.7.2"

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1201,6 +1201,7 @@ mod tests {
         transport::{self, dummy::*}
     };
     use libp2p_mplex::Multiplex;
+    use libp2p_noise as noise;
     use super::*;
 
     fn get_random_id() -> identity::PublicKey {
@@ -1213,17 +1214,18 @@ mod tests {
         T::OutEvent: Clone,
         O: Send + 'static
     {
-        let keypair1 = identity::Keypair::generate_ed25519();
-        let pubkey1 = keypair1.public();
-        let transport1 = transport::MemoryTransport::default()
+        let id_keys = identity::Keypair::generate_ed25519();
+        let pubkey = id_keys.public();
+        let noise_keys = noise::Keypair::<noise::X25519Spec>::new().into_authentic(&id_keys).unwrap();
+        let transport = transport::MemoryTransport::default()
             .upgrade(upgrade::Version::V1)
-            .authenticate(libp2p_secio::SecioConfig::new(keypair1))
+            .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
             .multiplex(libp2p_mplex::MplexConfig::new())
             .map(|(p, m), _| (p, StreamMuxerBox::new(m)))
             .map_err(|e| -> io::Error { panic!("Failed to create transport: {:?}", e); })
             .boxed();
-        let behaviour1 = CallTraceBehaviour::new(MockBehaviour::new(handler_proto));
-        SwarmBuilder::new(transport1, behaviour1, pubkey1.into()).build()
+        let behaviour = CallTraceBehaviour::new(MockBehaviour::new(handler_proto));
+        SwarmBuilder::new(transport, behaviour, pubkey.into()).build()
     }
 
     #[test]


### PR DESCRIPTION
This PR deprecates the `libp2p-secio` crate, as SECIO is [deprecated and removed from all libp2p implementations](https://blog.ipfs.io/2020-08-07-deprecating-secio/):

  * The crate itself is marked as deprecated with the next release.
  * The crate is removed from the top-level `libp2p` crate, only left as a workspace member until it is eventually removed altogether.
  * All existing tests, examples and documentation in the remaining crates use `libp2p-noise`.

I guess with the deprecation, https://github.com/libp2p/rust-libp2p/issues/1242 could also be closed as "won't fix".