### PR TITLE
[swarm] Configurable and "infinite" scores for external addresses.

### DIFF
--- a/misc/core-derive/src/lib.rs
+++ b/misc/core-derive/src/lib.rs
@@ -450,8 +450,8 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
                             event: #wrapped_event,
                         });
                     }
-                    std::task::Poll::Ready(#network_behaviour_action::ReportObservedAddr { address }) => {
-                        return std::task::Poll::Ready(#network_behaviour_action::ReportObservedAddr { address });
+                    std::task::Poll::Ready(#network_behaviour_action::ReportObservedAddr { address, score }) => {
+                        return std::task::Poll::Ready(#network_behaviour_action::ReportObservedAddr { address, score });
                     }
                     std::task::Poll::Pending => break,
                 }

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1412,8 +1412,8 @@ impl NetworkBehaviour for Gossipsub {
                 NetworkBehaviourAction::DialPeer { peer_id, condition } => {
                     NetworkBehaviourAction::DialPeer { peer_id, condition }
                 }
-                NetworkBehaviourAction::ReportObservedAddr { address } => {
-                    NetworkBehaviourAction::ReportObservedAddr { address }
+                NetworkBehaviourAction::ReportObservedAddr { address, score } => {
+                    NetworkBehaviourAction::ReportObservedAddr { address, score }
                 }
             });
         }

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -1046,7 +1046,7 @@ where
                 phase: AddProviderPhase::GetClosestPeers
             } => {
                 let provider_id = params.local_peer_id().clone();
-                let external_addresses = params.external_addresses().collect();
+                let external_addresses = params.external_addresses().map(|r| r.addr).collect();
                 let inner = QueryInner::new(QueryInfo::AddProvider {
                     context,
                     key,

--- a/protocols/request-response/src/throttled.rs
+++ b/protocols/request-response/src/throttled.rs
@@ -553,8 +553,8 @@ where
                     NetworkBehaviourAction::DialPeer { peer_id, condition },
                 | NetworkBehaviourAction::NotifyHandler { peer_id, handler, event } =>
                     NetworkBehaviourAction::NotifyHandler { peer_id, handler, event },
-                | NetworkBehaviourAction::ReportObservedAddr { address } =>
-                    NetworkBehaviourAction::ReportObservedAddr { address }
+                | NetworkBehaviourAction::ReportObservedAddr { address, score } =>
+                    NetworkBehaviourAction::ReportObservedAddr { address, score }
             };
 
             return Poll::Ready(event)

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 - Update `libp2p-core`.
 
+- Expose configurable scores for external addresses, as well as
+  the ability to remove them and to add addresses that are
+  retained "forever" (or until explicitly removed).
+  [PR 1842](https://github.com/libp2p/rust-libp2p/pull/1842).
+
 # 0.24.0 [2020-11-09]
 
 - Update dependencies.

--- a/swarm/src/registry.rs
+++ b/swarm/src/registry.rs
@@ -62,10 +62,10 @@ pub struct Addresses {
 
 /// An record in a prioritised list of addresses.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct AddressRecord {
     pub addr: Multiaddr,
     pub score: AddressScore,
-    _priv: (),
 }
 
 /// A report tracked for a finitely scored address.

--- a/swarm/src/registry.rs
+++ b/swarm/src/registry.rs
@@ -20,29 +20,143 @@
 
 use libp2p_core::Multiaddr;
 use smallvec::SmallVec;
-use std::{collections::VecDeque, num::NonZeroUsize};
+use std::{collections::VecDeque, cmp::Ordering, num::NonZeroUsize};
+use std::ops::{Add, Sub};
 
-/// Hold a ranked collection of [`Multiaddr`] values.
+/// A ranked collection of [`Multiaddr`] values.
 ///
-/// Every address has an associated score and iterating over addresses will return them
-/// in order from highest to lowest. When reaching the limit, addresses with the lowest
-/// score will be dropped first.
+/// Every address has an associated [score](`AddressScore`) and iterating
+/// over the addresses will return them in order from highest to lowest score.
+///
+/// In addition to the currently held addresses and their score, the collection
+/// keeps track of a limited history of the most-recently added addresses.
+/// This history determines how address scores are reduced over time as old
+/// scores expire in the context of new addresses being added:
+///
+///   * An address's score is increased by a given amount whenever it is
+///     [(re-)added](Addresses::add) to the collection.
+///   * An address's score is decreased by the same amount used when it
+///     was added when the least-recently seen addition is (as per the
+///     limited history) for this address in the context of [`Addresses::add`].
+///   * If an address's score reaches 0 in the context of [`Addresses::add`],
+///     it is removed from the collection.
+///
 #[derive(Debug, Clone)]
 pub struct Addresses {
-    /// The ranked sequence of addresses.
-    registry: SmallVec<[Record; 8]>,
-    /// Number of historical reports. Similar to `reports.capacity()`.
+    /// The ranked sequence of addresses, from highest to lowest score.
+    ///
+    /// By design, the number of finitely scored addresses stored here is
+    /// never larger (but may be smaller) than the number of historic `reports`
+    /// at any time.
+    registry: SmallVec<[AddressRecord; 8]>,
+    /// The configured limit of the `reports` history of added addresses,
+    /// and thus also of the size of the `registry` w.r.t. finitely scored
+    /// addresses.
     limit: NonZeroUsize,
-    /// Queue of last reports. Every new report is added to the queue. If the queue reaches its
-    /// capacity, we also pop the first element.
-    reports: VecDeque<Multiaddr>,
+    /// The limited history of added addresses. If the queue reaches the `limit`,
+    /// the first record, i.e. the least-recently added, is removed in the
+    /// context of [`Addresses::add`] and the corresponding record in the
+    /// `registry` has its score reduced accordingly.
+    reports: VecDeque<Report>,
 }
 
-// An address record associates a score to a Multiaddr.
+/// An record in a prioritised list of addresses.
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct Record {
+pub struct AddressRecord {
+    pub addr: Multiaddr,
+    pub score: AddressScore,
+    _priv: (),
+}
+
+/// A report tracked for a finitely scored address.
+#[derive(Debug, Clone)]
+struct Report {
+    addr: Multiaddr,
     score: u32,
-    addr: Multiaddr
+}
+
+impl AddressRecord {
+    fn new(addr: Multiaddr, score: AddressScore) -> Self {
+        AddressRecord {
+            addr, score, _priv: (),
+        }
+    }
+}
+
+/// The "score" of an address w.r.t. an ordered collection of addresses.
+///
+/// A score is a measure of the trusworthyness of a particular
+/// observation of an address. The same address may be repeatedly
+/// reported with the same or differing scores.
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
+pub enum AddressScore {
+    /// The score is "infinite", i.e. an address with this score is never
+    /// purged from the associated address records and remains sorted at
+    /// the beginning (possibly with other `Infinite`ly scored addresses).
+    Infinite,
+    /// The score is finite, i.e. an address with this score has
+    /// its score increased and decreased as per the frequency of
+    /// reports (i.e. additions) of the same address relative to
+    /// the reports of other addresses.
+    Finite(u32),
+}
+
+impl AddressScore {
+    fn is_zero(&self) -> bool {
+        &AddressScore::Finite(0) == self
+    }
+}
+
+impl PartialOrd for AddressScore {
+    fn partial_cmp(&self, other: &AddressScore) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for AddressScore {
+    fn cmp(&self, other: &AddressScore) -> Ordering {
+        // Semantics of cardinal numbers with a single infinite cardinal.
+        match (self, other) {
+            (AddressScore::Infinite, AddressScore::Infinite) =>
+                Ordering::Equal,
+            (AddressScore::Infinite, AddressScore::Finite(_)) =>
+                Ordering::Greater,
+            (AddressScore::Finite(_), AddressScore::Infinite) =>
+                Ordering::Less,
+            (AddressScore::Finite(a), AddressScore::Finite(b)) =>
+                a.cmp(b),
+        }
+    }
+}
+
+impl Add for AddressScore {
+    type Output = AddressScore;
+
+    fn add(self, rhs: AddressScore) -> Self::Output {
+        // Semantics of cardinal numbers with a single infinite cardinal.
+        match (self, rhs) {
+            (AddressScore::Infinite, AddressScore::Infinite) =>
+                AddressScore::Infinite,
+            (AddressScore::Infinite, AddressScore::Finite(_)) =>
+                AddressScore::Infinite,
+            (AddressScore::Finite(_), AddressScore::Infinite) =>
+                AddressScore::Infinite,
+            (AddressScore::Finite(a), AddressScore::Finite(b)) =>
+                AddressScore::Finite(a.saturating_add(b))
+        }
+    }
+}
+
+impl Sub<u32> for AddressScore {
+    type Output = AddressScore;
+
+    fn sub(self, rhs: u32) -> Self::Output {
+        // Semantics of cardinal numbers with a single infinite cardinal.
+        match self {
+            AddressScore::Infinite => AddressScore::Infinite,
+            AddressScore::Finite(score) => AddressScore::Finite(score.saturating_sub(rhs))
+        }
+    }
 }
 
 impl Default for Addresses {
@@ -51,8 +165,16 @@ impl Default for Addresses {
     }
 }
 
+/// The result of adding an address to an ordered list of
+/// addresses with associated scores.
+pub enum AddAddressResult {
+    Inserted,
+    Updated,
+}
+
 impl Addresses {
-    /// Create a new address collection of bounded length.
+    /// Create a new ranked address collection with the given size limit
+    /// for [finitely scored](AddressScore::Finite) addresses.
     pub fn new(limit: NonZeroUsize) -> Self {
         Addresses {
             registry: SmallVec::new(),
@@ -63,40 +185,61 @@ impl Addresses {
 
     /// Add a [`Multiaddr`] to the collection.
     ///
-    /// Adding an existing address is interpreted as additional
-    /// confirmation and thus increases its score.
-    pub fn add(&mut self, a: Multiaddr) {
-
-        let oldest = if self.reports.len() == self.limit.get() {
-            self.reports.pop_front()
-        } else {
-            None
-        };
-
-        if let Some(oldest) = oldest {
-            if let Some(in_registry) = self.registry.iter_mut().find(|r| r.addr == oldest) {
-                in_registry.score = in_registry.score.saturating_sub(1);
+    /// If the given address already exists in the collection,
+    /// the given score is added to the current score of the address.
+    ///
+    /// If the collection has already observed the configured
+    /// number of address additions, the least-recently added address
+    /// as per this limited history has its score reduced by the amount
+    /// used in this prior report, with removal from the collection
+    /// occurring when the score drops to 0.
+    pub fn add(&mut self, addr: Multiaddr, score: AddressScore) -> AddAddressResult {
+        // If enough reports (i.e. address additions) occurred, reduce
+        // the score of the least-recently added address.
+        if self.reports.len() == self.limit.get() {
+            let old_report = self.reports.pop_front().expect("len = limit > 0");
+            // If the address is still in the collection, decrease its score.
+            if let Some(record) = self.registry.iter_mut().find(|r| r.addr == old_report.addr) {
+                record.score = record.score - old_report.score;
                 isort(&mut self.registry);
             }
         }
 
         // Remove addresses that have a score of 0.
-        while self.registry.last().map(|e| e.score == 0).unwrap_or(false) {
+        while self.registry.last().map(|e| e.score.is_zero()).unwrap_or(false) {
             self.registry.pop();
         }
 
-        self.reports.push_back(a.clone());
+        // If the address score is finite, remember this report.
+        if let AddressScore::Finite(score) = score {
+            self.reports.push_back(Report { addr: addr.clone(), score });
+        }
 
+        // If the address is already in the collection, increase its score.
         for r in &mut self.registry {
-            if r.addr == a {
-                r.score = r.score.saturating_add(1);
+            if r.addr == addr {
+                r.score = r.score + score;
                 isort(&mut self.registry);
-                return
+                return AddAddressResult::Updated
             }
         }
 
-        let r = Record { score: 1, addr: a };
-        self.registry.push(r)
+        // It is a new record.
+        self.registry.push(AddressRecord::new(addr, score));
+        AddAddressResult::Inserted
+    }
+
+    /// Explicitly remove an address from the collection.
+    ///
+    /// Returns `true` if the address existed in the collection
+    /// and was thus removed, false otherwise.
+    pub fn remove(&mut self, addr: &Multiaddr) -> bool {
+        if let Some(pos) = self.registry.iter().position(|r| &r.addr == addr) {
+            self.registry.remove(pos);
+            true
+        } else {
+            false
+        }
     }
 
     /// Return an iterator over all [`Multiaddr`] values.
@@ -117,12 +260,12 @@ impl Addresses {
 /// An iterator over [`Multiaddr`] values.
 #[derive(Clone)]
 pub struct AddressIter<'a> {
-    items: &'a [Record],
+    items: &'a [AddressRecord],
     offset: usize
 }
 
 impl<'a> Iterator for AddressIter<'a> {
-    type Item = &'a Multiaddr;
+    type Item = &'a AddressRecord;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.offset == self.items.len() {
@@ -130,7 +273,7 @@ impl<'a> Iterator for AddressIter<'a> {
         }
         let item = &self.items[self.offset];
         self.offset += 1;
-        Some(&item.addr)
+        Some(&item)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -144,15 +287,15 @@ impl<'a> ExactSizeIterator for AddressIter<'a> {}
 /// An iterator over [`Multiaddr`] values.
 #[derive(Clone)]
 pub struct AddressIntoIter {
-    items: SmallVec<[Record; 8]>,
+    items: SmallVec<[AddressRecord; 8]>,
 }
 
 impl Iterator for AddressIntoIter {
-    type Item = Multiaddr;
+    type Item = AddressRecord;
 
     fn next(&mut self) -> Option<Self::Item> {
         if !self.items.is_empty() {
-            Some(self.items.remove(0).addr)
+            Some(self.items.remove(0))
         } else {
             None
         }
@@ -167,7 +310,7 @@ impl Iterator for AddressIntoIter {
 impl ExactSizeIterator for AddressIntoIter {}
 
 // Reverse insertion sort.
-fn isort(xs: &mut [Record]) {
+fn isort(xs: &mut [AddressRecord]) {
     for i in 1 .. xs.len() {
         for j in (1 ..= i).rev() {
             if xs[j].score <= xs[j - 1].score {
@@ -181,16 +324,34 @@ fn isort(xs: &mut [Record]) {
 #[cfg(test)]
 mod tests {
     use libp2p_core::multiaddr::{Multiaddr, Protocol};
-    use quickcheck::{Arbitrary, Gen, QuickCheck};
+    use quickcheck::*;
     use rand::Rng;
-    use std::num::NonZeroUsize;
-    use super::{isort, Addresses, Record};
+    use std::num::{NonZeroUsize, NonZeroU8};
+    use super::*;
+
+    impl Arbitrary for AddressScore {
+        fn arbitrary<G: Gen>(g: &mut G) -> AddressScore {
+            if g.gen_range(0, 10) == 0 { // ~10% "Infinitely" scored addresses
+                AddressScore::Infinite
+            } else {
+                AddressScore::Finite(g.gen())
+            }
+        }
+    }
+
+    impl Arbitrary for AddressRecord {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            let addr = Protocol::Tcp(g.gen::<u16>() % 256).into();
+            let score = AddressScore::arbitrary(g);
+            AddressRecord::new(addr, score)
+        }
+    }
 
     #[test]
     fn isort_sorts() {
-        fn property(xs: Vec<u32>) -> bool {
+        fn property(xs: Vec<AddressScore>) {
             let mut xs = xs.into_iter()
-                .map(|s| Record { score: s, addr: Multiaddr::empty() })
+                .map(|score| AddressRecord::new(Multiaddr::empty(), score))
                 .collect::<Vec<_>>();
 
             isort(&mut xs);
@@ -198,61 +359,98 @@ mod tests {
             for i in 1 .. xs.len() {
                 assert!(xs[i - 1].score >= xs[i].score)
             }
-
-            true
         }
-        QuickCheck::new().quickcheck(property as fn(Vec<u32>) -> bool)
+
+        quickcheck(property as fn(_));
     }
 
     #[test]
-    fn old_reports_disappear() {
-        let mut addresses = Addresses::default();
+    fn score_retention() {
+        fn prop(first: AddressRecord, other: AddressRecord) -> TestResult {
+            if first.addr == other.addr {
+                return TestResult::discard()
+            }
 
-        // Add an address a single time.
-        let single: Multiaddr = "/tcp/2108".parse().unwrap();
-        addresses.add(single.clone());
-        assert!(addresses.iter().find(|a| **a == single).is_some());
+            let mut addresses = Addresses::default();
 
-        // Then fill `addresses` with random stuff.
-        let other: Multiaddr = "/tcp/120".parse().unwrap();
-        for _ in 0 .. 2000 {
-            addresses.add(other.clone());
+            // Add the first address.
+            addresses.add(first.addr.clone(), first.score);
+            assert!(addresses.iter().any(|a| &a.addr == &first.addr));
+
+            // Add another address so often that the initial report of
+            // the first address may be purged and, since it was the
+            // only report, the address removed.
+            for _ in 0 .. addresses.limit.get() + 1 {
+                addresses.add(other.addr.clone(), other.score);
+            }
+
+            let exists = addresses.iter().any(|a| &a.addr == &first.addr);
+
+            match (first.score, other.score) {
+                // Only finite scores push out other finite scores.
+                (AddressScore::Finite(_), AddressScore::Finite(_)) => assert!(!exists),
+                _ => assert!(exists),
+            }
+
+            TestResult::passed()
         }
 
-        // Check that `single` disappeared from the list.
-        assert!(addresses.iter().find(|a| **a == single).is_none());
+        quickcheck(prop as fn(_,_) -> _);
     }
 
     #[test]
-    fn record_score_equals_last_n_reports() {
-        #[derive(PartialEq, Eq, Clone, Hash, Debug)]
-        struct Ma(Multiaddr);
+    fn finitely_scored_address_limit() {
+        fn prop(reports: Vec<AddressRecord>, limit: NonZeroU8) {
+            let mut addresses = Addresses::new(limit.into());
 
-        impl Arbitrary for Ma {
-            fn arbitrary<G: Gen>(g: &mut G) -> Self {
-                Ma(Protocol::Tcp(g.gen::<u16>() % 16).into())
+            // Add all reports.
+            for r in reports {
+                addresses.add(r.addr, r.score);
             }
+
+            // Count the finitely scored addresses.
+            let num_finite = addresses.iter().filter(|r| match r {
+                AddressRecord { score: AddressScore::Finite(_), .. } => true,
+                _ => false,
+            }).count();
+
+            // Check against the limit.
+            assert!(num_finite <= limit.get() as usize);
         }
 
-        fn property(xs: Vec<Ma>, n: u8) -> bool {
-            let n = std::cmp::max(n, 1);
-            let mut addresses = Addresses::new(NonZeroUsize::new(usize::from(n)).unwrap());
-            for Ma(a) in &xs {
-                addresses.add(a.clone())
+        quickcheck(prop as fn(_,_));
+    }
+
+    #[test]
+    fn record_score_sum() {
+        fn prop(records: Vec<AddressRecord>) -> bool {
+            // Make sure the address collection can hold all reports.
+            let n = std::cmp::max(records.len(), 1);
+            let mut addresses = Addresses::new(NonZeroUsize::new(n).unwrap());
+
+            // Add all address reports to the collection.
+            for r in records.iter() {
+                addresses.add(r.addr.clone(), r.score.clone());
             }
+
+            // Check that each address in the registry has the expected score.
             for r in &addresses.registry {
-                let count = xs.iter()
-                    .rev()
-                    .take(usize::from(n))
-                    .filter(|Ma(x)| x == &r.addr)
-                    .count();
-                if r.score as usize != count {
+                let expected_score = records.iter().fold(
+                    None::<AddressScore>, |sum, rec|
+                        if &rec.addr == &r.addr {
+                            sum.map_or(Some(rec.score), |s| Some(s + rec.score))
+                        } else {
+                            sum
+                        });
+
+                if Some(r.score) != expected_score {
                     return false
                 }
             }
+
             true
         }
 
-        QuickCheck::new().quickcheck(property as fn(Vec<Ma>, u8) -> bool)
+        quickcheck(prop as fn(_) -> _)
     }
 }

--- a/swarm/src/registry.rs
+++ b/swarm/src/registry.rs
@@ -78,7 +78,7 @@ struct Report {
 impl AddressRecord {
     fn new(addr: Multiaddr, score: AddressScore) -> Self {
         AddressRecord {
-            addr, score, _priv: (),
+            addr, score,
         }
     }
 }


### PR DESCRIPTION
## Motivation
It is currently not possible to add external addresses to a `Swarm` that are retained forever. All added or observed external addresses are added to an ordered list with a finite score (`1`) for every new addition and thus subject to being purged eventually. It is desirable to be able to add addresses to this collection that are retained until explicitly removed and always sorted at the beginning, not influencing the existing semantics for the additional finite scores and expiring addresses. It also seems desirable to let the score of a particular address report / observation be chosen freely, instead of being fixed to `1`. The motivation relates to https://github.com/paritytech/substrate/issues/7518.

To that end, this PR extends the address score arithmetic used for external addresses with an infinite cardinal, permitting addresses with such a score to be retained "forever" or until explicitly removed, thereby exposing address scores on the public API for more insight and configurability.

## Implementation

  * The score of an (external) address is now not just a `u32` but an `AddressScore`, i.e. either `AddressScore::Finite(u32)` or `AddressScore::Infinite`.
  * Only finitely scored addresses compete among each other for retention in the ordered address list, the same way as before. "Infinitely scored" addresses are always retained and sorted at the beginning, i.e. higher than any finite score.
  * `Swarm::add_external_address` now takes both a `Multiaddr` and an `AddressScore`.
  * Analogously to the above, `NetworkBehaviourAction::ReportObservedAddr` now also takes an `AddressScore` in addition to the `Multiaddr`. The `Identify` behaviour reports all addresses with a finite score of `1`, i.e. the same semantics as before.
  * A new method `Swarm::remove_external_address` for explicit removal, regardless of score. This allows for explicit curation of the external address list.
  * Iterating over the external addresses now also provides access to the score via iterating over `AddressRecord`s.
  * The external addresses given to the `NetworkBehaviour::poll` are also accompanied by their score (again via `AddressRecord`s).

