### PR TITLE
core/benches: Add rudimentary benchmark for PeerId::from_bytes and clone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,41 @@ jobs:
         command: clippy
         args: -- -A clippy::mutable_key_type -A clippy::type_complexity
 
+  run-benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.6.0
+      with:
+        access_token: ${{ github.token }}
+
+    - uses: actions/checkout@v2
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+
+    - name: Cache CARGO_HOME
+      uses: actions/cache@v2
+      with:
+        path: ~/.cargo
+        key: cargo-home-${{ hashFiles('Cargo.toml') }}
+
+    - name: Cache cargo build
+      uses: actions/cache@v2
+      with:
+        path: target
+        key: cargo-build-target-${{ hashFiles('Cargo.toml') }}
+
+    - name: Run cargo bench
+      uses: actions-rs/cargo@v1
+      with:
+        command: bench
+        args: --workspace
+
   integration-test:
     name: Integration tests
     runs-on: ubuntu-latest

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -41,6 +41,7 @@ ring = { version = "0.16.9", features = ["alloc", "std"], default-features = fal
 
 [dev-dependencies]
 async-std = "1.6.2"
+criterion = "0.3"
 libp2p-mplex = { path = "../muxers/mplex" }
 libp2p-noise = { path = "../protocols/noise" }
 libp2p-tcp = { path = "../transports/tcp", features = ["async-std"] }
@@ -54,3 +55,7 @@ prost-build = "0.6"
 [features]
 default = ["secp256k1"]
 secp256k1 = ["libsecp256k1"]
+
+[[bench]]
+name = "peer_id"
+harness = false

--- a/core/benches/peer_id.rs
+++ b/core/benches/peer_id.rs
@@ -1,0 +1,50 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use libp2p_core::{identity, PeerId};
+
+fn from_bytes(c: &mut Criterion) {
+    let peer_id_bytes = identity::Keypair::generate_ed25519()
+        .public()
+        .into_peer_id()
+        .into_bytes();
+
+    c.bench_function("from_bytes", |b| {
+        b.iter(|| {
+            black_box(PeerId::from_bytes(peer_id_bytes.clone()).unwrap());
+        })
+    });
+}
+
+fn clone(c: &mut Criterion) {
+    let peer_id = identity::Keypair::generate_ed25519()
+        .public()
+        .into_peer_id();
+
+    c.bench_function("clone", |b| {
+        b.iter(|| {
+            black_box(peer_id.clone());
+        })
+    });
+}
+
+criterion_group!(peer_id, from_bytes, clone);
+criterion_main!(peer_id);


### PR DESCRIPTION
I hope these somewhat simple benchmarks can back up discussions in https://github.com/libp2p/rust-libp2p/pull/1874 and https://github.com/libp2p/rust-libp2p/pull/1865 with data.

```
$ cd core/
$ cargo bench
[...]
from_bytes              time:   [187.15 ns 187.88 ns 188.79 ns]                                                       
                        change: [-11.163% -10.359% -8.9828%] (p = 0.00 < 0.05)                                        
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe

clone                   time:   [14.811 ns 14.868 ns 14.940 ns]                                                       
                        change: [-14.744% -14.274% -13.812%] (p = 0.00 < 0.05)                                        
                        Performance has improved.
Found 20 outliers among 100 measurements (20.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  6 (6.00%) high mild
  12 (12.00%) high severe


$ cat /proc/cpuinfo | grep "model name" | head -1
model name      : Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
```


In addition this pull request adds a CI step to ensure benchmarks continue to compile and run.