### PR TITLE
fix compile error caused by serde-v1.0.119

### DIFF
--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -15,7 +15,7 @@ byteorder = "1.3.1"
 data-encoding = "2.1"
 multihash = "0.11.0"
 percent-encoding = "2.1.0"
-serde = "1.0.70"
+serde = "=1.0.118"
 static_assertions = "1.1"
 unsigned-varint = "0.4"
 url = { version = "2.1.0", default-features = false }


### PR DESCRIPTION
lock version to v1.0.118