### PR TITLE
core/Cargo.toml: Update to ed25519-dalek v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
+# Version 0.29.1 [unreleased]
+
+- Update `libp2p-core`.
+
 # Version 0.29.0 [2020-10-16]
 
 - Update `libp2p-core`, `libp2p-floodsub`, `libp2p-gossipsub`, `libp2p-mplex`,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p"
 edition = "2018"
 description = "Peer-to-peer networking library"
-version = "0.29.0"
+version = "0.29.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -62,7 +62,7 @@ atomic = "0.5.0"
 bytes = "0.5"
 futures = "0.3.1"
 lazy_static = "1.2"
-libp2p-core = { version = "0.23.0", path = "core" }
+libp2p-core = { version = "0.23.1", path = "core" }
 libp2p-core-derive = { version = "0.20.2", path = "misc/core-derive" }
 libp2p-floodsub = { version = "0.23.0", path = "protocols/floodsub", optional = true }
 libp2p-gossipsub = { version = "0.23.0", path = "./protocols/gossipsub", optional = true }

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.1 [unreleased]
+
+- Update dependencies.
+
 # 0.23.0 [2020-10-16]
 
 - Rework transport boxing and move timeout configuration

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-core"
 edition = "2018"
 description = "Core traits and structs of libp2p"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 asn1_der = "0.6.1"
 bs58 = "0.3.0"
-ed25519-dalek = "1.0.0-pre.4"
+ed25519-dalek = "1.0.1"
 either = "1.5"
 fnv = "1.0"
 futures = { version = "0.3.1", features = ["executor", "thread-pool"] }


### PR DESCRIPTION
See https://github.com/paritytech/substrate/pull/7341#discussion_r508516095 for motivation.

I guess dependabot didn't spot this given the `pre.4` suffix.