### PR TITLE
*: Update to prost-build v0.7

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -49,7 +49,7 @@ quickcheck = "0.9.0"
 wasm-timer = "0.2"
 
 [build-dependencies]
-prost-build = "0.6"
+prost-build = "0.7"
 
 [features]
 default = ["secp256k1"]

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -21,5 +21,5 @@ rand = "0.7"
 smallvec = "1.0"
 
 [build-dependencies]
-prost-build = "0.6"
+prost-build = "0.7"
 

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -25,4 +25,4 @@ libp2p-noise = { path = "../../protocols/noise" }
 libp2p-tcp = { path = "../../transports/tcp" }
 
 [build-dependencies]
-prost-build = "0.6"
+prost-build = "0.7"

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -35,5 +35,5 @@ libp2p-yamux = { path = "../../muxers/yamux" }
 quickcheck = "0.9.0"
 
 [build-dependencies]
-prost-build = "0.6"
+prost-build = "0.7"
 

--- a/protocols/noise/Cargo.toml
+++ b/protocols/noise/Cargo.toml
@@ -35,4 +35,4 @@ quickcheck = "0.9.0"
 sodiumoxide = "0.2.5"
 
 [build-dependencies]
-prost-build = "0.6"
+prost-build = "0.7"

--- a/protocols/plaintext/Cargo.toml
+++ b/protocols/plaintext/Cargo.toml
@@ -25,5 +25,5 @@ quickcheck = "0.9.0"
 rand = "0.7"
 
 [build-dependencies]
-prost-build = "0.6"
+prost-build = "0.7"
 


### PR DESCRIPTION
Not quite sure why dependabot assumed that `prost-build` is up to date in https://github.com/libp2p/rust-libp2p/pull/1906#issuecomment-758605604. Either way, I think we should use the same version of `prost` and `prost-build`.