### PR TITLE
Prepare v0.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
-# Version 0.29.1 [unreleased]
+# Version 0.29.1 [2020-10-20]
 
 - Update `libp2p-core`.
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.23.1 [unreleased]
+# 0.23.1 [2020-10-20]
 
 - Update dependencies.
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,7 +22,7 @@ libsecp256k1 = { version = "0.3.1", optional = true }
 log = "0.4"
 multiaddr = { package = "parity-multiaddr", version = "0.9.2", path = "../misc/multiaddr" }
 multihash = "0.11.0"
-multistream-select = { version = "0.8.3", path = "../misc/multistream-select" }
+multistream-select = { version = "0.8.4", path = "../misc/multistream-select" }
 parking_lot = "0.11.0"
 pin-project = "1.0.0"
 prost = "0.6.1"


### PR DESCRIPTION
-  *: Update date in changelogs 

-  core/Cargo.toml: Bump multistream-select to v0.8.4 