### PR TITLE
swarm: Add ExpandedSwarm::is_connected

### DIFF
--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.25.1 [2020-11-26]
+
+- Add `ExpandedSwarm::is_connected`.
+  [PR 1862](https://github.com/libp2p/rust-libp2p/pull/1862).
+
 # 0.25.0 [2020-11-25]
 
 - Permit a configuration override for the substream upgrade protocol

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-swarm"
 edition = "2018"
 description = "The libp2p swarm"
-version = "0.25.0"
+version = "0.25.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -463,6 +463,11 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
         me.banned_peers.remove(&peer_id);
     }
 
+    /// Checks whether the [`Network`] has an established connection to a peer.
+    pub fn is_connected(me: &Self, peer_id: &PeerId) -> bool {
+        me.network.is_connected(peer_id)
+    }
+
     /// Returns the next event that happens in the `Swarm`.
     ///
     /// Includes events from the `NetworkBehaviour` but also events about the connections status.


### PR DESCRIPTION
Commit 335e55e6 removed the `ConnectionInfo` trait in favor of `PeerId`s. Commit
1bd013c8 removed `ExpandedSwarm::connection_info` as it would only return the
`PeerId` that the caller is already aware of.

One could use `ExpandedSwarm::connection_info` not only to retrieve the
`ConnectionInfo` for a given peer, but also to check whether the underlying
`Network` has a connection to the peer.

This commit exposes the `is_connected` method on `Network` via `ExpandedSwarm`
to check whether the `Network` has an established connection to a given peer.

---

One could as well expose other read-only methods on `Network` like `is_dialing`
and `is_disconnected`. For now this pull request only restores the status-quo.
Let me know what you prefer.
