### PR TITLE
 core/Cargo.toml: Require parity-multiaddr 0.9.2 for Ord bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
-# Version 0.28.1 [unreleased]
+# Version 0.28.1 [2020-09-10]
 
 - Update to `libp2p-core` `0.22.1`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
+# Version 0.28.1 [unreleased]
+
+- Update to `libp2p-core` `0.22.1`.
+
 # Version 0.28.0 [2020-09-09]
 
 - Update `libp2p-yamux` to `0.25.0`. *Step 4 of 4 in a multi-release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p"
 edition = "2018"
 description = "Peer-to-peer networking library"
-version = "0.28.0"
+version = "0.28.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -62,7 +62,7 @@ atomic = "0.4.6"
 bytes = "0.5"
 futures = "0.3.1"
 lazy_static = "1.2"
-libp2p-core = { version = "0.22.0", path = "core" }
+libp2p-core = { version = "0.22.1", path = "core" }
 libp2p-core-derive = { version = "0.20.2", path = "misc/core-derive" }
 libp2p-floodsub = { version = "0.22.0", path = "protocols/floodsub", optional = true }
 libp2p-gossipsub = { version = "0.22.0", path = "./protocols/gossipsub", optional = true }

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.22.1 [unreleased]
+
+- Require at least parity-multiaddr v0.9.2 in order to fulfill `Ord` bound on
+  `Multiaddr`.
+
 # 0.22.0 [2020-09-09]
 
 - Simplify incoming connection handling. The `IncomingConnectionEvent`

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.22.1 [unreleased]
 
 - Require at least parity-multiaddr v0.9.2 in order to fulfill `Ord` bound on
-  `Multiaddr`.
+  `Multiaddr`. [PR 1742](https://github.com/libp2p/rust-libp2p/pull/1742).
 
 # 0.22.0 [2020-09-09]
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.1 [unreleased]
+# 0.22.1 [2020-09-10]
 
 - Require at least parity-multiaddr v0.9.2 in order to fulfill `Ord` bound on
   `Multiaddr`. [PR 1742](https://github.com/libp2p/rust-libp2p/pull/1742).

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-core"
 edition = "2018"
 description = "Core traits and structs of libp2p"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -20,7 +20,7 @@ futures-timer = "3"
 lazy_static = "1.2"
 libsecp256k1 = { version = "0.3.1", optional = true }
 log = "0.4"
-multiaddr = { package = "parity-multiaddr", version = "0.9.1", path = "../misc/multiaddr" }
+multiaddr = { package = "parity-multiaddr", version = "0.9.2", path = "../misc/multiaddr" }
 multihash = "0.11.0"
 multistream-select = { version = "0.8.2", path = "../misc/multistream-select" }
 parking_lot = "0.10.0"


### PR DESCRIPTION
With b601ed4 libp2p-core requires the `Ord` bound on `Multiaddr`. This
bound is only implemented with parity-multiaddr `0.9.2`. Make sure
libp2p-core requires at least parity-multiaddr `0.9.2`.

I am not sure it is worth the patch release of both libp2p-core and libp2p. Let me know. Happy to do the release.