### PR TITLE
Replace `get_if_addrs` with `if-addrs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 - Update `libp2p-core`, `libp2p-floodsub`, `libp2p-gossipsub`, `libp2p-mplex`,
   `libp2p-noise`, `libp2p-plaintext`, `libp2p-pnet`, `libp2p-request-response`,
-  `libp2p-websocket` and `parity-multiaddr`.
+  `libp2p-tcp`, `libp2p-websocket` and `parity-multiaddr`.
 
 # Version 0.28.1 [2020-09-10]
 

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -27,4 +27,4 @@ void = "1.0"
 wasm-timer = "0.2.4"
 
 [dev-dependencies]
-get_if_addrs = "0.5.3"
+if-addrs = "0.6.4"

--- a/protocols/mdns/src/service.rs
+++ b/protocols/mdns/src/service.rs
@@ -632,7 +632,7 @@ mod tests {
         // properties.
         #[test]
         fn respect_query_interval() {
-            let own_ips: Vec<std::net::IpAddr> = get_if_addrs::get_if_addrs().unwrap()
+            let own_ips: Vec<std::net::IpAddr> = if_addrs::get_if_addrs().unwrap()
                 .into_iter()
                 .map(|i| i.addr.ip())
                 .collect();

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,3 +1,7 @@
+ # 0.22.1 [unreleased]
+
+- Replace `get_if_addrs` with `if-addrs`.
+
 # 0.22.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 async-std = { version = "1.6.2", optional = true }
 futures = "0.3.1"
 futures-timer = "3.0"
-get_if_addrs = "0.5.3"
+if-addrs = "0.6.4"
 ipnet = "2.0.0"
 libp2p-core = { version = "0.22.0", path = "../../core" }
 log = "0.4.1"

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-tcp"
 edition = "2018"
 description = "TCP/IP transport protocol for libp2p"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/transports/tcp/src/lib.rs
+++ b/transports/tcp/src/lib.rs
@@ -31,7 +31,7 @@
 
 use futures::{future::{self, Ready}, prelude::*};
 use futures_timer::Delay;
-use get_if_addrs::{IfAddr, get_if_addrs};
+use if_addrs::{IfAddr, get_if_addrs};
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use libp2p_core::{
     Transport,


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

The crate [get_if_addrs](https://github.com/maidsafe-archive/get_if_addrs) is no longer maintained by its authors.
I think the [if-addrs](https://github.com/messense/if-addrs) (forked from [get_if_addrs](https://github.com/maidsafe-archive/get_if_addrs)) is a good alternative.

If we find a better library written in pure rust later, we can use it instead of `if-addrs` (see #1489)