### PR TITLE
*: Prepare v0.34.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [`parity-multiaddr` CHANGELOG](misc/multiaddr/CHANGELOG.md)
 - [`libp2p-core-derive` CHANGELOG](misc/core-derive/CHANGELOG.md)
 
-# Version 0.34.0 [unreleased]
+# Version 0.34.0 [2021-01-12]
 
 - Update `libp2p-core` and all dependent crates.
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.0 [unreleased]
+# 0.27.0 [2021-01-12]
 
 - (Re)add `Transport::address_translation` to permit transport-specific
   translations of observed addresses onto listening addresses.

--- a/misc/multiaddr/CHANGELOG.md
+++ b/misc/multiaddr/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.11.0 [unreleased]
+# 0.11.0 [2021-01-12]
 
 - Update dependencies
 

--- a/misc/multistream-select/CHANGELOG.md
+++ b/misc/multistream-select/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.10.0 [unreleased]
+# 0.10.0 [2021-01-12]
 
 - Update dependencies.
 

--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.0 [unreleased]
+# 0.27.0 [2021-01-12]
 
 - Update dependencies.
 

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.30.0 [unreleased]
+# 0.30.0 [2021-01-12]
 
 - Update dependencies.
 

--- a/protocols/deflate/CHANGELOG.md
+++ b/protocols/deflate/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.0 [unreleased]
+# 0.27.0 [2021-01-12]
 
 - Update dependencies.
 

--- a/protocols/floodsub/CHANGELOG.md
+++ b/protocols/floodsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.0 [unreleased]
+# 0.27.0 [2021-01-12]
 
 - Update dependencies.
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.0 [unreleased]
+# 0.27.0 [2021-01-12]
 
 - Update dependencies.
 

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.0 [unreleased]
+# 0.27.0 [2021-01-12]
 
 - Update dependencies.
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.28.0 [unreleased]
+# 0.28.0 [2021-01-12]
 
 - Update dependencies.
 

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.28.0 [unreleased]
+# 0.28.0 [2021-01-12]
 
 - Update dependencies.
 

--- a/protocols/noise/CHANGELOG.md
+++ b/protocols/noise/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.29.0 [unreleased]
+# 0.29.0 [2021-01-12]
 
 - Update dependencies.
 

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.0 [unreleased]
+# 0.27.0 [2021-01-12]
 
 - Update dependencies.
 

--- a/protocols/plaintext/CHANGELOG.md
+++ b/protocols/plaintext/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.0 [unreleased]
+# 0.27.0 [2021-01-12]
 
 - Update dependencies.
 

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.9.0 [unreleased]
+# 0.9.0 [2021-01-12]
 
 - Update dependencies.
 

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.0 [unreleased]
+# 0.27.0 [2021-01-12]
 
 - Update dependencies.
 

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.0 [unreleased]
+# 0.27.0 [2021-01-12]
 
 - Update dependencies.
 

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.0 [unreleased]
+# 0.27.0 [2021-01-12]
 
 - Add support for port reuse and (re)add transport-specific
   address translation. Thereby use only `async-io` instead of

--- a/transports/uds/CHANGELOG.md
+++ b/transports/uds/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.0 [unreleased]
+# 0.27.0 [2021-01-12]
 
 - Update dependencies.
 

--- a/transports/wasm-ext/CHANGELOG.md
+++ b/transports/wasm-ext/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.0 [unreleased]
+# 0.27.0 [2021-01-12]
 
 - Update dependencies.
 

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.28.0 [unreleased]
+# 0.28.0 [2021-01-12]
 
 - Update dependencies.
 


### PR DESCRIPTION
I would like to release a new version of `libp2p` (`v0.34.0`) and new versions of its sub-crates.

I would suggest to wait for https://github.com/libp2p/rust-libp2p/pull/1917 to be merged before proceeding here. I don't think it is worth blocking the release for https://github.com/libp2p/rust-libp2p/pull/1916. https://github.com/libp2p/rust-libp2p/pull/1899 is blocked on a new release of `snow` (see https://github.com/libp2p/rust-libp2p/pull/1899#issuecomment-754096109).

@quininer @romanb do I understand correctly that we will hold off with https://github.com/libp2p/rust-libp2p/pull/1889 for now?

I do not plan to release a new version of `libp2p-secio` given its deprecation. Objections? I would even suggest removing the code in the future, only leaving a note with a reference to an older commit.