### PR TITLE
[multistream-select] Temporarily disable "parallel" negotiation.

### DIFF
--- a/misc/multistream-select/CHANGELOG.md
+++ b/misc/multistream-select/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.8.4 [2020-10-20]
+
+- Temporarily disable the internal selection of "parallel" protocol
+  negotiation for the dialer to later change the response format of the "ls"
+  message for spec compliance.
+
 # 0.8.3 [2020-10-16]
 
 - Fix a regression resulting in a panic with the `V1Lazy` protocol.

--- a/misc/multistream-select/CHANGELOG.md
+++ b/misc/multistream-select/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Temporarily disable the internal selection of "parallel" protocol
   negotiation for the dialer to later change the response format of the "ls"
-  message for spec compliance.
+  message for spec compliance. See https://github.com/libp2p/rust-libp2p/issues/1795.
 
 # 0.8.3 [2020-10-16]
 

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "multistream-select"
 description = "Multistream-select negotiation protocol for libp2p"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
As suggested by @mxinden in https://github.com/libp2p/rust-libp2p/issues/1795#issuecomment-710051380, in order to later change the "ls" responses for spec-compliance, this PR temporarily disables that negotiation strategy for the dialer. I thereby propose to immediately release this as a patch release in order to speed up the process. The next, follow-up release will obviously be not backward-compatible and require the latest patch version released here to already be deployed. I would like to pick up this new patch version already in https://github.com/paritytech/substrate/pull/7341.