### PR TITLE
Prepare release of `libp2p-v0.26`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
-# Version 0.26.0 [unreleased]
+# Version 0.26.0 [2020-09-09]
 
 - Update `libp2p-yamux` to `0.23.0`. *Step 2 of 4 in a multi-release
   upgrade process.* See the `libp2p-yamux` CHANGELOG for details.

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-09-09]
 
 - Update to `yamux-0.6.0`. As explain below, this is step 2 of 4 in a multi-release
   upgrade. This version recognises and sets the flag that causes the new semantics


### PR DESCRIPTION
Part 2 of the `libp2p-yamux` upgrade process.