### PR TITLE
[multistream-select] Fix panic with `V1Lazy` (regression) and more convenient transport boxing.

### DIFF
--- a/misc/multistream-select/CHANGELOG.md
+++ b/misc/multistream-select/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 0.8.3 [unreleased]
 
+- Fix a regression resulting in a panic with the `V1Lazy` protocol.
+  [PR 1783](https://github.com/libp2p/rust-libp2p/pull/1783).
+
 - Fix a potential deadlock during protocol negotiation due
   to a missing flush, potentially resulting in sporadic protocol
   upgrade timeouts.

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -19,6 +19,10 @@ unsigned-varint = "0.5"
 
 [dev-dependencies]
 async-std = "1.6.2"
+env_logger = "*"
+libp2p-core = { path = "../../core" }
+libp2p-mplex = { path = "../../muxers/mplex" }
+libp2p-plaintext = { path = "../../protocols/plaintext" }
 quickcheck = "0.9.0"
 rand = "0.7.2"
 rw-stream-sink = "0.2.1"

--- a/misc/multistream-select/src/negotiated.rs
+++ b/misc/multistream-select/src/negotiated.rs
@@ -127,6 +127,7 @@ impl<TInner> Negotiated<TInner> {
 
                     if let Message::Header(v) = &msg {
                         if *v == version {
+                            *this.state = State::Expecting { io, protocol, version };
                             continue
                         }
                     }

--- a/misc/multistream-select/tests/transport.rs
+++ b/misc/multistream-select/tests/transport.rs
@@ -1,0 +1,136 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use libp2p_core::{
+    connection::{ConnectionHandler, ConnectionHandlerEvent, Substream, SubstreamEndpoint},
+    identity,
+    muxing::StreamMuxerBox,
+    upgrade,
+    multiaddr::Protocol,
+    Multiaddr,
+    Network,
+    network::{NetworkEvent, NetworkConfig},
+    PeerId,
+    Transport,
+    transport::{self, MemoryTransport}
+};
+use libp2p_mplex::MplexConfig;
+use libp2p_plaintext::PlainText2Config;
+use futures::{channel::oneshot, ready, prelude::*};
+use rand::random;
+use std::{io, task::{Context, Poll}};
+
+type TestTransport = transport::Boxed<(PeerId, StreamMuxerBox), io::Error>;
+type TestNetwork = Network<TestTransport, (), (), TestHandler>;
+
+fn mk_transport(up: upgrade::Version) -> (PeerId, TestTransport) {
+    let keys = identity::Keypair::generate_ed25519();
+    let id = keys.public().into_peer_id();
+    (id, MemoryTransport::default()
+        .upgrade(up)
+        .authenticate(PlainText2Config { local_public_key: keys.public() })
+        .multiplex(MplexConfig::default())
+        .boxed())
+}
+
+/// Tests the transport upgrade process with all supported
+/// upgrade protocol versions.
+#[test]
+fn transport_upgrade() {
+    let _ = env_logger::try_init();
+
+    fn run(up: upgrade::Version) {
+        let (dialer_id, dialer_transport) = mk_transport(up);
+        let (listener_id, listener_transport) = mk_transport(up);
+
+        let listen_addr = Multiaddr::from(Protocol::Memory(random::<u64>()));
+
+        let mut dialer = TestNetwork::new(dialer_transport, dialer_id, NetworkConfig::default());
+        let mut listener = TestNetwork::new(listener_transport, listener_id, NetworkConfig::default());
+
+        listener.listen_on(listen_addr).unwrap();
+        let (addr_sender, addr_receiver) = oneshot::channel();
+
+        let client = async move {
+            let addr = addr_receiver.await.unwrap();
+            dialer.dial(&addr, TestHandler()).unwrap();
+            futures::future::poll_fn(move |cx| {
+                loop {
+                    match ready!(dialer.poll(cx)) {
+                        NetworkEvent::ConnectionEstablished { .. } => {
+                            return Poll::Ready(())
+                        }
+                        _ => {}
+                    }
+                }
+            }).await
+        };
+
+        let mut addr_sender = Some(addr_sender);
+        let server = futures::future::poll_fn(move |cx| {
+            loop {
+                match ready!(listener.poll(cx)) {
+                    NetworkEvent::NewListenerAddress { listen_addr, .. } => {
+                        addr_sender.take().unwrap().send(listen_addr).unwrap();
+                    }
+                    NetworkEvent::IncomingConnection { connection, .. } => {
+                        listener.accept(connection, TestHandler()).unwrap();
+                    }
+                    NetworkEvent::ConnectionEstablished { .. } => {
+                        return Poll::Ready(())
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        async_std::task::block_on(future::select(Box::pin(server), Box::pin(client)));
+    }
+
+    run(upgrade::Version::V1);
+    run(upgrade::Version::V1Lazy);
+}
+
+struct TestHandler();
+
+impl ConnectionHandler for TestHandler {
+    type InEvent = ();
+    type OutEvent = ();
+    type Error = io::Error;
+    type Substream = Substream<StreamMuxerBox>;
+    type OutboundOpenInfo = ();
+
+    fn inject_substream(&mut self, _: Self::Substream, _: SubstreamEndpoint<Self::OutboundOpenInfo>)
+    {}
+
+    fn inject_event(&mut self, _: Self::InEvent)
+    {}
+
+    fn inject_address_change(&mut self, _: &Multiaddr)
+    {}
+
+    fn poll(&mut self, _: &mut Context<'_>)
+        -> Poll<Result<ConnectionHandlerEvent<Self::OutboundOpenInfo, Self::OutEvent>, Self::Error>>
+    {
+        Poll::Pending
+        // Poll::Ready(Ok(ConnectionHandlerEvent::Custom(())))
+    }
+}
+

--- a/misc/multistream-select/tests/transport.rs
+++ b/misc/multistream-select/tests/transport.rs
@@ -130,7 +130,5 @@ impl ConnectionHandler for TestHandler {
         -> Poll<Result<ConnectionHandlerEvent<Self::OutboundOpenInfo, Self::OutEvent>, Self::Error>>
     {
         Poll::Pending
-        // Poll::Ready(Ok(ConnectionHandlerEvent::Custom(())))
     }
 }
-

--- a/protocols/gossipsub/tests/smoke.rs
+++ b/protocols/gossipsub/tests/smoke.rs
@@ -23,14 +23,13 @@ use log::debug;
 use quickcheck::{QuickCheck, TestResult};
 use rand::{random, seq::SliceRandom, SeedableRng};
 use std::{
-    io::Error,
     pin::Pin,
     task::{Context, Poll},
     time::Duration,
 };
 
 use libp2p_core::{
-    identity, multiaddr::Protocol, muxing::StreamMuxerBox, transport::MemoryTransport, upgrade,
+    identity, multiaddr::Protocol, transport::MemoryTransport, upgrade,
     Multiaddr, Transport,
 };
 use libp2p_gossipsub::{
@@ -151,10 +150,7 @@ fn build_node() -> (Multiaddr, Swarm<Gossipsub>) {
         .authenticate(PlainText2Config {
             local_public_key: public_key.clone(),
         })
-        .multiplex(yamux::Config::default())
-        .map(|(p, m), _| (p, StreamMuxerBox::new(m)))
-        .map_err(|e| -> Error { panic!("Failed to create transport: {:?}", e) })
-        .boxed();
+        .multiplex(yamux::Config::default());
 
     let peer_id = public_key.clone().into_peer_id();
 

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -38,7 +38,6 @@ use libp2p_core::{
     identity,
     transport::MemoryTransport,
     multiaddr::{Protocol, Multiaddr, multiaddr},
-    muxing::StreamMuxerBox,
     upgrade
 };
 use libp2p_noise as noise;
@@ -46,7 +45,7 @@ use libp2p_swarm::Swarm;
 use libp2p_yamux as yamux;
 use quickcheck::*;
 use rand::{Rng, random, thread_rng, rngs::StdRng, SeedableRng};
-use std::{collections::{HashSet, HashMap}, time::Duration, io, num::NonZeroUsize, u64};
+use std::{collections::{HashSet, HashMap}, time::Duration, num::NonZeroUsize, u64};
 use multihash::{wrap, Code, Multihash};
 
 type TestSwarm = Swarm<Kademlia<MemoryStore>>;
@@ -62,10 +61,7 @@ fn build_node_with_config(cfg: KademliaConfig) -> (Multiaddr, TestSwarm) {
     let transport = MemoryTransport::default()
         .upgrade(upgrade::Version::V1)
         .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
-        .multiplex(yamux::Config::default())
-        .map(|(p, m), _| (p, StreamMuxerBox::new(m)))
-        .map_err(|e| -> io::Error { panic!("Failed to create transport: {:?}", e); })
-        .boxed();
+        .multiplex(yamux::Config::default());
 
     let local_id = local_public_key.clone().into_peer_id();
     let store = MemoryStore::new(local_id.clone());

--- a/protocols/ping/tests/ping.rs
+++ b/protocols/ping/tests/ping.rs
@@ -25,7 +25,7 @@ use libp2p_core::{
     PeerId,
     identity,
     muxing::StreamMuxerBox,
-    transport::{Transport, boxed::Boxed},
+    transport::{self, Transport},
     upgrade
 };
 use libp2p_mplex as mplex;
@@ -196,7 +196,7 @@ fn max_failures() {
 
 fn mk_transport(muxer: MuxerChoice) -> (
     PeerId,
-    Boxed<
+    transport::Boxed<
         (PeerId, StreamMuxerBox),
         io::Error
     >
@@ -204,8 +204,7 @@ fn mk_transport(muxer: MuxerChoice) -> (
     let id_keys = identity::Keypair::generate_ed25519();
     let peer_id = id_keys.public().into_peer_id();
     let noise_keys = noise::Keypair::<noise::X25519Spec>::new().into_authentic(&id_keys).unwrap();
-
-    let transport = TcpConfig::new()
+    (peer_id, TcpConfig::new()
         .nodelay(true)
         .upgrade(upgrade::Version::V1)
         .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
@@ -215,11 +214,7 @@ fn mk_transport(muxer: MuxerChoice) -> (
             MuxerChoice::Mplex =>
                 upgrade::EitherUpgrade::B(mplex::MplexConfig::default()),
         })
-        .map(|(peer, muxer), _| (peer, StreamMuxerBox::new(muxer)))
-        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
-        .boxed();
-
-    (peer_id, transport)
+        .boxed())
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,8 +303,8 @@ pub fn build_tcp_ws_noise_mplex_yamux(keypair: identity::Keypair)
         .upgrade(core::upgrade::Version::V1)
         .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
         .multiplex(core::upgrade::SelectUpgrade::new(yamux::Config::default(), mplex::MplexConfig::new()))
-        .map(|(peer, muxer), _| (peer, core::muxing::StreamMuxerBox::new(muxer)))
-        .timeout(std::time::Duration::from_secs(20)))
+        .timeout(std::time::Duration::from_secs(20))
+        .boxed())
 }
 
 /// Builds an implementation of `Transport` that is suitable for usage with the `Swarm`.
@@ -335,6 +335,6 @@ pub fn build_tcp_ws_pnet_noise_mplex_yamux(keypair: identity::Keypair, psk: PreS
         .upgrade(core::upgrade::Version::V1)
         .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
         .multiplex(core::upgrade::SelectUpgrade::new(yamux::Config::default(), mplex::MplexConfig::new()))
-        .map(|(peer, muxer), _| (peer, core::muxing::StreamMuxerBox::new(muxer)))
-        .timeout(std::time::Duration::from_secs(20)))
+        .timeout(std::time::Duration::from_secs(20))
+        .boxed())
 }


### PR DESCRIPTION
Fixes a panic when using the `V1Lazy` negotiation protocol, a regression introduced in [1484](https://github.com/libp2p/rust-libp2p/pull/1484/files#diff-6ce2135f99a1031d8c2df76296d2be52L122-R136)(Upgrade to stable futures). Thereby adds integration tests for a transport upgrade with both `V1` and `V1Lazy` to the `multistream-select` crate to prevent future regressions.

As a small refactoring on the side, I changed `Transport::boxed` to always also box the `StreamMuxer` and the transport errors, as this is how boxed transport are pretty much always used. I don't think it is necessary to support boxing of a transport at various levels of granularity. Now, when you want a boxed transport you just need to tack on `.boxed()` at the end of the transport builder and get a boxed transport with a boxed stream muxer and boxed transport errors, i.e. a simple boxed type for the whole transport.