### PR TITLE
docs/release: Only choose crate name not bench name

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -25,7 +25,7 @@ documentation will refer to `X.Y.Z` as _major_, _minor_ and _patch_ version.
 
     ```bash
     cd $CRATE-PATH
-    tag="$(sed -En 's/^name = \"(.*)\"$/\1/p' Cargo.toml)-$(sed -En 's/^version = \"(.*)\"$/\1/p' Cargo.toml)"
+    tag="$(sed -En 's/^name = \"(.*)\"$/\1/p' Cargo.toml | head -n 1)-$(sed -En 's/^version = \"(.*)\"$/\1/p' Cargo.toml)"
     # Use `-s` for a GPG signed tag or `-a` for an annotated tag.
     git tag -s "${tag}" -m "${tag}"
     git push origin "${tag}"


### PR DESCRIPTION
Some `Cargo.toml` files contain multiple `name` fields, e.g. the crate name and
the benchmark name (see
https://github.com/libp2p/rust-libp2p/blob/master/core/Cargo.toml). Only choose
the first one when constructing the tag.