### PR TITLE
[kad] Update local routing table on new connections after protocol confirmation.

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,5 +1,14 @@
 # 0.25.0 [unreleased]
 
+- Upon newly established connections, delay routing table
+  updates until after the configured protocol name has
+  been confirmed by the connection handler, i.e. until
+  after at least one substream has been successfully
+  negotiated. In configurations with different protocol names,
+  this avoids undesirable nodes being included in the
+  local routing table at least temporarily.
+  [PR 1821](https://github.com/libp2p/rust-libp2p/pull/1821).
+
 - Update dependencies.
 
 # 0.24.0 [2020-10-16]

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -24,7 +24,13 @@ mod test;
 
 use crate::K_VALUE;
 use crate::addresses::Addresses;
-use crate::handler::{KademliaHandler, KademliaHandlerConfig, KademliaRequestId, KademliaHandlerEvent, KademliaHandlerIn};
+use crate::handler::{
+    KademliaHandlerProto,
+    KademliaHandlerConfig,
+    KademliaRequestId,
+    KademliaHandlerEvent,
+    KademliaHandlerIn
+};
 use crate::jobs::*;
 use crate::kbucket::{self, KBucketsTable, NodeStatus};
 use crate::protocol::{KademliaProtocolConfig, KadConnectionType, KadPeer};
@@ -38,7 +44,6 @@ use libp2p_swarm::{
     NetworkBehaviourAction,
     NotifyHandler,
     PollParameters,
-    ProtocolsHandler
 };
 use log::{info, debug, warn};
 use smallvec::SmallVec;
@@ -1428,11 +1433,11 @@ where
     for<'a> TStore: RecordStore<'a>,
     TStore: Send + 'static,
 {
-    type ProtocolsHandler = KademliaHandler<QueryId>;
+    type ProtocolsHandler = KademliaHandlerProto<QueryId>;
     type OutEvent = KademliaEvent;
 
     fn new_handler(&mut self) -> Self::ProtocolsHandler {
-        KademliaHandler::new(KademliaHandlerConfig {
+        KademliaHandlerProto::new(KademliaHandlerConfig {
             protocol_config: self.protocol_config.clone(),
             allow_listening: true,
             idle_timeout: self.connection_idle_timeout,
@@ -1462,17 +1467,11 @@ where
         peer_addrs
     }
 
-    fn inject_connection_established(&mut self, peer: &PeerId, _: &ConnectionId, endpoint: &ConnectedPoint) {
-        // The remote's address can only be put into the routing table,
-        // and thus shared with other nodes, if the local node is the dialer,
-        // since the remote address on an inbound connection is specific to
-        // that connection (e.g. typically the TCP port numbers).
-        let address = match endpoint {
-            ConnectedPoint::Dialer { address } => Some(address.clone()),
-            ConnectedPoint::Listener { .. } => None,
-        };
-
-        self.connection_updated(peer.clone(), address, NodeStatus::Connected);
+    fn inject_connection_established(&mut self, _: &PeerId, _: &ConnectionId, _: &ConnectedPoint) {
+        // When a connection is established, we don't know yet whether the
+        // remote supports the configured protocol name. Only once a connection
+        // handler reports [`KademliaHandlerEvent::ProtocolConfirmed`] do we
+        // update the local routing table.
     }
 
     fn inject_connected(&mut self, peer: &PeerId) {
@@ -1606,6 +1605,19 @@ where
         event: KademliaHandlerEvent<QueryId>
     ) {
         match event {
+            KademliaHandlerEvent::ProtocolConfirmed { endpoint } => {
+                debug_assert!(self.connected_peers.contains(&source));
+                // The remote's address can only be put into the routing table,
+                // and thus shared with other nodes, if the local node is the dialer,
+                // since the remote address on an inbound connection may be specific
+                // to that connection (e.g. typically the TCP port numbers).
+                let address = match endpoint {
+                    ConnectedPoint::Dialer { address } => Some(address.clone()),
+                    ConnectedPoint::Listener { .. } => None,
+                };
+                self.connection_updated(source, address, NodeStatus::Connected);
+            }
+
             KademliaHandlerEvent::FindNodeReq { key, request_id } => {
                 let closer_peers = self.find_closest(&kbucket::Key::new(key), &source);
                 self.queued_events.push_back(NetworkBehaviourAction::NotifyHandler {
@@ -1804,7 +1816,7 @@ where
 
     fn poll(&mut self, cx: &mut Context<'_>, parameters: &mut impl PollParameters) -> Poll<
         NetworkBehaviourAction<
-            <KademliaHandler<QueryId> as ProtocolsHandler>::InEvent,
+            KademliaHandlerIn<QueryId>,
             Self::OutEvent,
         >,
     > {


### PR DESCRIPTION
This is a proposal for closing https://github.com/libp2p/rust-libp2p/issues/1611. In order to avoid adding peers to the local routing table which use a different protocol name and thus actually a different overlay network, only update the local routing table for newly established connections once the associated connection handler reports that the protocol has been confirmed. The configured protocol is confirmed on a connection once the first inbound or outbound substream is successfully negotiated.