### PR TITLE
Cargo.toml: Bump libp2p-tcp patch version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ wasm-timer = "0.2.4"
 libp2p-deflate = { version = "0.22.0", path = "protocols/deflate", optional = true }
 libp2p-dns = { version = "0.22.0", path = "transports/dns", optional = true }
 libp2p-mdns = { version = "0.22.1", path = "protocols/mdns", optional = true }
-libp2p-tcp = { version = "0.22.0", path = "transports/tcp", optional = true }
+libp2p-tcp = { version = "0.22.1", path = "transports/tcp", optional = true }
 libp2p-websocket = { version = "0.23.1", path = "transports/websocket", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Follow up to https://github.com/libp2p/rust-libp2p/pull/1788.