### PR TITLE
Adds support for handling interface changes to mdns behaviour.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
+# Version 0.32.0 [unreleased]
+
+- Update to `libp2p-mdns-0.26`.
+
 # Version 0.31.2 [2020-12-02]
 
 - Bump minimum `libp2p-core` patch version.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default = [
     "identify",
     "kad",
     "gossipsub",
-    "mdns-async-std",
+    "mdns",
     "mplex",
     "noise",
     "ping",
@@ -37,8 +37,7 @@ floodsub = ["libp2p-floodsub"]
 identify = ["libp2p-identify"]
 kad = ["libp2p-kad"]
 gossipsub = ["libp2p-gossipsub"]
-mdns-async-std = ["libp2p-mdns", "libp2p-mdns/async-std"]
-mdns-tokio = ["libp2p-mdns", "libp2p-mdns/tokio"]
+mdns = ["libp2p-mdns"]
 mplex = ["libp2p-mplex"]
 noise = ["libp2p-noise"]
 ping = ["libp2p-ping"]
@@ -125,4 +124,4 @@ members = [
 
 [[example]]
 name = "chat-tokio"
-required-features = ["tcp-tokio", "mdns-tokio"]
+required-features = ["tcp-tokio", "mdns"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p"
 edition = "2018"
 description = "Peer-to-peer networking library"
-version = "0.31.2"
+version = "0.32.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -86,7 +86,7 @@ wasm-timer = "0.2.4"
 [target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")))'.dependencies]
 libp2p-deflate = { version = "0.25.0", path = "protocols/deflate", optional = true }
 libp2p-dns = { version = "0.25.0", path = "transports/dns", optional = true }
-libp2p-mdns = { version = "0.25.0", path = "protocols/mdns", optional = true }
+libp2p-mdns = { version = "0.26.0", path = "protocols/mdns", optional = true }
 libp2p-tcp = { version = "0.25.1", path = "transports/tcp", optional = true }
 libp2p-websocket = { version = "0.26.0", path = "transports/websocket", optional = true }
 

--- a/examples/chat-tokio.rs
+++ b/examples/chat-tokio.rs
@@ -46,8 +46,7 @@ use libp2p::{
     core::upgrade,
     identity,
     floodsub::{self, Floodsub, FloodsubEvent},
-    // `TokioMdns` is available through the `mdns-tokio` feature.
-    mdns::{TokioMdns, MdnsEvent},
+    mdns::{Mdns, MdnsEvent},
     mplex,
     noise,
     swarm::{NetworkBehaviourEventProcess, SwarmBuilder},
@@ -90,7 +89,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     #[derive(NetworkBehaviour)]
     struct MyBehaviour {
         floodsub: Floodsub,
-        mdns: TokioMdns,
+        mdns: Mdns,
     }
 
     impl NetworkBehaviourEventProcess<FloodsubEvent> for MyBehaviour {
@@ -122,7 +121,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Create a Swarm to manage peers and events.
     let mut swarm = {
-        let mdns = TokioMdns::new().await?;
+        let mdns = Mdns::new().await?;
         let mut behaviour = MyBehaviour {
             floodsub: Floodsub::new(peer_id.clone()),
             mdns,

--- a/examples/chat-tokio.rs
+++ b/examples/chat-tokio.rs
@@ -122,7 +122,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Create a Swarm to manage peers and events.
     let mut swarm = {
-        let mdns = TokioMdns::new()?;
+        let mdns = TokioMdns::new().await?;
         let mut behaviour = MyBehaviour {
             floodsub: Floodsub::new(peer_id.clone()),
             mdns,

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -121,7 +121,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Create a Swarm to manage peers and events
     let mut swarm = {
-        let mdns = Mdns::new()?;
+        let mdns = task::block_on(Mdns::new())?;
         let mut behaviour = MyBehaviour {
             floodsub: Floodsub::new(local_peer_id.clone()),
             mdns,

--- a/examples/distributed-key-value-store.rs
+++ b/examples/distributed-key-value-store.rs
@@ -151,7 +151,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         // Create a Kademlia behaviour.
         let store = MemoryStore::new(local_peer_id.clone());
         let kademlia = Kademlia::new(local_peer_id.clone(), store);
-        let mdns = Mdns::new()?;
+        let mdns = task::block_on(Mdns::new())?;
         let behaviour = MyBehaviour { kademlia, mdns };
         Swarm::new(transport, behaviour, local_peer_id)
     };

--- a/examples/mdns-passive-discovery.rs
+++ b/examples/mdns-passive-discovery.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // This example provides passive discovery of the libp2p nodes on the
     // network that send mDNS queries and answers.
     task::block_on(async move {
-        let mut service = MdnsService::new()?;
+        let mut service = MdnsService::new().await?;
         loop {
             let (srv, packet) = service.next().await;
             match packet {

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,10 +1,15 @@
 # 0.26.0 [unreleased]
 
+- Detect interface changes and join the MDNS multicast
+  group on all interfaces as they become available.
+  [PR 1830](https://github.com/libp2p/rust-libp2p/pull/1830).
+
 - Replace the use of macros for abstracting over `tokio`
   and `async-std` with the use of `async-io`. As a result
   there may now be an additional reactor thread running
   called `async-io` when using `tokio`, with the futures
   still being polled by the `tokio` runtime.
+  [PR 1830](https://github.com/libp2p/rust-libp2p/pull/1830).
 
 # 0.25.0 [2020-11-25]
 

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.26.0 [unreleased]
+
+- Replace the use of macros for abstracting over `tokio`
+  and `async-std` with the use of `async-io`. As a result
+  there may now be an additional reactor thread running
+  called `async-io` when using `tokio`, with the futures
+  still being polled by the `tokio` runtime.
+
 # 0.25.0 [2020-11-25]
 
 - Update `libp2p-swarm` and `libp2p-core`.

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -15,6 +15,7 @@ data-encoding = "2.0"
 dns-parser = "0.8"
 either = "1.5.3"
 futures = "0.3.1"
+if-watch = "0.1.2"
 lazy_static = "1.2"
 libp2p-core = { version = "0.25.0", path = "../../core" }
 libp2p-swarm = { version = "0.25.0", path = "../../swarm" }

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -11,22 +11,22 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 async-io = "1.2.0"
-either = "1.5.3"
-data-encoding = "2.0"
-dns-parser = "0.8"
-futures = "0.3.1"
-if-watch = "0.1.2"
-lazy_static = "1.2"
+either = "1.6.1"
+data-encoding = "2.3.1"
+dns-parser = "0.8.0"
+futures = "0.3.8"
+if-watch = "0.1.4"
+lazy_static = "1.4.0"
 libp2p-core = { version = "0.25.0", path = "../../core" }
 libp2p-swarm = { version = "0.25.0", path = "../../swarm" }
-log = "0.4"
-net2 = "0.2"
-rand = "0.7"
-smallvec = "1.0"
-void = "1.0"
-wasm-timer = "0.2.4"
+log = "0.4.11"
+net2 = "0.2.35"
+rand = "0.7.3"
+smallvec = "1.5.0"
+void = "1.0.2"
+wasm-timer = "0.2.5"
 
 [dev-dependencies]
 async-std = "1.7.0"
-if-addrs = "0.6.4"
-tokio = { version = "0.3", default-features = false, features = ["rt", "rt-multi-thread"] }
+if-addrs = "0.6.5"
+tokio = { version = "0.3.3", default-features = false, features = ["rt", "rt-multi-thread"] }

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -10,10 +10,10 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-std = { version = "1.6.2", optional = true }
+async-io = "1.2.0"
+either = "1.5.3"
 data-encoding = "2.0"
 dns-parser = "0.8"
-either = "1.5.3"
 futures = "0.3.1"
 if-watch = "0.1.2"
 lazy_static = "1.2"
@@ -23,10 +23,10 @@ log = "0.4"
 net2 = "0.2"
 rand = "0.7"
 smallvec = "1.0"
-tokio = { version = "0.3", default-features = false, features = ["net"], optional = true }
 void = "1.0"
 wasm-timer = "0.2.4"
 
 [dev-dependencies]
+async-std = "1.7.0"
 if-addrs = "0.6.4"
 tokio = { version = "0.3", default-features = false, features = ["rt", "rt-multi-thread"] }

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -10,8 +10,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-io = "1.2.0"
-either = "1.6.1"
+async-io = "1.3.0"
 data-encoding = "2.3.1"
 dns-parser = "0.8.0"
 futures = "0.3.8"
@@ -20,13 +19,12 @@ lazy_static = "1.4.0"
 libp2p-core = { version = "0.25.0", path = "../../core" }
 libp2p-swarm = { version = "0.25.0", path = "../../swarm" }
 log = "0.4.11"
-net2 = "0.2.35"
 rand = "0.7.3"
 smallvec = "1.5.0"
+socket2 = { version = "0.3.17", features = ["reuseport"] }
 void = "1.0.2"
-wasm-timer = "0.2.5"
 
 [dev-dependencies]
 async-std = "1.7.0"
 if-addrs = "0.6.5"
-tokio = { version = "0.3.3", default-features = false, features = ["rt", "rt-multi-thread"] }
+tokio = { version = "0.3.4", default-features = false, features = ["rt", "rt-multi-thread"] }

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -14,7 +14,7 @@ async-io = "1.3.0"
 data-encoding = "2.3.1"
 dns-parser = "0.8.0"
 futures = "0.3.8"
-if-watch = "0.1.4"
+if-watch = "0.1.6"
 lazy_static = "1.4.0"
 libp2p-core = { version = "0.25.0", path = "../../core" }
 libp2p-swarm = { version = "0.25.0", path = "../../swarm" }

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-mdns"
 edition = "2018"
-version = "0.25.0"
+version = "0.26.0"
 description = "Implementation of the libp2p mDNS discovery method"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"

--- a/protocols/mdns/src/behaviour.rs
+++ b/protocols/mdns/src/behaviour.rs
@@ -94,9 +94,9 @@ impl fmt::Debug for $maybe_busy_wrapper {
 
 impl $behaviour_name {
     /// Builds a new `Mdns` behaviour.
-    pub fn new() -> io::Result<$behaviour_name> {
+    pub async fn new() -> io::Result<$behaviour_name> {
         Ok($behaviour_name {
-            service: $maybe_busy_wrapper::Free(<$service_name>::new()?),
+            service: $maybe_busy_wrapper::Free(<$service_name>::new().await?),
             discovered_nodes: SmallVec::new(),
             closest_expiration: None,
         })

--- a/protocols/mdns/src/behaviour.rs
+++ b/protocols/mdns/src/behaviour.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::service::{MdnsPacket, build_query_response, build_service_discovery_response};
+use crate::service::{MdnsPacket, MdnsService, build_query_response, build_service_discovery_response};
 use futures::prelude::*;
 use libp2p_core::{
     Multiaddr,
@@ -41,14 +41,11 @@ use wasm_timer::{Delay, Instant};
 
 const MDNS_RESPONSE_TTL: std::time::Duration = Duration::from_secs(5 * 60);
 
-macro_rules! codegen {
-    ($feature_name:expr, $behaviour_name:ident, $maybe_busy_wrapper:ident, $service_name:ty) => {
-
 /// A `NetworkBehaviour` for mDNS. Automatically discovers peers on the local network and adds
 /// them to the topology.
-pub struct $behaviour_name {
+pub struct Mdns {
     /// The inner service.
-    service: $maybe_busy_wrapper,
+    service: MdnsBusyWrapper,
 
     /// List of nodes that we have discovered, the address, and when their TTL expires.
     ///
@@ -66,37 +63,37 @@ pub struct $behaviour_name {
 /// and a `MdnsPacket` (similar to the old Tokio socket send style). The two states are thus `Free`
 /// with an `MdnsService` or `Busy` with a future returning the original `MdnsService` and an
 /// `MdnsPacket`.
-enum $maybe_busy_wrapper {
-    Free($service_name),
-    Busy(Pin<Box<dyn Future<Output = ($service_name, MdnsPacket)> + Send>>),
+enum MdnsBusyWrapper {
+    Free(MdnsService),
+    Busy(Pin<Box<dyn Future<Output = (MdnsService, MdnsPacket)> + Send>>),
     Poisoned,
 }
 
-impl fmt::Debug for $maybe_busy_wrapper {
+impl fmt::Debug for MdnsBusyWrapper {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            $maybe_busy_wrapper::Free(service) => {
-                fmt.debug_struct("$maybe_busy_wrapper::Free")
+            Self::Free(service) => {
+                fmt.debug_struct("MdnsBusyWrapper::Free")
                     .field("service", service)
                     .finish()
             },
-            $maybe_busy_wrapper::Busy(_) => {
-                fmt.debug_struct("$maybe_busy_wrapper::Busy")
+            Self::Busy(_) => {
+                fmt.debug_struct("MdnsBusyWrapper::Busy")
                     .finish()
             }
-            $maybe_busy_wrapper::Poisoned => {
-                fmt.debug_struct("$maybe_busy_wrapper::Poisoned")
+            Self::Poisoned => {
+                fmt.debug_struct("MdnsBusyWrapper::Poisoned")
                     .finish()
             }
         }
     }
 }
 
-impl $behaviour_name {
+impl Mdns {
     /// Builds a new `Mdns` behaviour.
-    pub async fn new() -> io::Result<$behaviour_name> {
-        Ok($behaviour_name {
-            service: $maybe_busy_wrapper::Free(<$service_name>::new().await?),
+    pub async fn new() -> io::Result<Self> {
+        Ok(Self {
+            service: MdnsBusyWrapper::Free(MdnsService::new().await?),
             discovered_nodes: SmallVec::new(),
             closest_expiration: None,
         })
@@ -113,7 +110,7 @@ impl $behaviour_name {
     }
 }
 
-impl NetworkBehaviour for $behaviour_name {
+impl NetworkBehaviour for Mdns {
     type ProtocolsHandler = DummyProtocolsHandler;
     type OutEvent = MdnsEvent;
 
@@ -179,32 +176,32 @@ impl NetworkBehaviour for $behaviour_name {
 
         // Polling the mDNS service, and obtain the list of nodes discovered this round.
         let discovered = loop {
-            let service = mem::replace(&mut self.service, $maybe_busy_wrapper::Poisoned);
+            let service = mem::replace(&mut self.service, MdnsBusyWrapper::Poisoned);
 
             let packet = match service {
-                $maybe_busy_wrapper::Free(service) => {
-                    self.service = $maybe_busy_wrapper::Busy(Box::pin(service.next()));
+                MdnsBusyWrapper::Free(service) => {
+                    self.service = MdnsBusyWrapper::Busy(Box::pin(service.next()));
                     continue;
                 },
-                $maybe_busy_wrapper::Busy(mut fut) => {
+                MdnsBusyWrapper::Busy(mut fut) => {
                     match fut.as_mut().poll(cx) {
                         Poll::Ready((service, packet)) => {
-                            self.service = $maybe_busy_wrapper::Free(service);
+                            self.service = MdnsBusyWrapper::Free(service);
                             packet
                         },
                         Poll::Pending => {
-                            self.service = $maybe_busy_wrapper::Busy(fut);
+                            self.service = MdnsBusyWrapper::Busy(fut);
                             return Poll::Pending;
                         }
                     }
                 },
-                $maybe_busy_wrapper::Poisoned => panic!("Mdns poisoned"),
+                MdnsBusyWrapper::Poisoned => panic!("Mdns poisoned"),
             };
 
             match packet {
                 MdnsPacket::Query(query) => {
                     // MaybeBusyMdnsService should always be Free.
-                    if let $maybe_busy_wrapper::Free(ref mut service) = self.service {
+                    if let MdnsBusyWrapper::Free(ref mut service) = self.service {
                         let resp = build_query_response(
                             query.query_id(),
                             params.local_peer_id().clone(),
@@ -256,7 +253,7 @@ impl NetworkBehaviour for $behaviour_name {
                 },
                 MdnsPacket::ServiceDiscovery(disc) => {
                     // MaybeBusyMdnsService should always be Free.
-                    if let $maybe_busy_wrapper::Free(ref mut service) = self.service {
+                    if let MdnsBusyWrapper::Free(ref mut service) = self.service {
                         let resp = build_service_discovery_response(
                             disc.query_id(),
                             MDNS_RESPONSE_TTL,
@@ -281,22 +278,13 @@ impl NetworkBehaviour for $behaviour_name {
     }
 }
 
-impl fmt::Debug for $behaviour_name {
+impl fmt::Debug for Mdns {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Mdns")
             .field("service", &self.service)
             .finish()
     }
 }
-
-};
-}
-
-#[cfg(feature = "async-std")]
-codegen!("async-std", Mdns, MaybeBusyMdnsService, crate::service::MdnsService);
-
-#[cfg(feature = "tokio")]
-codegen!("tokio", TokioMdns, MaybeBusyTokioMdnsService, crate::service::TokioMdnsService);
 
 /// Event that can be produced by the `Mdns` behaviour.
 #[derive(Debug)]

--- a/protocols/mdns/src/dns.rs
+++ b/protocols/mdns/src/dns.rs
@@ -22,9 +22,7 @@
 //! `dns_parser` library.
 
 use crate::{META_QUERY_SERVICE, SERVICE_NAME};
-use data_encoding;
 use libp2p_core::{Multiaddr, PeerId};
-use rand;
 use std::{borrow::Cow, cmp, error, fmt, str, time::Duration};
 
 /// Maximum size of a DNS label as per RFC1035
@@ -226,7 +224,7 @@ fn segment_peer_id(peer_id: String) -> String {
 
 /// Combines and encodes a `PeerId` and service name for a DNS query.
 fn encode_peer_id(peer_id: &PeerId) -> Vec<u8> {
-    // DNS-safe encoding for the Peer ID 
+    // DNS-safe encoding for the Peer ID
     let raw_peer_id = data_encoding::BASE32_DNSCURVE.encode(&peer_id.as_bytes());
     // ensure we don't have any labels over 63 bytes long
     let encoded_peer_id = segment_peer_id(raw_peer_id);

--- a/protocols/mdns/src/lib.rs
+++ b/protocols/mdns/src/lib.rs
@@ -35,12 +35,10 @@ const SERVICE_NAME: &[u8] = b"_p2p._udp.local";
 /// Hardcoded name of the service used for DNS-SD.
 const META_QUERY_SERVICE: &[u8] = b"_services._dns-sd._udp.local";
 
-#[cfg(feature = "async-std")]
-pub use self::{behaviour::Mdns, service::MdnsService};
-#[cfg(feature = "tokio")]
-pub use self::{behaviour::TokioMdns, service::TokioMdnsService};
-
-pub use self::behaviour::MdnsEvent;
+pub use crate::{
+    behaviour::{Mdns, MdnsEvent},
+    service::MdnsService,
+};
 
 mod behaviour;
 mod dns;

--- a/protocols/mdns/src/service.rs
+++ b/protocols/mdns/src/service.rs
@@ -211,20 +211,22 @@ impl MdnsService {
                 let socket = self.socket.get_ref();
                 match event {
                     Ok(IfEvent::Up(inet)) => {
-                        if inet.prefix_len() != inet.max_prefix_len() || inet.addr().is_loopback() {
+                        if inet.addr().is_loopback() {
                             continue;
                         }
                         if let IpAddr::V4(addr) = inet.addr() {
+                            log::trace!("joining multicast on iface {}", addr);
                             if let Err(err) = socket.join_multicast_v4(&multicast, &addr) {
                                 log::error!("join multicast failed: {}", err);
                             }
                         }
                     }
                     Ok(IfEvent::Down(inet)) => {
-                        if inet.prefix_len() != inet.max_prefix_len() || inet.addr().is_loopback() {
+                        if inet.addr().is_loopback() {
                             continue;
                         }
                         if let IpAddr::V4(addr) = inet.addr() {
+                            log::trace!("leaving multicast on iface {}", addr);
                             if let Err(err) = socket.leave_multicast_v4(&multicast, &addr) {
                                 log::error!("leave multicast failed: {}", err);
                             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,8 +196,8 @@ pub use libp2p_gossipsub as gossipsub;
 #[cfg_attr(docsrs, doc(cfg(feature = "mplex")))]
 #[doc(inline)]
 pub use libp2p_mplex as mplex;
-#[cfg(any(feature = "mdns-async-std", feature = "mdns-tokio"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "mdns-async-std", feature = "mdns-tokio"))))]
+#[cfg(feature = "mdns")]
+#[cfg_attr(docsrs, doc(cfg(feature = "mdns")))]
 #[cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")))]
 #[doc(inline)]
 pub use libp2p_mdns as mdns;


### PR DESCRIPTION
Currently the mdns behaviour will panic if no adapter is available. To test on linux use the following commands:
```sh
sudo ifconfig wlan0 down
cargo run --example mdns-passive-discovery
sudo ifconfig wlan0 up
```

~Depends on https://github.com/paritytech/ip-watch/pull/1~

cc @Demi-Marie @rklaehn 