### PR TITLE
[mplex] Revert to being lenient with duplicate Close frames.

### DIFF
--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.23.1 [2020-10-28]
+
+- Be lenient with duplicate `Close` frames received. Version
+  `0.23.0` started treating duplicate `Close` frames for a
+  substream as a protocol violation. As some libp2p implementations
+  seem to occasionally send such frames and it is a harmless
+  redundancy, this releases reverts back to the pre-0.23 behaviour
+  of ignoring duplicate `Close` frames.
+
 # 0.23.0 [2020-10-16]
 
 - More granular execution of pending flushes, better logging and

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-mplex"
 edition = "2018"
 description = "Mplex multiplexing protocol for libp2p"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/muxers/mplex/src/io.rs
+++ b/muxers/mplex/src/io.rs
@@ -666,11 +666,9 @@ where
         if let Some(state) = self.substreams.remove(&id) {
             match state {
                 SubstreamState::RecvClosed { .. } | SubstreamState::Closed { .. } => {
-                    debug!("{}: Received unexpected `Close` frame for closed substream {}",
+                    debug!("{}: Ignoring `Close` frame for closed substream {}",
                         self.id, id);
-                    return self.on_error(
-                        io::Error::new(io::ErrorKind::Other,
-                        "Protocol error: Received `Close` frame for closed substream."))
+                    self.substreams.insert(id, state);
                 },
                 SubstreamState::Reset { buf } => {
                     debug!("{}: Ignoring `Close` frame for already reset substream {}",


### PR DESCRIPTION
Version  `0.23.0` started [treating duplicate `Close` frames for a substream as a protocol violation](https://github.com/libp2p/rust-libp2p/pull/1769#discussion_r493604381). As there seem to be libp2p implementations that occasionally send such frames (cf. https://github.com/sigp/lighthouse/issues/1832#issuecomment-717859849) and it is a harmless redundancy, I prefer and propose here again to be lenient about such redundant frames rather than requiring other implementations to change, especially since this may be considered a regression compared to previous versions of `libp2p-mplex`. This PR prepares release `libp2p-mplex-0.23.1`.