### PR TITLE
*CHANGELOG.md: Prepare v0.33.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
-# Version 0.33.0 [unreleased]
+# Version 0.33.0 [2020-12-17]
 
 - Update `libp2p-core` and all dependent crates.
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.26.0 [unreleased]
+# 0.26.0 [2020-12-17]
 
 - Make `PeerId` be `Copy`, including small `PeerId` API changes.
   [PR 1874](https://github.com/libp2p/rust-libp2p/pull/1874/).

--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.26.0 [unreleased]
+# 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.
 

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.29.0 [unreleased]
+# 0.29.0 [2020-12-17]
 
 - Update `libp2p-core`.
 

--- a/protocols/deflate/CHANGELOG.md
+++ b/protocols/deflate/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.26.0 [unreleased]
+# 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.
 

--- a/protocols/floodsub/CHANGELOG.md
+++ b/protocols/floodsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.26.0 [unreleased]
+# 0.26.0 [2020-12-17]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.26.0 [unreleased]
+# 0.26.0 [2020-12-17]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.26.0 [unreleased]
+# 0.26.0 [2020-12-17]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.0 [unreleased]
+# 0.27.0 [2020-12-17]
 
 - Update `libp2p-core` and `libp2p-swarm`.
 

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.0 [unreleased]
+# 0.27.0 [2020-12-17]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 

--- a/protocols/noise/CHANGELOG.md
+++ b/protocols/noise/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.28.0 [unreleased]
+# 0.28.0 [2020-12-17]
 
 - Update `libp2p-core`.
 

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.26.0 [unreleased]
+# 0.26.0 [2020-12-17]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 

--- a/protocols/plaintext/CHANGELOG.md
+++ b/protocols/plaintext/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.26.0 [unreleased]
+# 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.
 

--- a/protocols/pnet/CHANGELOG.md
+++ b/protocols/pnet/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.20.0 [unreleased]
+# 0.20.0 [2020-12-17]
 
 - Update dependencies.
 

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.8.0 [unreleased]
+# 0.8.0 [2020-12-17]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 

--- a/protocols/secio/CHANGELOG.md
+++ b/protocols/secio/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.26.0 [unreleased]
+# 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.
 

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.26.0 [unreleased]
+# 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.
 

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.26.0 [unreleased]
+# 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.
 

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.26.0 [unreleased]
+# 0.26.0 [2020-12-17]
 
 - Update `async-io`.
 

--- a/transports/uds/CHANGELOG.md
+++ b/transports/uds/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.26.0 [unreleased]
+# 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.
 

--- a/transports/wasm-ext/CHANGELOG.md
+++ b/transports/wasm-ext/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.26.0 [unreleased]
+# 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.
 

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.0 [unreleased]
+# 0.27.0 [2020-12-17]
 
 - Update `libp2p-core`.
 


### PR DESCRIPTION
I propose to cut another release (`v0.33.0`) of rust-libp2p and all its dependencies. While it would be nice to get https://github.com/libp2p/rust-libp2p/pull/1886 into https://github.com/paritytech/substrate/pull/7478/ via this release https://github.com/paritytech/substrate/pull/7478/ is not blocked on it. My motivation is much rather the general goal of cutting small releases often instead of cutting large releases rarely.