### PR TITLE
protocols/request-response: Derive Clone for {Inbound,Outbound}Failure

### DIFF
--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -6,6 +6,9 @@
   to the underlying connection closing.
   [PR 1886](https://github.com/libp2p/rust-libp2p/pull/1886).
 
+- Derive Clone for `InboundFailure` and `Outbound}Failure`.
+  [PR 1891](https://github.com/libp2p/rust-libp2p/pull/1891)
+
 # 0.7.0 [2020-12-08]
 
 - Refine emitted events for inbound requests, introducing

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -171,7 +171,7 @@ pub enum RequestResponseEvent<TRequest, TResponse, TChannelResponse = TResponse>
 
 /// Possible failures occurring in the context of sending
 /// an outbound request and receiving the response.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum OutboundFailure {
     /// The request could not be sent because a dialing attempt failed.
     DialFailure,
@@ -191,7 +191,7 @@ pub enum OutboundFailure {
 
 /// Possible failures occurring in the context of receiving an
 /// inbound request and sending a response.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum InboundFailure {
     /// The inbound request timed out, either while reading the
     /// incoming request or before a response is sent, e.g. if


### PR DESCRIPTION
With `InboundFailure` and `OutboundFailure` implementing `Clone` a user of `libp2p-request-response` can handle a failure in one place, and record the failure for statistical purposes (e.g. a monitoring system) in a different place without the need to introduce a new structure for the latter code path.

While the above would benefit Substrate (see https://github.com/paritytech/substrate/pull/7478#discussion_r526867672) it does allow ambiguity in terms of where an error that has been cloned before should be handled. For more details see the discussion on Substrate linked before.

