### PR TITLE
Prepare release v0.29.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
-# Version 0.29.0 [unreleased]
+# Version 0.29.0 [2020-10-16]
 
 - Update `libp2p-core`, `libp2p-floodsub`, `libp2p-gossipsub`, `libp2p-mplex`,
   `libp2p-noise`, `libp2p-plaintext`, `libp2p-pnet`, `libp2p-request-response`,

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-10-16]
 
 - Rework transport boxing and move timeout configuration
   to the transport builder.

--- a/misc/multiaddr/CHANGELOG.md
+++ b/misc/multiaddr/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.9.3 [unreleased]
+# 0.9.3 [2020-10-16]
 
 - Update dependencies.
 

--- a/misc/multistream-select/CHANGELOG.md
+++ b/misc/multistream-select/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.8.3 [unreleased]
+# 0.8.3 [2020-10-16]
 
 - Fix a regression resulting in a panic with the `V1Lazy` protocol.
   [PR 1783](https://github.com/libp2p/rust-libp2p/pull/1783).

--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-10-16]
 
 - More granular execution of pending flushes, better logging and
   avoiding unnecessary hashing.

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.26.0 [unreleased]
+# 0.26.0 [2020-10-16]
 
 - Update `libp2p-core`.
 

--- a/protocols/deflate/CHANGELOG.md
+++ b/protocols/deflate/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-10-16]
 
 - Bump `libp2p-core` dependency.
 

--- a/protocols/floodsub/CHANGELOG.md
+++ b/protocols/floodsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-10-16]
 
 - Update dependencies.
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-10-16]
 
 - Update dependencies.
 

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-10-16]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-10-16]
 
 - Update `libp2p-core` and `libp2p-swarm`.
 

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-10-16]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 

--- a/protocols/noise/CHANGELOG.md
+++ b/protocols/noise/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.25.0 [unreleased]
+# 0.25.0 [2020-10-16]
 
 - Update dependencies.
 

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-10-16]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 

--- a/protocols/plaintext/CHANGELOG.md
+++ b/protocols/plaintext/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-10-16]
 
 - Improve error logging
   [PR 1759](https://github.com/libp2p/rust-libp2p/pull/1759).

--- a/protocols/pnet/CHANGELOG.md
+++ b/protocols/pnet/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.19.2 [unreleased]
+# 0.19.2 [2020-10-16]
 
 - Update dependencies.
 

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.4.0 [unreleased]
+# 0.4.0 [2020-10-16]
 
 - Update dependencies.
 

--- a/protocols/secio/CHANGELOG.md
+++ b/protocols/secio/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-10-16]
 
 - Update dependencies.
 

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-10-16]
 
 - Require a `Boxed` transport to be given to the `Swarm`
   or `SwarmBuilder` to avoid unnecessary double-boxing of

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-10-16]
 
 - Bump `libp2p-core` dependency.
 

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-10-16]
 
 - Update `libp2p-core`.
 

--- a/transports/uds/CHANGELOG.md
+++ b/transports/uds/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-10-16]
 
 - Update `libp2p-core` dependency.
 

--- a/transports/wasm-ext/CHANGELOG.md
+++ b/transports/wasm-ext/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.0 [unreleased]
+# 0.23.0 [2020-10-16]
 
 - Update `libp2p-core` dependency.
 

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-10-16]
 
 - Update dependencies.
 


### PR DESCRIPTION
Release of `libp2p-0.29` and all unreleased sub-crates.