### PR TITLE
protocols/request-response: Report successful request handling

### DIFF
--- a/protocols/request-response/src/handler.rs
+++ b/protocols/request-response/src/handler.rs
@@ -134,6 +134,8 @@ where
     OutboundTimeout(RequestId),
     /// An outbound request failed to negotiate a mutually supported protocol.
     OutboundUnsupportedProtocols(RequestId),
+    /// An inbound request was successfully answered.
+    InboundSuccess(RequestId),
     /// An inbound request timed out.
     InboundTimeout(RequestId),
     /// An inbound request failed to negotiate a mutually supported protocol.
@@ -188,8 +190,11 @@ where
     fn inject_fully_negotiated_inbound(
         &mut self,
         (): (),
-        _: RequestId
+        request_id: RequestId
     ) {
+        self.pending_events.push_back(
+            RequestResponseHandlerEvent::InboundSuccess(request_id)
+        );
     }
 
     fn inject_fully_negotiated_outbound(
@@ -331,4 +336,3 @@ where
         Poll::Pending
     }
 }
-

--- a/protocols/request-response/src/throttled.rs
+++ b/protocols/request-response/src/throttled.rs
@@ -539,12 +539,12 @@ where
                     let event = RequestResponseEvent::OutboundFailure { peer, request_id, error };
                     NetworkBehaviourAction::GenerateEvent(Event::Event(event))
                 }
-                | NetworkBehaviourAction::GenerateEvent(RequestResponseEvent::InboundFailure {
+                | NetworkBehaviourAction::GenerateEvent(RequestResponseEvent::InboundFinished {
                     peer,
                     request_id,
-                    error
+                    result
                 }) => {
-                    let event = RequestResponseEvent::InboundFailure { peer, request_id, error };
+                    let event = RequestResponseEvent::InboundFinished { peer, request_id, result };
                     NetworkBehaviourAction::GenerateEvent(Event::Event(event))
                 }
                 | NetworkBehaviourAction::DialAddress { address } =>


### PR DESCRIPTION
When failing to respond to an inbound request, the `RequestResponse`
`NetworkBehaviour` would emit an `InboundFailure` event. When succeeding
to respond to an inbound request nothing would be emitted.

With this commit the `RequestResponse` `NetworkBehaviour` emits a
`InboundFinished` event for all inbound requests. The event contains a
`result` describing whether handling the inbound request succeeded or
failed. This can for example be used for statistics, counting the number
of requests handled per second.

Note: The `Throttled` `NetworkBehaviour` handles two types of incoming
requests. (1) user level requests and (2) credit grants. In case
handling the latter fails the `Throttled` `NetworkBehaviour` reports
this failure. This can be unexpected as the user would receive a failure
event for a request it never tried to handle. With this commit the
confusion can be even larger as a user would receive a success event for
a request it never handled.