### PR TITLE
Prepare release of `libp2p-0.32`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
-# Version 0.32.0 [unreleased]
+# Version 0.32.0 [2020-12-08]
 
 - Update `libp2p-request-response`.
 

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.26.0 [unreleased]
+# 0.26.0 [2020-12-08]
 
 - Create multiple multicast response packets as required to avoid
   hitting the limit of 9000 bytes per MDNS packet.

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.7.0 [unreleased]
+# 0.7.0 [2020-12-08]
 
 - Refine emitted events for inbound requests, introducing
   the `ResponseSent` event and the `ResponseOmission`


### PR DESCRIPTION
This release includes new releases of `libp2p-request-response` ([changelog](https://github.com/libp2p/rust-libp2p/blob/master/protocols/request-response/CHANGELOG.md#070-unreleased)) and `libp2p-mdns` ([changelog](https://github.com/libp2p/rust-libp2p/blob/master/protocols/mdns/CHANGELOG.md#0260-unreleased)).