### PR TITLE
misc/multiaddr: Backport serde-related fix to v0.9

### DIFF
--- a/misc/multiaddr/CHANGELOG.md
+++ b/misc/multiaddr/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.9.7 [2021-01-14]
+
+- Fix compilation with serde 1.0.119. See original
+  [PR 1912](https://github.com/libp2p/rust-libp2p/pull/1912).
+
 # 0.9.6 [2020-11-17]
 
 - Move the `from_url` module and functionality behind the `url` feature,

--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -6,7 +6,7 @@ description = "Implementation of the multiaddr format"
 homepage = "https://github.com/libp2p/rust-libp2p"
 keywords = ["multiaddr", "ipfs"]
 license = "MIT"
-version = "0.9.6"
+version = "0.9.7"
 
 [features]
 default = ["url"]

--- a/misc/multiaddr/src/onion_addr.rs
+++ b/misc/multiaddr/src/onion_addr.rs
@@ -1,7 +1,4 @@
-use std::borrow::Cow;
-use std::fmt::Debug;
-use serde::export::Formatter;
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 /// Represents an Onion v3 address
 #[derive(Clone)]
@@ -44,8 +41,8 @@ impl<'a> From<(&'a [u8; 35], u16)> for Onion3Addr<'a> {
     }
 }
 
-impl Debug for Onion3Addr<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+impl fmt::Debug for Onion3Addr<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
        f.debug_tuple("Onion3Addr")
            .field(&format!("{:02x?}", &self.0[..]))
            .field(&self.1)


### PR DESCRIPTION
Backport https://github.com/libp2p/rust-libp2p/pull/1912 to `parity-multiaddr` `v0.9` as `v0.9.7`.