### PR TITLE
*: Update to tokio v1.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ libp2p-websocket = { version = "0.28.0", path = "transports/websocket", optional
 [dev-dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }
 env_logger = "0.8.1"
-tokio = { version = "0.3", features = ["io-util", "io-std", "stream", "macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1.0.1", features = ["io-util", "io-std", "macros", "rt", "rt-multi-thread"] }
 
 [workspace]
 members = [

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -27,4 +27,4 @@ void = "1.0.2"
 [dev-dependencies]
 async-std = "1.7.0"
 if-addrs = "0.6.5"
-tokio = { version = "0.3.4", default-features = false, features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1.0.1", default-features = false, features = ["rt", "rt-multi-thread"] }

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -20,7 +20,7 @@ libc = "0.2.80"
 libp2p-core = { version = "0.27.0", path = "../../core" }
 log = "0.4.11"
 socket2 = { version = "0.3.17", features = ["reuseport"] }
-tokio-crate = { package = "tokio", version = "0.3", default-features = false, features = ["net"], optional = true }
+tokio-crate = { package = "tokio", version = "1.0.1", default-features = false, features = ["net"], optional = true }
 
 [features]
 default = ["async-io"]
@@ -29,5 +29,5 @@ async-io = ["async-io-crate", "if-watch"]
 
 [dev-dependencies]
 async-std = { version = "1.6.5", features = ["attributes"] }
-tokio-crate = { package = "tokio", version = "0.3", default-features = false, features = ["net", "rt"] }
+tokio-crate = { package = "tokio", version = "1.0.1", default-features = false, features = ["net", "rt"] }
 env_logger = "0.8.2"

--- a/transports/uds/Cargo.toml
+++ b/transports/uds/Cargo.toml
@@ -14,7 +14,7 @@ async-std = { version = "1.6.2", optional = true }
 libp2p-core = { version = "0.27.0", path = "../../core" }
 log = "0.4.1"
 futures = "0.3.1"
-tokio = { version = "0.3", default-features = false, features = ["net"], optional = true }
+tokio = { version = "1.0.1", default-features = false, features = ["net"], optional = true }
 
 [target.'cfg(all(unix, not(target_os = "emscripten")))'.dev-dependencies]
 tempfile = "3.0"


### PR DESCRIPTION
Now that `bytes` is up-to-date we can update to `tokio` `v1.0.1`. Replaces https://github.com/libp2p/rust-libp2p/pull/1907.

I would suggest we merge this before the new release (https://github.com/libp2p/rust-libp2p/pull/1918).