### PR TITLE
[websocket] Update minimum async-tls patch version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
+# Version 0.32.1 [2020-12-09]
+
+- Update minimum patch version of `libp2p-websocket`.
+
 # Version 0.32.0 [2020-12-08]
 
 - Update `libp2p-request-response`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p"
 edition = "2018"
 description = "Peer-to-peer networking library"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -88,7 +88,7 @@ libp2p-deflate = { version = "0.25.0", path = "protocols/deflate", optional = tr
 libp2p-dns = { version = "0.25.0", path = "transports/dns", optional = true }
 libp2p-mdns = { version = "0.26.0", path = "protocols/mdns", optional = true }
 libp2p-tcp = { version = "0.25.1", path = "transports/tcp", optional = true }
-libp2p-websocket = { version = "0.26.1", path = "transports/websocket", optional = true }
+libp2p-websocket = { version = "0.26.2", path = "transports/websocket", optional = true }
 
 [dev-dependencies]
 async-std = "1.6.2"

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.26.2 [2020-12-09]
+
+- Update minimum patch version for `async-tls`.
+
 # 0.26.1 [2020-12-07]
 
 - Update `rustls`.

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-websocket"
 edition = "2018"
 description = "WebSocket transport for libp2p"
-version = "0.26.1"
+version = "0.26.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -10,7 +10,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-tls = "0.10.0"
+async-tls = "0.10.2"
 either = "1.5.3"
 futures = "0.3.1"
 libp2p-core = { version = "0.25.0", path = "../../core" }


### PR DESCRIPTION
After the upgrade to rustls 0.19, this is the minimum version required to build, avoiding temporarily puzzling compile errors if someone has `0.10.0` in a `Cargo.lock`. Prepares a patch release.