### PR TITLE
[mplex] Refactoring with Patches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ libp2p-floodsub = { version = "0.22.0", path = "protocols/floodsub", optional = 
 libp2p-gossipsub = { version = "0.22.1", path = "./protocols/gossipsub", optional = true }
 libp2p-identify = { version = "0.22.0", path = "protocols/identify", optional = true }
 libp2p-kad = { version = "0.23.1", path = "protocols/kad", optional = true }
-libp2p-mplex = { version = "0.22.1", path = "muxers/mplex", optional = true }
+libp2p-mplex = { version = "0.23.0", path = "muxers/mplex", optional = true }
 libp2p-noise = { version = "0.24.1", path = "protocols/noise", optional = true }
 libp2p-ping = { version = "0.22.0", path = "protocols/ping", optional = true }
 libp2p-plaintext = { version = "0.23.0", path = "protocols/plaintext", optional = true }

--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 - Address a potential stall when reading from substreams.
 
-- Send a `Reset` to the remote when a substream is dropped
-  and remove that substream from the tracked open substreams,
+- Send a `Reset` or `Close` to the remote when a substream is dropped,
+  as appropriate for the current state of the substream,
+  removing that substream from the tracked open substreams,
   to avoid artificially running into substream limits.
 
 - Change the semantics of the `max_substreams` configuration. Now,

--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -1,4 +1,19 @@
-# 0.22.1 [unreleased]
+# 0.23.0 [unreleased]
+
+- Address a potential stall when reading from substreams.
+
+- Send a `Reset` to the remote when a substream is dropped
+  and remove that substream from the tracked open substreams,
+  to avoid artificially running into substream limits.
+
+- Change the semantics of the `max_substreams` configuration. Now,
+  outbound substream attempts beyond the configured limit are delayed,
+  with a task wakeup once an existing substream closes, i.e. the limit
+  results in back-pressure for new outbound substreams. New inbound
+  substreams beyond the limit are immediately answered with a `Reset`.
+  If too many (by some internal threshold) pending `Reset` frames accumulate,
+  e.g. as a result of an aggressive number of inbound substreams being
+  opened beyond the configured limit, the connection is closed ("DoS protection").
 
 - Update dependencies.
 

--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -11,7 +11,7 @@
   with a task wakeup once an existing substream closes, i.e. the limit
   results in back-pressure for new outbound substreams. New inbound
   substreams beyond the limit are immediately answered with a `Reset`.
-  If too many (by some internal threshold) pending `Reset` frames accumulate,
+  If too many (by some internal threshold) pending frames accumulate,
   e.g. as a result of an aggressive number of inbound substreams being
   opened beyond the configured limit, the connection is closed ("DoS protection").
 

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-mplex"
 edition = "2018"
 description = "Mplex multiplexing protocol for libp2p"
-version = "0.22.1"
+version = "0.23.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/muxers/mplex/src/codec.rs
+++ b/muxers/mplex/src/codec.rs
@@ -21,7 +21,7 @@
 use libp2p_core::Endpoint;
 use futures_codec::{Decoder, Encoder};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
-use std::mem;
+use std::{fmt, mem};
 use bytes::{BufMut, Bytes, BytesMut};
 use unsigned_varint::{codec, encode};
 
@@ -50,6 +50,15 @@ pub(crate) const MAX_FRAME_SIZE: usize = 1024 * 1024;
 pub struct LocalStreamId {
     num: u32,
     role: Endpoint,
+}
+
+impl fmt::Display for LocalStreamId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.role {
+            Endpoint::Dialer => write!(f, "({}/initiator)", self.num),
+            Endpoint::Listener => write!(f, "({}/receiver)", self.num),
+        }
+    }
 }
 
 /// A unique identifier used by the remote node for a substream.

--- a/muxers/mplex/src/codec.rs
+++ b/muxers/mplex/src/codec.rs
@@ -128,23 +128,6 @@ impl Frame<RemoteStreamId> {
     pub fn local_id(&self) -> LocalStreamId {
         self.remote_id().into_local()
     }
-
-    /// Returns true if this is a `Data` frame.
-    pub fn is_data(&self) -> bool {
-        match self {
-            Frame::Data { .. } => true,
-            _ => false,
-        }
-    }
-
-    /// Returns true if this is an `Open` frame.
-    pub fn is_open(&self) -> bool {
-        if let Frame::Open { .. } = self {
-            true
-        } else {
-            false
-        }
-    }
 }
 
 pub struct Codec {

--- a/muxers/mplex/src/codec.rs
+++ b/muxers/mplex/src/codec.rs
@@ -204,7 +204,6 @@ impl Decoder for Codec {
 
                     let buf = src.split_to(len);
                     let num = (header >> 3) as u32;
-                    // let stream_id = RemoteStreamId { num, role: None };
                     let out = match header & 7 {
                         0 => Frame::Open { stream_id: RemoteStreamId::dialer(num) },
                         1 => Frame::Data { stream_id: RemoteStreamId::listener(num), data: buf.freeze() },

--- a/muxers/mplex/src/codec.rs
+++ b/muxers/mplex/src/codec.rs
@@ -30,47 +30,107 @@ use unsigned_varint::{codec, encode};
 // send a 4 TB-long packet full of zeroes that we kill our process with an OOM error.
 pub(crate) const MAX_FRAME_SIZE: usize = 1024 * 1024;
 
-#[derive(Debug, Clone)]
-pub enum Elem {
-    Open { substream_id: u32 },
-    Data { substream_id: u32, endpoint: Endpoint, data: Bytes },
-    Close { substream_id: u32, endpoint: Endpoint },
-    Reset { substream_id: u32, endpoint: Endpoint },
+/// A unique identifier used by the local node for a substream.
+///
+/// `LocalStreamId`s are sent with frames to the remote, where
+/// they are received as `RemoteStreamId`s.
+///
+/// > **Note**: Streams are identified by a number and a role encoded as a flag
+/// > on each frame that is either odd (for receivers) or even (for initiators).
+/// > `Open` frames do not have a flag, but are sent unidirectionally. As a
+/// > consequence, we need to remember if a stream was initiated by us or remotely
+/// > and we store the information from our point of view as a `LocalStreamId`,
+/// > i.e. receiving an `Open` frame results in a local ID with role `Endpoint::Listener`,
+/// > whilst sending an `Open` frame results in a local ID with role `Endpoint::Dialer`.
+/// > Receiving a frame with a flag identifying the remote as a "receiver" means that
+/// > we initiated the stream, so the local ID has the role `Endpoint::Dialer`.
+/// > Conversely, when receiving a frame with a flag identifying the remote as a "sender",
+/// > the corresponding local ID has the role `Endpoint::Listener`.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct LocalStreamId {
+    num: u32,
+    role: Endpoint,
 }
 
-impl Elem {
-    /// Returns the ID of the substream of the message.
-    pub fn substream_id(&self) -> u32 {
+/// A unique identifier used by the remote node for a substream.
+///
+/// `RemoteStreamId`s are received with frames from the remote
+/// and mapped by the receiver to `LocalStreamId`s via
+/// [`RemoteStreamId::into_local()`].
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct RemoteStreamId {
+    num: u32,
+    role: Endpoint,
+}
+
+impl LocalStreamId {
+    pub fn dialer(num: u32) -> Self {
+        Self { num, role: Endpoint::Dialer }
+    }
+
+    pub fn next(self) -> Self {
+        Self {
+            num: self.num.checked_add(1).expect("Mplex substream ID overflowed"),
+            .. self
+        }
+    }
+}
+
+impl RemoteStreamId {
+    fn dialer(num: u32) -> Self {
+        Self { num, role: Endpoint::Dialer }
+    }
+
+    fn listener(num: u32) -> Self {
+        Self { num, role: Endpoint::Listener }
+    }
+
+    /// Converts this `RemoteStreamId` into the corresponding `LocalStreamId`
+    /// that identifies the same substream.
+    pub fn into_local(self) -> LocalStreamId {
+        LocalStreamId {
+            num: self.num,
+            role: !self.role,
+        }
+    }
+}
+
+/// An Mplex protocol frame.
+#[derive(Debug, Clone)]
+pub enum Frame<T> {
+    Open { stream_id: T },
+    Data { stream_id: T, data: Bytes },
+    Close { stream_id: T },
+    Reset { stream_id: T },
+}
+
+impl Frame<RemoteStreamId> {
+    fn remote_id(&self) -> RemoteStreamId {
         match *self {
-            Elem::Open { substream_id } => substream_id,
-            Elem::Data { substream_id, .. } => substream_id,
-            Elem::Close { substream_id, .. } => substream_id,
-            Elem::Reset { substream_id, .. } => substream_id,
+            Frame::Open { stream_id } => stream_id,
+            Frame::Data { stream_id, .. } => stream_id,
+            Frame::Close { stream_id, .. } => stream_id,
+            Frame::Reset { stream_id, .. } => stream_id,
         }
     }
 
-    pub fn endpoint(&self) -> Option<Endpoint> {
-        match *self {
-            Elem::Open { .. } => None,
-            Elem::Data { endpoint, .. } => Some(endpoint),
-            Elem::Close { endpoint, .. } => Some(endpoint),
-            Elem::Reset { endpoint, .. } => Some(endpoint)
-        }
+    /// Gets the `LocalStreamId` corresponding to the `RemoteStreamId`
+    /// received with this frame.
+    pub fn local_id(&self) -> LocalStreamId {
+        self.remote_id().into_local()
     }
 
-    /// Returns true if this message is `Close` or `Reset`.
-    #[inline]
-    pub fn is_close_or_reset_msg(&self) -> bool {
+    /// Returns true if this is a `Data` frame.
+    pub fn is_data(&self) -> bool {
         match self {
-            Elem::Close { .. } | Elem::Reset { .. } => true,
+            Frame::Data { .. } => true,
             _ => false,
         }
     }
 
-    /// Returns true if this message is `Open`.
-    #[inline]
-    pub fn is_open_msg(&self) -> bool {
-        if let Elem::Open { .. } = self {
+    /// Returns true if this is an `Open` frame.
+    pub fn is_open(&self) -> bool {
+        if let Frame::Open { .. } = self {
             true
         } else {
             false
@@ -101,7 +161,7 @@ impl Codec {
 }
 
 impl Decoder for Codec {
-    type Item = Elem;
+    type Item = Frame<RemoteStreamId>;
     type Error = IoError;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
@@ -143,15 +203,16 @@ impl Decoder for Codec {
                     }
 
                     let buf = src.split_to(len);
-                    let substream_id = (header >> 3) as u32;
+                    let num = (header >> 3) as u32;
+                    // let stream_id = RemoteStreamId { num, role: None };
                     let out = match header & 7 {
-                        0 => Elem::Open { substream_id },
-                        1 => Elem::Data { substream_id, endpoint: Endpoint::Listener, data: buf.freeze() },
-                        2 => Elem::Data { substream_id, endpoint: Endpoint::Dialer, data: buf.freeze() },
-                        3 => Elem::Close { substream_id, endpoint: Endpoint::Listener },
-                        4 => Elem::Close { substream_id, endpoint: Endpoint::Dialer },
-                        5 => Elem::Reset { substream_id, endpoint: Endpoint::Listener },
-                        6 => Elem::Reset { substream_id, endpoint: Endpoint::Dialer },
+                        0 => Frame::Open { stream_id: RemoteStreamId::dialer(num) },
+                        1 => Frame::Data { stream_id: RemoteStreamId::listener(num), data: buf.freeze() },
+                        2 => Frame::Data { stream_id: RemoteStreamId::dialer(num), data: buf.freeze() },
+                        3 => Frame::Close { stream_id: RemoteStreamId::listener(num) },
+                        4 => Frame::Close { stream_id: RemoteStreamId::dialer(num) },
+                        5 => Frame::Reset { stream_id: RemoteStreamId::listener(num) },
+                        6 => Frame::Reset { stream_id: RemoteStreamId::dialer(num) },
                         _ => {
                             let msg = format!("Invalid mplex header value 0x{:x}", header);
                             return Err(IoError::new(IoErrorKind::InvalidData, msg));
@@ -171,31 +232,31 @@ impl Decoder for Codec {
 }
 
 impl Encoder for Codec {
-    type Item = Elem;
+    type Item = Frame<LocalStreamId>;
     type Error = IoError;
 
     fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
         let (header, data) = match item {
-            Elem::Open { substream_id } => {
-                (u64::from(substream_id) << 3, Bytes::new())
+            Frame::Open { stream_id } => {
+                (u64::from(stream_id.num) << 3, Bytes::new())
             },
-            Elem::Data { substream_id, endpoint: Endpoint::Listener, data } => {
-                (u64::from(substream_id) << 3 | 1, data)
+            Frame::Data { stream_id: LocalStreamId { num, role: Endpoint::Listener }, data } => {
+                (u64::from(num) << 3 | 1, data)
             },
-            Elem::Data { substream_id, endpoint: Endpoint::Dialer, data } => {
-                (u64::from(substream_id) << 3 | 2, data)
+            Frame::Data { stream_id: LocalStreamId { num, role: Endpoint::Dialer }, data } => {
+                (u64::from(num) << 3 | 2, data)
             },
-            Elem::Close { substream_id, endpoint: Endpoint::Listener } => {
-                (u64::from(substream_id) << 3 | 3, Bytes::new())
+            Frame::Close { stream_id: LocalStreamId { num, role: Endpoint::Listener } } => {
+                (u64::from(num) << 3 | 3, Bytes::new())
             },
-            Elem::Close { substream_id, endpoint: Endpoint::Dialer } => {
-                (u64::from(substream_id) << 3 | 4, Bytes::new())
+            Frame::Close { stream_id: LocalStreamId { num, role: Endpoint::Dialer } } => {
+                (u64::from(num) << 3 | 4, Bytes::new())
             },
-            Elem::Reset { substream_id, endpoint: Endpoint::Listener } => {
-                (u64::from(substream_id) << 3 | 5, Bytes::new())
+            Frame::Reset { stream_id: LocalStreamId { num, role: Endpoint::Listener } } => {
+                (u64::from(num) << 3 | 5, Bytes::new())
             },
-            Elem::Reset { substream_id, endpoint: Endpoint::Dialer } => {
-                (u64::from(substream_id) << 3 | 6, Bytes::new())
+            Frame::Reset { stream_id: LocalStreamId { num, role: Endpoint::Dialer } } => {
+                (u64::from(num) << 3 | 6, Bytes::new())
             },
         };
 
@@ -225,9 +286,9 @@ mod tests {
     #[test]
     fn encode_large_messages_fails() {
         let mut enc = Codec::new();
-        let endpoint = Endpoint::Dialer;
+        let role = Endpoint::Dialer;
         let data = Bytes::from(&[123u8; MAX_FRAME_SIZE + 1][..]);
-        let bad_msg = Elem::Data{ substream_id: 123, endpoint, data };
+        let bad_msg = Frame::Data { stream_id: LocalStreamId { num: 123, role }, data };
         let mut out = BytesMut::new();
         match enc.encode(bad_msg, &mut out) {
             Err(e) => assert_eq!(e.to_string(), "data size exceed maximum"),
@@ -235,7 +296,7 @@ mod tests {
         }
 
         let data = Bytes::from(&[123u8; MAX_FRAME_SIZE][..]);
-        let ok_msg = Elem::Data{ substream_id: 123, endpoint, data };
+        let ok_msg = Frame::Data { stream_id: LocalStreamId { num: 123, role }, data };
         assert!(enc.encode(ok_msg, &mut out).is_ok());
     }
 }

--- a/muxers/mplex/src/config.rs
+++ b/muxers/mplex/src/config.rs
@@ -1,0 +1,106 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use crate::codec::MAX_FRAME_SIZE;
+use std::cmp;
+
+/// Configuration for the multiplexer.
+#[derive(Debug, Clone)]
+pub struct MplexConfig {
+    /// Maximum number of simultaneously-open substreams.
+    pub(crate) max_substreams: usize,
+    /// Maximum number of frames in the internal buffer.
+    pub(crate) max_buffer_len: usize,
+    /// Behaviour when the buffer size limit is reached.
+    pub(crate) max_buffer_behaviour: MaxBufferBehaviour,
+    /// When sending data, split it into frames whose maximum size is this value
+    /// (max 1MByte, as per the Mplex spec).
+    pub(crate) split_send_size: usize,
+}
+
+impl MplexConfig {
+    /// Builds the default configuration.
+    pub fn new() -> MplexConfig {
+        Default::default()
+    }
+
+    /// Sets the maximum number of simultaneously open substreams.
+    ///
+    /// When the limit is reached, opening of outbound substreams
+    /// is delayed until another substream closes, whereas new
+    /// inbound substreams are immediately answered with a `Reset`.
+    /// If the number of inbound substreams that need to be reset
+    /// accumulates too quickly (judged by internal bounds), the
+    /// connection is closed, the connection is closed with an error
+    /// due to the misbehaved remote.
+    pub fn max_substreams(&mut self, max: usize) -> &mut Self {
+        self.max_substreams = max;
+        self
+    }
+
+    /// Sets the maximum number of frames buffered that have
+    /// not yet been consumed.
+    ///
+    /// A limit is necessary in order to avoid DoS attacks.
+    pub fn max_buffer_len(&mut self, max: usize) -> &mut Self {
+        self.max_buffer_len = max;
+        self
+    }
+
+    /// Sets the behaviour when the maximum buffer length has been reached.
+    ///
+    /// See the documentation of `MaxBufferBehaviour`.
+    pub fn max_buffer_len_behaviour(&mut self, behaviour: MaxBufferBehaviour) -> &mut Self {
+        self.max_buffer_behaviour = behaviour;
+        self
+    }
+
+    /// Sets the frame size used when sending data. Capped at 1Mbyte as per the
+    /// Mplex spec.
+    pub fn split_send_size(&mut self, size: usize) -> &mut Self {
+        let size = cmp::min(size, MAX_FRAME_SIZE);
+        self.split_send_size = size;
+        self
+    }
+}
+
+/// Behaviour when the maximum length of the buffer is reached.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum MaxBufferBehaviour {
+    /// Produce an error on all the substreams.
+    CloseAll,
+    /// No new message will be read from the underlying connection if the buffer is full.
+    ///
+    /// This can potentially introduce a deadlock if you are waiting for a message from a substream
+    /// before processing the messages received on another substream.
+    Block,
+}
+
+impl Default for MplexConfig {
+    fn default() -> MplexConfig {
+        MplexConfig {
+            max_substreams: 128,
+            max_buffer_len: 4096,
+            max_buffer_behaviour: MaxBufferBehaviour::CloseAll,
+            split_send_size: 1024,
+        }
+    }
+}
+

--- a/muxers/mplex/src/io.rs
+++ b/muxers/mplex/src/io.rs
@@ -1,0 +1,687 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use bytes::Bytes;
+use crate::{MplexConfig, MaxBufferBehaviour};
+use crate::codec::{Codec, Frame, LocalStreamId, RemoteStreamId};
+use log::{debug, trace};
+use fnv::FnvHashMap;
+use futures::{prelude::*, ready, stream::Fuse};
+use futures::task::{ArcWake, waker_ref, WakerRef};
+use futures_codec::Framed;
+use parking_lot::Mutex;
+use std::collections::hash_map::Entry;
+use std::{cmp, io, mem, sync::Arc, task::{Context, Poll, Waker}};
+
+pub use std::io::{Result, Error, ErrorKind};
+
+/// A multiplexed I/O stream.
+pub struct Multiplexed<C> {
+    /// The current operating status.
+    status: Status,
+    /// The underlying I/O stream.
+    io: Fuse<Framed<C, Codec>>,
+    /// The configuration.
+    config: MplexConfig,
+    /// Buffer of received frames that have not yet been consumed.
+    buffer: Vec<Frame<RemoteStreamId>>,
+    /// Whether a flush is pending before reading frames can proceed.
+    pending_flush: bool,
+    /// Streams for which a `Reset` frame should be sent.
+    pending_reset: Vec<LocalStreamId>,
+    /// The substreams that are considered at least half-open.
+    open_substreams: FnvHashMap<LocalStreamId, SubstreamState>,
+    /// The ID for the next outbound substream.
+    next_outbound_stream_id: LocalStreamId,
+    /// Registry of wakers for pending tasks interested in reading.
+    notifier_read: Arc<NotifierRead>,
+    /// Registry of wakers for pending tasks interested in writing.
+    notifier_write: Arc<NotifierWrite>,
+    /// Registry of wakers for pending tasks interested in opening
+    /// an outbound substream, when the configured limit is reached.
+    notifier_open: Arc<NotifierOpen>,
+}
+
+/// The operation status of a `Multiplexed` I/O stream.
+#[derive(Debug)]
+enum Status {
+    /// The stream is considered open and healthy.
+    Ok,
+    /// The stream has been actively closed.
+    Closed,
+    /// The stream has encountered a fatal error.
+    Err(io::Error),
+}
+
+impl<C> Multiplexed<C>
+where
+    C: AsyncRead + AsyncWrite + Unpin
+{
+    /// Creates a new multiplexed I/O stream.
+    pub fn new(io: C, config: MplexConfig) -> Self {
+        let max_buffer_len = config.max_buffer_len;
+        Multiplexed {
+            config,
+            status: Status::Ok,
+            io: Framed::new(io, Codec::new()).fuse(),
+            buffer: Vec::with_capacity(cmp::min(max_buffer_len, 512)),
+            open_substreams: Default::default(),
+            pending_flush: false,
+            pending_reset: Vec::new(),
+            next_outbound_stream_id: LocalStreamId::dialer(0),
+            notifier_read: Arc::new(NotifierRead {
+                pending: Mutex::new(Default::default()),
+            }),
+            notifier_write: Arc::new(NotifierWrite {
+                pending: Mutex::new(Default::default()),
+            }),
+            notifier_open: Arc::new(NotifierOpen {
+                pending: Mutex::new(Default::default())
+            })
+        }
+    }
+
+    /// Flushes the underlying I/O stream.
+    pub fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match &self.status {
+            Status::Closed => return Poll::Ready(Ok(())),
+            Status::Err(e) => return Poll::Ready(Err(io::Error::new(e.kind(), e.to_string()))),
+            Status::Ok => {}
+        }
+
+        // Send any pending reset frames.
+        ready!(self.send_pending_reset(cx))?;
+
+        // Flush the underlying I/O stream.
+        let waker = NotifierWrite::register(&self.notifier_write, cx.waker());
+        match ready!(self.io.poll_flush_unpin(&mut Context::from_waker(&waker))) {
+            Err(e) => self.on_error(e),
+            Ok(()) => {
+                self.pending_flush = false;
+                Poll::Ready(Ok(()))
+            }
+        }
+    }
+
+    /// Closes the underlying I/O stream.
+    ///
+    /// > **Note**: No `Close` or `Reset` frames are sent on open substreams
+    /// > before closing the underlying connection. However, the connection
+    /// > close implies a flush of any frames already sent.
+    pub fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match &self.status {
+            Status::Closed => return Poll::Ready(Ok(())),
+            Status::Err(e) => return Poll::Ready(Err(io::Error::new(e.kind(), e.to_string()))),
+            Status::Ok => {}
+        }
+
+        // Note: We do not make the effort to send pending `Reset` frames
+        // here, we only close (and thus flush) the underlying I/O stream.
+
+        let waker = NotifierWrite::register(&self.notifier_write, cx.waker());
+        match self.io.poll_close_unpin(&mut Context::from_waker(&waker)) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(e)) => self.on_error(e),
+            Poll::Ready(Ok(())) => {
+                self.pending_reset = Vec::new();
+                // We do not support read-after-close on the underlying
+                // I/O stream, hence clearing the buffer and substreams.
+                self.buffer = Vec::new();
+                self.open_substreams = Default::default();
+                self.status = Status::Closed;
+                Poll::Ready(Ok(()))
+            }
+        }
+    }
+
+    /// Waits for a new inbound substream, returning the corresponding `LocalStreamId`.
+    pub fn poll_next_stream(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<LocalStreamId>> {
+        self.guard_ok()?;
+
+        // Wait for the next inbound `Open` frame.
+        let stream_id = ready!(self.poll_recv_frame(cx, None, |frame| match frame {
+            Frame::Open { stream_id } => Some(stream_id.into_local()),
+            _ => None,
+        }))?.expect("Unexpected end of substream.");
+
+        debug!("New inbound substream: {:?}", stream_id);
+
+        Poll::Ready(Ok(stream_id))
+    }
+
+    /// Creates a new (outbound) substream, returning the allocated stream ID.
+    pub fn poll_open_stream(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<LocalStreamId>> {
+        self.guard_ok()?;
+
+        // Check the stream limits.
+        if self.open_substreams.len() >= self.config.max_substreams {
+            debug!("Maximum number of substreams reached: {}", self.config.max_substreams);
+            let _ = NotifierOpen::register(&self.notifier_open, cx.waker());
+            return Poll::Pending
+        }
+
+        // Send the `Open` frame.
+        let waker = NotifierWrite::register(&self.notifier_write, cx.waker());
+        match ready!(self.io.poll_ready_unpin(&mut Context::from_waker(&waker))) {
+            Ok(()) => {
+                let stream_id = self.next_outbound_stream_id();
+                let frame = Frame::Open { stream_id };
+                match self.io.start_send_unpin(frame) {
+                    Ok(()) => {
+                        self.open_substreams.insert(stream_id, SubstreamState::Open);
+                        // The flush is delayed and the `Open` frame may be sent
+                        // together with other frames in the same transport packet.
+                        self.pending_flush = true;
+                        Poll::Ready(Ok(stream_id))
+                    }
+                    Err(e) => self.on_error(e),
+                }
+            },
+            Err(e) => self.on_error(e)
+        }
+    }
+
+
+    /// Resets an open substream, immediately closing it both for reading and writing.
+    ///
+    /// As opposed to a regular close, resetting a stream does not give the
+    /// remote the opportunity to cleanly finish writing.
+    pub fn reset_stream(&mut self, id: LocalStreamId) {
+        let at_limit = self.open_substreams.len() >= self.config.max_substreams;
+        if self.open_substreams.remove(&id).is_some() {
+            if let Err(e) = self.guard_ok() {
+                log::trace!("Cannot reset stream: {:?}", e);
+                return
+            }
+            self.buffer.retain(|elem| elem.local_id() != id);
+            if at_limit && self.open_substreams.len() < self.config.max_substreams {
+                // Notify tasks that had interest in opening a substream.
+                ArcWake::wake_by_ref(&self.notifier_open);
+            }
+            if self.pending_reset.len() >= MAX_PENDING_RESETS {
+                log::debug!("Too many pending resets. Ignoring reset for {:?}", id);
+                return
+            }
+            log::debug!("Scheduling reset for stream {:?}", id);
+            self.pending_reset.push(id);
+        }
+    }
+
+    /// Writes data to a substream.
+    pub fn poll_write_stream(&mut self, cx: &mut Context<'_>, id: LocalStreamId, buf: &[u8])
+        -> Poll<io::Result<usize>>
+    {
+        self.guard_ok()?;
+
+        // Check if the stream is open for writing.
+        match self.open_substreams.get(&id) {
+            None => return Poll::Ready(Err(io::ErrorKind::BrokenPipe.into())),
+            Some(SubstreamState::SendClosed) => return Poll::Ready(Err(io::ErrorKind::WriteZero.into())),
+            _ => {}
+        }
+
+        // Determine the size of the frame to send.
+        let frame_len = cmp::min(buf.len(), self.config.split_send_size);
+
+        // Send the data frame.
+        ready!(self.poll_send_frame(cx, || {
+            let data = Bytes::copy_from_slice(&buf[.. frame_len]);
+            Frame::Data { stream_id: id, data }
+        }))?;
+
+        Poll::Ready(Ok(frame_len))
+    }
+
+    /// Reads data from a substream.
+    pub fn poll_read_stream(&mut self, cx: &mut Context<'_>, id: LocalStreamId)
+        -> Poll<io::Result<Option<Bytes>>>
+    {
+        self.guard_ok()?;
+
+        self.poll_recv_frame(cx, Some(id), |frame| match frame {
+            Frame::Data { data, .. } => Some(data.clone()),
+            _ => None
+        })
+    }
+
+    /// Flushes a substream.
+    ///
+    /// > **Note**: This is equivalent to `poll_flush()`, i.e. to flushing
+    /// > all substreams, except that this operation is an error on if
+    /// > the underlying I/O stream is already closed.
+    pub fn poll_flush_stream(&mut self, cx: &mut Context<'_>, id: LocalStreamId)
+        -> Poll<io::Result<()>>
+    {
+        self.guard_ok()?;
+
+        ready!(self.poll_flush(cx))?;
+        trace!("Flushed substream {:?}", id);
+
+        Poll::Ready(Ok(()))
+    }
+
+    /// Closes a stream for writing.
+    ///
+    /// > **Note**: As opposed to `poll_close()`, a flush it not implied.
+    pub fn poll_close_stream(&mut self, cx: &mut Context<'_>, id: LocalStreamId)
+        -> Poll<io::Result<()>>
+    {
+        self.guard_ok()?;
+
+        let at_limit = self.open_substreams.len() >= self.config.max_substreams;
+        match self.open_substreams.get(&id) {
+            None | Some(SubstreamState::SendClosed) => Poll::Ready(Ok(())),
+            Some(&state) => {
+                ready!(self.poll_send_frame(cx, || Frame::Close { stream_id: id }))?;
+                if state == SubstreamState::Open {
+                    debug!("Closed substream {:?} (half-close)", id);
+                    self.open_substreams.insert(id, SubstreamState::SendClosed);
+                } else if state == SubstreamState::RecvClosed {
+                    debug!("Closed substream {:?}", id);
+                    self.open_substreams.remove(&id);
+                    if at_limit && self.open_substreams.len() < self.config.max_substreams {
+                        ArcWake::wake_by_ref(&self.notifier_open);
+                    }
+                }
+                Poll::Ready(Ok(()))
+            }
+        }
+    }
+
+    /// Sends a (lazily constructed) mplex frame on the underlying I/O stream.
+    ///
+    /// The frame is only constructed if the underlying sink is ready to
+    /// send another frame.
+    fn poll_send_frame<F>(&mut self, cx: &mut Context<'_>, frame: F)
+        -> Poll<io::Result<()>>
+    where
+        F: FnOnce() -> Frame<LocalStreamId>
+    {
+        let waker = NotifierWrite::register(&self.notifier_write, cx.waker());
+        match ready!(self.io.poll_ready_unpin(&mut Context::from_waker(&waker))) {
+            Ok(()) => {
+                let frame = frame();
+                trace!("Sending {:?}", frame);
+                match self.io.start_send_unpin(frame) {
+                    Ok(()) => Poll::Ready(Ok(())),
+                    Err(e) => self.on_error(e)
+                }
+            },
+            Err(e) => self.on_error(e)
+        }
+    }
+
+    /// Polls the underlying I/O stream for the next frame chosen
+    /// by the given selection function.
+    ///
+    /// Returns `Pending` if no frame satisfying the selection function
+    /// is available, but the stream or substream is still open or
+    /// half-closed (i.e. readable). All skipped frames are buffered and
+    /// tasks that previously registered interest in the streams for which
+    /// the skipped frames were received are notified.
+    ///
+    /// If `Some` stream ID is given, `Ok(None)` signals EOF for
+    /// that substream. If `None` is given for the stream ID,
+    /// `Ok(None)` is never returned. If the underlying connection
+    /// encounters EOF, a corresponding error is returned.
+    fn poll_recv_frame<F, O>(
+        &mut self,
+        cx: &mut Context<'_>,
+        stream_id: Option<LocalStreamId>,
+        mut select: F,
+    ) -> Poll<io::Result<Option<O>>>
+    where
+        F: FnMut(&Frame<RemoteStreamId>) -> Option<O>,
+    {
+        // Try to send pending reset frames, if there are any, without blocking,
+        if let Poll::Ready(Err(e)) = self.send_pending_reset(cx) {
+            return Poll::Ready(Err(e))
+        }
+
+        // Perform any pending flush before reading.
+        if self.pending_flush {
+            trace!("Executing pending flush.");
+            ready!(self.poll_flush(cx))?;
+            debug_assert!(!self.pending_flush);
+        }
+
+        // Refine the selection function such that the given function
+        // only gets frames for the targeted stream.
+        let mut select = |f: &Frame<RemoteStreamId>|
+            if stream_id.map_or(true, |id| id == f.local_id()) {
+                select(f)
+            } else {
+                None
+            };
+
+        // Try to read from the buffer first.
+        if let Some((pos, out)) = self.buffer.iter()
+            .enumerate()
+            .find_map(|(pos, frame)| select(frame).map(|out| (pos, out)))
+        {
+            // The buffer was full and no longer is, so notify all pending readers.
+            if self.buffer.len() == self.config.max_buffer_len {
+                ArcWake::wake_by_ref(&self.notifier_read);
+            }
+            self.buffer.remove(pos);
+            return Poll::Ready(Ok(Some(out)));
+        }
+
+        loop {
+            // Check if the targeted substream (if any) reached EOF.
+            if let Some(id) = &stream_id {
+                match self.open_substreams.get(id) {
+                    Some(SubstreamState::RecvClosed) | None => return Poll::Ready(Ok(None)),
+                    _ => {}
+                }
+            }
+
+            // Check if the inbound frame buffer is full.
+            debug_assert!(self.buffer.len() <= self.config.max_buffer_len);
+            if self.buffer.len() == self.config.max_buffer_len {
+                debug!("Frame buffer full ({} frames).", self.buffer.len());
+                match self.config.max_buffer_behaviour {
+                    MaxBufferBehaviour::CloseAll => {
+                        return self.on_error(io::Error::new(io::ErrorKind::Other,
+                            format!("Frame buffer full ({} frames).", self.buffer.len())))
+                    },
+                    MaxBufferBehaviour::Block => {
+                        // If there are any pending tasks for frames in the buffer,
+                        // use this opportunity to try to wake one of them.
+                        let mut woken = false;
+                        for frame in self.buffer.iter() {
+                            woken = self.notifier_read.wake_by_id(frame.local_id());
+                            if woken {
+                                // The current task is still interested in another frame,
+                                // so we register it for a wakeup some time after the
+                                // already `woken` task.
+                                let _ = NotifierRead::register(&self.notifier_read, cx.waker(), stream_id);
+                                break
+                            }
+                        }
+                        if !woken {
+                            // No task was woken, thus the current task _must_ poll
+                            // again to guarantee (an attempt at) making progress.
+                            cx.waker().clone().wake();
+                        }
+                        return Poll::Pending
+                    },
+                }
+            }
+
+            // Try to read another frame from the underlying I/O stream.
+            let waker = NotifierRead::register(&self.notifier_read, cx.waker(), stream_id);
+            let frame = match ready!(self.io.poll_next_unpin(&mut Context::from_waker(&waker))) {
+                Some(Ok(frame)) => frame,
+                Some(Err(e)) => return self.on_error(e),
+                None => return self.on_error(io::ErrorKind::UnexpectedEof.into())
+            };
+
+            trace!("Received: {:?}", frame);
+
+            // Handle Open/Close/Reset frames.
+            match frame {
+                Frame::Open { stream_id } => {
+                    let id = stream_id.into_local();
+
+                    if self.open_substreams.contains_key(&id) {
+                        debug!("Ignoring received `Open` Frame for open substream: {:?}", id);
+                        continue
+                    }
+
+                    if self.open_substreams.len() >= self.config.max_substreams {
+                        debug!("Maximum number of substreams exceeded: {}", self.config.max_substreams);
+                        if self.pending_reset.len() >= MAX_PENDING_RESETS {
+                            return self.on_error(io::Error::new(io::ErrorKind::Other,
+                                "Too many pending stream resets."))
+                        }
+                        self.pending_reset.push(stream_id.into_local());
+                        continue
+                    }
+
+                    self.open_substreams.insert(id, SubstreamState::Open);
+                }
+                Frame::Close { stream_id } => {
+                    let at_limit = self.open_substreams.len() >= self.config.max_substreams;
+                    if let Entry::Occupied(mut e) = self.open_substreams.entry(stream_id.into_local()) {
+                        match e.get() {
+                            SubstreamState::RecvClosed => {
+                                trace!("Received redundant `Close` frame.");
+                            },
+                            SubstreamState::SendClosed => {
+                                debug!("Substream closed by remote: {:?}", stream_id);
+                                e.remove();
+                                if at_limit && self.open_substreams.len() < self.config.max_substreams {
+                                    ArcWake::wake_by_ref(&self.notifier_open);
+                                }
+                            },
+                            SubstreamState::Open => {
+                                debug!("Substream half-closed by remote: {:?}", stream_id);
+                                e.insert(SubstreamState::RecvClosed);
+                            },
+                        }
+                    }
+                }
+                Frame::Reset { stream_id } => {
+                    let at_limit = self.open_substreams.len() >= self.config.max_substreams;
+                    if let Some(state) = self.open_substreams.remove(&stream_id.into_local()) {
+                        debug!("Substream {:?} in state {:?} reset by remote", stream_id, state);
+                        if at_limit && self.open_substreams.len() < self.config.max_substreams {
+                            ArcWake::wake_by_ref(&self.notifier_open);
+                        }
+                    } else {
+                        trace!("Received reset for unknown stream: {:?}", stream_id);
+                    }
+                }
+                _ => ()
+            }
+
+            if let Some(frame) = select(&frame) {
+                // The caller is interested in this frame.
+                return Poll::Ready(Ok(Some(frame)));
+            } else {
+                // The caller is not interested in this frame, so we need to buffer
+                // it and wake those tasks who are interested.
+                let id = frame.local_id();
+                if self.can_read(&id) || frame.is_open() {
+                    trace!("Buffering frame: {:?} (total: {})", frame, self.buffer.len() + 1);
+                    self.buffer.push(frame);
+                    self.notifier_read.wake_by_id(id);
+                } else if frame.is_data() {
+                    debug!("Dropping {:?} for closed or unknown substream: {:?}", frame, id);
+                }
+            }
+        }
+    }
+
+    /// Generates the next outbound stream ID.
+    fn next_outbound_stream_id(&mut self) -> LocalStreamId {
+        let id = self.next_outbound_stream_id;
+        self.next_outbound_stream_id = self.next_outbound_stream_id.next();
+        id
+    }
+
+    /// Checks whether a substream is open for reading.
+    fn can_read(&self, id: &LocalStreamId) -> bool {
+        match self.open_substreams.get(id) {
+            Some(SubstreamState::Open) | Some(SubstreamState::SendClosed) => true,
+            _ => false,
+        }
+    }
+
+    /// Sends pending `Reset` frames, without flushing.
+    fn send_pending_reset(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        while let Some(id) = self.pending_reset.pop() {
+            if self.poll_send_frame(cx, || Frame::Reset { stream_id: id })?.is_pending() {
+                self.pending_reset.push(id);
+                return Poll::Pending
+            }
+        }
+
+        Poll::Ready(Ok(()))
+    }
+
+    /// Records a fatal error for the multiplexed I/O stream.
+    fn on_error<T>(&mut self, e: io::Error) -> Poll<io::Result<T>> {
+        self.status = Status::Err(io::Error::new(e.kind(), e.to_string()));
+        self.pending_reset =  Vec::new();
+        self.open_substreams = Default::default();
+        self.buffer = Default::default();
+        Poll::Ready(Err(e))
+    }
+
+    /// Checks that the multiplexed stream has status `Ok`,
+    /// i.e. is not closed and did not encounter a fatal error.
+    fn guard_ok(&self) -> io::Result<()> {
+        match &self.status {
+            Status::Closed => Err(io::Error::new(io::ErrorKind::Other, "Connection is closed")),
+            Status::Err(e) => Err(io::Error::new(e.kind(), e.to_string())),
+            Status::Ok => Ok(())
+        }
+    }
+}
+
+/// The operating states of a substream.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum SubstreamState {
+    /// An `Open` frame has been received or sent.
+    Open,
+    /// A `Close` frame has been sent, but the stream is still open
+    /// for reading (half-close).
+    SendClosed,
+    /// A `Close` frame has been received but the stream is still
+    /// open for writing (remote half-close).
+    RecvClosed
+}
+
+struct NotifierRead {
+    /// List of wakers to wake when read operations can proceed
+    /// on a substream (or in general, for the key `None`).
+    pending: Mutex<FnvHashMap<Option<LocalStreamId>, Waker>>,
+}
+
+struct NotifierWrite {
+    /// List of wakers to wake when write operations on the
+    /// underlying I/O stream can proceed.
+    pending: Mutex<Vec<Waker>>,
+}
+
+impl NotifierWrite {
+    /// Registers interest of a task in writing to some substream.
+    ///
+    /// The returned waker should be passed to an I/O write operation
+    /// that schedules a wakeup, if necessary.
+    #[must_use]
+    fn register<'a>(self: &'a Arc<Self>, waker: &Waker) -> WakerRef<'a> {
+        let mut pending = self.pending.lock();
+        if pending.iter().all(|w| !w.will_wake(waker)) {
+            pending.push(waker.clone());
+        }
+        waker_ref(self)
+    }
+}
+
+impl ArcWake for NotifierWrite {
+    fn wake_by_ref(this: &Arc<Self>) {
+        let wakers = mem::replace(&mut *this.pending.lock(), Default::default());
+        for waker in wakers {
+            waker.wake();
+        }
+    }
+}
+
+impl NotifierRead {
+    /// Registers interest of a task in reading from a particular
+    /// stream, or any stream if `stream` is `None`.
+    ///
+    /// The returned waker should be passed to an I/O read operation
+    /// that schedules a wakeup, if necessary.
+    #[must_use]
+    fn register<'a>(self: &'a Arc<Self>, waker: &Waker, stream: Option<LocalStreamId>)
+        -> WakerRef<'a>
+    {
+        let mut pending = self.pending.lock();
+        pending.insert(stream, waker.clone());
+        waker_ref(self)
+    }
+
+    /// Wakes the last task that has previously registered interest
+    /// in reading data from a particular stream (or any stream).
+    ///
+    /// Returns `true` if a task has been woken.
+    fn wake_by_id(&self, id: LocalStreamId) -> bool {
+        let mut woken = false;
+        let mut pending = self.pending.lock();
+
+        if let Some(waker) = pending.remove(&None) {
+            waker.wake();
+            woken = true;
+        }
+
+        if let Some(waker) = pending.remove(&Some(id)) {
+            waker.wake();
+            woken = true;
+        }
+
+        woken
+    }
+}
+
+impl ArcWake for NotifierRead {
+    fn wake_by_ref(this: &Arc<Self>) {
+        let wakers = mem::replace(&mut *this.pending.lock(), Default::default());
+        for (_, waker) in wakers {
+            waker.wake();
+        }
+    }
+}
+
+struct NotifierOpen {
+    /// List of wakers to wake when a new substream can be opened.
+    pending: Mutex<Vec<Waker>>,
+}
+
+impl NotifierOpen {
+    /// Registers interest of a task in opening a new substream.
+    fn register<'a>(self: &'a Arc<Self>, waker: &Waker) -> WakerRef<'a> {
+        let mut pending = self.pending.lock();
+        if pending.iter().all(|w| !w.will_wake(waker)) {
+            pending.push(waker.clone());
+        }
+        waker_ref(self)
+    }
+}
+
+impl ArcWake for NotifierOpen {
+    fn wake_by_ref(this: &Arc<Self>) {
+        let wakers = mem::replace(&mut *this.pending.lock(), Default::default());
+        for waker in wakers {
+            waker.wake();
+        }
+    }
+}
+
+
+/// The maximum number of pending stream resets we are willing
+/// to buffer. If this limit is exceeded as a result of an
+/// inbound `Open` frame that exceeds the substream limits,
+/// the remote is too ill-behaved and the multiplexed stream
+/// terminates with an error.
+const MAX_PENDING_RESETS: usize = 1000;

--- a/muxers/mplex/src/io.rs
+++ b/muxers/mplex/src/io.rs
@@ -149,7 +149,7 @@ where
                 self.pending_frames = VecDeque::new();
                 // We do not support read-after-close on the underlying
                 // I/O stream, hence clearing the buffer and substreams.
-                self.buffer = Vec::new();
+                self.buffer = Default::default();
                 self.open_substreams = Default::default();
                 self.status = Status::Closed;
                 Poll::Ready(Ok(()))

--- a/muxers/mplex/src/io.rs
+++ b/muxers/mplex/src/io.rs
@@ -321,7 +321,7 @@ where
     /// Flushes a substream.
     ///
     /// > **Note**: This is equivalent to `poll_flush()`, i.e. to flushing
-    /// > all substreams, except that this operation is an error on if
+    /// > all substreams, except that this operation returns an error if
     /// > the underlying I/O stream is already closed.
     pub fn poll_flush_stream(&mut self, cx: &mut Context<'_>, id: LocalStreamId)
         -> Poll<io::Result<()>>
@@ -751,4 +751,3 @@ impl ArcWake for NotifierOpen {
 /// to buffer. If this limit is exceeded, the multiplexed stream is
 /// considered unhealthy and terminates with an error.
 const MAX_PENDING_FRAMES: usize = 1000;
-

--- a/muxers/mplex/src/lib.rs
+++ b/muxers/mplex/src/lib.rs
@@ -151,7 +151,7 @@ where
     }
 
     fn destroy_substream(&self, sub: Self::Substream) {
-        self.io.lock().reset_stream(sub.id);
+        self.io.lock().drop_stream(sub.id);
     }
 
     fn close(&self, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {

--- a/muxers/mplex/src/lib.rs
+++ b/muxers/mplex/src/lib.rs
@@ -19,125 +19,21 @@
 // DEALINGS IN THE SOFTWARE.
 
 mod codec;
+mod config;
+mod io;
 
-use std::{cmp, iter, mem, pin::Pin, task::Context, task::Poll};
-use std::io::{Error as IoError, ErrorKind as IoErrorKind};
-use std::sync::Arc;
-use std::task::Waker;
+pub use config::{MplexConfig, MaxBufferBehaviour};
+
+use codec::LocalStreamId;
+use std::{cmp, iter, task::Context, task::Poll};
 use bytes::Bytes;
 use libp2p_core::{
-    Endpoint,
     StreamMuxer,
     muxing::StreamMuxerEvent,
     upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo},
 };
-use log::{debug, trace};
 use parking_lot::Mutex;
-use fnv::FnvHashSet;
-use futures::{prelude::*, future, ready, stream::Fuse};
-use futures::task::{ArcWake, waker_ref};
-use futures_codec::Framed;
-
-/// Configuration for the multiplexer.
-#[derive(Debug, Clone)]
-pub struct MplexConfig {
-    /// Maximum number of simultaneously-open substreams.
-    max_substreams: usize,
-    /// Maximum number of elements in the internal buffer.
-    max_buffer_len: usize,
-    /// Behaviour when the buffer size limit is reached.
-    max_buffer_behaviour: MaxBufferBehaviour,
-    /// When sending data, split it into frames whose maximum size is this value
-    /// (max 1MByte, as per the Mplex spec).
-    split_send_size: usize,
-}
-
-impl MplexConfig {
-    /// Builds the default configuration.
-    pub fn new() -> MplexConfig {
-        Default::default()
-    }
-
-    /// Sets the maximum number of simultaneously opened substreams, after which an error is
-    /// generated and the connection closes.
-    ///
-    /// A limit is necessary in order to avoid DoS attacks.
-    pub fn max_substreams(&mut self, max: usize) -> &mut Self {
-        self.max_substreams = max;
-        self
-    }
-
-    /// Sets the maximum number of pending incoming messages.
-    ///
-    /// A limit is necessary in order to avoid DoS attacks.
-    pub fn max_buffer_len(&mut self, max: usize) -> &mut Self {
-        self.max_buffer_len = max;
-        self
-    }
-
-    /// Sets the behaviour when the maximum buffer length has been reached.
-    ///
-    /// See the documentation of `MaxBufferBehaviour`.
-    pub fn max_buffer_len_behaviour(&mut self, behaviour: MaxBufferBehaviour) -> &mut Self {
-        self.max_buffer_behaviour = behaviour;
-        self
-    }
-
-    /// Sets the frame size used when sending data. Capped at 1Mbyte as per the
-    /// Mplex spec.
-    pub fn split_send_size(&mut self, size: usize) -> &mut Self {
-        let size = cmp::min(size, codec::MAX_FRAME_SIZE);
-        self.split_send_size = size;
-        self
-    }
-
-    fn upgrade<C>(self, i: C) -> Multiplex<C>
-    where
-        C: AsyncRead + AsyncWrite + Unpin
-    {
-        let max_buffer_len = self.max_buffer_len;
-        Multiplex {
-            inner: Mutex::new(MultiplexInner {
-                error: Ok(()),
-                inner: Framed::new(i, codec::Codec::new()).fuse(),
-                config: self,
-                buffer: Vec::with_capacity(cmp::min(max_buffer_len, 512)),
-                opened_substreams: Default::default(),
-                next_outbound_stream_id: 0,
-                notifier_read: Arc::new(Notifier {
-                    to_wake: Mutex::new(Default::default()),
-                }),
-                notifier_write: Arc::new(Notifier {
-                    to_wake: Mutex::new(Default::default()),
-                }),
-                is_shutdown: false,
-            })
-        }
-    }
-}
-
-impl Default for MplexConfig {
-    fn default() -> MplexConfig {
-        MplexConfig {
-            max_substreams: 128,
-            max_buffer_len: 4096,
-            max_buffer_behaviour: MaxBufferBehaviour::CloseAll,
-            split_send_size: 1024,
-        }
-    }
-}
-
-/// Behaviour when the maximum length of the buffer is reached.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum MaxBufferBehaviour {
-    /// Produce an error on all the substreams.
-    CloseAll,
-    /// No new message will be read from the underlying connection if the buffer is full.
-    ///
-    /// This can potentially introduce a deadlock if you are waiting for a message from a substream
-    /// before processing the messages received on another substream.
-    Block,
-}
+use futures::{prelude::*, future, ready};
 
 impl UpgradeInfo for MplexConfig {
     type Info = &'static [u8];
@@ -153,11 +49,13 @@ where
     C: AsyncRead + AsyncWrite + Unpin,
 {
     type Output = Multiplex<C>;
-    type Error = IoError;
-    type Future = future::Ready<Result<Self::Output, IoError>>;
+    type Error = io::Error;
+    type Future = future::Ready<Result<Self::Output, io::Error>>;
 
     fn upgrade_inbound(self, socket: C, _: Self::Info) -> Self::Future {
-        future::ready(Ok(self.upgrade(socket)))
+        future::ready(Ok(Multiplex {
+            io: Mutex::new(io::Multiplexed::new(socket, self)),
+        }))
     }
 }
 
@@ -166,11 +64,13 @@ where
     C: AsyncRead + AsyncWrite + Unpin,
 {
     type Output = Multiplex<C>;
-    type Error = IoError;
-    type Future = future::Ready<Result<Self::Output, IoError>>;
+    type Error = io::Error;
+    type Future = future::Ready<Result<Self::Output, io::Error>>;
 
     fn upgrade_outbound(self, socket: C, _: Self::Info) -> Self::Future {
-        future::ready(Ok(self.upgrade(socket)))
+        future::ready(Ok(Multiplex {
+            io: Mutex::new(io::Multiplexed::new(socket, self))
+        }))
     }
 }
 
@@ -179,478 +79,103 @@ where
 /// This implementation isn't capable of detecting when the underlying socket changes its address,
 /// and no [`StreamMuxerEvent::AddressChange`] event is ever emitted.
 pub struct Multiplex<C> {
-    inner: Mutex<MultiplexInner<C>>,
-}
-
-// Struct shared throughout the implementation.
-struct MultiplexInner<C> {
-    // Error that happened earlier. Should poison any attempt to use this `MultiplexError`.
-    error: Result<(), IoError>,
-    // Underlying stream.
-    inner: Fuse<Framed<C, codec::Codec>>,
-    /// The original configuration.
-    config: MplexConfig,
-    // Buffer of elements pulled from the stream but not processed yet.
-    buffer: Vec<codec::Elem>,
-    // List of Ids of opened substreams. Used to filter out messages that don't belong to any
-    // substream. Note that this is handled exclusively by `next_match`.
-    // The `Endpoint` value denotes who initiated the substream from our point of view
-    // (see note [StreamId]).
-    opened_substreams: FnvHashSet<(u32, Endpoint)>,
-    // Id of the next outgoing substream.
-    next_outbound_stream_id: u32,
-    /// List of wakers to wake when a read event happens on the underlying stream.
-    notifier_read: Arc<Notifier>,
-    /// List of wakers to wake when a write event happens on the underlying stream.
-    notifier_write: Arc<Notifier>,
-    /// If true, the connection has been shut down. We need to be careful not to accidentally
-    /// call `Sink::poll_complete` or `Sink::start_send` after `Sink::close`.
-    is_shutdown: bool,
-}
-
-struct Notifier {
-    /// List of wakers to wake.
-    to_wake: Mutex<Vec<Waker>>,
-}
-
-impl Notifier {
-    fn insert(&self, waker: &Waker) {
-        let mut to_wake = self.to_wake.lock();
-        if to_wake.iter().all(|w| !w.will_wake(waker)) {
-            to_wake.push(waker.clone());
-        }
-    }
-}
-
-impl ArcWake for Notifier {
-    fn wake_by_ref(arc_self: &Arc<Self>) {
-        let wakers = mem::replace(&mut *arc_self.to_wake.lock(), Default::default());
-        for waker in wakers {
-            waker.wake();
-        }
-    }
-}
-
-// Note [StreamId]: mplex no longer partitions stream IDs into odd (for initiators) and
-// even ones (for receivers). Streams are instead identified by a number and whether the flag
-// is odd (for receivers) or even (for initiators). `Open` frames do not have a flag, but are
-// sent unidirectional. As a consequence, we need to remember if the stream was initiated by us
-// or remotely and we store the information from our point of view, i.e. receiving an `Open` frame
-// is stored as `(<u32>, Listener)`, sending an `Open` frame as `(<u32>, Dialer)`. Receiving
-// a `Data` frame with flag `MessageReceiver` (= 1) means that we initiated the stream, so the
-// entry has been stored as `(<u32>, Dialer)`. So, when looking up streams based on frames
-// received, we have to invert the `Endpoint`, except for `Open`.
-
-/// Processes elements in `inner` until one matching `filter` is found.
-///
-/// If `Pending` is returned, the waker is kept and notified later, just like with any `Poll`.
-/// `Ready(Ok())` is almost always returned. An error is returned if the stream is EOF.
-fn next_match<C, F, O>(inner: &mut MultiplexInner<C>, cx: &mut Context<'_>, mut filter: F) -> Poll<Result<O, IoError>>
-where C: AsyncRead + AsyncWrite + Unpin,
-      F: FnMut(&codec::Elem) -> Option<O>,
-{
-    // If an error happened earlier, immediately return it.
-    if let Err(ref err) = inner.error {
-        return Poll::Ready(Err(IoError::new(err.kind(), err.to_string())));
-    }
-
-    if let Some((offset, out)) = inner.buffer.iter().enumerate().filter_map(|(n, v)| filter(v).map(|v| (n, v))).next() {
-        // Found a matching entry in the existing buffer!
-
-        // The buffer was full and no longer is, so let's notify everything.
-        if inner.buffer.len() == inner.config.max_buffer_len {
-            ArcWake::wake_by_ref(&inner.notifier_read);
-        }
-
-        inner.buffer.remove(offset);
-        return Poll::Ready(Ok(out));
-    }
-
-    loop {
-        // Check if we reached max buffer length first.
-        debug_assert!(inner.buffer.len() <= inner.config.max_buffer_len);
-        if inner.buffer.len() == inner.config.max_buffer_len {
-            debug!("Reached mplex maximum buffer length");
-            match inner.config.max_buffer_behaviour {
-                MaxBufferBehaviour::CloseAll => {
-                    inner.error = Err(IoError::new(IoErrorKind::Other, "reached maximum buffer length"));
-                    return Poll::Ready(Err(IoError::new(IoErrorKind::Other, "reached maximum buffer length")));
-                },
-                MaxBufferBehaviour::Block => {
-                    inner.notifier_read.insert(cx.waker());
-                    return Poll::Pending
-                },
-            }
-        }
-
-        inner.notifier_read.insert(cx.waker());
-        let elem = match Stream::poll_next(Pin::new(&mut inner.inner), &mut Context::from_waker(&waker_ref(&inner.notifier_read))) {
-            Poll::Ready(Some(Ok(item))) => item,
-            Poll::Ready(None) => return Poll::Ready(Err(IoErrorKind::BrokenPipe.into())),
-            Poll::Pending => return Poll::Pending,
-            Poll::Ready(Some(Err(err))) => {
-                let err2 = IoError::new(err.kind(), err.to_string());
-                inner.error = Err(err);
-                return Poll::Ready(Err(err2));
-            },
-        };
-
-        trace!("Received message: {:?}", elem);
-
-        // Handle substreams opening/closing.
-        match elem {
-            codec::Elem::Open { substream_id } => {
-                if !inner.opened_substreams.insert((substream_id, Endpoint::Listener)) {
-                    debug!("Received open message for substream {} which was already open", substream_id)
-                }
-            }
-            codec::Elem::Close { substream_id, endpoint, .. } | codec::Elem::Reset { substream_id, endpoint, .. } => {
-                inner.opened_substreams.remove(&(substream_id, !endpoint));
-            }
-            _ => ()
-        }
-
-        if let Some(out) = filter(&elem) {
-            return Poll::Ready(Ok(out));
-        } else {
-            let endpoint = elem.endpoint().unwrap_or(Endpoint::Dialer);
-            if inner.opened_substreams.contains(&(elem.substream_id(), !endpoint)) || elem.is_open_msg() {
-                inner.buffer.push(elem);
-            } else if !elem.is_close_or_reset_msg() {
-                debug!("Ignored message {:?} because the substream wasn't open", elem);
-            }
-        }
-    }
-}
-
-// Small convenience function that tries to write `elem` to the stream.
-fn poll_send<C>(inner: &mut MultiplexInner<C>, cx: &mut Context<'_>, elem: codec::Elem) -> Poll<Result<(), IoError>>
-where C: AsyncRead + AsyncWrite + Unpin
-{
-    ensure_no_error_no_close(inner)?;
-
-    inner.notifier_write.insert(cx.waker());
-
-    match Sink::poll_ready(Pin::new(&mut inner.inner), &mut Context::from_waker(&waker_ref(&inner.notifier_write))) {
-        Poll::Ready(Ok(())) => {
-            match Sink::start_send(Pin::new(&mut inner.inner), elem) {
-                Ok(()) => Poll::Ready(Ok(())),
-                Err(err) => Poll::Ready(Err(err))
-            }
-        },
-        Poll::Pending => Poll::Pending,
-        Poll::Ready(Err(err)) => {
-            inner.error = Err(IoError::new(err.kind(), err.to_string()));
-            Poll::Ready(Err(err))
-        }
-    }
-}
-
-fn ensure_no_error_no_close<C>(inner: &mut MultiplexInner<C>) -> Result<(), IoError>
-where
-    C: AsyncRead + AsyncWrite + Unpin
-{
-    if inner.is_shutdown {
-        return Err(IoError::new(IoErrorKind::Other, "connection is shut down"))
-    }
-    if let Err(ref e) = inner.error {
-        return Err(IoError::new(e.kind(), e.to_string()))
-    }
-    Ok(())
+    io: Mutex<io::Multiplexed<C>>
 }
 
 impl<C> StreamMuxer for Multiplex<C>
-where C: AsyncRead + AsyncWrite + Unpin
+where
+    C: AsyncRead + AsyncWrite + Unpin
 {
     type Substream = Substream;
     type OutboundSubstream = OutboundSubstream;
-    type Error = IoError;
+    type Error = io::Error;
 
-    fn poll_event(&self, cx: &mut Context<'_>) -> Poll<Result<StreamMuxerEvent<Self::Substream>, IoError>> {
-        let mut inner = self.inner.lock();
-
-        if inner.opened_substreams.len() >= inner.config.max_substreams {
-            debug!("Refused substream; reached maximum number of substreams {}", inner.config.max_substreams);
-            return Poll::Ready(Err(IoError::new(IoErrorKind::ConnectionRefused,
-                                    "exceeded maximum number of open substreams")));
-        }
-
-        let num = ready!(next_match(&mut inner, cx, |elem| {
-            match elem {
-                codec::Elem::Open { substream_id } => Some(*substream_id),
-                _ => None,
-            }
-        }));
-
-        let num = match num {
-            Ok(n) => n,
-            Err(err) => return Poll::Ready(Err(err)),
-        };
-
-        debug!("Successfully opened inbound substream {}", num);
-        Poll::Ready(Ok(StreamMuxerEvent::InboundSubstream(Substream {
-            current_data: Bytes::new(),
-            num,
-            endpoint: Endpoint::Listener,
-            local_open: true,
-            remote_open: true,
-        })))
+    fn poll_event(&self, cx: &mut Context<'_>)
+        -> Poll<io::Result<StreamMuxerEvent<Self::Substream>>>
+    {
+        let stream_id = ready!(self.io.lock().poll_next_stream(cx))?;
+        let stream = Substream::new(stream_id);
+        Poll::Ready(Ok(StreamMuxerEvent::InboundSubstream(stream)))
     }
 
     fn open_outbound(&self) -> Self::OutboundSubstream {
-        let mut inner = self.inner.lock();
-
-        // Assign a substream ID now.
-        let substream_id = {
-            let n = inner.next_outbound_stream_id;
-            inner.next_outbound_stream_id = inner.next_outbound_stream_id.checked_add(1)
-                .expect("Mplex substream ID overflowed");
-            n
-        };
-
-        inner.opened_substreams.insert((substream_id, Endpoint::Dialer));
-
-        OutboundSubstream {
-            num: substream_id,
-            state: OutboundSubstreamState::SendElem(codec::Elem::Open { substream_id }),
-        }
+        OutboundSubstream {}
     }
 
-    fn poll_outbound(&self, cx: &mut Context<'_>, substream: &mut Self::OutboundSubstream) -> Poll<Result<Self::Substream, IoError>> {
-        loop {
-            let mut inner = self.inner.lock();
-
-            let polling = match substream.state {
-                OutboundSubstreamState::SendElem(ref elem) => {
-                    poll_send(&mut inner, cx, elem.clone())
-                },
-                OutboundSubstreamState::Flush => {
-                    ensure_no_error_no_close(&mut inner)?;
-                    let inner = &mut *inner; // Avoids borrow errors
-                    inner.notifier_write.insert(cx.waker());
-                    Sink::poll_flush(Pin::new(&mut inner.inner), &mut Context::from_waker(&waker_ref(&inner.notifier_write)))
-                },
-                OutboundSubstreamState::Done => {
-                    panic!("Polling outbound substream after it's been succesfully open");
-                },
-            };
-
-            match polling {
-                Poll::Ready(Ok(())) => (),
-                Poll::Pending => return Poll::Pending,
-                Poll::Ready(Err(err)) => {
-                    debug!("Failed to open outbound substream {}", substream.num);
-                    inner.buffer.retain(|elem| {
-                        elem.substream_id() != substream.num || elem.endpoint() == Some(Endpoint::Dialer)
-                    });
-                    inner.error = Err(IoError::new(err.kind(), err.to_string()));
-                    return Poll::Ready(Err(err));
-                },
-            };
-
-            drop(inner);
-
-            // Going to next step.
-            match substream.state {
-                OutboundSubstreamState::SendElem(_) => {
-                    substream.state = OutboundSubstreamState::Flush;
-                },
-                OutboundSubstreamState::Flush => {
-                    debug!("Successfully opened outbound substream {}", substream.num);
-                    substream.state = OutboundSubstreamState::Done;
-                    return Poll::Ready(Ok(Substream {
-                        num: substream.num,
-                        current_data: Bytes::new(),
-                        endpoint: Endpoint::Dialer,
-                        local_open: true,
-                        remote_open: true,
-                    }));
-                },
-                OutboundSubstreamState::Done => unreachable!(),
-            }
-        }
+    fn poll_outbound(&self, cx: &mut Context<'_>, _: &mut Self::OutboundSubstream)
+        -> Poll<Result<Self::Substream, io::Error>>
+    {
+        let stream_id = ready!(self.io.lock().poll_open_stream(cx))?;
+        return Poll::Ready(Ok(Substream::new(stream_id)))
     }
 
     fn destroy_outbound(&self, _substream: Self::OutboundSubstream) {
-        // Nothing to do.
+        // Nothing to do, since `open_outbound` creates no new local state.
     }
 
-    fn read_substream(&self, cx: &mut Context<'_>, substream: &mut Self::Substream, buf: &mut [u8]) -> Poll<Result<usize, IoError>> {
+    fn read_substream(&self, cx: &mut Context<'_>, substream: &mut Self::Substream, buf: &mut [u8])
+        -> Poll<Result<usize, io::Error>>
+    {
         loop {
-            // First, transfer from `current_data`.
+            // Try to read from the current (i.e. last received) frame.
             if !substream.current_data.is_empty() {
                 let len = cmp::min(substream.current_data.len(), buf.len());
                 buf[..len].copy_from_slice(&substream.current_data.split_to(len));
                 return Poll::Ready(Ok(len));
             }
 
-            // If the remote writing side is closed, return EOF.
-            if !substream.remote_open {
-                return Poll::Ready(Ok(0));
-            }
-
-            // Try to find a packet of data in the buffer.
-            let mut inner = self.inner.lock();
-            let next_data_poll = next_match(&mut inner, cx, |elem| {
-                match elem {
-                    codec::Elem::Data { substream_id, endpoint, data, .. }
-                        if *substream_id == substream.num && *endpoint != substream.endpoint => // see note [StreamId]
-                    {
-                        Some(Some(data.clone()))
-                    }
-                    codec::Elem::Close { substream_id, endpoint }
-                        if *substream_id == substream.num && *endpoint != substream.endpoint => // see note [StreamId]
-                    {
-                        Some(None)
-                    }
-                    _ => None
-                }
-            });
-
-            // We're in a loop, so all we need to do is set `substream.current_data` to the data we
-            // just read and wait for the next iteration.
-            match next_data_poll {
-                Poll::Ready(Ok(Some(data))) => substream.current_data = data,
-                Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
-                Poll::Ready(Ok(None)) => {
-                    substream.remote_open = false;
-                    return Poll::Ready(Ok(0));
-                },
-                Poll::Pending => {
-                    // There was no data packet in the buffer about this substream; maybe it's
-                    // because it has been closed.
-                    if inner.opened_substreams.contains(&(substream.num, substream.endpoint)) {
-                        return Poll::Pending
-                    } else {
-                        return Poll::Ready(Ok(0))
-                    }
-                },
+            // Read the next data frame from the multiplexed stream.
+            match ready!(self.io.lock().poll_read_stream(cx, substream.id))? {
+                Some(data) => { substream.current_data = data; }
+                None => { return Poll::Ready(Ok(0)) }
             }
         }
     }
 
-    fn write_substream(&self, cx: &mut Context<'_>, substream: &mut Self::Substream, buf: &[u8]) -> Poll<Result<usize, IoError>> {
-        if !substream.local_open {
-            return Poll::Ready(Err(IoErrorKind::BrokenPipe.into()));
-        }
-
-        let mut inner = self.inner.lock();
-
-        let to_write = cmp::min(buf.len(), inner.config.split_send_size);
-
-        let elem = codec::Elem::Data {
-            substream_id: substream.num,
-            data: Bytes::copy_from_slice(&buf[..to_write]),
-            endpoint: substream.endpoint,
-        };
-
-        match poll_send(&mut inner, cx, elem) {
-            Poll::Ready(Ok(())) => Poll::Ready(Ok(to_write)),
-            Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
-            Poll::Pending => Poll::Pending,
-        }
+    fn write_substream(&self, cx: &mut Context<'_>, substream: &mut Self::Substream, buf: &[u8])
+        -> Poll<Result<usize, io::Error>>
+    {
+        self.io.lock().poll_write_stream(cx, substream.id, buf)
     }
 
-    fn flush_substream(&self, cx: &mut Context<'_>, _substream: &mut Self::Substream) -> Poll<Result<(), IoError>> {
-        let mut inner = self.inner.lock();
-        ensure_no_error_no_close(&mut inner)?;
-        let inner = &mut *inner; // Avoids borrow errors
-        inner.notifier_write.insert(cx.waker());
-        let result = Sink::poll_flush(Pin::new(&mut inner.inner), &mut Context::from_waker(&waker_ref(&inner.notifier_write)));
-        if let Poll::Ready(Err(err)) = &result {
-            inner.error = Err(IoError::new(err.kind(), err.to_string()));
-        }
-        result
+    fn flush_substream(&self, cx: &mut Context<'_>, substream: &mut Self::Substream)
+        -> Poll<Result<(), io::Error>>
+    {
+        self.io.lock().poll_flush_stream(cx, substream.id)
     }
 
-    fn shutdown_substream(&self, cx: &mut Context<'_>, sub: &mut Self::Substream) -> Poll<Result<(), IoError>> {
-        if !sub.local_open {
-            return Poll::Ready(Ok(()));
-        }
-
-        let elem = codec::Elem::Close {
-            substream_id: sub.num,
-            endpoint: sub.endpoint,
-        };
-
-        let mut inner = self.inner.lock();
-        let result = poll_send(&mut inner, cx, elem);
-        if let Poll::Ready(Ok(())) = result {
-            sub.local_open = false;
-        }
-        result
+    fn shutdown_substream(&self, cx: &mut Context<'_>, substream: &mut Self::Substream)
+        -> Poll<Result<(), io::Error>>
+    {
+        self.io.lock().poll_close_stream(cx, substream.id)
     }
 
     fn destroy_substream(&self, sub: Self::Substream) {
-        self.inner.lock().buffer.retain(|elem| {
-            elem.substream_id() != sub.num || elem.endpoint() == Some(sub.endpoint)
-        })
+        self.io.lock().reset_stream(sub.id);
     }
 
-    fn close(&self, cx: &mut Context<'_>) -> Poll<Result<(), IoError>> {
-        let inner = &mut *self.inner.lock();
-        if inner.is_shutdown {
-            return Poll::Ready(Ok(()))
-        }
-        if let Err(ref e) = inner.error {
-            return Poll::Ready(Err(IoError::new(e.kind(), e.to_string())))
-        }
-        inner.notifier_write.insert(cx.waker());
-        match Sink::poll_close(Pin::new(&mut inner.inner), &mut Context::from_waker(&waker_ref(&inner.notifier_write))) {
-            Poll::Ready(Ok(())) => {
-                inner.is_shutdown = true;
-                Poll::Ready(Ok(()))
-            }
-            Poll::Ready(Err(err)) => {
-                inner.error = Err(IoError::new(err.kind(), err.to_string()));
-                Poll::Ready(Err(err))
-            }
-            Poll::Pending => Poll::Pending,
-        }
+    fn close(&self, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.io.lock().poll_close(cx)
     }
 
-    fn flush_all(&self, cx: &mut Context<'_>) -> Poll<Result<(), IoError>> {
-        let inner = &mut *self.inner.lock();
-        if inner.is_shutdown {
-            return Poll::Ready(Ok(()))
-        }
-        if let Err(ref e) = inner.error {
-            return Poll::Ready(Err(IoError::new(e.kind(), e.to_string())))
-        }
-        inner.notifier_write.insert(cx.waker());
-        let result = Sink::poll_flush(Pin::new(&mut inner.inner), &mut Context::from_waker(&waker_ref(&inner.notifier_write)));
-        if let Poll::Ready(Err(err)) = &result {
-            inner.error = Err(IoError::new(err.kind(), err.to_string()));
-        }
-        result
+    fn flush_all(&self, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.io.lock().poll_flush(cx)
     }
 }
 
 /// Active attempt to open an outbound substream.
-pub struct OutboundSubstream {
-    /// Substream number.
-    num: u32,
-    state: OutboundSubstreamState,
-}
-
-enum OutboundSubstreamState {
-    /// We need to send `Elem` on the underlying stream.
-    SendElem(codec::Elem),
-    /// We need to flush the underlying stream.
-    Flush,
-    /// The substream is open and the `OutboundSubstream` is now useless.
-    Done,
-}
+pub struct OutboundSubstream {}
 
 /// Active substream to the remote.
 pub struct Substream {
-    /// Substream number.
-    num: u32,
-    // Read buffer. Contains data read from `inner` but not yet dispatched by a call to `read()`.
+    /// The unique, local identifier of the substream.
+    id: LocalStreamId,
+    /// The current data frame the substream is reading from.
     current_data: Bytes,
-    endpoint: Endpoint,
-    /// If true, our writing side is still open.
-    local_open: bool,
-    /// If true, the remote writing side is still open.
-    remote_open: bool,
+}
+
+impl Substream {
+    fn new(id: LocalStreamId) -> Self {
+        Self { id, current_data: Bytes::new() }
+    }
 }


### PR DESCRIPTION
## Overview

This is a rather substantial refactoring of `libp2p-mplex`, though the control-flow skeleton remains the same, as dictated by the `StreamMuxer` API. In the context of looking into https://github.com/libp2p/rust-libp2p/issues/1758, besides a bug in `libp2p-ping` that only occurs with mplex and for which I will open a separate PR, the following two problems in `libp2p-mplex` became apparent and are intended to be addressed here:

  * Avoid stalls caused by a read operation on one substream reading (and buffering) frames for another substream without
    notifying the corresponding task. While testing https://github.com/libp2p/rust-libp2p/issues/1758, even when the `ping_pong` tests ran through, there were occasional stalls in between. It turned out that, when a read operation for one substream buffers frames for another, the corresponding task that may be waiting on these buffered frames is not notified. This led to situations in the `ping_pong` test where both sides sent each other the outbound ping simultaneously, each on its own substream, and after the read operations for the inbound substreams returned `Pending`, the read operation for the outbound substreams waiting for the responses would read and buffer the inbound ping of the remote for the other substream and, not finding any frames for themselves yet, again returning `Pending` without waking up the task(s) interested in the newly buffered frame(s). Only the ping timeout triggered the polling again. To avoid needless polling of the same task, it seemed necessary to me that read-interest for substreams is tracked for the particular substream IDs, instead of "globally".

  * Remove dropped substreams from the tracked set of open substreams, to avoid artificially running into substream limits.

> This PR alone is necessary but not sufficient to r-e-s-o-l-v-e https://github.com/libp2p/rust-libp2p/issues/1758, since there is also a small bug in `libp2p-ping` when used in combination with `libp2p-mplex`. This bug will receive a separate, follow-up PR.

## Related Context

Both of the above problems probably relate to https://github.com/libp2p/rust-libp2p/issues/1629 and https://github.com/libp2p/rust-libp2p/issues/1504 which report mplex symptoms that seem highly related (hitting unexpected substream limits and intermittent stalls). Though the latter is closed because panics were fixed, the problem with unexpectedly hitting the substream limit remained unsolved there, I think.

## Other Changes

While I was at it, I also went ahead with https://github.com/libp2p/rust-libp2p/issues/313 and thus another change here is:

  * Schedule sending of a `Reset` frame when an open substream gets dropped.

Furthermore, the semantics of the `max_substreams` configuration changed as follows:

  * Old behaviour: The connection is immediately closed with an error, regardless of whether the limit is reached by an attempt to open an outbound substream or by a new inbound substream.
  * New behaviour: Outbound substream attempts beyond the configured limit are delayed (`Poll::Pending`) with a wakeup once an existing substream closes, i.e. the limit results in back-pressure for new outbound substreams. New inbound substreams beyond the limit are immediately answered with a `Reset`, again a form of back-pressure. If too many (by some internal threshold) pending `Reset` frames accumulate, e.g. as a result of an aggressive number of inbound substreams being opened beyond the configured limit, the connection is closed ("DoS protection").

## Testing

While the multiplexers themselves still need more testing, also compatibility testing (https://github.com/libp2p/rust-libp2p/issues/508), and ideally comparative performance testing, I have so far done the following (besides passing the libp2p test suite where mplex is often used, of course):

  * A follow-up PR for `libp2p-ping` that fixes a small bug and depends on this PR will randomise the choice of multiplexer used for integration tests, expecting the same behaviour. This kind of testing essentially revealed all the issues mentioned here as a result of looking into https://github.com/libp2p/rust-libp2p/issues/1758.
  * A subtrate node seems to start and sync fine, configured only with mplex and using this branch.