### PR TITLE
protocols/plaintext: Remove wrong debug log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ libp2p-kad = { version = "0.23.1", path = "protocols/kad", optional = true }
 libp2p-mplex = { version = "0.22.0", path = "muxers/mplex", optional = true }
 libp2p-noise = { version = "0.24.1", path = "protocols/noise", optional = true }
 libp2p-ping = { version = "0.22.0", path = "protocols/ping", optional = true }
-libp2p-plaintext = { version = "0.22.0", path = "protocols/plaintext", optional = true }
+libp2p-plaintext = { version = "0.22.1", path = "protocols/plaintext", optional = true }
 libp2p-pnet = { version = "0.19.1", path = "protocols/pnet", optional = true }
 libp2p-request-response = { version = "0.3.0", path = "protocols/request-response", optional = true }
 libp2p-swarm = { version = "0.22.0", path = "swarm" }

--- a/protocols/plaintext/CHANGELOG.md
+++ b/protocols/plaintext/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.22.1 [unreleased]
+
+- Improve error logging.
+
 # 0.22.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.

--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-plaintext"
 edition = "2018"
 description = "Plaintext encryption dummy protocol for libp2p"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
Don't log errors happening after plaintext handshake as errors happening
during plaintext handshake.