### PR TITLE
[mplex, yamux] Streamline configuration API.

### DIFF
--- a/examples/ipfs-private.rs
+++ b/examples/ipfs-private.rs
@@ -44,7 +44,7 @@ use libp2p::{
     noise,
     swarm::NetworkBehaviourEventProcess,
     tcp::TcpConfig,
-    yamux::Config as YamuxConfig,
+    yamux::YamuxConfig,
     Multiaddr, NetworkBehaviour, PeerId, Swarm, Transport,
 };
 use std::{

--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 0.24.0 [unreleased]
 
+- Tweak the naming in the `MplexConfig` API for better
+  consistency with `libp2p-yamux`.
+  [PR 1822](https://github.com/libp2p/rust-libp2p/pull/1822).
+
 - Update dependencies.
 
 # 0.23.1 [2020-10-28]

--- a/muxers/mplex/src/config.rs
+++ b/muxers/mplex/src/config.rs
@@ -55,7 +55,7 @@ impl MplexConfig {
     /// accumulates too quickly (judged by internal bounds), the
     /// connection is closed with an error due to the misbehaved
     /// remote.
-    pub fn max_substreams(&mut self, max: usize) -> &mut Self {
+    pub fn set_max_num_streams(&mut self, max: usize) -> &mut Self {
         self.max_substreams = max;
         self
     }
@@ -63,7 +63,7 @@ impl MplexConfig {
     /// Sets the maximum number of frames buffered per substream.
     ///
     /// A limit is necessary in order to avoid DoS attacks.
-    pub fn max_buffer_len(&mut self, max: usize) -> &mut Self {
+    pub fn set_max_buffer_size(&mut self, max: usize) -> &mut Self {
         self.max_buffer_len = max;
         self
     }
@@ -72,14 +72,14 @@ impl MplexConfig {
     /// for a substream.
     ///
     /// See the documentation of [`MaxBufferBehaviour`].
-    pub fn max_buffer_len_behaviour(&mut self, behaviour: MaxBufferBehaviour) -> &mut Self {
+    pub fn set_max_buffer_behaviour(&mut self, behaviour: MaxBufferBehaviour) -> &mut Self {
         self.max_buffer_behaviour = behaviour;
         self
     }
 
     /// Sets the frame size used when sending data. Capped at 1Mbyte as per the
     /// Mplex spec.
-    pub fn split_send_size(&mut self, size: usize) -> &mut Self {
+    pub fn set_split_send_size(&mut self, size: usize) -> &mut Self {
         let size = cmp::min(size, MAX_FRAME_SIZE);
         self.split_send_size = size;
         self

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 0.27.0 [unreleased]
 
+- Tweak the naming in the `MplexConfig` API for better
+  consistency with `libp2p-mplex`.
+  [PR 1822](https://github.com/libp2p/rust-libp2p/pull/1822).
+
 - Update dependencies.
 
 # 0.26.0 [2020-10-16]

--- a/protocols/gossipsub/tests/smoke.rs
+++ b/protocols/gossipsub/tests/smoke.rs
@@ -150,7 +150,7 @@ fn build_node() -> (Multiaddr, Swarm<Gossipsub>) {
         .authenticate(PlainText2Config {
             local_public_key: public_key.clone(),
         })
-        .multiplex(yamux::Config::default())
+        .multiplex(yamux::YamuxConfig::default())
         .boxed();
 
     let peer_id = public_key.clone().into_peer_id();

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -61,7 +61,7 @@ fn build_node_with_config(cfg: KademliaConfig) -> (Multiaddr, TestSwarm) {
     let transport = MemoryTransport::default()
         .upgrade(upgrade::Version::V1)
         .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
-        .multiplex(yamux::Config::default())
+        .multiplex(yamux::YamuxConfig::default())
         .boxed();
 
     let local_id = local_public_key.clone().into_peer_id();

--- a/protocols/ping/tests/ping.rs
+++ b/protocols/ping/tests/ping.rs
@@ -207,7 +207,7 @@ fn mk_transport(muxer: MuxerChoice) -> (
         .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
         .multiplex(match muxer {
             MuxerChoice::Yamux =>
-                upgrade::EitherUpgrade::A(yamux::Config::default()),
+                upgrade::EitherUpgrade::A(yamux::YamuxConfig::default()),
             MuxerChoice::Mplex =>
                 upgrade::EitherUpgrade::B(mplex::MplexConfig::default()),
         })

--- a/protocols/request-response/tests/ping.rs
+++ b/protocols/request-response/tests/ping.rs
@@ -221,7 +221,7 @@ fn mk_transport() -> (PeerId, transport::Boxed<(PeerId, StreamMuxerBox)>) {
         .nodelay(true)
         .upgrade(upgrade::Version::V1)
         .authenticate(NoiseConfig::xx(noise_keys).into_authenticated())
-        .multiplex(libp2p_yamux::Config::default())
+        .multiplex(libp2p_yamux::YamuxConfig::default())
         .boxed())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@
 //! let id_keys = Keypair::generate_ed25519();
 //! let noise_keys = noise::Keypair::<noise::X25519Spec>::new().into_authentic(&id_keys).unwrap();
 //! let noise = noise::NoiseConfig::xx(noise_keys).into_authenticated();
-//! let yamux = yamux::Config::default();
+//! let yamux = yamux::YamuxConfig::default();
 //! let transport = tcp.upgrade(upgrade::Version::V1).authenticate(noise).multiplex(yamux);
 //! # }
 //! ```
@@ -302,7 +302,7 @@ pub fn build_tcp_ws_noise_mplex_yamux(keypair: identity::Keypair)
     Ok(transport
         .upgrade(core::upgrade::Version::V1)
         .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
-        .multiplex(core::upgrade::SelectUpgrade::new(yamux::Config::default(), mplex::MplexConfig::new()))
+        .multiplex(core::upgrade::SelectUpgrade::new(yamux::YamuxConfig::default(), mplex::MplexConfig::default()))
         .timeout(std::time::Duration::from_secs(20))
         .boxed())
 }
@@ -334,7 +334,7 @@ pub fn build_tcp_ws_pnet_noise_mplex_yamux(keypair: identity::Keypair, psk: PreS
         .and_then(move |socket, _| PnetConfig::new(psk).handshake(socket))
         .upgrade(core::upgrade::Version::V1)
         .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
-        .multiplex(core::upgrade::SelectUpgrade::new(yamux::Config::default(), mplex::MplexConfig::new()))
+        .multiplex(core::upgrade::SelectUpgrade::new(yamux::YamuxConfig::default(), mplex::MplexConfig::default()))
         .timeout(std::time::Duration::from_secs(20))
         .boxed())
 }


### PR DESCRIPTION
This is a proposal for streamlining the configuration APIs of `libp2p-mplex` and `libp2p-yamux`, i.e. to close https://github.com/libp2p/rust-libp2p/issues/1531. I made the following choices:

  * For all configuration options that exist for both multiplexers and have the same semantics, use the same names for the
    configuration.
  * Rename `yamux::Config` to `YamuxConfig` for consistency with the majority of other protocols, e.g. `MplexConfig`, `PingConfig`,  `KademliaConfig`, etc.
  * Completely hide `yamux` APIs within `libp2p-yamux`. This is a trade-off. It allows to fully control the libp2p API and streamline it with other muxer APIs, consciously choosing e.g. which configuration options to make configurable in libp2p and which to fix to certain values (e.g. we currently always fix `read_after_close` which is not actually configurable for libp2p). It also means that new incompatible version bumps of yamux need not necessarily require analogous bumps for `libp2p-yamux`, as no `yamux` types are exposed. The cost is naturally some more duplication of configuration options in the API, as well as the need to update `libp2p-yamux` if `yamux` introduces new configuration options that `libp2p-yamux` wants to expose as well. Overall I think fully hiding `yamux` from the API, i.e. making it an implementation detail, is preferable.