### PR TITLE
[kad] Increase default payload limits.

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 0.23.0 [unreleased]
 
+- Increase default max packet size from 4KiB to 16KiB.
+  See [issue 1622](https://github.com/libp2p/rust-libp2p/issues/1622).
+
 - Add `Distance::log2` ([PR 1719](https://github.com/libp2p/rust-libp2p/pull/1719)).
 
 - Update `libp2p-swarm` and `libp2p-core`.

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -43,6 +43,9 @@ use wasm_timer::Instant;
 /// The protocol name used for negotiating with multistream-select.
 pub const DEFAULT_PROTO_NAME: &[u8] = b"/ipfs/kad/1.0.0";
 
+/// The default maximum size for a varint length-delimited packet.
+pub const DEFAULT_MAX_PACKET_SIZE: usize = 16 * 1024;
+
 /// Status of our connection to a node reported by the Kademlia protocol.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum KadConnectionType {
@@ -167,7 +170,7 @@ impl Default for KademliaProtocolConfig {
     fn default() -> Self {
         KademliaProtocolConfig {
             protocol_name: Cow::Borrowed(DEFAULT_PROTO_NAME),
-            max_packet_size: 4096,
+            max_packet_size: DEFAULT_MAX_PACKET_SIZE,
         }
     }
 }


### PR DESCRIPTION
For better interoperability by default, picking up the suggestion of @mxinden  in https://github.com/libp2p/rust-libp2p/issues/1622.