### PR TITLE
[mplex] Split the receive buffer per substream.

### DIFF
--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -22,4 +22,8 @@ unsigned-varint = { version = "0.5", features = ["futures-codec"] }
 
 [dev-dependencies]
 async-std = "1.6.2"
+env_logger = "0.6"
+futures = "0.3"
 libp2p-tcp = { path = "../../transports/tcp", features = ["async-std"] }
+quickcheck = "0.9"
+rand = "0.7"

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -17,6 +17,7 @@ futures_codec = "0.4"
 libp2p-core = { version = "0.22.0", path = "../../core" }
 log = "0.4"
 parking_lot = "0.11"
+smallvec = "1.4"
 unsigned-varint = { version = "0.5", features = ["futures-codec"] }
 
 [dev-dependencies]

--- a/muxers/mplex/src/codec.rs
+++ b/muxers/mplex/src/codec.rs
@@ -114,19 +114,13 @@ pub enum Frame<T> {
 }
 
 impl Frame<RemoteStreamId> {
-    fn remote_id(&self) -> RemoteStreamId {
+    pub fn remote_id(&self) -> RemoteStreamId {
         match *self {
             Frame::Open { stream_id } => stream_id,
             Frame::Data { stream_id, .. } => stream_id,
             Frame::Close { stream_id, .. } => stream_id,
             Frame::Reset { stream_id, .. } => stream_id,
         }
-    }
-
-    /// Gets the `LocalStreamId` corresponding to the `RemoteStreamId`
-    /// received with this frame.
-    pub fn local_id(&self) -> LocalStreamId {
-        self.remote_id().into_local()
     }
 }
 

--- a/muxers/mplex/src/codec.rs
+++ b/muxers/mplex/src/codec.rs
@@ -77,10 +77,23 @@ impl LocalStreamId {
         Self { num, role: Endpoint::Dialer }
     }
 
+    #[cfg(test)]
+    pub fn listener(num: u32) -> Self {
+        Self { num, role: Endpoint::Listener }
+    }
+
     pub fn next(self) -> Self {
         Self {
             num: self.num.checked_add(1).expect("Mplex substream ID overflowed"),
             .. self
+        }
+    }
+
+    #[cfg(test)]
+    pub fn into_remote(self) -> RemoteStreamId {
+        RemoteStreamId {
+            num: self.num,
+            role: !self.role,
         }
     }
 }
@@ -105,7 +118,7 @@ impl RemoteStreamId {
 }
 
 /// An Mplex protocol frame.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Frame<T> {
     Open { stream_id: T },
     Data { stream_id: T, data: Bytes },

--- a/muxers/mplex/src/config.rs
+++ b/muxers/mplex/src/config.rs
@@ -105,7 +105,7 @@ impl Default for MplexConfig {
     fn default() -> MplexConfig {
         MplexConfig {
             max_substreams: 128,
-            max_buffer_len: 4096,
+            max_buffer_len: 32,
             max_buffer_behaviour: MaxBufferBehaviour::ResetStream,
             split_send_size: 1024,
         }

--- a/muxers/mplex/src/io.rs
+++ b/muxers/mplex/src/io.rs
@@ -382,7 +382,7 @@ where
             if let Some(blocked_id) = &self.blocked_stream {
                 // We have a blocked stream and cannot continue reading
                 // new frames for any stream, until frames are taken from
-                // the blocked stream's buffer. Try to wake pending readers
+                // the blocked stream's buffer. Try to wake a pending reader
                 // of the blocked stream.
                 if !self.notifier_read.wake_read_stream(*blocked_id) {
                     // No task dedicated to the blocked stream woken, so schedule

--- a/muxers/mplex/src/io.rs
+++ b/muxers/mplex/src/io.rs
@@ -191,8 +191,8 @@ where
                     let id = stream_id.into_local();
                     if let Some(state) = self.substreams.get_mut(&id) {
                         if let Some(buf) = state.recv_buf_open() {
+                            trace!("Buffering {:?} for stream {} (total: {})", data, id, buf.len() + 1);
                             buf.push(data);
-                            trace!("Buffered {:?} for stream {} (total: {})", data, id, buf.len());
                             self.notifier_read.wake_read_stream(id);
                         } else {
                             trace!("Dropping data {:?} for closed or reset substream {}", data, id);
@@ -409,8 +409,8 @@ where
                     if let Some(state) = self.substreams.get_mut(&id) {
                         if let Some(buf) = state.recv_buf_open() {
                             debug_assert!(buf.len() <= self.config.max_buffer_len);
+                            trace!("Buffering {:?} for stream {} (total: {})", data, id, buf.len() + 1);
                             buf.push(data);
-                            trace!("Buffered {:?} for stream {} (total: {})", data, id, buf.len());
                             self.notifier_read.wake_read_stream(id);
                             if buf.len() > self.config.max_buffer_len {
                                 debug!("Frame buffer of stream {} is full.", id);


### PR DESCRIPTION
This PR picks up a discussion from https://github.com/libp2p/rust-libp2p/pull/1769#discussion_r494942944 about splitting the shared receive buffer per substream. This split allows more efficient reading from the buffer for a particular substream, to efficiently drop all still buffered frames for a particular stream when it is dropped, and to reset only the offending substream if it reaches its buffer limit with `MaxBufferBehaviour::ResetStream`. Previously this was implemented as `MaxBufferBehaviour::CloseAll` and resulted in the entire connection closing. The buffer split should generally be advantageous whenever not all substreams are read at the same pace and some temporarily fall behind in consuming their data.