### PR TITLE
protocols/gossipsub/tests/smoke: Improve wait_for reporting

### DIFF
--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1454,7 +1454,7 @@ impl fmt::Debug for GossipsubRpc {
 }
 
 /// Event that can happen on the gossipsub behaviour.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum GossipsubEvent {
     /// A message has been received. This contains the PeerId that we received the message from,
     /// the message id (used if the application layer needs to propagate the message) and the
@@ -1534,4 +1534,3 @@ impl fmt::Debug for PublishConfig {
         }
     }
 }
-


### PR DESCRIPTION
Small improvement for `protocols/gossipsub/tests/smoke.rs` providing more information on failure, hopefully helping us to track down the CI failures.

I am able to reproduce https://github.com/libp2p/rust-libp2p/issues/1725 occasionally but haven't found the cause (yet).