### PR TITLE
is_pending_outbound fixes

### DIFF
--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -431,9 +431,14 @@ where
     /// [`PeerId`] initiated by [`RequestResponse::send_request`] is still
     /// pending, i.e. waiting for a response.
     pub fn is_pending_outbound(&self, peer: &PeerId, request_id: &RequestId) -> bool {
-        self.connected.get(peer)
+        // check if request id is exists in already established connections
+        let est_conn = self.connected.get(peer)
             .map(|cs| cs.iter().any(|c| c.pending_inbound_responses.contains(request_id)))
-            .unwrap_or(false)
+            .unwrap_or(false);
+        // check if peer exists in pending connections
+        let pen_conn = self.pending_outbound_requests.contains_key(peer);
+
+        est_conn || pen_conn
     }
 
     /// Checks whether an inbound request from the peer with the provided

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -437,7 +437,7 @@ where
             .unwrap_or(false);
         // Check if request is still pending to be sent.
         let pen_conn = self.pending_outbound_requests.get(peer)
-            .map(|cs| cs.iter().any(|c| {c.request_id == *request_id}))
+            .map(|rps| rps.iter().any(|rp| {rp.request_id == *request_id}))
             .unwrap_or(false);
 
         est_conn || pen_conn

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -431,12 +431,14 @@ where
     /// [`PeerId`] initiated by [`RequestResponse::send_request`] is still
     /// pending, i.e. waiting for a response.
     pub fn is_pending_outbound(&self, peer: &PeerId, request_id: &RequestId) -> bool {
-        // check if request id is exists in already established connections
+        // Check if request is already sent on established connection.
         let est_conn = self.connected.get(peer)
             .map(|cs| cs.iter().any(|c| c.pending_inbound_responses.contains(request_id)))
             .unwrap_or(false);
-        // check if peer exists in pending connections
-        let pen_conn = self.pending_outbound_requests.contains_key(peer);
+        // Check if request is still pending to be sent.
+        let pen_conn = self.pending_outbound_requests.get(peer)
+            .map(|cs| cs.iter().any(|c| {c.request_id == *request_id}))
+            .unwrap_or(false);
 
         est_conn || pen_conn
     }

--- a/protocols/request-response/tests/ping.rs
+++ b/protocols/request-response/tests/ping.rs
@@ -93,6 +93,7 @@ fn ping_protocol() {
         let addr = rx.next().await.unwrap();
         swarm2.add_address(&peer1_id, addr.clone());
         let mut req_id = swarm2.send_request(&peer1_id, ping.clone());
+        assert!(swarm2.is_pending_outbound(&peer2_id, &req_id));
 
         loop {
             match swarm2.next().await {

--- a/protocols/request-response/tests/ping.rs
+++ b/protocols/request-response/tests/ping.rs
@@ -93,7 +93,7 @@ fn ping_protocol() {
         let addr = rx.next().await.unwrap();
         swarm2.add_address(&peer1_id, addr.clone());
         let mut req_id = swarm2.send_request(&peer1_id, ping.clone());
-        assert!(swarm2.is_pending_outbound(&peer2_id, &req_id));
+        assert!(swarm2.is_pending_outbound(&peer1_id, &req_id));
 
         loop {
             match swarm2.next().await {

--- a/protocols/request-response/tests/ping.rs
+++ b/protocols/request-response/tests/ping.rs
@@ -106,7 +106,7 @@ fn ping_protocol() {
                     assert_eq!(&peer, &peer1_id);
                     assert_eq!(req_id, request_id);
                     if count >= num_pings {
-                       break 
+                        return
                     } else {
                         req_id = swarm2.send_request(&peer1_id, ping.clone());
                     }
@@ -114,11 +114,6 @@ fn ping_protocol() {
                 e => panic!("Peer2: Unexpected event: {:?}", e)
             }
         }
-
-        let req_id2 = swarm2.send_request(&peer1_id, ping.clone());
-        // check if is_pending_outbound returns false for a finished request when we have already issued a new one
-        assert!(swarm2.is_pending_outbound(&peer1_id, &req_id) == false);
-        assert!(swarm2.is_pending_outbound(&peer1_id, &req_id2));
     };
 
     async_std::task::spawn(Box::pin(peer1));

--- a/protocols/request-response/tests/ping.rs
+++ b/protocols/request-response/tests/ping.rs
@@ -110,17 +110,15 @@ fn ping_protocol() {
                     } else {
                         req_id = swarm2.send_request(&peer1_id, ping.clone());
                     }
-                    println!("hi, {}", req_id);
                 },
                 e => panic!("Peer2: Unexpected event: {:?}", e)
             }
         }
 
-        // check if is_pending_outbound returns false for a finished request when we have already issued a new one
         let req_id2 = swarm2.send_request(&peer1_id, ping.clone());
+        // check if is_pending_outbound returns false for a finished request when we have already issued a new one
         assert!(swarm2.is_pending_outbound(&peer1_id, &req_id) == false);
         assert!(swarm2.is_pending_outbound(&peer1_id, &req_id2));
-
     };
 
     async_std::task::spawn(Box::pin(peer1));

--- a/protocols/request-response/tests/ping.rs
+++ b/protocols/request-response/tests/ping.rs
@@ -106,14 +106,21 @@ fn ping_protocol() {
                     assert_eq!(&peer, &peer1_id);
                     assert_eq!(req_id, request_id);
                     if count >= num_pings {
-                        return
+                       break 
                     } else {
                         req_id = swarm2.send_request(&peer1_id, ping.clone());
                     }
+                    println!("hi, {}", req_id);
                 },
                 e => panic!("Peer2: Unexpected event: {:?}", e)
             }
         }
+
+        // check if is_pending_outbound returns false for a finished request when we have already issued a new one
+        let req_id2 = swarm2.send_request(&peer1_id, ping.clone());
+        assert!(swarm2.is_pending_outbound(&peer1_id, &req_id) == false);
+        assert!(swarm2.is_pending_outbound(&peer1_id, &req_id2));
+
     };
 
     async_std::task::spawn(Box::pin(peer1));


### PR DESCRIPTION
`is_pending_outbound` returns true if the connection
to the mentioned peer hasn't been established, yet.

Closes issue: #1885

Signed-off-by: Tejas Sanap <sanap.tejas@gmail.com>