### PR TITLE
[multistream] Make the lazy variant more interoperable.

### DIFF
--- a/misc/multistream-select/CHANGELOG.md
+++ b/misc/multistream-select/CHANGELOG.md
@@ -1,6 +1,14 @@
 # 0.9.0 [unreleased]
 
-- Make the `V1Lazy` upgrade strategy more interoperable with `V1`.
+- Make the `V1Lazy` upgrade strategy more interoperable with `V1`. Specifically,
+  the listener now behaves identically with `V1` and `V1Lazy`. Furthermore, the
+  multistream-select protocol header is now also identical, making `V1` and `V1Lazy`
+  indistinguishable on the wire. The remaining central effect of `V1Lazy` is that the dialer,
+  if it only supports a single protocol in a negotiation, optimistically settles on that
+  protocol without immediately flushing the negotiation data (i.e. protocol proposal)
+  and without waiting for the corresponding confirmation before it is able to start
+  sending application data, expecting the used protocol to be confirmed with
+  the response.
 
 - Fix the encoding and decoding of `ls` responses to
   be spec-compliant and interoperable with other implementations.

--- a/misc/multistream-select/CHANGELOG.md
+++ b/misc/multistream-select/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.9.0 [unreleased]
 
+- Make the `V1Lazy` upgrade strategy more interoperable with `V1`.
+
 - Fix the encoding and decoding of `ls` responses to
   be spec-compliant and interoperable with other implementations.
   For a clean upgrade, `0.8.4` must already be deployed.

--- a/misc/multistream-select/src/dialer_select.rs
+++ b/misc/multistream-select/src/dialer_select.rs
@@ -219,7 +219,7 @@ where
                             // the dialer expects a regular `V1` response.
                             Version::V1Lazy => {
                                 log::debug!("Dialer: Expecting proposed protocol: {}", p);
-                                let hl = HeaderLine::V1;
+                                let hl = HeaderLine::from(Version::V1Lazy);
                                 let io = Negotiated::expecting(io.into_reader(), p, Some(hl));
                                 return Poll::Ready(Ok((protocol, io)))
                             }

--- a/misc/multistream-select/src/lib.rs
+++ b/misc/multistream-select/src/lib.rs
@@ -48,28 +48,23 @@
 //!
 //! ## [`Negotiated`](self::Negotiated)
 //!
-//! When a dialer or listener participating in a negotiation settles
-//! on a protocol to use, the [`DialerSelectFuture`] respectively
-//! [`ListenerSelectFuture`] yields a [`Negotiated`](self::Negotiated)
-//! I/O stream.
-//!
-//! Notably, when a `DialerSelectFuture` resolves to a `Negotiated`, it may not yet
-//! have written the last negotiation message to the underlying I/O stream and may
-//! still be expecting confirmation for that protocol, despite having settled on
-//! a protocol to use.
-//!
-//! Similarly, when a `ListenerSelectFuture` resolves to a `Negotiated`, it may not
-//! yet have sent the last negotiation message despite having settled on a protocol
-//! proposed by the dialer that it supports.
-//!
-//! This behaviour allows both the dialer and the listener to send data
-//! relating to the negotiated protocol together with the last negotiation
-//! message(s), which, in the case of the dialer only supporting a single
-//! protocol, results in 0-RTT negotiation. Note, however, that a dialer
-//! that performs multiple 0-RTT negotiations in sequence for different
-//! protocols layered on top of each other may trigger undesirable behaviour
-//! for a listener not supporting one of the intermediate protocols.
-//! See [`dialer_select_proto`](self::dialer_select_proto).
+//! A `Negotiated` represents an I/O stream that has settled on a protocol
+//! to use. By default, with [`Version::V1`], protocol negotiation is always
+//! at least one dedicated round-trip message exchange, before application
+//! data for the negotiated protocol can be sent by the dialer. There is
+//! a variant [`Version::V1Lazy`] that permits 0-RTT negotiation if the
+//! dialer only supports a single protocol. In that case, when a dialer
+//! settles on a protocol to use, the [`DialerSelectFuture`] yields a
+//! [`Negotiated`](self::Negotiated) I/O stream before the negotiation
+//! data has been flushed. It is then expecting confirmation for that protocol
+//! as the first messages read from the stream. This behaviour allows the dialer
+//! to immediately send data relating to the negotiated protocol together with the
+//! remaining negotiation message(s). Note, however, that a dialer that performs
+//! multiple 0-RTT negotiations in sequence for different protocols layered on
+//! top of each other may trigger undesirable behaviour for a listener not
+//! supporting one of the intermediate protocols. See
+//! [`dialer_select_proto`](self::dialer_select_proto) and the documentation
+//! of [`Version::V1Lazy`] for further details.
 //!
 //! ## Examples
 //!

--- a/misc/multistream-select/src/lib.rs
+++ b/misc/multistream-select/src/lib.rs
@@ -97,7 +97,54 @@ mod protocol;
 mod tests;
 
 pub use self::negotiated::{Negotiated, NegotiatedComplete, NegotiationError};
-pub use self::protocol::{ProtocolError, Version};
+pub use self::protocol::ProtocolError;
 pub use self::dialer_select::{dialer_select_proto, DialerSelectFuture};
 pub use self::listener_select::{listener_select_proto, ListenerSelectFuture};
 
+/// Supported multistream-select versions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Version {
+    /// Version 1 of the multistream-select protocol. See [1] and [2].
+    ///
+    /// [1]: https://github.com/libp2p/specs/blob/master/connections/README.md#protocol-negotiation
+    /// [2]: https://github.com/multiformats/multistream-select
+    V1,
+    /// A "lazy" variant of version 1 that is identical on the wire but whereby
+    /// the dialer delays flushing protocol negotiation data in order to combine
+    /// it with initial application data, thus performing 0-RTT negotiation.
+    ///
+    /// This strategy is only applicable for the node with the role of "dialer"
+    /// in the negotiation and only if the dialer supports just a single
+    /// application protocol. In that case the dialer immedidately "settles"
+    /// on that protocol, buffering the negotiation messages to be sent
+    /// with the first round of application protocol data (or an attempt
+    /// is made to read from the `Negotiated` I/O stream).
+    ///
+    /// A listener will behave identically to `V1`. This ensures interoperability with `V1`.
+    /// Notably, it will immediately send the multistream header as well as the protocol
+    /// confirmation, resulting in multiple frames being sent on the underlying transport.
+    /// Nevertheless, if the listener supports the protocol that the dialer optimistically
+    /// settled on, it can be a 0-RTT negotiation.
+    ///
+    /// > **Note**: `V1Lazy` is specific to `rust-libp2p`. The wire protocol is identical to `V1`
+    /// > and generally interoperable with peers only supporting `V1`. Nevertheless, there is a
+    /// > pitfall that is rarely encountered: When nesting multiple protocol negotiations, the
+    /// > listener should either be known to support all of the dialer's optimistically chosen
+    /// > protocols or there is must be no intermediate protocol without a payload and none of
+    /// > the protocol payloads must have the potential for being mistaken for a multistream-select
+    /// > protocol message. This avoids rare edge-cases whereby the listener may not recognize
+    /// > upgrade boundaries and erroneously process a request despite not supporting one of
+    /// > the intermediate protocols that the dialer committed to. See [1] and [2].
+    ///
+    /// [1]: https://github.com/multiformats/go-multistream/issues/20
+    /// [2]: https://github.com/libp2p/rust-libp2p/pull/1212
+    V1Lazy,
+    // Draft: https://github.com/libp2p/specs/pull/95
+    // V2,
+}
+
+impl Default for Version {
+    fn default() -> Self {
+        Version::V1
+    }
+}

--- a/misc/multistream-select/src/listener_select.rs
+++ b/misc/multistream-select/src/listener_select.rs
@@ -81,7 +81,7 @@ where
     N: AsRef<[u8]>
 {
     RecvHeader { io: MessageIO<R> },
-    SendHeader { io: MessageIO<R>, version: Version },
+    SendHeader { io: MessageIO<R> },
     RecvMessage { io: MessageIO<R> },
     SendMessage {
         io: MessageIO<R>,
@@ -111,8 +111,8 @@ where
             match mem::replace(this.state, State::Done) {
                 State::RecvHeader { mut io } => {
                     match io.poll_next_unpin(cx) {
-                        Poll::Ready(Some(Ok(Message::Header(version)))) => {
-                            *this.state = State::SendHeader { io, version }
+                        Poll::Ready(Some(Ok(Message::Header(Version::V1)))) => {
+                            *this.state = State::SendHeader { io }
                         }
                         Poll::Ready(Some(Ok(_))) => {
                             return Poll::Ready(Err(ProtocolError::InvalidMessage.into()))
@@ -129,24 +129,21 @@ where
                     }
                 }
 
-                State::SendHeader { mut io, version } => {
+                State::SendHeader { mut io } => {
                     match Pin::new(&mut io).poll_ready(cx) {
                         Poll::Pending => {
-                            *this.state = State::SendHeader { io, version };
+                            *this.state = State::SendHeader { io };
                             return Poll::Pending
                         },
                         Poll::Ready(Ok(())) => {},
                         Poll::Ready(Err(err)) => return Poll::Ready(Err(From::from(err))),
                     }
 
-                    if let Err(err) = Pin::new(&mut io).start_send(Message::Header(version)) {
+                    if let Err(err) = Pin::new(&mut io).start_send(Message::Header(Version::V1)) {
                         return Poll::Ready(Err(From::from(err)));
                     }
 
-                    *this.state = match version {
-                        Version::V1 => State::Flush { io, protocol: None },
-                        Version::V1Lazy => State::RecvMessage { io },
-                    }
+                    *this.state = State::Flush { io, protocol: None };
                 }
 
                 State::RecvMessage { mut io } => {

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -702,8 +702,8 @@ fn get_record_many() {
                             ..
                         })) => {
                             assert_eq!(id, qid);
-                            assert_eq!(records.len(), num_results);
-                            assert_eq!(records.first().unwrap().record, record);
+                            assert!(records.len() >= num_results);
+                            assert!(records.into_iter().all(|r| r.record == record));
                             return Poll::Ready(());
                         }
                         // Ignore any other event.


### PR DESCRIPTION
Closes https://github.com/libp2p/rust-libp2p/issues/1853. The remaining optimisation for `V1Lazy` for a listener in the negotiation, whereby the listener delays flushing of the multistream version header, is hereby removed. The only remaining effect of `V1Lazy` as compared to `V1` is on the side of the dialer, which delays flushing of its singular protocol proposal (i.e. if it has no alternatives) in order to send it together with the first application data, e.g. a request, or an attempt is made to read from the negotiated stream, which similarly triggers a flush of the pending protocol proposal, as before. This permits `V1Lazy` dialers to be interoperable with `V1` listeners. The remaining theoretical pitfall whereby  application data gets misinterpreted as another protocol proposal by a listener remains, however unlikely.

`V1` remains the default, but after sufficient experience we may eventually be bold enough to make this lazy dialer flush a part of the default `V1` implementation, removing the dedicated `V1Lazy` version identifier. As an experiment I temporarily changed the default upgrade strategy to `V1Lazy` for all substreams and at least all the tests and the `ipfs-kad` example worked fine.