### PR TITLE
*: Switch futures_codec to asynchronous-codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@
 
 # Version 0.34.0 [unreleased]
 
-- Update `libp2p-request-response`.
+- Update `libp2p-gossipsub`, `libp2p-kad` and `libp2p-request-response`.
+
+- Update dependencies.
 
 # Version 0.33.0 [2020-12-17]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,34 +61,34 @@ atomic = "0.5.0"
 bytes = "1"
 futures = "0.3.1"
 lazy_static = "1.2"
-libp2p-core = { version = "0.26.0", path = "core" }
+libp2p-core = { version = "0.27.0", path = "core" }
 libp2p-core-derive = { version = "0.21.0", path = "misc/core-derive" }
-libp2p-floodsub = { version = "0.26.0", path = "protocols/floodsub", optional = true }
-libp2p-gossipsub = { version = "0.26.0", path = "./protocols/gossipsub", optional = true }
-libp2p-identify = { version = "0.26.0", path = "protocols/identify", optional = true }
-libp2p-kad = { version = "0.27.0", path = "protocols/kad", optional = true }
-libp2p-mplex = { version = "0.26.0", path = "muxers/mplex", optional = true }
-libp2p-noise = { version = "0.28.0", path = "protocols/noise", optional = true }
-libp2p-ping = { version = "0.26.0", path = "protocols/ping", optional = true }
-libp2p-plaintext = { version = "0.26.0", path = "protocols/plaintext", optional = true }
+libp2p-floodsub = { version = "0.27.0", path = "protocols/floodsub", optional = true }
+libp2p-gossipsub = { version = "0.27.0", path = "./protocols/gossipsub", optional = true }
+libp2p-identify = { version = "0.27.0", path = "protocols/identify", optional = true }
+libp2p-kad = { version = "0.28.0", path = "protocols/kad", optional = true }
+libp2p-mplex = { version = "0.27.0", path = "muxers/mplex", optional = true }
+libp2p-noise = { version = "0.29.0", path = "protocols/noise", optional = true }
+libp2p-ping = { version = "0.27.0", path = "protocols/ping", optional = true }
+libp2p-plaintext = { version = "0.27.0", path = "protocols/plaintext", optional = true }
 libp2p-pnet = { version = "0.20.0", path = "protocols/pnet", optional = true }
 libp2p-request-response = { version = "0.9.0", path = "protocols/request-response", optional = true }
-libp2p-swarm = { version = "0.26.0", path = "swarm" }
-libp2p-uds = { version = "0.26.0", path = "transports/uds", optional = true }
-libp2p-wasm-ext = { version = "0.26.0", path = "transports/wasm-ext", optional = true }
-libp2p-yamux = { version = "0.29.0", path = "muxers/yamux", optional = true }
-multiaddr = { package = "parity-multiaddr", version = "0.10.0", path = "misc/multiaddr" }
+libp2p-swarm = { version = "0.27.0", path = "swarm" }
+libp2p-uds = { version = "0.27.0", path = "transports/uds", optional = true }
+libp2p-wasm-ext = { version = "0.27.0", path = "transports/wasm-ext", optional = true }
+libp2p-yamux = { version = "0.30.0", path = "muxers/yamux", optional = true }
+multiaddr = { package = "parity-multiaddr", version = "0.11.0", path = "misc/multiaddr" }
 parking_lot = "0.11.0"
 pin-project = "1.0.0"
 smallvec = "1.0"
 wasm-timer = "0.2.4"
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")))'.dependencies]
-libp2p-deflate = { version = "0.26.0", path = "protocols/deflate", optional = true }
-libp2p-dns = { version = "0.26.0", path = "transports/dns", optional = true }
-libp2p-mdns = { version = "0.27.0", path = "protocols/mdns", optional = true }
-libp2p-tcp = { version = "0.26.0", path = "transports/tcp", optional = true }
-libp2p-websocket = { version = "0.27.0", path = "transports/websocket", optional = true }
+libp2p-deflate = { version = "0.27.0", path = "protocols/deflate", optional = true }
+libp2p-dns = { version = "0.27.0", path = "transports/dns", optional = true }
+libp2p-mdns = { version = "0.28.0", path = "protocols/mdns", optional = true }
+libp2p-tcp = { version = "0.27.0", path = "transports/tcp", optional = true }
+libp2p-websocket = { version = "0.28.0", path = "transports/websocket", optional = true }
 
 [dev-dependencies]
 async-std = "1.6.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ all-features = true
 
 [dependencies]
 atomic = "0.5.0"
-bytes = "0.5"
+bytes = "1"
 futures = "0.3.1"
 lazy_static = "1.2"
 libp2p-core = { version = "0.26.0", path = "core" }

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.0 [unreleased]
+
+- Update dependencies.
+
 # 0.26.0 [2020-12-17]
 
 - Make `PeerId` be `Copy`, including small `PeerId` API changes.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-core"
 edition = "2018"
 description = "Core traits and structs of libp2p"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -20,9 +20,9 @@ futures-timer = "3"
 lazy_static = "1.2"
 libsecp256k1 = { version = "0.3.1", optional = true }
 log = "0.4"
-multiaddr = { package = "parity-multiaddr", version = "0.10.0", path = "../misc/multiaddr" }
+multiaddr = { package = "parity-multiaddr", version = "0.11", path = "../misc/multiaddr" }
 multihash = { version = "0.13", default-features = false, features = ["std", "multihash-impl", "identity", "sha2"] }
-multistream-select = { version = "0.9.1", path = "../misc/multistream-select" }
+multistream-select = { version = "0.10", path = "../misc/multistream-select" }
 parking_lot = "0.11.0"
 pin-project = "1.0.0"
 prost = "0.7"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,7 +25,7 @@ multihash = { version = "0.13", default-features = false, features = ["std", "mu
 multistream-select = { version = "0.9.1", path = "../misc/multistream-select" }
 parking_lot = "0.11.0"
 pin-project = "1.0.0"
-prost = "0.6.1"
+prost = "0.7"
 rand = "0.7"
 rw-stream-sink = "0.2.0"
 sha2 = "0.9.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -31,7 +31,7 @@ rw-stream-sink = "0.2.0"
 sha2 = "0.9.1"
 smallvec = "1.0"
 thiserror = "1.0"
-unsigned-varint = "0.5"
+unsigned-varint = "0.6"
 void = "1"
 zeroize = "1"
 

--- a/misc/multiaddr/CHANGELOG.md
+++ b/misc/multiaddr/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.11.0 [unreleased]
+
+- Update dependencies
+
 # 0.10.0 [2020-11-25]
 
 - Upgrade multihash to `0.13`.

--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -6,7 +6,7 @@ description = "Implementation of the multiaddr format"
 homepage = "https://github.com/libp2p/rust-libp2p"
 keywords = ["multiaddr", "ipfs"]
 license = "MIT"
-version = "0.10.0"
+version = "0.11.0"
 
 [features]
 default = ["url"]

--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -20,7 +20,7 @@ multihash = { version = "0.13", default-features = false, features = ["std", "mu
 percent-encoding = "2.1.0"
 serde = "1.0.70"
 static_assertions = "1.1"
-unsigned-varint = "0.5"
+unsigned-varint = "0.6"
 url = { version = "2.1.0", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/misc/multistream-select/CHANGELOG.md
+++ b/misc/multistream-select/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.0 [unreleased]
+
+- Update dependencies.
+
 # 0.9.1 [2020-12-02]
 
 - Ensure uniform outcomes for failed negotiations with both

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3"
 log = "0.4"
 pin-project = "1.0.0"
 smallvec = "1.0"
-unsigned-varint = "0.5"
+unsigned-varint = "0.6"
 
 [dev-dependencies]
 async-std = "1.6.2"

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "multistream-select"
 description = "Multistream-select negotiation protocol for libp2p"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["network-programming", "asynchronous"]
 edition = "2018"
 
 [dependencies]
-bytes = "0.5"
+bytes = "1"
 futures = "0.3"
 log = "0.4"
 pin-project = "1.0.0"

--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.0 [unreleased]
+
+- Update dependencies.
+
 # 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -19,7 +19,7 @@ nohash-hasher = "0.2"
 parking_lot = "0.11"
 rand = "0.7"
 smallvec = "1.4"
-unsigned-varint = { version = "0.5", features = ["futures-codec"] }
+unsigned-varint = { version = "0.6", features = ["asynchronous_codec"] }
 
 [dev-dependencies]
 async-std = "1.7.0"

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -10,9 +10,9 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-bytes = "0.5"
+bytes = "1"
 futures = "0.3.1"
-futures_codec = "0.4.1"
+asynchronous-codec = "0.5.0"
 libp2p-core = { version = "0.26.0", path = "../../core" }
 log = "0.4"
 nohash-hasher = "0.2"

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-mplex"
 edition = "2018"
 description = "Mplex multiplexing protocol for libp2p"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 bytes = "1"
 futures = "0.3.1"
 asynchronous-codec = "0.5.0"
-libp2p-core = { version = "0.26.0", path = "../../core" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
 log = "0.4"
 nohash-hasher = "0.2"
 parking_lot = "0.11"

--- a/muxers/mplex/src/codec.rs
+++ b/muxers/mplex/src/codec.rs
@@ -19,7 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use bytes::{BufMut, Bytes, BytesMut};
-use futures_codec::{Decoder, Encoder};
+use asynchronous_codec::{Decoder, Encoder};
 use libp2p_core::Endpoint;
 use std::{fmt, hash::{Hash, Hasher}, io, mem};
 use unsigned_varint::{codec, encode};

--- a/muxers/mplex/src/io.rs
+++ b/muxers/mplex/src/io.rs
@@ -24,7 +24,7 @@ use crate::codec::{Codec, Frame, LocalStreamId, RemoteStreamId};
 use log::{debug, trace};
 use futures::{prelude::*, ready, stream::Fuse};
 use futures::task::{AtomicWaker, ArcWake, waker_ref, WakerRef};
-use futures_codec::Framed;
+use asynchronous_codec::Framed;
 use nohash_hasher::{IntMap, IntSet};
 use parking_lot::Mutex;
 use smallvec::SmallVec;
@@ -1006,7 +1006,7 @@ mod tests {
     use async_std::task;
     use bytes::BytesMut;
     use futures::prelude::*;
-    use futures_codec::{Decoder, Encoder};
+    use asynchronous_codec::{Decoder, Encoder};
     use quickcheck::*;
     use rand::prelude::*;
     use std::collections::HashSet;

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.30.0 [unreleased]
+
+- Update dependencies.
+
 # 0.29.0 [2020-12-17]
 
 - Update `libp2p-core`.

--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-yamux"
 edition = "2018"
 description = "Yamux multiplexing protocol for libp2p"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.26.0", path = "../../core" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
 parking_lot = "0.11"
 thiserror = "1.0"
 yamux = "0.8.0"

--- a/protocols/deflate/CHANGELOG.md
+++ b/protocols/deflate/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.0 [unreleased]
+
+- Update dependencies.
+
 # 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.

--- a/protocols/deflate/Cargo.toml
+++ b/protocols/deflate/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-deflate"
 edition = "2018"
 description = "Deflate encryption protocol for libp2p"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.26.0", path = "../../core" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
 flate2 = "1.0"
 
 [dev-dependencies]

--- a/protocols/floodsub/CHANGELOG.md
+++ b/protocols/floodsub/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.0 [unreleased]
+
+- Update dependencies.
+
 # 0.26.0 [2020-12-17]
 
 - Update `libp2p-swarm` and `libp2p-core`.

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3.1"
 libp2p-core = { version = "0.26.0", path = "../../core" }
 libp2p-swarm = { version = "0.26.0", path = "../../swarm" }
 log = "0.4"
-prost = "0.6.1"
+prost = "0.7"
 rand = "0.7"
 smallvec = "1.0"
 

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-floodsub"
 edition = "2018"
 description = "Floodsub protocol for libp2p"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -13,8 +13,8 @@ categories = ["network-programming", "asynchronous"]
 cuckoofilter = "0.5.0"
 fnv = "1.0"
 futures = "0.3.1"
-libp2p-core = { version = "0.26.0", path = "../../core" }
-libp2p-swarm = { version = "0.26.0", path = "../../swarm" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-swarm = { version = "0.27.0", path = "../../swarm" }
 log = "0.4"
 prost = "0.7"
 rand = "0.7"

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.27.0 [unreleased]
+
+- Update dependencies.
+
+- Implement Gossipsub v1.1 specification.
+  [PR 1720](https://github.com/libp2p/rust-libp2p/pull/1720)
+
 # 0.26.0 [2020-12-17]
 
 - Update `libp2p-swarm` and `libp2p-core`.

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-gossipsub"
 edition = "2018"
 description = "Gossipsub protocol for libp2p"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Age Manning <Age@AgeManning.com>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -10,8 +10,8 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-libp2p-swarm = { version = "0.26.0", path = "../../swarm" }
-libp2p-core = { version = "0.26.0", path = "../../core" }
+libp2p-swarm = { version = "0.27.0", path = "../../swarm" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
 bytes = "1.0"
 byteorder = "1.3.2"
 fnv = "1.0.6"

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4.8"
 sha2 = "0.9.1"
 base64 = "0.13.0"
 smallvec = "1.1.0"
-prost = "0.6.1"
+prost = "0.7"
 hex_fmt = "0.3.0"
 lru_time_cache = "0.11.0"
 

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -12,12 +12,12 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 libp2p-swarm = { version = "0.26.0", path = "../../swarm" }
 libp2p-core = { version = "0.26.0", path = "../../core" }
-bytes = "0.5.4"
+bytes = "1.0"
 byteorder = "1.3.2"
 fnv = "1.0.6"
 futures = "0.3.1"
 rand = "0.7.3"
-futures_codec = "0.4.0"
+asynchronous-codec = "0.5.0"
 wasm-timer = "0.2.4"
 unsigned-varint = { version = "0.5", features = ["futures-codec"] }
 log = "0.4.8"

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -19,7 +19,7 @@ futures = "0.3.1"
 rand = "0.7.3"
 asynchronous-codec = "0.5.0"
 wasm-timer = "0.2.4"
-unsigned-varint = { version = "0.5", features = ["futures-codec"] }
+unsigned-varint = { version = "0.6", features = ["asynchronous_codec"] }
 log = "0.4.8"
 sha2 = "0.9.1"
 base64 = "0.13.0"

--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -22,7 +22,7 @@ use crate::behaviour::GossipsubRpc;
 use crate::config::ValidationMode;
 use crate::protocol::{GossipsubCodec, ProtocolConfig};
 use futures::prelude::*;
-use futures_codec::Framed;
+use asynchronous_codec::Framed;
 use libp2p_core::upgrade::{InboundUpgrade, OutboundUpgrade};
 use libp2p_swarm::protocols_handler::{
     KeepAlive, ProtocolsHandler, ProtocolsHandlerEvent, ProtocolsHandlerUpgrErr, SubstreamProtocol,

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -27,7 +27,7 @@ use bytes::Bytes;
 use bytes::BytesMut;
 use futures::future;
 use futures::prelude::*;
-use futures_codec::{Decoder, Encoder, Framed};
+use asynchronous_codec::{Decoder, Encoder, Framed};
 use libp2p_core::{identity::PublicKey, InboundUpgrade, OutboundUpgrade, PeerId, UpgradeInfo};
 use log::{debug, warn};
 use prost::Message as ProtobufMessage;

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.0 [unreleased]
+
+- Update dependencies.
+
 # 0.26.0 [2020-12-17]
 
 - Update `libp2p-swarm` and `libp2p-core`.

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-identify"
 edition = "2018"
 description = "Nodes identifcation protocol for libp2p"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,8 +11,8 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.26.0", path = "../../core" }
-libp2p-swarm = { version = "0.26.0", path = "../../swarm" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-swarm = { version = "0.27.0", path = "../../swarm" }
 log = "0.4.1"
 prost = "0.7"
 smallvec = "1.0"

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.1"
 libp2p-core = { version = "0.26.0", path = "../../core" }
 libp2p-swarm = { version = "0.26.0", path = "../../swarm" }
 log = "0.4.1"
-prost = "0.6.1"
+prost = "0.7"
 smallvec = "1.0"
 wasm-timer = "0.2"
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.28.0 [unreleased]
+
+- Update dependencies.
+
 # 0.27.0 [2020-12-17]
 
 - Update `libp2p-core` and `libp2p-swarm`.

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -19,7 +19,7 @@ futures = "0.3.1"
 log = "0.4"
 libp2p-core = { version = "0.26.0", path = "../../core" }
 libp2p-swarm = { version = "0.26.0", path = "../../swarm" }
-prost = "0.6.1"
+prost = "0.7"
 rand = "0.7.2"
 sha2 = "0.9.1"
 smallvec = "1.0"

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -11,10 +11,10 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 arrayvec = "0.5.1"
-bytes = "0.5"
+bytes = "1"
 either = "1.5"
 fnv = "1.0"
-futures_codec = "0.4"
+asynchronous-codec = "0.5"
 futures = "0.3.1"
 log = "0.4"
 libp2p-core = { version = "0.26.0", path = "../../core" }

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -25,7 +25,7 @@ sha2 = "0.9.1"
 smallvec = "1.0"
 wasm-timer = "0.2"
 uint = "0.8"
-unsigned-varint = { version = "0.5", features = ["futures-codec"] }
+unsigned-varint = { version = "0.6", features = ["asynchronous_codec"] }
 void = "1.0"
 
 [dev-dependencies]

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-kad"
 edition = "2018"
 description = "Kademlia protocol for libp2p"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -17,8 +17,8 @@ fnv = "1.0"
 asynchronous-codec = "0.5"
 futures = "0.3.1"
 log = "0.4"
-libp2p-core = { version = "0.26.0", path = "../../core" }
-libp2p-swarm = { version = "0.26.0", path = "../../swarm" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-swarm = { version = "0.27.0", path = "../../swarm" }
 prost = "0.7"
 rand = "0.7.2"
 sha2 = "0.9.1"

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -31,7 +31,7 @@ use codec::UviBytes;
 use crate::dht_proto as proto;
 use crate::record::{self, Record};
 use futures::prelude::*;
-use futures_codec::Framed;
+use asynchronous_codec::Framed;
 use libp2p_core::{Multiaddr, PeerId};
 use libp2p_core::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use prost::Message;

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.28.0 [unreleased]
+
+- Update dependencies.
+
 # 0.27.0 [2020-12-17]
 
 - Update `libp2p-swarm` and `libp2p-core`.

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-mdns"
 edition = "2018"
-version = "0.27.0"
+version = "0.28.0"
 description = "Implementation of the libp2p mDNS discovery method"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
@@ -16,8 +16,8 @@ dns-parser = "0.8.0"
 futures = "0.3.8"
 if-watch = "0.1.6"
 lazy_static = "1.4.0"
-libp2p-core = { version = "0.26.0", path = "../../core" }
-libp2p-swarm = { version = "0.26.0", path = "../../swarm" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-swarm = { version = "0.27.0", path = "../../swarm" }
 log = "0.4.11"
 rand = "0.7.3"
 smallvec = "1.5.0"

--- a/protocols/noise/CHANGELOG.md
+++ b/protocols/noise/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.29.0 [unreleased]
+
+- Update dependencies.
+
 # 0.28.0 [2020-12-17]
 
 - Update `libp2p-core`.

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-noise"
 description = "Cryptographic handshake protocol using the noise framework."
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -12,7 +12,7 @@ bytes = "1"
 curve25519-dalek = "3.0.0"
 futures = "0.3.1"
 lazy_static = "1.2"
-libp2p-core = { version = "0.26.0", path = "../../core" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
 log = "0.4"
 prost = "0.7"
 rand = "0.7.2"

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.1"
 lazy_static = "1.2"
 libp2p-core = { version = "0.26.0", path = "../../core" }
 log = "0.4"
-prost = "0.6.1"
+prost = "0.7"
 rand = "0.7.2"
 sha2 = "0.9.1"
 static_assertions = "1"

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/libp2p/rust-libp2p"
 edition = "2018"
 
 [dependencies]
-bytes = "0.5"
+bytes = "1"
 curve25519-dalek = "3.0.0"
 futures = "0.3.1"
 lazy_static = "1.2"

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.0 [unreleased]
+
+- Update dependencies.
+
 # 0.26.0 [2020-12-17]
 
 - Update `libp2p-swarm` and `libp2p-core`.

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-ping"
 edition = "2018"
 description = "Ping protocol for libp2p"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,8 +11,8 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.26.0", path = "../../core" }
-libp2p-swarm = { version = "0.26.0", path = "../../swarm" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-swarm = { version = "0.27.0", path = "../../swarm" }
 log = "0.4.1"
 rand = "0.7.2"
 void = "1.0"

--- a/protocols/plaintext/CHANGELOG.md
+++ b/protocols/plaintext/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.0 [unreleased]
+
+- Update dependencies.
+
 # 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.

--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-plaintext"
 edition = "2018"
 description = "Plaintext encryption dummy protocol for libp2p"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 bytes = "1"
 futures = "0.3.1"
 asynchronous-codec = "0.5.0"
-libp2p-core = { version = "0.26.0", path = "../../core" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
 log = "0.4.8"
 prost = "0.7"
 unsigned-varint = { version = "0.6", features = ["asynchronous_codec"] }

--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3.1"
 asynchronous-codec = "0.5.0"
 libp2p-core = { version = "0.26.0", path = "../../core" }
 log = "0.4.8"
-prost = "0.6.1"
+prost = "0.7"
 unsigned-varint = { version = "0.6", features = ["asynchronous_codec"] }
 void = "1.0.2"
 

--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -10,9 +10,9 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-bytes = "0.5"
+bytes = "1"
 futures = "0.3.1"
-futures_codec = "0.4.0"
+asynchronous-codec = "0.5.0"
 libp2p-core = { version = "0.26.0", path = "../../core" }
 log = "0.4.8"
 prost = "0.6.1"

--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -16,7 +16,7 @@ asynchronous-codec = "0.5.0"
 libp2p-core = { version = "0.26.0", path = "../../core" }
 log = "0.4.8"
 prost = "0.6.1"
-unsigned-varint = { version = "0.5.1", features = ["futures-codec"] }
+unsigned-varint = { version = "0.6", features = ["asynchronous_codec"] }
 void = "1.0.2"
 
 [dev-dependencies]

--- a/protocols/plaintext/src/handshake.rs
+++ b/protocols/plaintext/src/handshake.rs
@@ -24,7 +24,7 @@ use crate::structs_proto::Exchange;
 
 use bytes::{Bytes, BytesMut};
 use futures::prelude::*;
-use futures_codec::Framed;
+use asynchronous_codec::Framed;
 use libp2p_core::{PublicKey, PeerId};
 use log::{debug, trace};
 use prost::Message;

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,4 +1,6 @@
 # 0.9.0 [unreleased]
+  
+- Update dependencies.
 
 - Re-export `throttled`-specific response channel. [PR
   1902](https://github.com/libp2p/rust-libp2p/pull/1902).

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 async-trait = "0.1"
-bytes = "0.5.6"
+bytes = "1"
 futures = "0.3.1"
 libp2p-core = { version = "0.26.0", path = "../../core" }
 libp2p-swarm = { version = "0.26.0", path = "../../swarm" }

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["network-programming", "asynchronous"]
 async-trait = "0.1"
 bytes = "1"
 futures = "0.3.1"
-libp2p-core = { version = "0.26.0", path = "../../core" }
-libp2p-swarm = { version = "0.26.0", path = "../../swarm" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-swarm = { version = "0.27.0", path = "../../swarm" }
 log = "0.4.11"
 lru = "0.6"
 minicbor = { version = "0.7", features = ["std", "derive"] }

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -20,7 +20,7 @@ lru = "0.6"
 minicbor = { version = "0.7", features = ["std", "derive"] }
 rand = "0.7"
 smallvec = "1.4"
-unsigned-varint = { version = "0.5", features = ["std", "futures"] }
+unsigned-varint = { version = "0.6", features = ["std", "futures"] }
 wasm-timer = "0.2"
 
 [dev-dependencies]

--- a/protocols/secio/CHANGELOG.md
+++ b/protocols/secio/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.0 [unreleased]
+
+- Update dependencies.
+
 # 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -21,7 +21,7 @@ hmac = "0.9.0"
 lazy_static = "1.2.0"
 libp2p-core = { version = "0.26.0", path = "../../core" }
 log = "0.4.6"
-prost = "0.6.1"
+prost = "0.7"
 pin-project = "1.0.0"
 quicksink = "0.1"
 rand = "0.7"

--- a/protocols/secio/Cargo.toml
+++ b/protocols/secio/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-secio"
 edition = "2018"
 description = "Secio encryption protocol for libp2p"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -19,9 +19,9 @@ ctr = "0.3"
 futures = "0.3.1"
 hmac = "0.9.0"
 lazy_static = "1.2.0"
-libp2p-core = { version = "0.26.0", path = "../../core" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
 log = "0.4.6"
-prost = "0.7"
+prost = "0.6.1"
 pin-project = "1.0.0"
 quicksink = "0.1"
 rand = "0.7"

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.0 [unreleased]
+
+- Update dependencies.
+
 # 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-swarm"
 edition = "2018"
 description = "The libp2p swarm"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 either = "1.6.0"
 futures = "0.3.1"
-libp2p-core = { version = "0.26.0", path = "../core" }
+libp2p-core = { version = "0.27.0", path = "../core" }
 log = "0.4"
 rand = "0.7"
 smallvec = "1.0"

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.0 [unreleased]
+
+- Update dependencies.
+
 # 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-dns"
 edition = "2018"
 description = "DNS transport implementation for libp2p"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -10,6 +10,6 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-libp2p-core = { version = "0.26.0", path = "../../core" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
 log = "0.4.1"
 futures = "0.3.1"

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.0 [unreleased]
+
+- Update dependencies.
+
 # 0.26.0 [2020-12-17]
 
 - Update `async-io`.

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-tcp"
 edition = "2018"
 description = "TCP/IP transport protocol for libp2p"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -15,7 +15,7 @@ futures = "0.3.1"
 futures-timer = "3.0"
 if-addrs = "0.6.4"
 ipnet = "2.0.0"
-libp2p-core = { version = "0.26.0", path = "../../core" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
 log = "0.4.1"
 socket2 = { version = "0.3.12" }
 tokio = { version = "0.3", default-features = false, features = ["net"], optional = true }

--- a/transports/uds/CHANGELOG.md
+++ b/transports/uds/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.0 [unreleased]
+
+- Update dependencies.
+
 # 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.

--- a/transports/uds/Cargo.toml
+++ b/transports/uds/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-uds"
 edition = "2018"
 description = "Unix domain sockets transport for libp2p"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [target.'cfg(all(unix, not(target_os = "emscripten")))'.dependencies]
 async-std = { version = "1.6.2", optional = true }
-libp2p-core = { version = "0.26.0", path = "../../core" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
 log = "0.4.1"
 futures = "0.3.1"
 tokio = { version = "0.3", default-features = false, features = ["net"], optional = true }

--- a/transports/wasm-ext/CHANGELOG.md
+++ b/transports/wasm-ext/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.0 [unreleased]
+
+- Update dependencies.
+
 # 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.

--- a/transports/wasm-ext/Cargo.toml
+++ b/transports/wasm-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-wasm-ext"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 edition = "2018"
 description = "Allows passing in an external transport in a WASM environment"
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 futures = "0.3.1"
 js-sys = "0.3.19"
-libp2p-core = { version = "0.26.0", path = "../../core" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
 parity-send-wrapper = "0.1.0"
 wasm-bindgen = "0.2.42"
 wasm-bindgen-futures = "0.4.4"

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.28.0 [unreleased]
+
+- Update dependencies.
+
 # 0.27.0 [2020-12-17]
 
 - Update `libp2p-core`.

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-websocket"
 edition = "2018"
 description = "WebSocket transport for libp2p"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 async-tls = "0.11.0"
 either = "1.5.3"
 futures = "0.3.1"
-libp2p-core = { version = "0.26.0", path = "../../core" }
+libp2p-core = { version = "0.27.0", path = "../../core" }
 log = "0.4.8"
 quicksink = "0.1"
 rustls = "0.19.0"


### PR DESCRIPTION
`futures-codec` has not been updated in the recent months. It still
depends on `bytes` `v0.5` preventing all downstream dependencies to
upgrade to `bytes` `v1.0`.

This commit replaces `futures_codec` in favor of `asynchronous-codec`
The latter is a fully upgraded fork of the former.

Closes https://github.com/libp2p/rust-libp2p/pull/1900. Depends on https://github.com/paritytech/unsigned-varint/pull/47.

See also https://github.com/matthunz/futures-codec/pull/51 and https://github.com/matthunz/futures-codec/pull/57.

In addition to the above, this pull request upgrades `rust-libp2p` to `bytes` `v1`.