### PR TITLE
Update minimum async-tls patch version

### DIFF
--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Update minimum patch version for `async-tls` due to
+  `async-tls 0.10.2` is yanked in upstream.
+
 # 0.26.2 [2020-12-09]
 
 - Update minimum patch version for `async-tls`.

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-tls = "0.10.2"
+async-tls = "0.11.0"
 either = "1.5.3"
 futures = "0.3.1"
 libp2p-core = { version = "0.25.0", path = "../../core" }


### PR DESCRIPTION
`async-tls 0.10.2` is yanked in upstream.