### PR TITLE
Prepare `libp2p-v0.28.0`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
-# Version 0.28.0 [unreleased]
+# Version 0.28.0 [2020-09-09]
 
 - Update `libp2p-yamux` to `0.25.0`. *Step 4 of 4 in a multi-release
   upgrade process.* See the `libp2p-yamux` CHANGELOG for details.

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.25.0 [unreleased]
+# 0.25.0 [2020-09-09]
 
 - Update to `yamux-0.8.0`. Upgrade step 4 of 4. This version always implements
   the additive meaning w.r.t. initial window updates. The configuration option


### PR DESCRIPTION
This release marks the end of the `libp2p-yamux` upgrade process.