### PR TITLE
libp2p-pnet: patch salsa20 dependency

### DIFF
--- a/protocols/pnet/Cargo.toml
+++ b/protocols/pnet/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 futures = "0.3.1"
 log = "0.4.8"
-salsa20 = "0.6.0"
+salsa20 = "0.7"
 sha3 = "0.9"
 rand = "0.7"
 pin-project = "0.4.17"

--- a/protocols/pnet/src/crypt_writer.rs
+++ b/protocols/pnet/src/crypt_writer.rs
@@ -25,7 +25,7 @@ use futures::{
 };
 use log::trace;
 use pin_project::pin_project;
-use salsa20::{stream_cipher::SyncStreamCipher, XSalsa20};
+use salsa20::{cipher::SyncStreamCipher, XSalsa20};
 use std::{fmt, pin::Pin};
 
 /// A writer that encrypts and forwards to an inner writer

--- a/protocols/pnet/src/lib.rs
+++ b/protocols/pnet/src/lib.rs
@@ -30,7 +30,7 @@ use log::trace;
 use pin_project::pin_project;
 use rand::RngCore;
 use salsa20::{
-    stream_cipher::{NewStreamCipher, SyncStreamCipher},
+    cipher::{NewStreamCipher, SyncStreamCipher},
     Salsa20, XSalsa20,
 };
 use sha3::{digest::ExtendableOutput, Shake128};


### PR DESCRIPTION
Issue #1890 
Patch the `salsa20` dependency of libp2p-pnet to the current version `v0.7` since `v0.6` depends on the deprecated crate  `stream-cypher`.
