### PR TITLE
Prepare release of `libp2p-v0.25`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
-# Version 0.25.0 [unreleased]
+# Version 0.25.0 [2020-09-09]
 
 - Update `libp2p-yamux` to `0.22.0`. *This version starts a multi-release
   upgrade process.* See the `libp2p-yamux` CHANGELOG for details.

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.0 [unreleased]
+# 0.22.0 [2020-09-09]
 
 - Simplify incoming connection handling. The `IncomingConnectionEvent`
   has been removed. Instead, pass the `IncomingConnection` obtained

--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.0 [unreleased]
+# 0.22.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.
 

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.0 [unreleased]
+# 0.22.0 [2020-09-09]
 
 - Update to `yamux-0.5.0`. *This is the start of a multi-release transition* to a
   different behaviour w.r.t. the initial window update frame. Tracked in [[1]],

--- a/protocols/deflate/CHANGELOG.md
+++ b/protocols/deflate/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.0 [unreleased]
+# 0.22.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.
 

--- a/protocols/floodsub/CHANGELOG.md
+++ b/protocols/floodsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.0 [unreleased]
+# 0.22.0 [2020-09-09]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.0 [unreleased]
+# 0.22.0 [2020-09-09]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.0 [unreleased]
+# 0.22.0 [2020-09-09]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-09-09]
 
 - Increase default max packet size from 4KiB to 16KiB.
   See [issue 1622](https://github.com/libp2p/rust-libp2p/issues/1622).

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.0 [unreleased]
+# 0.22.0 [2020-09-09]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 

--- a/protocols/noise/CHANGELOG.md
+++ b/protocols/noise/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.
 

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.0 [unreleased]
+# 0.22.0 [2020-09-09]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 

--- a/protocols/plaintext/CHANGELOG.md
+++ b/protocols/plaintext/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.0 [unreleased]
+# 0.22.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.
 

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.3.0 [unreleased]
+# 0.3.0 [2020-09-09]
 
 - Add support for opt-in request-based flow-control to any
   request-response protocol via `RequestResponse::throttled()`.

--- a/protocols/secio/CHANGELOG.md
+++ b/protocols/secio/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.0 [unreleased]
+# 0.22.0 [2020-09-09]
 
 - As of this release, SECIO is deprecated. Please use `libp2p-noise` instead.
   For some more context, [see here](https://blog.ipfs.io/2020-08-07-deprecating-secio/).

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.0 [unreleased]
+# 0.22.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.
 

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.0 [unreleased]
+# 0.22.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.
 

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.0 [unreleased]
+# 0.22.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.
 

--- a/transports/uds/CHANGELOG.md
+++ b/transports/uds/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.0 [unreleased]
+# 0.22.0 [2020-09-09]
 
 - Update `libp2p-core` dependency.
 

--- a/transports/wasm-ext/CHANGELOG.md
+++ b/transports/wasm-ext/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.0 [unreleased]
+# 0.22.0 [2020-09-09]
 
 - Update `libp2p-core` dependency.
 

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.
 


### PR DESCRIPTION
Prepare release of `libp2p-v0.25` and all unreleased sub-crates. Since changelogs and versions are already set accordingly, this PR is just a formality for visibility of the release(s).