### PR TITLE
Refine boxing during transport construction.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,22 +62,22 @@ atomic = "0.5.0"
 bytes = "0.5"
 futures = "0.3.1"
 lazy_static = "1.2"
-libp2p-core = { version = "0.22.2", path = "core" }
+libp2p-core = { version = "0.23.0", path = "core" }
 libp2p-core-derive = { version = "0.20.2", path = "misc/core-derive" }
 libp2p-floodsub = { version = "0.23.0", path = "protocols/floodsub", optional = true }
-libp2p-gossipsub = { version = "0.22.1", path = "./protocols/gossipsub", optional = true }
-libp2p-identify = { version = "0.22.0", path = "protocols/identify", optional = true }
-libp2p-kad = { version = "0.23.1", path = "protocols/kad", optional = true }
+libp2p-gossipsub = { version = "0.23.0", path = "./protocols/gossipsub", optional = true }
+libp2p-identify = { version = "0.23.0", path = "protocols/identify", optional = true }
+libp2p-kad = { version = "0.24.0", path = "protocols/kad", optional = true }
 libp2p-mplex = { version = "0.23.0", path = "muxers/mplex", optional = true }
-libp2p-noise = { version = "0.24.1", path = "protocols/noise", optional = true }
-libp2p-ping = { version = "0.22.0", path = "protocols/ping", optional = true }
+libp2p-noise = { version = "0.25.0", path = "protocols/noise", optional = true }
+libp2p-ping = { version = "0.23.0", path = "protocols/ping", optional = true }
 libp2p-plaintext = { version = "0.23.0", path = "protocols/plaintext", optional = true }
 libp2p-pnet = { version = "0.19.2", path = "protocols/pnet", optional = true }
 libp2p-request-response = { version = "0.4.0", path = "protocols/request-response", optional = true }
-libp2p-swarm = { version = "0.22.1", path = "swarm" }
-libp2p-uds = { version = "0.22.0", path = "transports/uds", optional = true }
-libp2p-wasm-ext = { version = "0.22.0", path = "transports/wasm-ext", optional = true }
-libp2p-yamux = { version = "0.25.0", path = "muxers/yamux", optional = true }
+libp2p-swarm = { version = "0.23.0", path = "swarm" }
+libp2p-uds = { version = "0.23.0", path = "transports/uds", optional = true }
+libp2p-wasm-ext = { version = "0.23.0", path = "transports/wasm-ext", optional = true }
+libp2p-yamux = { version = "0.26.0", path = "muxers/yamux", optional = true }
 multiaddr = { package = "parity-multiaddr", version = "0.9.3", path = "misc/multiaddr" }
 multihash = "0.11.0"
 parking_lot = "0.11.0"
@@ -86,11 +86,11 @@ smallvec = "1.0"
 wasm-timer = "0.2.4"
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")))'.dependencies]
-libp2p-deflate = { version = "0.22.0", path = "protocols/deflate", optional = true }
-libp2p-dns = { version = "0.22.0", path = "transports/dns", optional = true }
-libp2p-mdns = { version = "0.22.1", path = "protocols/mdns", optional = true }
-libp2p-tcp = { version = "0.22.1", path = "transports/tcp", optional = true }
-libp2p-websocket = { version = "0.23.1", path = "transports/websocket", optional = true }
+libp2p-deflate = { version = "0.23.0", path = "protocols/deflate", optional = true }
+libp2p-dns = { version = "0.23.0", path = "transports/dns", optional = true }
+libp2p-mdns = { version = "0.23.0", path = "protocols/mdns", optional = true }
+libp2p-tcp = { version = "0.23.0", path = "transports/tcp", optional = true }
+libp2p-websocket = { version = "0.24.0", path = "transports/websocket", optional = true }
 
 [dev-dependencies]
 async-std = "1.6.2"

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 0.22.2 [unreleased]
+# 0.23.0 [unreleased]
+
+- Rework transport boxing and move timeout configuration
+  to the transport builder.
+  [PR 1794](https://github.com/libp2p/rust-libp2p/pull/1794).
 
 - Update dependencies.
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-core"
 edition = "2018"
 description = "Core traits and structs of libp2p"
-version = "0.22.2"
+version = "0.23.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -306,22 +306,20 @@ impl<T> Multiplexed<T> {
 
     /// Adds a timeout to the setup and protocol upgrade process for all
     /// inbound and outbound connections established through the transport.
-    pub fn timeout(self, timeout: Duration) -> Multiplexed<TransportTimeout<Self>> {
-        Multiplexed(TransportTimeout::new(self, timeout))
+    pub fn timeout(self, timeout: Duration) -> Multiplexed<TransportTimeout<T>> {
+        Multiplexed(TransportTimeout::new(self.0, timeout))
     }
 
     /// Adds a timeout to the setup and protocol upgrade process for all
     /// outbound connections established through the transport.
-    pub fn outbound_timeout(self, timeout: Duration) -> Multiplexed<TransportTimeout<Self>>
-    {
-        Multiplexed(TransportTimeout::with_outgoing_timeout(self, timeout))
+    pub fn outbound_timeout(self, timeout: Duration) -> Multiplexed<TransportTimeout<T>> {
+        Multiplexed(TransportTimeout::with_outgoing_timeout(self.0, timeout))
     }
 
     /// Adds a timeout to the setup and protocol upgrade process for all
     /// inbound connections established through the transport.
-    pub fn inbound_timeout(self, timeout: Duration) -> Multiplexed<TransportTimeout<Self>>
-    {
-        Multiplexed(TransportTimeout::with_ingoing_timeout(self, timeout))
+    pub fn inbound_timeout(self, timeout: Duration) -> Multiplexed<TransportTimeout<T>> {
+        Multiplexed(TransportTimeout::with_ingoing_timeout(self.0, timeout))
     }
 }
 

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -31,8 +31,10 @@ use crate::{
         TransportError,
         ListenerEvent,
         and_then::AndThen,
+        boxed::boxed,
+        timeout::TransportTimeout,
     },
-    muxing::StreamMuxer,
+    muxing::{StreamMuxer, StreamMuxerBox},
     upgrade::{
         self,
         OutboundUpgrade,
@@ -46,7 +48,13 @@ use crate::{
 };
 use futures::{prelude::*, ready};
 use multiaddr::Multiaddr;
-use std::{error::Error, fmt, pin::Pin, task::Context, task::Poll};
+use std::{
+    error::Error,
+    fmt,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration
+};
 
 /// A `Builder` facilitates upgrading of a [`Transport`] for use with
 /// a [`Network`].
@@ -54,14 +62,14 @@ use std::{error::Error, fmt, pin::Pin, task::Context, task::Poll};
 /// The upgrade process is defined by the following stages:
 ///
 ///    [`authenticate`](Builder::authenticate)`{1}`
-/// -> [`apply`](Builder::apply)`{*}`
-/// -> [`multiplex`](Builder::multiplex)`{1}`
+/// -> [`apply`](Authenticated::apply)`{*}`
+/// -> [`multiplex`](Authenticated::multiplex)`{1}`
 ///
 /// It thus enforces the following invariants on every transport
-/// obtained from [`multiplex`](Builder::multiplex):
+/// obtained from [`multiplex`](Authenticated::multiplex):
 ///
 ///   1. The transport must be [authenticated](Builder::authenticate)
-///      and [multiplexed](Builder::multiplex).
+///      and [multiplexed](Authenticated::multiplex).
 ///   2. Authentication must precede the negotiation of a multiplexer.
 ///   3. Applying a multiplexer is the last step in the upgrade process.
 ///   4. The [`Transport::Output`] conforms to the requirements of a [`Network`],
@@ -69,6 +77,7 @@ use std::{error::Error, fmt, pin::Pin, task::Context, task::Poll};
 ///      [`StreamMuxer`] (from the multiplexing upgrade).
 ///
 /// [`Network`]: crate::Network
+#[derive(Clone)]
 pub struct Builder<T> {
     inner: T,
     version: upgrade::Version,
@@ -97,7 +106,7 @@ where
     ///
     ///   * I/O upgrade: `C -> (I, D)`.
     ///   * Transport output: `C -> (I, D)`
-    pub fn authenticate<C, D, U, I, E>(self, upgrade: U) -> Builder<
+    pub fn authenticate<C, D, U, I, E>(self, upgrade: U) -> Authenticated<
         AndThen<T, impl FnOnce(C, ConnectedPoint) -> Authenticate<C, U> + Clone>
     > where
         T: Transport<Output = C>,
@@ -109,95 +118,11 @@ where
         E: Error + 'static,
     {
         let version = self.version;
-        Builder::new(self.inner.and_then(move |conn, endpoint| {
+        Authenticated(Builder::new(self.inner.and_then(move |conn, endpoint| {
             Authenticate {
                 inner: upgrade::apply(conn, upgrade, endpoint, version)
             }
-        }), version)
-    }
-
-    /// Applies an arbitrary upgrade on an authenticated, non-multiplexed
-    /// transport.
-    ///
-    /// The upgrade receives the I/O resource (i.e. connection) `C` and
-    /// must produce a new I/O resource `D`. Any number of such upgrades
-    /// can be performed.
-    ///
-    /// ## Transitions
-    ///
-    ///   * I/O upgrade: `C -> D`.
-    ///   * Transport output: `(I, C) -> (I, D)`.
-    pub fn apply<C, D, U, I, E>(self, upgrade: U) -> Builder<Upgrade<T, U>>
-    where
-        T: Transport<Output = (I, C)>,
-        C: AsyncRead + AsyncWrite + Unpin,
-        D: AsyncRead + AsyncWrite + Unpin,
-        I: ConnectionInfo,
-        U: InboundUpgrade<Negotiated<C>, Output = D, Error = E>,
-        U: OutboundUpgrade<Negotiated<C>, Output = D, Error = E> + Clone,
-        E: Error + 'static,
-    {
-        Builder::new(Upgrade::new(self.inner, upgrade), self.version)
-    }
-
-    /// Upgrades the transport with a (sub)stream multiplexer.
-    ///
-    /// The supplied upgrade receives the I/O resource `C` and must
-    /// produce a [`StreamMuxer`] `M`. The transport must already be authenticated.
-    /// This ends the (regular) transport upgrade process, yielding the underlying,
-    /// configured transport.
-    ///
-    /// ## Transitions
-    ///
-    ///   * I/O upgrade: `C -> M`.
-    ///   * Transport output: `(I, C) -> (I, M)`.
-    pub fn multiplex<C, M, U, I, E>(self, upgrade: U)
-        -> AndThen<T, impl FnOnce((I, C), ConnectedPoint) -> Multiplex<C, U, I> + Clone>
-    where
-        T: Transport<Output = (I, C)>,
-        C: AsyncRead + AsyncWrite + Unpin,
-        M: StreamMuxer,
-        I: ConnectionInfo,
-        U: InboundUpgrade<Negotiated<C>, Output = M, Error = E>,
-        U: OutboundUpgrade<Negotiated<C>, Output = M, Error = E> + Clone,
-        E: Error + 'static,
-    {
-        let version = self.version;
-        self.inner.and_then(move |(i, c), endpoint| {
-            let upgrade = upgrade::apply(c, upgrade, endpoint, version);
-            Multiplex { info: Some(i), upgrade }
-        })
-    }
-
-    /// Like [`Builder::multiplex`] but accepts a function which returns the upgrade.
-    ///
-    /// The supplied function is applied to [`ConnectionInfo`] and [`ConnectedPoint`]
-    /// and returns an upgrade which receives the I/O resource `C` and must
-    /// produce a [`StreamMuxer`] `M`. The transport must already be authenticated.
-    /// This ends the (regular) transport upgrade process, yielding the underlying,
-    /// configured transport.
-    ///
-    /// ## Transitions
-    ///
-    ///   * I/O upgrade: `C -> M`.
-    ///   * Transport output: `(I, C) -> (I, M)`.
-    pub fn multiplex_ext<C, M, U, I, E, F>(self, up: F)
-        -> AndThen<T, impl FnOnce((I, C), ConnectedPoint) -> Multiplex<C, U, I> + Clone>
-    where
-        T: Transport<Output = (I, C)>,
-        C: AsyncRead + AsyncWrite + Unpin,
-        M: StreamMuxer,
-        I: ConnectionInfo,
-        U: InboundUpgrade<Negotiated<C>, Output = M, Error = E>,
-        U: OutboundUpgrade<Negotiated<C>, Output = M, Error = E> + Clone,
-        E: Error + 'static,
-        F: for<'a> FnOnce(&'a I, &'a ConnectedPoint) -> U + Clone
-    {
-        let version = self.version;
-        self.inner.and_then(move |(i, c), endpoint| {
-            let upgrade = upgrade::apply(c, up(&i, &endpoint), endpoint, version);
-            Multiplex { info: Some(i), upgrade }
-        })
+        }), version))
     }
 }
 
@@ -234,7 +159,7 @@ where
 /// An upgrade that negotiates a (sub)stream multiplexer on
 /// top of an authenticated transport.
 ///
-/// Configured through [`Builder::multiplex`].
+/// Configured through [`Authenticated::multiplex`].
 #[pin_project::pin_project]
 pub struct Multiplex<C, U, I>
 where
@@ -265,10 +190,164 @@ where
     }
 }
 
+/// An transport with peer authentication, obtained from [`Builder::authenticate`].
+#[derive(Clone)]
+pub struct Authenticated<T>(Builder<T>);
+
+impl<T> Authenticated<T>
+where
+    T: Transport,
+    T::Error: 'static
+{
+    /// Applies an arbitrary upgrade.
+    ///
+    /// The upgrade receives the I/O resource (i.e. connection) `C` and
+    /// must produce a new I/O resource `D`. Any number of such upgrades
+    /// can be performed.
+    ///
+    /// ## Transitions
+    ///
+    ///   * I/O upgrade: `C -> D`.
+    ///   * Transport output: `(I, C) -> (I, D)`.
+    pub fn apply<C, D, U, I, E>(self, upgrade: U) -> Authenticated<Upgrade<T, U>>
+    where
+        T: Transport<Output = (I, C)>,
+        C: AsyncRead + AsyncWrite + Unpin,
+        D: AsyncRead + AsyncWrite + Unpin,
+        I: ConnectionInfo,
+        U: InboundUpgrade<Negotiated<C>, Output = D, Error = E>,
+        U: OutboundUpgrade<Negotiated<C>, Output = D, Error = E> + Clone,
+        E: Error + 'static,
+    {
+        Authenticated(Builder::new(Upgrade::new(self.0.inner, upgrade), self.0.version))
+    }
+
+    /// Upgrades the transport with a (sub)stream multiplexer.
+    ///
+    /// The supplied upgrade receives the I/O resource `C` and must
+    /// produce a [`StreamMuxer`] `M`. The transport must already be authenticated.
+    /// This ends the (regular) transport upgrade process.
+    ///
+    /// ## Transitions
+    ///
+    ///   * I/O upgrade: `C -> M`.
+    ///   * Transport output: `(I, C) -> (I, M)`.
+    pub fn multiplex<C, M, U, I, E>(self, upgrade: U) -> Multiplexed<
+        AndThen<T, impl FnOnce((I, C), ConnectedPoint) -> Multiplex<C, U, I> + Clone>
+    > where
+        T: Transport<Output = (I, C)>,
+        C: AsyncRead + AsyncWrite + Unpin,
+        M: StreamMuxer,
+        I: ConnectionInfo,
+        U: InboundUpgrade<Negotiated<C>, Output = M, Error = E>,
+        U: OutboundUpgrade<Negotiated<C>, Output = M, Error = E> + Clone,
+        E: Error + 'static,
+    {
+        let version = self.0.version;
+        Multiplexed(self.0.inner.and_then(move |(i, c), endpoint| {
+            let upgrade = upgrade::apply(c, upgrade, endpoint, version);
+            Multiplex { info: Some(i), upgrade }
+        }))
+    }
+
+    /// Like [`Authenticated::multiplex`] but accepts a function which returns the upgrade.
+    ///
+    /// The supplied function is applied to [`ConnectionInfo`] and [`ConnectedPoint`]
+    /// and returns an upgrade which receives the I/O resource `C` and must
+    /// produce a [`StreamMuxer`] `M`. The transport must already be authenticated.
+    /// This ends the (regular) transport upgrade process.
+    ///
+    /// ## Transitions
+    ///
+    ///   * I/O upgrade: `C -> M`.
+    ///   * Transport output: `(I, C) -> (I, M)`.
+    pub fn multiplex_ext<C, M, U, I, E, F>(self, up: F) -> Multiplexed<
+        AndThen<T, impl FnOnce((I, C), ConnectedPoint) -> Multiplex<C, U, I> + Clone>
+    > where
+        T: Transport<Output = (I, C)>,
+        C: AsyncRead + AsyncWrite + Unpin,
+        M: StreamMuxer,
+        I: ConnectionInfo,
+        U: InboundUpgrade<Negotiated<C>, Output = M, Error = E>,
+        U: OutboundUpgrade<Negotiated<C>, Output = M, Error = E> + Clone,
+        E: Error + 'static,
+        F: for<'a> FnOnce(&'a I, &'a ConnectedPoint) -> U + Clone
+    {
+        let version = self.0.version;
+        Multiplexed(self.0.inner.and_then(move |(i, c), endpoint| {
+            let upgrade = upgrade::apply(c, up(&i, &endpoint), endpoint, version);
+            Multiplex { info: Some(i), upgrade }
+        }))
+    }
+}
+
+/// A authenticated and multiplexed transport, obtained from
+/// [`Authenticated::multiplex`].
+#[derive(Clone)]
+pub struct Multiplexed<T>(T);
+
+impl<T> Multiplexed<T> {
+    /// Boxes the authenticated, multiplexed transport, including
+    /// the [`StreamMuxer`] and custom transport errors.
+    pub fn boxed<I, M>(self) -> super::Boxed<(I, StreamMuxerBox)>
+    where
+        T: Transport<Output = (I, M)> + Sized + Clone + Send + Sync + 'static,
+        T::Dial: Send + 'static,
+        T::Listener: Send + 'static,
+        T::ListenerUpgrade: Send + 'static,
+        T::Error: Send + Sync,
+        I: ConnectionInfo,
+        M: StreamMuxer + Send + Sync + 'static,
+        M::Substream: Send + 'static,
+        M::OutboundSubstream: Send + 'static
+    {
+        boxed(self.map(|(i, m), _| (i, StreamMuxerBox::new(m))))
+    }
+
+    /// Adds a timeout to the setup and protocol upgrade process for all
+    /// inbound and outbound connections established through the transport.
+    pub fn timeout(self, timeout: Duration) -> Multiplexed<TransportTimeout<Self>> {
+        Multiplexed(TransportTimeout::new(self, timeout))
+    }
+
+    /// Adds a timeout to the setup and protocol upgrade process for all
+    /// outbound connections established through the transport.
+    pub fn outbound_timeout(self, timeout: Duration) -> Multiplexed<TransportTimeout<Self>>
+    {
+        Multiplexed(TransportTimeout::with_outgoing_timeout(self, timeout))
+    }
+
+    /// Adds a timeout to the setup and protocol upgrade process for all
+    /// inbound connections established through the transport.
+    pub fn inbound_timeout(self, timeout: Duration) -> Multiplexed<TransportTimeout<Self>>
+    {
+        Multiplexed(TransportTimeout::with_ingoing_timeout(self, timeout))
+    }
+}
+
+impl<T> Transport for Multiplexed<T>
+where
+    T: Transport,
+{
+    type Output = T::Output;
+    type Error = T::Error;
+    type Listener = T::Listener;
+    type ListenerUpgrade = T::ListenerUpgrade;
+    type Dial = T::Dial;
+
+    fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        self.0.dial(addr)
+    }
+
+    fn listen_on(self, addr: Multiaddr) -> Result<Self::Listener, TransportError<Self::Error>> {
+        self.0.listen_on(addr)
+    }
+}
+
 /// An inbound or outbound upgrade.
 type EitherUpgrade<C, U> = future::Either<InboundUpgradeApply<C, U>, OutboundUpgradeApply<C, U>>;
 
-/// An upgrade on an authenticated, non-multiplexed [`Transport`].
+/// A custom upgrade on an [`Authenticated`] transport.
 ///
 /// See [`Transport::upgrade`]
 #[derive(Debug, Copy, Clone)]

--- a/core/tests/network_dial_error.rs
+++ b/core/tests/network_dial_error.rs
@@ -40,7 +40,7 @@ use std::{io, task::Poll};
 use util::TestHandler;
 
 type TestNetwork = Network<TestTransport, (), (), TestHandler>;
-type TestTransport = transport::Boxed<(PeerId, StreamMuxerBox), io::Error>;
+type TestTransport = transport::Boxed<(PeerId, StreamMuxerBox)>;
 
 fn new_network(cfg: NetworkConfig) -> TestNetwork {
     let local_key = identity::Keypair::generate_ed25519();
@@ -50,6 +50,7 @@ fn new_network(cfg: NetworkConfig) -> TestNetwork {
         .upgrade(upgrade::Version::V1)
         .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
         .multiplex(libp2p_mplex::MplexConfig::new())
+        .boxed()
         .and_then(|(peer, mplex), _| {
             // Gracefully close the connection to allow protocol
             // negotiation to complete.

--- a/examples/chat-tokio.rs
+++ b/examples/chat-tokio.rs
@@ -77,7 +77,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let transport = TokioTcpConfig::new().nodelay(true)
         .upgrade(upgrade::Version::V1)
         .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
-        .multiplex(mplex::MplexConfig::new());
+        .multiplex(mplex::MplexConfig::new())
+        .boxed();
 
     // Create a Floodsub topic
     let floodsub_topic = floodsub::Topic::new("chat");

--- a/misc/multistream-select/tests/transport.rs
+++ b/misc/multistream-select/tests/transport.rs
@@ -37,7 +37,7 @@ use futures::{channel::oneshot, ready, prelude::*};
 use rand::random;
 use std::{io, task::{Context, Poll}};
 
-type TestTransport = transport::Boxed<(PeerId, StreamMuxerBox), io::Error>;
+type TestTransport = transport::Boxed<(PeerId, StreamMuxerBox)>;
 type TestNetwork = Network<TestTransport, (), (), TestHandler>;
 
 fn mk_transport(up: upgrade::Version) -> (PeerId, TestTransport) {

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -14,7 +14,7 @@ bytes = "0.5"
 fnv = "1.0"
 futures = "0.3.1"
 futures_codec = "0.4"
-libp2p-core = { version = "0.22.0", path = "../../core" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
 log = "0.4"
 parking_lot = "0.11"
 smallvec = "1.4"

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.26.0 [unreleased]
+
+- Update `libp2p-core`.
+
 # 0.25.0 [2020-09-09]
 
 - Update to `yamux-0.8.0`. Upgrade step 4 of 4. This version always implements

--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-yamux"
 edition = "2018"
 description = "Yamux multiplexing protocol for libp2p"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.22.0", path = "../../core" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
 parking_lot = "0.11"
 thiserror = "1.0"
 yamux = "0.8.0"

--- a/protocols/deflate/CHANGELOG.md
+++ b/protocols/deflate/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.0 [unreleased]
+
+- Bump `libp2p-core` dependency.
+
 # 0.22.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.

--- a/protocols/deflate/Cargo.toml
+++ b/protocols/deflate/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-deflate"
 edition = "2018"
 description = "Deflate encryption protocol for libp2p"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.22.0", path = "../../core" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
 flate2 = "1.0"
 
 [dev-dependencies]

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["network-programming", "asynchronous"]
 cuckoofilter = "0.5.0"
 fnv = "1.0"
 futures = "0.3.1"
-libp2p-core = { version = "0.22.0", path = "../../core" }
-libp2p-swarm = { version = "0.22.0", path = "../../swarm" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
+libp2p-swarm = { version = "0.23.0", path = "../../swarm" }
 log = "0.4"
 prost = "0.6.1"
 rand = "0.7"

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.1 [unreleased]
+# 0.23.0 [unreleased]
 
 - Update dependencies.
 

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-gossipsub"
 edition = "2018"
 description = "Gossipsub protocol for libp2p"
-version = "0.22.1"
+version = "0.23.0"
 authors = ["Age Manning <Age@AgeManning.com>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -10,8 +10,8 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-libp2p-swarm = { version = "0.22.0", path = "../../swarm" }
-libp2p-core = { version = "0.22.0", path = "../../core" }
+libp2p-swarm = { version = "0.23.0", path = "../../swarm" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
 bytes = "0.5.4"
 byteorder = "1.3.2"
 fnv = "1.0.6"

--- a/protocols/gossipsub/tests/smoke.rs
+++ b/protocols/gossipsub/tests/smoke.rs
@@ -150,7 +150,8 @@ fn build_node() -> (Multiaddr, Swarm<Gossipsub>) {
         .authenticate(PlainText2Config {
             local_public_key: public_key.clone(),
         })
-        .multiplex(yamux::Config::default());
+        .multiplex(yamux::Config::default())
+        .boxed();
 
     let peer_id = public_key.clone().into_peer_id();
 

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.0 [unreleased]
+
+- Update `libp2p-swarm` and `libp2p-core`.
+
 # 0.22.0 [2020-09-09]
 
 - Update `libp2p-swarm` and `libp2p-core`.

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-identify"
 edition = "2018"
 description = "Nodes identifcation protocol for libp2p"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,8 +11,8 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.22.0", path = "../../core" }
-libp2p-swarm = { version = "0.22.0", path = "../../swarm" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
+libp2p-swarm = { version = "0.23.0", path = "../../swarm" }
 log = "0.4.1"
 prost = "0.6.1"
 smallvec = "1.0"

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -299,7 +299,7 @@ mod tests {
     #[test]
     fn periodic_id_works() {
         let (mut swarm1, pubkey1) = {
-            let (pubkey, transport) = transport(); // TODO
+            let (pubkey, transport) = transport();
             let protocol = Identify::new("a".to_string(), "b".to_string(), pubkey.clone());
             let swarm = Swarm::new(transport, protocol, pubkey.clone().into_peer_id());
             (swarm, pubkey)

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -273,7 +273,8 @@ mod tests {
     use libp2p_core::{
         identity,
         PeerId,
-        muxing::StreamMuxer,
+        muxing::StreamMuxerBox,
+        transport,
         Transport,
         upgrade
     };
@@ -281,15 +282,8 @@ mod tests {
     use libp2p_tcp::TcpConfig;
     use libp2p_swarm::{Swarm, SwarmEvent};
     use libp2p_mplex::MplexConfig;
-    use std::{fmt, io};
 
-    fn transport() -> (identity::PublicKey, impl Transport<
-        Output = (PeerId, impl StreamMuxer<Substream = impl Send, OutboundSubstream = impl Send, Error = impl Into<io::Error>>),
-        Listener = impl Send,
-        ListenerUpgrade = impl Send,
-        Dial = impl Send,
-        Error = impl fmt::Debug
-    > + Clone) {
+    fn transport() -> (identity::PublicKey, transport::Boxed<(PeerId, StreamMuxerBox)>) {
         let id_keys = identity::Keypair::generate_ed25519();
         let noise_keys = noise::Keypair::<noise::X25519Spec>::new().into_authentic(&id_keys).unwrap();
         let pubkey = id_keys.public();
@@ -297,14 +291,15 @@ mod tests {
             .nodelay(true)
             .upgrade(upgrade::Version::V1)
             .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
-            .multiplex(MplexConfig::new());
+            .multiplex(MplexConfig::new())
+            .boxed();
         (pubkey, transport)
     }
 
     #[test]
     fn periodic_id_works() {
         let (mut swarm1, pubkey1) = {
-            let (pubkey, transport) = transport();
+            let (pubkey, transport) = transport(); // TODO
             let protocol = Identify::new("a".to_string(), "b".to_string(), pubkey.clone());
             let swarm = Swarm::new(transport, protocol, pubkey.clone().into_peer_id());
             (swarm, pubkey)

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,4 +1,6 @@
-# 0.23.1 [unreleased]
+# 0.24.0 [unreleased]
+
+- Update `libp2p-core` and `libp2p-swarm`.
 
 - Update `sha2` dependency.
 

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-kad"
 edition = "2018"
 description = "Kademlia protocol for libp2p"
-version = "0.23.1"
+version = "0.24.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -17,8 +17,8 @@ fnv = "1.0"
 futures_codec = "0.4"
 futures = "0.3.1"
 log = "0.4"
-libp2p-core = { version = "0.22.0", path = "../../core" }
-libp2p-swarm = { version = "0.22.0", path = "../../swarm" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
+libp2p-swarm = { version = "0.23.0", path = "../../swarm" }
 multihash = "0.11.0"
 prost = "0.6.1"
 rand = "0.7.2"

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -61,7 +61,8 @@ fn build_node_with_config(cfg: KademliaConfig) -> (Multiaddr, TestSwarm) {
     let transport = MemoryTransport::default()
         .upgrade(upgrade::Version::V1)
         .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
-        .multiplex(yamux::Config::default());
+        .multiplex(yamux::Config::default())
+        .boxed();
 
     let local_id = local_public_key.clone().into_peer_id();
     let store = MemoryStore::new(local_id.clone());

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,4 +1,6 @@
-# 0.22.1 [unreleased]
+# 0.23.0 [unreleased]
+
+- Update `libp2p-swarm` and `libp2p-core`.
 
 - Double receive buffer to 4KiB. [PR 1779](https://github.com/libp2p/rust-libp2p/pull/1779/files).
 

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-mdns"
 edition = "2018"
-version = "0.22.1"
+version = "0.23.0"
 description = "Implementation of the libp2p mDNS discovery method"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
@@ -16,8 +16,8 @@ dns-parser = "0.8"
 either = "1.5.3"
 futures = "0.3.1"
 lazy_static = "1.2"
-libp2p-core = { version = "0.22.0", path = "../../core" }
-libp2p-swarm = { version = "0.22.0", path = "../../swarm" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
+libp2p-swarm = { version = "0.23.0", path = "../../swarm" }
 log = "0.4"
 net2 = "0.2"
 rand = "0.7"

--- a/protocols/noise/CHANGELOG.md
+++ b/protocols/noise/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.1 [unreleased]
+# 0.25.0 [unreleased]
 
 - Update dependencies.
 

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-noise"
 description = "Cryptographic handshake protocol using the noise framework."
-version = "0.24.1"
+version = "0.25.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -12,7 +12,7 @@ bytes = "0.5"
 curve25519-dalek = "3.0.0"
 futures = "0.3.1"
 lazy_static = "1.2"
-libp2p-core = { version = "0.22.0", path = "../../core" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
 log = "0.4"
 prost = "0.6.1"
 rand = "0.7.2"

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,4 +1,6 @@
-# 0.22.1 [unreleased]
+# 0.23.0 [unreleased]
+
+- Update `libp2p-swarm` and `libp2p-core`.
 
 - Ensure the outbound ping is flushed before awaiting
   the response. Otherwise the behaviour depends on

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-ping"
 edition = "2018"
 description = "Ping protocol for libp2p"
-version = "0.22.1"
+version = "0.23.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,8 +11,8 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.22.0", path = "../../core" }
-libp2p-swarm = { version = "0.22.0", path = "../../swarm" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
+libp2p-swarm = { version = "0.23.0", path = "../../swarm" }
 log = "0.4.1"
 rand = "0.7.2"
 void = "1.0"

--- a/protocols/ping/tests/ping.rs
+++ b/protocols/ping/tests/ping.rs
@@ -37,7 +37,7 @@ use libp2p_yamux as yamux;
 use futures::{prelude::*, channel::mpsc};
 use quickcheck::*;
 use rand::prelude::*;
-use std::{io, num::NonZeroU8, time::Duration};
+use std::{num::NonZeroU8, time::Duration};
 
 #[test]
 fn ping_pong() {
@@ -196,10 +196,7 @@ fn max_failures() {
 
 fn mk_transport(muxer: MuxerChoice) -> (
     PeerId,
-    transport::Boxed<
-        (PeerId, StreamMuxerBox),
-        io::Error
-    >
+    transport::Boxed<(PeerId, StreamMuxerBox)>
 ) {
     let id_keys = identity::Keypair::generate_ed25519();
     let peer_id = id_keys.public().into_peer_id();

--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 bytes = "0.5"
 futures = "0.3.1"
 futures_codec = "0.4.0"
-libp2p-core = { version = "0.22.0", path = "../../core" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
 log = "0.4.8"
 prost = "0.6.1"
 unsigned-varint = { version = "0.5.1", features = ["futures-codec"] }

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["network-programming", "asynchronous"]
 async-trait = "0.1"
 bytes = "0.5.6"
 futures = "0.3.1"
-libp2p-core = { version = "0.22.0", path = "../../core" }
-libp2p-swarm = { version = "0.22.0", path = "../../swarm" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
+libp2p-swarm = { version = "0.23.0", path = "../../swarm" }
 log = "0.4.11"
 lru = "0.6"
 minicbor = { version = "0.6", features = ["std", "derive"] }

--- a/protocols/request-response/tests/ping.rs
+++ b/protocols/request-response/tests/ping.rs
@@ -213,7 +213,7 @@ fn ping_protocol_throttled() {
     let () = async_std::task::block_on(peer2);
 }
 
-fn mk_transport() -> (PeerId, transport::Boxed<(PeerId, StreamMuxerBox), io::Error>) {
+fn mk_transport() -> (PeerId, transport::Boxed<(PeerId, StreamMuxerBox)>) {
     let id_keys = identity::Keypair::generate_ed25519();
     let peer_id = id_keys.public().into_peer_id();
     let noise_keys = Keypair::<X25519Spec>::new().into_authentic(&id_keys).unwrap();

--- a/protocols/secio/CHANGELOG.md
+++ b/protocols/secio/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.1 [unreleased]
+# 0.23.0 [unreleased]
 
 - Update dependencies.
 

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-secio"
 edition = "2018"
 description = "Secio encryption protocol for libp2p"
-version = "0.22.1"
+version = "0.23.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -19,7 +19,7 @@ ctr = "0.3"
 futures = "0.3.1"
 hmac = "0.9.0"
 lazy_static = "1.2.0"
-libp2p-core = { version = "0.22.0", path = "../../core" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
 log = "0.4.6"
 prost = "0.6.1"
 pin-project = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,7 @@ pub use self::transport_ext::TransportExt;
 #[cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "noise", feature = "mplex", feature = "yamux"))]
 #[cfg_attr(docsrs, doc(cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "noise", feature = "mplex", feature = "yamux"))))]
 pub fn build_development_transport(keypair: identity::Keypair)
-    -> std::io::Result<impl Transport<Output = (PeerId, impl core::muxing::StreamMuxer<OutboundSubstream = impl Send, Substream = impl Send, Error = impl Into<std::io::Error>> + Send + Sync), Error = impl std::error::Error + Send, Listener = impl Send, Dial = impl Send, ListenerUpgrade = impl Send> + Clone>
+    -> std::io::Result<core::transport::Boxed<(PeerId, core::muxing::StreamMuxerBox)>>
 {
      build_tcp_ws_noise_mplex_yamux(keypair)
 }
@@ -283,7 +283,7 @@ pub fn build_development_transport(keypair: identity::Keypair)
 #[cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "noise", feature = "mplex", feature = "yamux"))]
 #[cfg_attr(docsrs, doc(cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "noise", feature = "mplex", feature = "yamux"))))]
 pub fn build_tcp_ws_noise_mplex_yamux(keypair: identity::Keypair)
-    -> std::io::Result<impl Transport<Output = (PeerId, impl core::muxing::StreamMuxer<OutboundSubstream = impl Send, Substream = impl Send, Error = impl Into<std::io::Error>> + Send + Sync), Error = impl std::error::Error + Send, Listener = impl Send, Dial = impl Send, ListenerUpgrade = impl Send> + Clone>
+    -> std::io::Result<core::transport::Boxed<(PeerId, core::muxing::StreamMuxerBox)>>
 {
     let transport = {
         #[cfg(feature = "tcp-async-std")]
@@ -314,7 +314,7 @@ pub fn build_tcp_ws_noise_mplex_yamux(keypair: identity::Keypair)
 #[cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "noise", feature = "mplex", feature = "yamux", feature = "pnet"))]
 #[cfg_attr(docsrs, doc(cfg(all(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")), any(feature = "tcp-async-std", feature = "tcp-tokio"), feature = "websocket", feature = "noise", feature = "mplex", feature = "yamux", feature = "pnet"))))]
 pub fn build_tcp_ws_pnet_noise_mplex_yamux(keypair: identity::Keypair, psk: PreSharedKey)
-    -> std::io::Result<impl Transport<Output = (PeerId, impl core::muxing::StreamMuxer<OutboundSubstream = impl Send, Substream = impl Send, Error = impl Into<std::io::Error>> + Send + Sync), Error = impl std::error::Error + Send, Listener = impl Send, Dial = impl Send, ListenerUpgrade = impl Send> + Clone>
+    -> std::io::Result<core::transport::Boxed<(PeerId, core::muxing::StreamMuxerBox)>>
 {
     let transport = {
         #[cfg(feature = "tcp-async-std")]

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,4 +1,9 @@
-# 0.22.1 [unreleased]
+# 0.23.0 [unreleased]
+
+- Require a `Boxed` transport to be given to the `Swarm`
+  or `SwarmBuilder` to avoid unnecessary double-boxing of
+  transports and simplify API bounds.
+  [PR 1794](https://github.com/libp2p/rust-libp2p/pull/1794)
 
 - Respect inbound timeouts and upgrade versions in the `MultiHandler`.
   [PR 1786](https://github.com/libp2p/rust-libp2p/pull/1786).

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-swarm"
 edition = "2018"
 description = "The libp2p swarm"
-version = "0.22.1"
+version = "0.23.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 either = "1.6.0"
 futures = "0.3.1"
-libp2p-core = { version = "0.22.0", path = "../core" }
+libp2p-core = { version = "0.23.0", path = "../core" }
 log = "0.4"
 rand = "0.7"
 smallvec = "1.0"

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.0 [unreleased]
+
+- Bump `libp2p-core` dependency.
+
 # 0.22.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-dns"
 edition = "2018"
 description = "DNS transport implementation for libp2p"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -10,6 +10,6 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-libp2p-core = { version = "0.22.0", path = "../../core" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
 log = "0.4.1"
 futures = "0.3.1"

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,4 +1,6 @@
- # 0.22.1 [unreleased]
+# 0.23.0 [unreleased]
+
+- Update `libp2p-core`.
 
 - Replace `get_if_addrs` with `if-addrs`.
 

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-tcp"
 edition = "2018"
 description = "TCP/IP transport protocol for libp2p"
-version = "0.22.1"
+version = "0.23.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -15,7 +15,7 @@ futures = "0.3.1"
 futures-timer = "3.0"
 if-addrs = "0.6.4"
 ipnet = "2.0.0"
-libp2p-core = { version = "0.22.0", path = "../../core" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
 log = "0.4.1"
 socket2 = "0.3.12"
 tokio = { version = "0.2", default-features = false, features = ["tcp"], optional = true }

--- a/transports/uds/CHANGELOG.md
+++ b/transports/uds/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.0 [unreleased]
+
+- Update `libp2p-core` dependency.
+
 # 0.22.0 [2020-09-09]
 
 - Update `libp2p-core` dependency.

--- a/transports/uds/Cargo.toml
+++ b/transports/uds/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-uds"
 edition = "2018"
 description = "Unix domain sockets transport for libp2p"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [target.'cfg(all(unix, not(target_os = "emscripten")))'.dependencies]
 async-std = { version = "1.6.2", optional = true }
-libp2p-core = { version = "0.22.0", path = "../../core" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
 log = "0.4.1"
 futures = "0.3.1"
 tokio = { version = "0.2", default-features = false, features = ["uds"], optional = true }

--- a/transports/wasm-ext/CHANGELOG.md
+++ b/transports/wasm-ext/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.0 [unreleased]
+
+- Update `libp2p-core` dependency.
+
 # 0.22.0 [2020-09-09]
 
 - Update `libp2p-core` dependency.

--- a/transports/wasm-ext/Cargo.toml
+++ b/transports/wasm-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-wasm-ext"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 edition = "2018"
 description = "Allows passing in an external transport in a WASM environment"
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 futures = "0.3.1"
 js-sys = "0.3.19"
-libp2p-core = { version = "0.22.0", path = "../../core" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
 parity-send-wrapper = "0.1.0"
 wasm-bindgen = "0.2.42"
 wasm-bindgen-futures = "0.4.4"

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.1 [unreleased]
+# 0.24.0 [unreleased]
 
 - Update dependencies.
 

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-websocket"
 edition = "2018"
 description = "WebSocket transport for libp2p"
-version = "0.23.1"
+version = "0.24.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 async-tls = "0.10.0"
 either = "1.5.3"
 futures = "0.3.1"
-libp2p-core = { version = "0.22.0", path = "../../core" }
+libp2p-core = { version = "0.23.0", path = "../../core" }
 log = "0.4.8"
 quicksink = "0.1"
 rustls = "0.18.0"


### PR DESCRIPTION
After https://github.com/libp2p/rust-libp2p/pull/1783 I had to realise while experimenting with the latest `rust-libp2p` in substrate that there is still a use-case for boxing non-multiplexed transports, mainly the odd case where a transport is used without a `Network`. Instead of just re-exposing the `transport::upgrade::boxed::boxed()` constructor directly for these cases, I decided to try some refinements of the API.

In summary:

  * Introduced `Authenticated` and `Multiplexed` newtypes in the transport upgrade builder pipeline for a more type-directed API.
  * There is now both the revived `Transport::boxed() -> Boxed<Self::Output>` and the new `Multiplexed::boxed() -> Boxed<(TConnInfo, StreamMuxerBox)>`.
  * `Transport::timeout()` moved to `Multiplexed::timeout()` to better reflect the common use-case and avoid the pitfall where the timeout is applied too early in the transport builder pipeline. It also makes the `Transport` trait a bit leaner.
  * The `Swarm` now expects a `Boxed<(PeerId, StreamMuxerBox)>` transport. This avoids repeating `Send` / `Sync` / `'static` constraints required for boxing the transport in the Swarm API (which always boxes the transport) and also avoids common accidental use of double-boxed transports if the transport passed to the `Swarm` is already boxed (which also happens right now in substrate).
  * The `build_*` functions of `src/lib.rs` now return a `transport::Boxed<(PeerId, StreamMuxerBox)>`. This is just a change of return type from `impl Transport` to `Boxed`, the implementation already boxed anyway. This obsoletes https://github.com/libp2p/rust-libp2p/issues/783.

Some more details:

  * `Transport::boxed()` no longer requires a multiplexed transport, as was the case before https://github.com/libp2p/rust-libp2p/pull/1783. I.e. `Transport::boxed()` can be used with any transport and yields a `transport::boxed::Boxed` for some opaque output `Transport::Output`.
  * `Transport::boxed()` now always also boxes the transport errors, leaving only the opaque `Transport::Output` unboxed. Every use-case I've seen for `Transport::boxed()` also wanted boxed transport errors.
  * `Transport::upgrade()` yields a `transport::upgrade::Builder` as usual.
  * `transport::upgrade::Builder::authenticate()` yields a `transport::upgrade::Authenticated` (newtype).
  * `transport::upgrade::Authenticated::apply()` yields a `transport::upgrade::Authenticated` (previously this was `Builder::apply() -> Builder`).
  * `transport::upgrade::Authenticated::multiplex()` yields a `transport::upgrade::Multiplexed` transport (newtype).
  * `transport::upgrade::Multiplexed::timeout()` yields a `transport::upgrade::Multiplexed<TransportTimeout<T>>`.
  * `transport::upgrade::Multiplexed::boxed()` yields a `transport::boxed::Boxed` whose output muxer is a `StreamMuxerBox`.

