### PR TITLE
swarm: Remove NotifyHandler::All

### DIFF
--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -329,7 +329,7 @@ impl From<ProtocolsHandlerUpgrErr<io::Error>> for KademliaHandlerQueryErr {
 }
 
 /// Event to send to the handler.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum KademliaHandlerIn<TUserData> {
     /// Resets the (sub)stream associated with the given request ID,
     /// thus signaling an error to the remote.
@@ -429,7 +429,7 @@ pub enum KademliaHandlerIn<TUserData> {
 
 /// Unique identifier for a request. Must be passed back in order to answer a request from
 /// the remote.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct KademliaRequestId {
     /// Unique identifier for an incoming connection.
     connec_unique_id: UniqueConnecId,

--- a/protocols/request-response/src/handler/protocol.rs
+++ b/protocols/request-response/src/handler/protocol.rs
@@ -118,7 +118,7 @@ where
 /// Request substream upgrade protocol.
 ///
 /// Sends a request and receives a response.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct RequestProtocol<TCodec>
 where
     TCodec: RequestResponseCodec

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Update `libp2p-core`.
 
+- Remove `NotifyHandler::All` thus removing the requirement for events send from
+  a `NetworkBehaviour` to a `ProtocolsHandler` to be `Clone`.
+  [PR 1880](https://github.com/libp2p/rust-libp2p/pull/1880).
+
 # 0.25.1 [2020-11-26]
 
 - Add `ExpandedSwarm::is_connected`.

--- a/swarm/src/behaviour.rs
+++ b/swarm/src/behaviour.rs
@@ -218,7 +218,7 @@ pub trait NetworkBehaviourEventProcess<TEvent> {
 /// in whose context it is executing.
 ///
 /// [`Swarm`]: super::Swarm
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum NetworkBehaviourAction<TInEvent, TOutEvent> {
     /// Instructs the `Swarm` to return an event when it is being polled.
     GenerateEvent(TOutEvent),
@@ -264,7 +264,7 @@ pub enum NetworkBehaviourAction<TInEvent, TOutEvent> {
     NotifyHandler {
         /// The peer for whom a `ProtocolsHandler` should be notified.
         peer_id: PeerId,
-        /// The ID of the connection whose `ProtocolsHandler` to notify.
+        /// The options w.r.t. which connection handler to notify of the event.
         handler: NotifyHandler,
         /// The event to send.
         event: TInEvent,
@@ -325,15 +325,13 @@ impl<TInEvent, TOutEvent> NetworkBehaviourAction<TInEvent, TOutEvent> {
     }
 }
 
-/// The options w.r.t. which connection handlers to notify of an event.
+/// The options w.r.t. which connection handler to notify of an event.
 #[derive(Debug, Clone)]
 pub enum NotifyHandler {
     /// Notify a particular connection handler.
     One(ConnectionId),
     /// Notify an arbitrary connection handler.
     Any,
-    /// Notify all connection handlers.
-    All
 }
 
 /// The available conditions under which a new dialing attempt to


### PR DESCRIPTION
### Suggestion

With this pull request I would like to suggest removing the ability of a `NetworkBehaviour` to notify all `ProtocolHandler`s for a given peer with a single `NetworkBehaviourActionEvent`. More concretely I am suggesting to remove `NotifyHandler::All`. An
implementor of `NetworkBehaviour` can still notify all `ProtocolHandler`s for a given peer by emitting one `NotifyHandler` event per connection to that peer.

### Reasoning

The general ability to notify all handlers for a peer forces events send from the behaviour to the handler to be `Clone`. Reason is that the swarm needs to forward a clone of the event to each handler. A behaviour that always sends events to a single peer only still has to guarantee that that event is `Clone`.

### Example 

As a concrete example https://github.com/libp2p/rust-libp2p/pull/1838/ implementing the libp2p relay spec needs to send substreams between `ProtocolHandler`s. Substreams are always send to concrete `ProtocolHandler`s, never to all `ProtocolHandler`s. Today a substream needs to be wrapped in an `Arc<Mutex<_>>` (or similar) in order to be `Clone` before one can send it to another `ProtocolHandler`. Removing the ability to send to all `ProtocolHandler`s would relief the relay implementation of having to wrap each substream before sending.

### Alternative

Today the `ExpandedSwarm` requires `TInEvent` to be `Clone` in order to be able to notify all handlers for a given peer. Instead of removing the feature one could as well introduce a second `TInEvent2` which would not require clone, using the former to notify all handlers and the latter to notify specific handlers. A behaviour only requiring the latter could set the former to `()`. In my eyes this alternative would not be worth the complexity it introduces.

### Users

As far as I can tell `NotifyHandler::All` is not used in rust-libp2p nor Substrate. Does anyone know of any users of `NotifyHandler::All`?

**Is anyone objecting to this change or has alternative suggestions?**

