### PR TITLE
[ping] Add missing flush after write.

### DIFF
--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.22.1 [unreleased]
+
+- Ensure the outbound ping is flushed before awaiting
+  the response. Otherwise the behaviour depends on
+  implementation details of the stream muxer used.
+  The current behaviour resulted in stalls with Mplex.
+
 # 0.22.0 [2020-09-09]
 
 - Update `libp2p-swarm` and `libp2p-core`.

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-ping"
 edition = "2018"
 description = "Ping protocol for libp2p"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -23,4 +23,5 @@ async-std = "1.6.2"
 libp2p-tcp = { path = "../../transports/tcp", features = ["async-std"] }
 libp2p-noise = { path = "../../protocols/noise" }
 libp2p-yamux = { path = "../../muxers/yamux" }
+libp2p-mplex = { path = "../../muxers/mplex" }
 quickcheck = "0.9.0"

--- a/protocols/ping/src/protocol.rs
+++ b/protocols/ping/src/protocol.rs
@@ -87,8 +87,10 @@ where
     let payload: [u8; PING_SIZE] = thread_rng().sample(distributions::Standard);
     log::debug!("Preparing ping payload {:?}", payload);
     stream.write_all(&payload).await?;
+    stream.flush().await?;
     let started = Instant::now();
     let mut recv_payload = [0u8; PING_SIZE];
+    log::debug!("Awaiting pong for {:?}", payload);
     stream.read_exact(&mut recv_payload).await?;
     if recv_payload == payload {
         Ok((stream, started.elapsed()))
@@ -103,7 +105,9 @@ where
     S: AsyncRead + AsyncWrite + Unpin
 {
     let mut payload = [0u8; PING_SIZE];
+    log::debug!("Waiting for ping ...");
     stream.read_exact(&mut payload).await?;
+    log::debug!("Sending pong for {:?}", payload);
     stream.write_all(&payload).await?;
     stream.flush().await?;
     Ok(stream)


### PR DESCRIPTION
After sending the ping and before awaiting the pong, the stream must be flushed to guarantee the data is sent before awaiting the reply. This is not necessary with `libp2p-yamux` where every sent frame is flushed, but with mplex it may remain sitting in a buffer otherwise. This problem was revealed by https://github.com/libp2p/rust-libp2p/issues/1758 together with some other mplex issues addressed in https://github.com/libp2p/rust-libp2p/pull/1769. This PR is on top of #1769 since the tests randomise usage of mplex and yamux and only pass consistently with these patches. For a proper diff (it is small), see [here](https://github.com/romanb/rust-libp2p/compare/patch-mplex...romanb:ping-mplex).

Together with #1769, closes #1758.