### PR TITLE
.github: Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Closes https://github.com/libp2p/rust-libp2p/issues/1743.

According to the [post-acquisition-by-github docs](https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates) this should work without any further configuration.

