### PR TITLE
Fix a typo in gossipsub

### DIFF
--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -19,7 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 //! Gossipsub is a P2P pubsub (publish/subscription) routing layer designed to extend upon
-//! flooodsub and meshsub routing protocols.
+//! floodsub and meshsub routing protocols.
 //!
 //! # Overview
 //!


### PR DESCRIPTION
Removes an extra O in gossipsub's docs.