### PR TITLE
swarm/src/protocols_handler: Use FuturesUnordered in NodeHandlerWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 # Version 0.29.0 [unreleased]
 
 - Update `libp2p-core`, `libp2p-floodsub`, `libp2p-gossipsub`, `libp2p-mplex`,
-  `libp2p-noise`, `libp2p-plaintext`, `libp2p-request-response`,
+  `libp2p-noise`, `libp2p-plaintext`, `libp2p-request-response`, `libp2p-swarm`,
   `libp2p-websocket` and `parity-multiaddr`.
 
 # Version 0.28.1 [2020-09-10]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ libp2p-ping = { version = "0.22.0", path = "protocols/ping", optional = true }
 libp2p-plaintext = { version = "0.23.0", path = "protocols/plaintext", optional = true }
 libp2p-pnet = { version = "0.19.1", path = "protocols/pnet", optional = true }
 libp2p-request-response = { version = "0.4.0", path = "protocols/request-response", optional = true }
-libp2p-swarm = { version = "0.22.0", path = "swarm" }
+libp2p-swarm = { version = "0.23.0", path = "swarm" }
 libp2p-uds = { version = "0.22.0", path = "transports/uds", optional = true }
 libp2p-wasm-ext = { version = "0.22.0", path = "transports/wasm-ext", optional = true }
 libp2p-yamux = { version = "0.25.0", path = "muxers/yamux", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ libp2p-ping = { version = "0.22.0", path = "protocols/ping", optional = true }
 libp2p-plaintext = { version = "0.23.0", path = "protocols/plaintext", optional = true }
 libp2p-pnet = { version = "0.19.2", path = "protocols/pnet", optional = true }
 libp2p-request-response = { version = "0.4.0", path = "protocols/request-response", optional = true }
-libp2p-swarm = { version = "0.23.0", path = "swarm" }
+libp2p-swarm = { version = "0.22.1", path = "swarm" }
 libp2p-uds = { version = "0.22.0", path = "transports/uds", optional = true }
 libp2p-wasm-ext = { version = "0.22.0", path = "transports/wasm-ext", optional = true }
 libp2p-yamux = { version = "0.25.0", path = "muxers/yamux", optional = true }

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.22.1 [unreleased]
 
 - Instead of iterating each inbound and outbound substream upgrade looking for
   one to make progress, use a `FuturesUnordered` for both pending inbound and

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.23.0 [unreleased]
+
+- Instead of iterating each inbound and outbound substream upgrade looking for
+  one to make progress, use a `FuturesUnordered` for both pending inbound and
+  pending outbound upgrades. As a result only those upgrades are polled that are
+  ready to progress.
+
+  Implementors of `InboundUpgrade` and `OutboundUpgrade` need to ensure to wake
+  up the underlying task once they are ready to make progress as they won't be
+  polled otherwise.
+
+  [PR 1775](https://github.com/libp2p/rust-libp2p/pull/1775)
+
 # 0.22.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-swarm"
 edition = "2018"
 description = "The libp2p swarm"
-version = "0.23.0"
+version = "0.22.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-swarm"
 edition = "2018"
 description = "The libp2p swarm"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
> Futures managed by FuturesUnordered will only be polled when they
generate wake-up notifications. This reduces the required amount of work
needed to poll large numbers of futures.

https://docs.rs/futures/0.3.5/futures/stream/struct.FuturesUnordered.html

Instead of iterating each inbound and outbound upgrade looking for one
to make progress, use a `FuturesUnordered` for both pending inbound and
pending outbound upgrades. As a result only those upgrades are polled
that are ready to progress.