### PR TITLE
protocols/request-response: Remove InboundFailure::ConnectionClosed

### DIFF
--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -192,8 +192,6 @@ pub enum InboundFailure {
     Timeout,
     /// The local peer supports none of the requested protocols.
     UnsupportedProtocols,
-    /// The connection closed before a response was delivered.
-    ConnectionClosed,
 }
 
 /// A channel for sending a response to an inbound request.


### PR DESCRIPTION
The `InboundFailure::ConnectionClosed` event is never emitted by the `RequestResponse` `NetworkBehaviour`. Responses to be send on a closed connection are simply dropped.

See https://github.com/libp2p/rust-libp2p/pull/1860#issuecomment-734326388 for details.

For now the event is just removed to fix the status quo. In the future we might want to extend the events emitted by `RequestResponse` regarding inbound requests to give users more visibility. This is not trivial, see https://github.com/libp2p/rust-libp2p/pull/1860 for details.

What do you think?