### PR TITLE
[swarm] MultiHandler: Respect inbound timeouts and upgrade versions.

### DIFF
--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 0.22.1 [unreleased]
 
+- Respect inbound timeouts and upgrade versions in the `MultiHandler`.
+  [PR 1786](https://github.com/libp2p/rust-libp2p/pull/1786).
+
 - Instead of iterating each inbound and outbound substream upgrade looking for
   one to make progress, use a `FuturesUnordered` for both pending inbound and
   pending outbound upgrades. As a result only those upgrades are polled that are


### PR DESCRIPTION
At the moment the `ProtocolsHandler::listen_protocol()` implementation of the `MultiHandler` discards configured timeouts and upgrade protocol versions on the inner handlers. The former results in the `MultiHandler` always having a default `10` second timeout on inbound substream upgrades, regardless of the configuration on the inner handlers. The latter results in the `MultiHandler` always using the `upgrade::V1` negotiation protocol for inbound substream upgrades, which may not match what the inner handlers use for their corresponding outbound substreams - of course it should still be the same version used in all handlers, but it may not be `V1`. So this PR does the following:

  1. The `MultiHandler` uses the maximum of all configured inbound timeouts on the inner handlers. Typically these are all the same but need not necessarily be.
  2. The `MultiHandler` uses the `upgrade::Version` used by the inner handlers, unless they are not all the same, in which case a warning is logged and `V1` used. 