### PR TITLE
Add From impl for kbucket::Key

### DIFF
--- a/protocols/kad/src/kbucket/key.rs
+++ b/protocols/kad/src/kbucket/key.rs
@@ -25,6 +25,8 @@ use sha2::digest::generic_array::{GenericArray, typenum::U32};
 use std::borrow::Borrow;
 use std::hash::{Hash, Hasher};
 
+use crate::record;
+
 construct_uint! {
     /// 256-bit unsigned integer.
     pub(super) struct U256(4);
@@ -108,6 +110,18 @@ impl From<PeerId> for Key<PeerId> {
            preimage: p,
            bytes
        }
+    }
+}
+
+impl From<Vec<u8>> for Key<Vec<u8>> {
+    fn from(b: Vec<u8>) -> Self {
+        Key::new(b)
+    }
+}
+
+impl From<record::Key> for Key<record::Key> {
+    fn from(k: record::Key) -> Self {
+        Key::new(k)
     }
 }
 

--- a/protocols/kad/src/kbucket/key.rs
+++ b/protocols/kad/src/kbucket/key.rs
@@ -24,7 +24,6 @@ use sha2::{Digest, Sha256};
 use sha2::digest::generic_array::{GenericArray, typenum::U32};
 use std::borrow::Borrow;
 use std::hash::{Hash, Hasher};
-
 use crate::record;
 
 construct_uint! {


### PR DESCRIPTION
- From<record::Key>
- From<Vec<u8>
- this will enable to use additional types in kad.get_closest_peers as it was possible in pre 0.33 version