### PR TITLE
Prepare release of `libp2p-0.27.0`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
-# Version 0.27.0 [unreleased]
+# Version 0.27.0 [2020-09-09]
 
 - Update `libp2p-yamux` to `0.24.0`. *Step 3 of 4 in a multi-release
   upgrade process.* See the `libp2p-yamux` CHANGELOG for details.

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-09-09]
 
 - Update to `yamux-0.7.0`. Upgrade step 3 of 4. This version sets the flag but will
   always interpret initial window updates as additive.


### PR DESCRIPTION
This is step 3 of the `libp2p-yamux` upgrade process.