### PR TITLE
*: Update changelogs to release v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
-# Version 0.30.0 [unreleased]
+# Version 0.30.0 [2020-11-09]
 
 - Update `libp2p-mdns`, `libp2p-tcp` and `libp2p-uds` as well as `libp2p-core`
   and all its dependers.

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-11-09]
 
 - Remove `ConnectionInfo` trait and replace it with `PeerId`
   everywhere. This was already effectively the case because

--- a/misc/multistream-select/CHANGELOG.md
+++ b/misc/multistream-select/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.8.5 [unreleased]
+# 0.8.5 [2020-11-09]
 
 - During negotiation do not interpret EOF error as an IO error, but instead as a
   negotiation error. See https://github.com/libp2p/rust-libp2p/pull/1823.

--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-11-09]
 
 - Tweak the naming in the `MplexConfig` API for better
   consistency with `libp2p-yamux`.

--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -7,6 +7,7 @@
   chance to read from the buffer(s) before the `MaxBufferBehaviour`
   takes effect. This is primarily relevant for
   `MaxBufferBehaviour::ResetStream`.
+  [PR 1825](https://github.com/libp2p/rust-libp2p/pull/1825/).
 
 - Tweak the naming in the `MplexConfig` API for better
   consistency with `libp2p-yamux`.

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.0 [unreleased]
+# 0.27.0 [2020-11-09]
 
 - Tweak the naming in the `MplexConfig` API for better
   consistency with `libp2p-mplex`.

--- a/protocols/deflate/CHANGELOG.md
+++ b/protocols/deflate/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-11-09]
 
 - Update dependencies.
 

--- a/protocols/floodsub/CHANGELOG.md
+++ b/protocols/floodsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-11-09]
 
 - Update dependencies.
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-11-09]
 
 - Update dependencies.
 

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-11-09]
 
 - Update dependencies.
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.25.0 [unreleased]
+# 0.25.0 [2020-11-09]
 
 - Upon newly established connections, delay routing table
   updates until after the configured protocol name has

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-11-09]
 
 - Update dependencies.
 

--- a/protocols/noise/CHANGELOG.md
+++ b/protocols/noise/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.26.0 [unreleased]
+# 0.26.0 [2020-11-09]
 
 - Update dependencies.
 

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-11-09]
 
 - Update dependencies.
 

--- a/protocols/plaintext/CHANGELOG.md
+++ b/protocols/plaintext/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-11-09]
 
 - Update dependencies.
 

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.5.0 [unreleased]
+# 0.5.0 [2020-11-09]
 
 - Update dependencies.
 

--- a/protocols/secio/CHANGELOG.md
+++ b/protocols/secio/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-11-09]
 
 - Update dependencies.
 

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-11-09]
 
 - Update dependencies.
 

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-11-09]
 
 - Update dependencies.
 

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-11-09]
 
 - Update dependencies.
 

--- a/transports/uds/CHANGELOG.md
+++ b/transports/uds/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-11-09]
 
 - Update dependencies.
 

--- a/transports/wasm-ext/CHANGELOG.md
+++ b/transports/wasm-ext/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0 [unreleased]
+# 0.24.0 [2020-11-09]
 
 - Fix the WebSocket implementation parsing `x-parity-ws` multiaddresses as `x-parity-wss`.
 - Update dependencies.

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.25.0 [unreleased]
+# 0.25.0 [2020-11-09]
 
 - Update dependencies.
 


### PR DESCRIPTION
I would like to cut a new release of libp2p - v0.30.0.

I suggest including https://github.com/libp2p/rust-libp2p/pull/1825 and https://github.com/libp2p/rust-libp2p/pull/1823. Anything else you would like to be included?

I would suggest not yet rolling out the second step of the `ls` upgrade (https://github.com/libp2p/rust-libp2p/pull/1811), but instead leaving more time for v0.29.1 to be rolled out.