### PR TITLE
.github/workflow: Don't require nightly for doc link check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,11 +101,6 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Install nightly Rust
-      # TODO: intra-doc links are available on nightly only
-      # see https://doc.rust-lang.org/nightly/rustdoc/lints.html#intra_doc_link_resolution_failure
-      run: rustup default nightly-2020-09-17
-
     - name: Check rustdoc links
       run: RUSTDOCFLAGS="--deny broken_intra_doc_links" cargo doc --verbose --workspace --no-deps --document-private-items
 


### PR DESCRIPTION
The `broken_intra_doc_links` lint stabilized with Rust `v1.48`, thus the
special usage of `nightly` is not needed anymore in the pipeline step.

Fixes https://github.com/libp2p/rust-libp2p/issues/1864.