### PR TITLE
core/benches: Add PeerId sort_vec benchmark

### DIFF
--- a/core/benches/peer_id.rs
+++ b/core/benches/peer_id.rs
@@ -46,5 +46,23 @@ fn clone(c: &mut Criterion) {
     });
 }
 
-criterion_group!(peer_id, from_bytes, clone);
+fn sort_vec(c: &mut Criterion) {
+    let peer_ids: Vec<_> = (0..100)
+        .map(|_| {
+            identity::Keypair::generate_ed25519()
+                .public()
+                .into_peer_id()
+        })
+        .collect();
+
+    c.bench_function("sort_vec", |b| {
+        b.iter(|| {
+            let mut peer_ids = peer_ids.clone();
+            peer_ids.sort_unstable();
+            black_box(peer_ids);
+        })
+    });
+}
+
+criterion_group!(peer_id, from_bytes, clone, sort_vec);
 criterion_main!(peer_id);


### PR DESCRIPTION
Small follow up on https://github.com/libp2p/rust-libp2p/pull/1875 adding an altered version of the `sort_vec` benchmark suggested in https://github.com/libp2p/rust-libp2p/pull/1875#issuecomment-739893901.