### PR TITLE
[plaintext] Retain remaining read buffer after handshake.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
+# Version 0.30.1 [unreleased]
+
+- Update `libp2p-plaintext`.
+
 # Version 0.30.0 [2020-11-09]
 
 - Update `libp2p-mdns`, `libp2p-tcp` and `libp2p-uds` as well as `libp2p-core`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p"
 edition = "2018"
 description = "Peer-to-peer networking library"
-version = "0.30.0"
+version = "0.30.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -71,7 +71,7 @@ libp2p-kad = { version = "0.25.0", path = "protocols/kad", optional = true }
 libp2p-mplex = { version = "0.24.0", path = "muxers/mplex", optional = true }
 libp2p-noise = { version = "0.26.0", path = "protocols/noise", optional = true }
 libp2p-ping = { version = "0.24.0", path = "protocols/ping", optional = true }
-libp2p-plaintext = { version = "0.24.0", path = "protocols/plaintext", optional = true }
+libp2p-plaintext = { version = "0.24.1", path = "protocols/plaintext", optional = true }
 libp2p-pnet = { version = "0.19.2", path = "protocols/pnet", optional = true }
 libp2p-request-response = { version = "0.5.0", path = "protocols/request-response", optional = true }
 libp2p-swarm = { version = "0.24.0", path = "swarm" }

--- a/protocols/plaintext/CHANGELOG.md
+++ b/protocols/plaintext/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.24.1 [unreleased]
+
+- Ensure that no follow-up protocol data is dropped at the end of the
+  plaintext protocol handshake.
+  [PR 1831](https://github.com/libp2p/rust-libp2p/pull/1831).
+
 # 0.24.0 [2020-11-09]
 
 - Update dependencies.

--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-plaintext"
 edition = "2018"
 description = "Plaintext encryption dummy protocol for libp2p"
-version = "0.24.0"
+version = "0.24.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
When the plaintext protocol handshake finishes and the `Framed` I/O used during the handshake is discarded in favor of the underlying I/O stream, the remaining read buffer of `Framed` must be retained, as it may have buffered data beyond the end of the handshake. This problem manifests itself in potential stalls / timeouts during protocol negotiation, because a peer does not necessarily wait for confirmation of a protocol before it sends the proposal for the next protocol upgrade. E.g. `/multistream/1.0.0 \n /mplex/6.7.0` for the mplex upgrade may already be received and buffered by the `Framed` of the plaintext handshake by a peer before the handshake is complete. That peer will read the final handshake frame but then discard the remaining read buffer of `Framed`, leaving the remote waiting for the protocol confirmation for the next upgrade, but that proposal got "lost". The problem first appeared in https://github.com/libp2p/rust-libp2p/pull/1765 where it was missed during review.

This surfaced, without looking for it, during some benchmark attempts with the TCP transport and plaintext protocol in order to settle https://github.com/libp2p/rust-libp2p/pull/802. However, because the symptoms are the same, I'm reasonably certain that this is the actual cause of the early connection negotiation stalls observed in https://github.com/libp2p/rust-libp2p/issues/1629#issuecomment-701396435, unrelated to the random upgrade timeouts (which should already be fixed), since that test setup intentionally uses the plaintext protocol. So hopefully this should resolve the remaining problem(s) mentioned in #1629 that I had trouble to reproduce earlier.