### PR TITLE
Fix compilation with serde 1.0.119

### DIFF
--- a/misc/multiaddr/src/onion_addr.rs
+++ b/misc/multiaddr/src/onion_addr.rs
@@ -1,7 +1,4 @@
-use std::borrow::Cow;
-use std::fmt::Debug;
-use serde::export::Formatter;
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 /// Represents an Onion v3 address
 #[derive(Clone)]
@@ -44,8 +41,8 @@ impl<'a> From<(&'a [u8; 35], u16)> for Onion3Addr<'a> {
     }
 }
 
-impl Debug for Onion3Addr<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+impl fmt::Debug for Onion3Addr<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
        f.debug_tuple("Onion3Addr")
            .field(&format!("{:02x?}", &self.0[..]))
            .field(&self.1)


### PR DESCRIPTION
I have no idea why, but the person who introduced this code decided to use `serde::export::Formatter`, which is a hidden export not supposed to be used, instead of `std::fmt::Formatter`, even though they're the same thing.

In serde 1.0.119, the `export` module is no longer public, which broke the build.
