### PR TITLE
[mplex] Tweak default config and yield before exceeding buffer limits.

### DIFF
--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -1,5 +1,13 @@
 # 0.24.0 [unreleased]
 
+- Change the default configuration to use `MaxBufferBehaviour::Block`
+  and yield from waiting for the next substream or reading from a
+  particular substream whenever the current read loop may have
+  already filled a substream buffer, to give the current task a
+  chance to read from the buffer(s) before the `MaxBufferBehaviour`
+  takes effect. This is primarily relevant for
+  `MaxBufferBehaviour::ResetStream`.
+
 - Tweak the naming in the `MplexConfig` API for better
   consistency with `libp2p-yamux`.
   [PR 1822](https://github.com/libp2p/rust-libp2p/pull/1822).


### PR DESCRIPTION
This PR is a small follow-up to https://github.com/libp2p/rust-libp2p/issues/1814#issuecomment-722355848. It contains the following changes:

  * The default `MplexConfig` uses `MaxBufferBehaviour::Block` as I think it is the better default.
  * Whenever we may have entirely filled a substream buffer in the context of either waiting for the next inbound stream (`poll_next_stream`) or reading from a particular substream (`poll_read_stream`), we yield the current task, allowing it to be polled again to have a chance to read from the buffers before the `MaxBufferBehaviour` takes effect.
  * Documentation tweaks.