### PR TITLE
[libp2p-dns] Implement `/dnsaddr` resolution.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,35 +64,35 @@ atomic = "0.5.0"
 bytes = "1"
 futures = "0.3.1"
 lazy_static = "1.2"
-libp2p-core = { version = "0.27.2", path = "core",  default-features = false }
+libp2p-core = { version = "0.28.0", path = "core",  default-features = false }
 libp2p-floodsub = { version = "0.28.0", path = "protocols/floodsub", optional = true }
 libp2p-gossipsub = { version = "0.29.0", path = "./protocols/gossipsub", optional = true }
 libp2p-identify = { version = "0.28.0", path = "protocols/identify", optional = true }
 libp2p-kad = { version = "0.29.0", path = "protocols/kad", optional = true }
-libp2p-mplex = { version = "0.27.2", path = "muxers/mplex", optional = true }
-libp2p-noise = { version = "0.29.0", path = "transports/noise", optional = true }
+libp2p-mplex = { version = "0.28.0", path = "muxers/mplex", optional = true }
+libp2p-noise = { version = "0.30.0", path = "transports/noise", optional = true }
 libp2p-ping = { version = "0.28.0", path = "protocols/ping", optional = true }
-libp2p-plaintext = { version = "0.27.1", path = "transports/plaintext", optional = true }
+libp2p-plaintext = { version = "0.28.0", path = "transports/plaintext", optional = true }
 libp2p-pnet = { version = "0.20.0", path = "transports/pnet", optional = true }
 libp2p-relay = { version = "0.1.0", path = "protocols/relay", optional = true }
 libp2p-request-response = { version = "0.10.0", path = "protocols/request-response", optional = true }
 libp2p-swarm = { version = "0.28.0", path = "swarm" }
 libp2p-swarm-derive = { version = "0.22.0", path = "swarm-derive" }
-libp2p-uds = { version = "0.27.0", path = "transports/uds", optional = true }
-libp2p-wasm-ext = { version = "0.27.0", path = "transports/wasm-ext", default-features = false, optional = true }
-libp2p-yamux = { version = "0.30.1", path = "muxers/yamux", optional = true }
-multiaddr = { package = "parity-multiaddr", version = "0.11.1", path = "misc/multiaddr" }
+libp2p-uds = { version = "0.28.0", path = "transports/uds", optional = true }
+libp2p-wasm-ext = { version = "0.28.0", path = "transports/wasm-ext", default-features = false, optional = true }
+libp2p-yamux = { version = "0.31.0", path = "muxers/yamux", optional = true }
+multiaddr = { package = "parity-multiaddr", version = "0.11.2", path = "misc/multiaddr" }
 parking_lot = "0.11.0"
 pin-project = "1.0.0"
 smallvec = "1.6.1"
 wasm-timer = "0.2.4"
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")))'.dependencies]
-libp2p-deflate = { version = "0.27.1", path = "transports/deflate", optional = true }
+libp2p-deflate = { version = "0.28.0", path = "transports/deflate", optional = true }
 libp2p-dns = { version = "0.28.0", path = "transports/dns", optional = true, default-features = false }
 libp2p-mdns = { version = "0.29.0", path = "protocols/mdns", optional = true }
-libp2p-tcp = { version = "0.27.1", path = "transports/tcp", default-features = false, optional = true }
-libp2p-websocket = { version = "0.28.0", path = "transports/websocket", optional = true }
+libp2p-tcp = { version = "0.28.0", path = "transports/tcp", default-features = false, optional = true }
+libp2p-websocket = { version = "0.29.0", path = "transports/websocket", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,12 @@
-# 0.27.2 [unreleased]
+# 0.28.0 [unreleased]
+
+- `Network::dial()` understands `/p2p` addresses and `Transport::dial`
+  gets a "fully qualified" `/p2p` address when dialing a specific peer,
+  whether through the `Network::peer()` API or via `Network::dial()`
+  with a `/p2p` address.
+
+- `Network::dial()` and `network::Peer::dial()` return a `DialError`
+  on error.
 
 - Shorten and unify `Debug` impls of public keys.
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-core"
 edition = "2018"
 description = "Core traits and structs of libp2p"
-version = "0.27.2"
+version = "0.28.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/core/src/connection/pool.rs
+++ b/core/src/connection/pool.rs
@@ -554,7 +554,7 @@ impl<TInEvent, TOutEvent, THandler, TTransErr, THandlerErr>
 
     /// Returns an iterator over all connected peers, i.e. those that have
     /// at least one established connection in the pool.
-    pub fn iter_connected<'a>(&'a self) -> impl Iterator<Item = &'a PeerId> + 'a {
+    pub fn iter_connected(&self) -> impl Iterator<Item = &PeerId> {
         self.established.keys()
     }
 

--- a/core/src/network/peer.rs
+++ b/core/src/network/peer.rs
@@ -45,7 +45,7 @@ use std::{
     error,
     fmt,
 };
-use super::{Network, DialingOpts};
+use super::{Network, DialingOpts, DialError};
 
 /// The possible representations of a peer in a [`Network`], as
 /// seen by the local node.
@@ -210,7 +210,7 @@ where
     pub fn dial<I>(self, address: Multiaddr, remaining: I, handler: THandler)
         -> Result<
             (ConnectionId, DialingPeer<'a, TTrans, TInEvent, TOutEvent, THandler>),
-            ConnectionLimit
+            DialError
         >
     where
         I: IntoIterator<Item = Multiaddr>,
@@ -219,7 +219,9 @@ where
             Peer::Connected(p) => (p.peer_id, p.network),
             Peer::Dialing(p) => (p.peer_id, p.network),
             Peer::Disconnected(p) => (p.peer_id, p.network),
-            Peer::Local => return Err(ConnectionLimit { current: 0, limit: 0 })
+            Peer::Local => return Err(DialError::ConnectionLimit(ConnectionLimit {
+                current: 0, limit: 0
+            }))
         };
 
         let id = network.dial_peer(DialingOpts {

--- a/core/src/transport/memory.rs
+++ b/core/src/transport/memory.rs
@@ -263,19 +263,14 @@ impl Drop for Listener {
 
 /// If the address is `/memory/n`, returns the value of `n`.
 fn parse_memory_addr(a: &Multiaddr) -> Result<u64, ()> {
-    let mut iter = a.iter();
-
-    let port = if let Some(Protocol::Memory(port)) = iter.next() {
-        port
-    } else {
-        return Err(());
-    };
-
-    if iter.next().is_some() {
-        return Err(());
+    let mut protocols = a.iter();
+    match protocols.next() {
+        Some(Protocol::Memory(port)) => match protocols.next() {
+            None | Some(Protocol::P2p(_)) => Ok(port),
+            _ => Err(())
+        }
+        _ => Err(())
     }
-
-    Ok(port)
 }
 
 /// A channel represents an established, in-memory, logical connection between two endpoints.

--- a/misc/multiaddr/CHANGELOG.md
+++ b/misc/multiaddr/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.11.2 [unreleased]
+
+- Add `Multiaddr::ends_with()`.
+
 # 0.11.1 [2021-02-15]
 
 - Update dependencies

--- a/misc/multiaddr/Cargo.toml
+++ b/misc/multiaddr/Cargo.toml
@@ -6,7 +6,7 @@ description = "Implementation of the multiaddr format"
 homepage = "https://github.com/libp2p/rust-libp2p"
 keywords = ["multiaddr", "ipfs"]
 license = "MIT"
-version = "0.11.1"
+version = "0.11.2"
 
 [features]
 default = ["url"]

--- a/misc/multiaddr/src/lib.rs
+++ b/misc/multiaddr/src/lib.rs
@@ -174,6 +174,16 @@ impl Multiaddr {
 
         if replaced { Some(address) } else { None }
     }
+
+    /// Checks whether the given `Multiaddr` is a suffix of this `Multiaddr`.
+    pub fn ends_with(&self, other: &Multiaddr) -> bool {
+        let n = self.bytes.len();
+        let m = other.bytes.len();
+        if n < m {
+            return false
+        }
+        self.bytes[(n - m) ..] == other.bytes[..]
+    }
 }
 
 impl fmt::Debug for Multiaddr {

--- a/misc/multiaddr/tests/lib.rs
+++ b/misc/multiaddr/tests/lib.rs
@@ -56,6 +56,18 @@ fn push_pop_identity() {
     QuickCheck::new().quickcheck(prop as fn(Ma, Proto) -> bool)
 }
 
+#[test]
+fn ends_with() {
+    fn prop(Ma(m): Ma) {
+        let n = m.iter().count();
+        for i in 0 .. n {
+            let suffix = m.iter().skip(i).collect::<Multiaddr>();
+            assert!(m.ends_with(&suffix));
+        }
+    }
+    QuickCheck::new().quickcheck(prop as fn(_))
+}
+
 
 // Arbitrary impls
 

--- a/misc/multistream-select/src/dialer_select.rs
+++ b/misc/multistream-select/src/dialer_select.rs
@@ -260,7 +260,7 @@ where
                             let protocol = this.protocols.next().ok_or(NegotiationError::Failed)?;
                             *this.state = SeqState::SendProtocol { io, protocol }
                         }
-                        _ => return Poll::Ready(Err(ProtocolError::InvalidMessage.into())),
+                        _ => return Poll::Ready(Err(ProtocolError::InvalidMessage.into()))
                     }
                 }
 

--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.27.2 [unreleased]
+# 0.28.0 [unreleased]
 
 - Update dependencies.
 

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-mplex"
 edition = "2018"
 description = "Mplex multiplexing protocol for libp2p"
-version = "0.27.2"
+version = "0.28.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 bytes = "1"
 futures = "0.3.1"
 asynchronous-codec = "0.6"
-libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-core = { version = "0.28.0", path = "../../core" }
 log = "0.4"
 nohash-hasher = "0.2"
 parking_lot = "0.11"

--- a/muxers/mplex/src/io.rs
+++ b/muxers/mplex/src/io.rs
@@ -238,7 +238,7 @@ where
                     num_buffered += 1;
                 }
                 Frame::Close { stream_id } => {
-                    self.on_close(stream_id.into_local())?;
+                    self.on_close(stream_id.into_local());
                 }
                 Frame::Reset { stream_id } => {
                     self.on_reset(stream_id.into_local())
@@ -460,7 +460,7 @@ where
                 }
                 Frame::Close { stream_id } => {
                     let stream_id = stream_id.into_local();
-                    self.on_close(stream_id)?;
+                    self.on_close(stream_id);
                     if id == stream_id {
                         return Poll::Ready(Ok(None))
                     }
@@ -683,7 +683,7 @@ where
     }
 
     /// Processes an inbound `Close` frame.
-    fn on_close(&mut self, id: LocalStreamId) -> io::Result<()> {
+    fn on_close(&mut self, id: LocalStreamId) {
         if let Some(state) = self.substreams.remove(&id) {
             match state {
                 SubstreamState::RecvClosed { .. } | SubstreamState::Closed { .. } => {
@@ -715,8 +715,6 @@ where
             trace!("{}: Ignoring `Close` for unknown substream {}. Possibly dropped earlier.",
                 self.id, id);
         }
-
-        Ok(())
     }
 
     /// Generates the next outbound stream ID.

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.31.0 [unreleased]
+
+- Update `libp2p-core`.
+
 # 0.30.1 [2021-02-17]
 
 - Update `yamux` to `0.8.1`.

--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-yamux"
 edition = "2018"
 description = "Yamux multiplexing protocol for libp2p"
-version = "0.30.1"
+version = "0.31.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-core = { version = "0.28.0", path = "../../core" }
 parking_lot = "0.11"
 thiserror = "1.0"
 yamux = "0.8.1"

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 cuckoofilter = "0.5.0"
 fnv = "1.0"
 futures = "0.3.1"
-libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-core = { version = "0.28.0", path = "../../core" }
 libp2p-swarm = { version = "0.28.0", path = "../../swarm" }
 log = "0.4"
 prost = "0.7"

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 libp2p-swarm = { version = "0.28.0", path = "../../swarm" }
-libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-core = { version = "0.28.0", path = "../../core" }
 bytes = "1.0"
 byteorder = "1.3.4"
 fnv = "1.0.7"

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-core = { version = "0.28.0", path = "../../core" }
 libp2p-swarm = { version = "0.28.0", path = "../../swarm" }
 log = "0.4.1"
 prost = "0.7"

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -17,7 +17,7 @@ fnv = "1.0"
 asynchronous-codec = "0.6"
 futures = "0.3.1"
 log = "0.4"
-libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-core = { version = "0.28.0", path = "../../core" }
 libp2p-swarm = { version = "0.28.0", path = "../../swarm" }
 prost = "0.7"
 rand = "0.7.2"

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -16,7 +16,7 @@ dns-parser = "0.8.0"
 futures = "0.3.13"
 if-watch = "0.2.0"
 lazy_static = "1.4.0"
-libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-core = { version = "0.28.0", path = "../../core" }
 libp2p-swarm = { version = "0.28.0", path = "../../swarm" }
 log = "0.4.14"
 rand = "0.8.3"

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-core = { version = "0.28.0", path = "../../core" }
 libp2p-swarm = { version = "0.28.0", path = "../../swarm" }
 log = "0.4.1"
 rand = "0.7.2"

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -14,7 +14,7 @@ asynchronous-codec = "0.6"
 bytes = "1"
 futures = "0.3.1"
 futures-timer = "3"
-libp2p-core = { version = "0.27", path = "../../core" }
+libp2p-core = { version = "0.28", path = "../../core" }
 libp2p-swarm = { version = "0.28", path = "../../swarm" }
 log = "0.4"
 pin-project = "1"

--- a/protocols/relay/src/transport.rs
+++ b/protocols/relay/src/transport.rs
@@ -401,14 +401,12 @@ impl<T: Transport> Stream for RelayListener<T> {
                     Poll::Ready(Some(BehaviourToListenerMsg::IncomingRelayedConnection {
                         stream,
                         src_peer_id,
-                        relay_peer_id,
                         relay_addr,
+                        relay_peer_id: _
                     })) => {
                         return Poll::Ready(Some(Ok(ListenerEvent::Upgrade {
                             upgrade: RelayedListenerUpgrade::Relayed(Some(stream)),
-                            local_addr: relay_addr
-                                .with(Protocol::P2p(relay_peer_id.into()))
-                                .with(Protocol::P2pCircuit),
+                            local_addr: relay_addr.with(Protocol::P2pCircuit),
                             remote_addr: Protocol::P2p(src_peer_id.into()).into(),
                         })));
                     }

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 async-trait = "0.1"
 bytes = "1"
 futures = "0.3.1"
-libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-core = { version = "0.28.0", path = "../../core" }
 libp2p-swarm = { version = "0.28.0", path = "../../swarm" }
 log = "0.4.11"
 lru = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,9 +283,9 @@ pub async fn development_transport(keypair: identity::Keypair)
 {
     let transport = {
         let tcp = tcp::TcpConfig::new().nodelay(true);
-        let transport = dns::DnsConfig::system(tcp).await?;
-        let websockets = websocket::WsConfig::new(transport.clone());
-        transport.or_transport(websockets)
+        let dns_tcp = dns::DnsConfig::system(tcp).await?;
+        let ws_dns_tcp = websocket::WsConfig::new(dns_tcp.clone());
+        dns_tcp.or_transport(ws_dns_tcp)
     };
 
     let noise_keys = noise::Keypair::<noise::X25519Spec>::new()
@@ -318,9 +318,9 @@ pub fn tokio_development_transport(keypair: identity::Keypair)
 {
     let transport = {
         let tcp = tcp::TokioTcpConfig::new().nodelay(true);
-        let transport = dns::TokioDnsConfig::system(tcp)?;
-        let websockets = websocket::WsConfig::new(transport.clone());
-        transport.or_transport(websockets)
+        let dns_tcp = dns::TokioDnsConfig::system(tcp)?;
+        let ws_dns_tcp = websocket::WsConfig::new(dns_tcp.clone());
+        dns_tcp.or_transport(ws_dns_tcp)
     };
 
     let noise_keys = noise::Keypair::<noise::X25519Spec>::new()

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 0.28.0 [unreleased]
 
+- New error variant `DialError::InvalidAddress`
+
+- `Swarm::dial_addr()` now returns a `DialError` on error.
+
 - Remove the option for a substream-specific multistream select protocol override.
   The override at this granularity is no longer deemed useful, in particular because
   it can usually not be configured for existing protocols like `libp2p-kad` and others.

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 either = "1.6.0"
 futures = "0.3.1"
-libp2p-core = { version = "0.27.0", path = "../core" }
+libp2p-core = { version = "0.28.0", path = "../core" }
 log = "0.4"
 rand = "0.7"
 smallvec = "1.6.1"

--- a/transports/deflate/CHANGELOG.md
+++ b/transports/deflate/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.28.0 [unreleased]
+
+- Update `libp2p-core`.
+
 # 0.27.1 [2021-01-27]
 
 - Ensure read buffers are initialised.

--- a/transports/deflate/Cargo.toml
+++ b/transports/deflate/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-deflate"
 edition = "2018"
 description = "Deflate encryption protocol for libp2p"
-version = "0.27.1"
+version = "0.28.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-core = { version = "0.28.0", path = "../../core" }
 flate2 = "1.0"
 
 [dev-dependencies]

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 0.28.0 [unreleased]
 
+- Update `libp2p-core`.
+
+- Add support for resolving `/dnsaddr` addresses.
+
 - Use `trust-dns-resolver`, removing the internal thread pool and
   expanding the configurability of `libp2p-dns` by largely exposing the
   configuration of `trust-dns-resolver`.

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-core = { version = "0.28.0", path = "../../core" }
 log = "0.4.1"
 futures = "0.3.1"
 trust-dns-resolver = { version = "0.20", default-features = false, features = ["system-config"] }

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4.1"
 futures = "0.3.1"
 trust-dns-resolver = { version = "0.20", default-features = false, features = ["system-config"] }
 async-std-resolver = { version = "0.20", optional = true }
+smallvec = "1.6"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -301,7 +301,7 @@ where
             // attempt, return that error. Otherwise there were no valid DNS records
             // for the given address to begin with (i.e. DNS lookups succeeded but
             // produced no records relevant for the given `addr`).
-            Err(last_err.unwrap_or(
+            Err(last_err.unwrap_or_else(||
                 DnsErr::ResolveError(
                     ResolveErrorKind::Message("No matching records found.").into())))
         }.boxed().right_future())
@@ -483,7 +483,7 @@ fn invalid_data(e: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> io::E
 }
 
 fn fqdn(name: &Cow<'_, str>) -> String {
-    if name.ends_with(".") {
+    if name.ends_with('.') {
         name.to_string()
     } else {
         format!("{}.", name)

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -24,10 +24,11 @@
 //! [`DnsConfig`] and `TokioDnsConfig` for use with `async-std` and `tokio`,
 //! respectively.
 //!
-//! A [`GenDnsConfig`] is a [`Transport`] wrapper that is created around
+//! A [`GenDnsConfig`] is an address-rewriting [`Transport`] wrapper around
 //! an inner `Transport`. The composed transport behaves like the inner
-//! transport, except that [`Transport::dial`] resolves `/dns`, `/dns4/` and
-//! `/dns6/` components of a given `Multiaddr` through a DNS.
+//! transport, except that [`Transport::dial`] resolves `/dns/...`, `/dns4/...`,
+//! `/dns6/...` and `/dnsaddr/...` components of the given `Multiaddr` through
+//! a DNS, replacing them with the resolved protocols (typically TCP/IP).
 //!
 //! The `async-std` feature and hence the `DnsConfig` are
 //! enabled by default. Tokio users can furthermore opt-in
@@ -37,14 +38,14 @@
 //!
 //![trust-dns-resolver]: https://docs.rs/trust-dns-resolver/latest/trust_dns_resolver/#dns-over-tls-and-dns-over-https
 
-use futures::{prelude::*, future::BoxFuture, stream::FuturesOrdered};
+use futures::{prelude::*, future::BoxFuture};
 use libp2p_core::{
     Transport,
     multiaddr::{Protocol, Multiaddr},
     transport::{TransportError, ListenerEvent}
 };
-use log::{debug, trace};
-use std::{error, fmt, net::IpAddr};
+use smallvec::SmallVec;
+use std::{borrow::Cow, convert::TryFrom, error, fmt, iter, net::IpAddr, str};
 #[cfg(any(feature = "async-std", feature = "tokio"))]
 use std::io;
 #[cfg(any(feature = "async-std", feature = "tokio"))]
@@ -61,6 +62,24 @@ use async_std_resolver::{AsyncStdConnection, AsyncStdConnectionProvider};
 
 pub use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
 pub use trust_dns_resolver::error::{ResolveError, ResolveErrorKind};
+
+/// The prefix for `dnsaddr` protocol TXT record lookups.
+const DNSADDR_PREFIX: &'static str = "_dnsaddr.";
+
+/// The maximum number of dialing attempts to resolved addresses.
+const MAX_DIAL_ATTEMPTS: usize = 16;
+
+/// The maximum number of DNS lookups when dialing.
+///
+/// This limit is primarily a safeguard against too many, possibly
+/// even cyclic, indirections in the addresses obtained from the
+/// TXT records of a `/dnsaddr`.
+const MAX_DNS_LOOKUPS: usize = 32;
+
+/// The maximum number of TXT records applicable for the address
+/// being dialed that are considered for further lookups as a
+/// result of a single `/dnsaddr` lookup.
+const MAX_TXT_RECORDS: usize = 16;
 
 /// A `Transport` wrapper for performing DNS lookups when dialing `Multiaddr`esses
 /// using `async-std` for all async I/O.
@@ -137,7 +156,7 @@ where
 
 impl<T, C, P> Transport for GenDnsConfig<T, C, P>
 where
-    T: Transport + Send + 'static,
+    T: Transport + Clone + Send + 'static,
     T::Error: Send,
     T::Dial: Send,
     C: DnsHandle<Error = ResolveError>,
@@ -171,44 +190,120 @@ where
     }
 
     fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-        // Check if there are any domain names in the address. If not, proceed
-        // straight away with dialing on the underlying transport.
-        if !addr.iter().any(|p| match p {
-            Protocol::Dns(_) | Protocol::Dns4(_) | Protocol::Dns6(_) => true,
-            _ => false
-        }) {
-            trace!("Pass-through address without DNS: {}", addr);
-            let inner_dial = self.inner.dial(addr)
-                .map_err(|err| err.map(DnsErr::Transport))?;
-            return Ok(inner_dial.map_err::<_, fn(_) -> _>(DnsErr::Transport).left_future());
-        }
-
         // Asynchronlously resolve all DNS names in the address before proceeding
         // with dialing on the underlying transport.
         Ok(async move {
             let resolver = self.resolver;
             let inner = self.inner;
 
-            trace!("Resolving DNS: {}", addr);
+            let mut last_err = None;
+            let mut dns_lookups = 0;
+            let mut dial_attempts = 0;
+            // We optimise for the common case of a single DNS component
+            // in the address that is resolved with a single lookup.
+            let mut unresolved = SmallVec::<[Multiaddr; 1]>::new();
+            unresolved.push(addr.clone());
 
-            let resolved = addr.into_iter()
-                .map(|proto| resolve(proto, &resolver))
-                .collect::<FuturesOrdered<_>>()
-                .collect::<Vec<Result<Protocol<'_>, Self::Error>>>()
-                .await
-                .into_iter()
-                .collect::<Result<Vec<Protocol<'_>>, Self::Error>>()?
-                .into_iter()
-                .collect::<Multiaddr>();
+            // Resolve (i.e. replace) all DNS protocol components, initiating
+            // dialing attempts as soon as there is another fully resolved
+            // address.
+            while let Some(addr) = unresolved.pop() {
+                if let Some((i, name)) = addr.iter().enumerate().find(|(_, p)| match p {
+                    Protocol::Dns(_) |
+                    Protocol::Dns4(_) |
+                    Protocol::Dns6(_) |
+                    Protocol::Dnsaddr(_) => true,
+                    _ => false
+                }) {
+                    if dns_lookups == MAX_DNS_LOOKUPS {
+                        log::debug!("Too many DNS lookups. Dropping unresolved {}.", addr);
+                        last_err = Some(DnsErr::TooManyLookups);
+                        // There may still be fully resolved addresses in `unresolved`,
+                        // so keep going until `unresolved` is empty.
+                        continue
+                    }
+                    dns_lookups += 1;
+                    match resolve(&name, &resolver).await {
+                        Err(e) => {
+                            if unresolved.is_empty() {
+                                return Err(e)
+                            }
+                            // If there are still unresolved addresses, there is
+                            // a chance of success, but we track the last error.
+                            last_err = Some(e);
+                        }
+                        Ok(Resolved::One(ip)) => {
+                            log::trace!("Resolved {} -> {}", name, ip);
+                            let addr = addr.replace(i, |_| Some(ip)).expect("`i` is a valid index");
+                            unresolved.push(addr);
+                        }
+                        Ok(Resolved::Many(ips)) => {
+                            for ip in ips {
+                                log::trace!("Resolved {} -> {}", name, ip);
+                                let addr = addr.replace(i, |_| Some(ip)).expect("`i` is a valid index");
+                                unresolved.push(addr);
+                            }
+                        }
+                        Ok(Resolved::Addrs(addrs)) => {
+                            let suffix = addr.iter().skip(i + 1).collect::<Multiaddr>();
+                            let prefix = addr.iter().take(i).collect::<Multiaddr>();
+                            let mut n = 0;
+                            for a in addrs {
+                                if a.ends_with(&suffix) {
+                                    if n < MAX_TXT_RECORDS {
+                                        n += 1;
+                                        log::trace!("Resolved {} -> {}", name, a);
+                                        let addr = prefix.iter().chain(a.iter()).collect::<Multiaddr>();
+                                        unresolved.push(addr);
+                                    } else {
+                                        log::debug!("Too many TXT records. Dropping resolved {}.", a);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    // We have a fully resolved address, so try to dial it.
+                    log::debug!("Dialing {}", addr);
 
-            debug!("DNS resolved: {} => {}", addr, resolved);
+                    let transport = inner.clone();
+                    let result = match transport.dial(addr) {
+                        Ok(out) => {
+                            // We only count attempts that the inner transport
+                            // actually accepted, i.e. for which it produced
+                            // a dialing future.
+                            dial_attempts += 1;
+                            out.await.map_err(DnsErr::Transport)
+                        }
+                        Err(TransportError::MultiaddrNotSupported(a)) =>
+                            Err(DnsErr::MultiaddrNotSupported(a)),
+                        Err(TransportError::Other(err)) => Err(DnsErr::Transport(err))
+                    };
 
-            match inner.dial(resolved) {
-                Ok(out) => out.await.map_err(DnsErr::Transport),
-                Err(TransportError::MultiaddrNotSupported(a)) =>
-                    Err(DnsErr::MultiaddrNotSupported(a)),
-                Err(TransportError::Other(err)) => Err(DnsErr::Transport(err))
+                    match result {
+                        Ok(out) => return Ok(out),
+                        Err(err) => {
+                            log::debug!("Dial error: {:?}.", err);
+                            if unresolved.is_empty() {
+                                return Err(err)
+                            }
+                            if dial_attempts == MAX_DIAL_ATTEMPTS {
+                                log::debug!("Aborting dialing after {} attempts.", MAX_DIAL_ATTEMPTS);
+                                return Err(err)
+                            }
+                            last_err = Some(err);
+                        }
+                    }
+                }
             }
+
+            // At this point, if there was at least one failed dialing
+            // attempt, return that error. Otherwise there were no valid DNS records
+            // for the given address to begin with (i.e. DNS lookups succeeded but
+            // produced no records relevant for the given `addr`).
+            Err(last_err.unwrap_or(
+                DnsErr::ResolveError(
+                    ResolveErrorKind::Message("No matching records found.").into())))
         }.boxed().right_future())
     }
 
@@ -226,6 +321,13 @@ pub enum DnsErr<TErr> {
     ResolveError(ResolveError),
     /// DNS resolution was successful, but the underlying transport refused the resolved address.
     MultiaddrNotSupported(Multiaddr),
+    /// DNS resolution involved too many lookups.
+    ///
+    /// DNS resolution on dialing performs up to 32 DNS lookups. If these
+    /// are not sufficient to obtain a fully-resolved address, this error
+    /// is returned and the DNS records for the domain(s) being dialed
+    /// should be investigated.
+    TooManyLookups,
 }
 
 impl<TErr> fmt::Display for DnsErr<TErr>
@@ -236,6 +338,7 @@ where TErr: fmt::Display
             DnsErr::Transport(err) => write!(f, "{}", err),
             DnsErr::ResolveError(err) => write!(f, "{}", err),
             DnsErr::MultiaddrNotSupported(a) => write!(f, "Unsupported resolved address: {}", a),
+            DnsErr::TooManyLookups => write!(f, "Too many DNS lookups"),
         }
     }
 }
@@ -248,14 +351,33 @@ where TErr: error::Error + 'static
             DnsErr::Transport(err) => Some(err),
             DnsErr::ResolveError(err) => Some(err),
             DnsErr::MultiaddrNotSupported(_) => None,
+            DnsErr::TooManyLookups => None,
         }
     }
 }
 
-/// Asynchronously resolves the domain name of a `Dns`, `Dns4` or `Dns6` protocol
-/// component. If the given protocol is not a DNS component, it is returned unchanged.
-fn resolve<'a, E: 'a, C, P>(proto: Protocol<'a>, resolver: &'a AsyncResolver<C,P>)
-    -> impl Future<Output = Result<Protocol<'a>, DnsErr<E>>> + 'a
+/// The successful outcome of [`resolve`] for a given [`Protocol`].
+enum Resolved<'a> {
+    /// The given `Protocol` has been resolved to a single `Protocol`,
+    /// which may be identical to the one given, in case it is not
+    /// a DNS protocol component.
+    One(Protocol<'a>),
+    /// The given `Protocol` has been resolved to multiple alternative
+    /// `Protocol`s as a result of a DNS lookup.
+    Many(Vec<Protocol<'a>>),
+    /// The given `Protocol` has been resolved to a new list of `Multiaddr`s
+    /// obtained from DNS TXT records representing possible alternatives.
+    /// These addresses may contain further DNS names that need resolving.
+    Addrs(Vec<Multiaddr>),
+}
+
+/// Asynchronously resolves the domain name of a `Dns`, `Dns4`, `Dns6` or `Dnsaddr` protocol
+/// component. If the given protocol is of a different type, it is returned unchanged as a
+/// [`Resolved::One`].
+fn resolve<'a, E: 'a + Send, C, P>(
+    proto: &Protocol<'a>,
+    resolver: &'a AsyncResolver<C,P>,
+) -> BoxFuture<'a, Result<Resolved<'a>, DnsErr<E>>>
 where
     C: DnsHandle<Error = ResolveError>,
     P: ConnectionProvider<Conn = C>,
@@ -263,38 +385,104 @@ where
     match proto {
         Protocol::Dns(ref name) => {
             resolver.lookup_ip(fqdn(name)).map(move |res| match res {
-                Ok(ips) => Ok(ips.into_iter()
-                    .next()
-                    .map(Protocol::from)
-                    .expect("If there are no results, `Err(NoRecordsFound)` is expected.")),
-                Err(e) => return Err(DnsErr::ResolveError(e))
-            }).left_future()
+                Ok(ips) => {
+                    let mut ips = ips.into_iter();
+                    let one = ips.next()
+                        .expect("If there are no results, `Err(NoRecordsFound)` is expected.");
+                    if let Some(two) = ips.next() {
+                        Ok(Resolved::Many(
+                            iter::once(one).chain(iter::once(two))
+                                .chain(ips)
+                                .map(Protocol::from)
+                                .collect()))
+                    } else {
+                        Ok(Resolved::One(Protocol::from(one)))
+                    }
+                }
+                Err(e) => Err(DnsErr::ResolveError(e))
+            }).boxed()
         }
         Protocol::Dns4(ref name) => {
             resolver.ipv4_lookup(fqdn(name)).map(move |res| match res {
-                Ok(ips) => Ok(ips.into_iter()
-                    .map(IpAddr::from)
-                    .next()
-                    .map(Protocol::from)
-                    .expect("If there are no results, `Err(NoRecordsFound)` is expected.")),
-                Err(e) => return Err(DnsErr::ResolveError(e))
-            }).left_future().left_future().right_future()
+                Ok(ips) => {
+                    let mut ips = ips.into_iter();
+                    let one = ips.next()
+                        .expect("If there are no results, `Err(NoRecordsFound)` is expected.");
+                    if let Some(two) = ips.next() {
+                        Ok(Resolved::Many(
+                            iter::once(one).chain(iter::once(two))
+                                .chain(ips)
+                                .map(IpAddr::from)
+                                .map(Protocol::from)
+                                .collect()))
+                    } else {
+                        Ok(Resolved::One(Protocol::from(IpAddr::from(one))))
+                    }
+                }
+                Err(e) => Err(DnsErr::ResolveError(e))
+            }).boxed()
         }
         Protocol::Dns6(ref name) => {
             resolver.ipv6_lookup(fqdn(name)).map(move |res| match res {
-                Ok(ips) => Ok(ips.into_iter()
-                    .map(IpAddr::from)
-                    .next()
-                    .map(Protocol::from)
-                    .expect("If there are no results, `Err(NoRecordsFound)` is expected.")),
-                Err(e) => return Err(DnsErr::ResolveError(e))
-            }).right_future().left_future().right_future()
+                Ok(ips) => {
+                    let mut ips = ips.into_iter();
+                    let one = ips.next()
+                        .expect("If there are no results, `Err(NoRecordsFound)` is expected.");
+                    if let Some(two) = ips.next() {
+                        Ok(Resolved::Many(
+                            iter::once(one).chain(iter::once(two))
+                                .chain(ips)
+                                .map(IpAddr::from)
+                                .map(Protocol::from)
+                                .collect()))
+                    } else {
+                        Ok(Resolved::One(Protocol::from(IpAddr::from(one))))
+                    }
+                }
+                Err(e) => Err(DnsErr::ResolveError(e))
+            }).boxed()
         },
-        proto => future::ready(Ok(proto)).right_future().right_future()
+        Protocol::Dnsaddr(ref name) => {
+            let name = Cow::Owned([DNSADDR_PREFIX, name].concat());
+            resolver.txt_lookup(fqdn(&name)).map(move |res| match res {
+                Ok(txts) => {
+                    let mut addrs = Vec::new();
+                    for txt in txts {
+                        if let Some(chars) = txt.txt_data().first() {
+                            match parse_dnsaddr_txt(chars) {
+                                Err(e) => {
+                                    // Skip over seemingly invalid entries.
+                                    log::debug!("Invalid TXT record: {:?}", e);
+                                }
+                                Ok(a) => {
+                                    addrs.push(a);
+                                }
+                            }
+                        }
+                    }
+                    Ok(Resolved::Addrs(addrs))
+                }
+                Err(e) => Err(DnsErr::ResolveError(e))
+            }).boxed()
+        }
+        proto => future::ready(Ok(Resolved::One(proto.clone()))).boxed()
     }
 }
 
-fn fqdn(name: &std::borrow::Cow<'_, str>) -> String {
+/// Parses a `<character-string>` of a `dnsaddr` TXT record.
+fn parse_dnsaddr_txt(txt: &[u8]) -> io::Result<Multiaddr> {
+    let s = str::from_utf8(txt).map_err(invalid_data)?;
+    match s.strip_prefix("dnsaddr=") {
+        None => Err(invalid_data("Missing `dnsaddr=` prefix.")),
+        Some(a) => Ok(Multiaddr::try_from(a).map_err(invalid_data)?)
+    }
+}
+
+fn invalid_data(e: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, e)
+}
+
+fn fqdn(name: &Cow<'_, str>) -> String {
     if name.ends_with(".") {
         name.to_string()
     } else {
@@ -308,6 +496,7 @@ mod tests {
     use futures::{future::BoxFuture, stream::BoxStream};
     use libp2p_core::{
         Transport,
+        PeerId,
         multiaddr::{Protocol, Multiaddr},
         transport::ListenerEvent,
         transport::TransportError,
@@ -332,17 +521,12 @@ mod tests {
             }
 
             fn dial(self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
-                let addr = addr.iter().collect::<Vec<_>>();
-                assert_eq!(addr.len(), 2);
-                match addr[1] {
-                    Protocol::Tcp(_) => (),
-                    _ => panic!(),
-                };
-                match addr[0] {
-                    Protocol::Ip4(_) => (),
-                    Protocol::Ip6(_) => (),
-                    _ => panic!(),
-                };
+                // Check that all DNS components have been resolved, i.e. replaced.
+                assert!(!addr.iter().any(|p| match p {
+                    Protocol::Dns(_) | Protocol::Dns4(_) | Protocol::Dns6(_) | Protocol::Dnsaddr(_)
+                        => true,
+                    _ => false,
+                }));
                 Ok(Box::pin(future::ready(Ok(()))))
             }
 
@@ -383,6 +567,37 @@ mod tests {
                 .await
                 .unwrap();
 
+            // Success due to the DNS TXT records at _dnsaddr.bootstrap.libp2p.io.
+            let _ = transport
+                .clone()
+                .dial("/dnsaddr/bootstrap.libp2p.io".parse().unwrap())
+                .unwrap()
+                .await
+                .unwrap();
+
+            // Success due to the DNS TXT records at _dnsaddr.bootstrap.libp2p.io having
+            // an entry with suffix `/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN`,
+            // i.e. a bootnode with such a peer ID.
+            let _ = transport
+                .clone()
+                .dial("/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN".parse().unwrap())
+                .unwrap()
+                .await
+                .unwrap();
+
+            // Failure due to the DNS TXT records at _dnsaddr.libp2p.io not having
+            // an entry with a random `p2p` suffix.
+            match transport
+                .clone()
+                .dial(format!("/dnsaddr/bootstrap.libp2p.io/p2p/{}", PeerId::random()).parse().unwrap())
+                .unwrap()
+                .await
+            {
+                Err(DnsErr::ResolveError(_)) => {},
+                Err(e) => panic!("Unexpected error: {:?}", e),
+                Ok(_) => panic!("Unexpected success.")
+            }
+
             // Failure due to no records.
             match transport
                 .clone()
@@ -401,19 +616,27 @@ mod tests {
 
         #[cfg(feature = "async-std")]
         {
+            // Be explicit about the resolver used. At least on github CI, TXT
+            // type record lookups may not work with the system DNS resolver.
+            let config = ResolverConfig::quad9();
+            let opts = ResolverOpts::default();
             async_std_crate::task::block_on(
-                DnsConfig::system(CustomTransport).then(|dns| run(dns.unwrap()))
+                DnsConfig::custom(CustomTransport, config, opts).then(|dns| run(dns.unwrap()))
             );
         }
 
         #[cfg(feature = "tokio")]
         {
+            // Be explicit about the resolver used. At least on github CI, TXT
+            // type record lookups may not work with the system DNS resolver.
+            let config = ResolverConfig::quad9();
+            let opts = ResolverOpts::default();
             let rt = tokio_crate::runtime::Builder::new_current_thread()
                 .enable_io()
                 .enable_time()
                 .build()
                 .unwrap();
-            rt.block_on(run(TokioDnsConfig::system(CustomTransport).unwrap()));
+            rt.block_on(run(TokioDnsConfig::custom(CustomTransport, config, opts).unwrap()));
         }
     }
 }

--- a/transports/noise/CHANGELOG.md
+++ b/transports/noise/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.30.0 [unreleased]
+
+- Update `libp2p-core`.
+
 # 0.29.0 [2021-01-12]
 
 - Update dependencies.

--- a/transports/noise/Cargo.toml
+++ b/transports/noise/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-noise"
 description = "Cryptographic handshake protocol using the noise framework."
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -12,7 +12,7 @@ bytes = "1"
 curve25519-dalek = "3.0.0"
 futures = "0.3.1"
 lazy_static = "1.2"
-libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-core = { version = "0.28.0", path = "../../core" }
 log = "0.4"
 prost = "0.7"
 rand = "0.7.2"

--- a/transports/plaintext/CHANGELOG.md
+++ b/transports/plaintext/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.28.0 [unreleased]
+
+- Update `libp2p-core`.
+
 # 0.27.1 [2021-02-15]
 
 - Update dependencies.

--- a/transports/plaintext/Cargo.toml
+++ b/transports/plaintext/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-plaintext"
 edition = "2018"
 description = "Plaintext encryption dummy protocol for libp2p"
-version = "0.27.1"
+version = "0.28.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 bytes = "1"
 futures = "0.3.1"
 asynchronous-codec = "0.6"
-libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-core = { version = "0.28.0", path = "../../core" }
 log = "0.4.8"
 prost = "0.7"
 unsigned-varint = { version = "0.7", features = ["asynchronous_codec"] }

--- a/transports/plaintext/src/handshake.rs
+++ b/transports/plaintext/src/handshake.rs
@@ -51,7 +51,7 @@ pub struct Remote {
 }
 
 impl HandshakeContext<Local> {
-    fn new(config: PlainText2Config) -> Result<Self, PlainTextError> {
+    fn new(config: PlainText2Config) -> Self {
         let exchange = Exchange {
             id: Some(config.local_public_key.clone().into_peer_id().to_bytes()),
             pubkey: Some(config.local_public_key.clone().into_protobuf_encoding())
@@ -59,12 +59,12 @@ impl HandshakeContext<Local> {
         let mut buf = Vec::with_capacity(exchange.encoded_len());
         exchange.encode(&mut buf).expect("Vec<u8> provides capacity as needed");
 
-        Ok(Self {
+        Self {
             config,
             state: Local {
                 exchange_bytes: buf
             }
-        })
+        }
     }
 
     fn with_remote(self, exchange_bytes: BytesMut)
@@ -119,7 +119,7 @@ where
     let mut framed_socket = Framed::new(socket, UviBytes::default());
 
     trace!("starting handshake");
-    let context = HandshakeContext::new(config)?;
+    let context = HandshakeContext::new(config);
 
     trace!("sending exchange to remote");
     framed_socket.send(BytesMut::from(&context.state.exchange_bytes[..])).await?;

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 0.27.2 [unreleased]
+# 0.28.0 [unreleased]
+
+- Update `libp2p-core`.
+
+- Permit `/p2p` addresses.
 
 - Update to `if-watch-0.2`.
 

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-tcp"
 edition = "2018"
 description = "TCP/IP transport protocol for libp2p"
-version = "0.27.2"
+version = "0.28.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -17,7 +17,7 @@ if-watch = { version = "0.2.0", optional = true }
 if-addrs = { version = "0.6.4", optional = true }
 ipnet = "2.0.0"
 libc = "0.2.80"
-libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-core = { version = "0.28.0", path = "../../core" }
 log = "0.4.11"
 socket2 = { version = "0.4.0", features = ["all"] }
 tokio-crate = { package = "tokio", version = "1.0.1", default-features = false, features = ["net"], optional = true }

--- a/transports/uds/CHANGELOG.md
+++ b/transports/uds/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.28.0 [unreleased]
+
+- Update `libp2p-core`.
+
+- Permit `/p2p` addresses.
+
 # 0.27.0 [2021-01-12]
 
 - Update dependencies.

--- a/transports/uds/Cargo.toml
+++ b/transports/uds/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-uds"
 edition = "2018"
 description = "Unix domain sockets transport for libp2p"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [target.'cfg(all(unix, not(target_os = "emscripten")))'.dependencies]
 async-std = { version = "1.6.2", optional = true }
-libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-core = { version = "0.28.0", path = "../../core" }
 log = "0.4.1"
 futures = "0.3.1"
 tokio = { version = "1.0.1", default-features = false, features = ["net"], optional = true }

--- a/transports/uds/src/lib.rs
+++ b/transports/uds/src/lib.rs
@@ -140,23 +140,20 @@ codegen!(
 /// paths.
 // This type of logic should probably be moved into the multiaddr package
 fn multiaddr_to_path(addr: &Multiaddr) -> Result<PathBuf, ()> {
-    let mut iter = addr.iter();
-    let path = iter.next();
-
-    if iter.next().is_some() {
-        return Err(());
+    let mut protocols = addr.iter();
+    match protocols.next() {
+        Some(Protocol::Unix(ref path)) => {
+            let path = PathBuf::from(path.as_ref());
+            if !path.is_absolute() {
+                return Err(())
+            }
+            match protocols.next() {
+                None | Some(Protocol::P2p(_)) => Ok(path),
+                Some(_) => Err(())
+            }
+        }
+        _ => Err(())
     }
-
-    let out: PathBuf = match path {
-        Some(Protocol::Unix(ref path)) => path.as_ref().into(),
-        _ => return Err(())
-    };
-
-    if !out.is_absolute() {
-        return Err(());
-    }
-
-    Ok(out)
 }
 
 #[cfg(all(test, feature = "async-std"))]

--- a/transports/wasm-ext/CHANGELOG.md
+++ b/transports/wasm-ext/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.28.0 [unreleased]
+
+- Update `libp2p-core`.
+
 # 0.27.0 [2021-01-12]
 
 - Update dependencies.

--- a/transports/wasm-ext/Cargo.toml
+++ b/transports/wasm-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-wasm-ext"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 edition = "2018"
 description = "Allows passing in an external transport in a WASM environment"
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 futures = "0.3.1"
 js-sys = "0.3.19"
-libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-core = { version = "0.28.0", path = "../../core" }
 parity-send-wrapper = "0.1.0"
 wasm-bindgen = "0.2.42"
 wasm-bindgen-futures = "0.4.4"

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.29.0 [unreleased]
+
+- Update `libp2p-core`.
+
+- Permit dialing `/p2p` addresses.
+
 # 0.28.0 [2021-01-12]
 
 - Update dependencies.

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-websocket"
 edition = "2018"
 description = "WebSocket transport for libp2p"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 futures-rustls = "0.21"
 either = "1.5.3"
 futures = "0.3.1"
-libp2p-core = { version = "0.27.0", path = "../../core" }
+libp2p-core = { version = "0.28.0", path = "../../core" }
 log = "0.4.8"
 quicksink = "0.1"
 rw-stream-sink = "0.2.0"

--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -44,6 +44,13 @@ pub struct WsConfig<T> {
 
 impl<T> WsConfig<T> {
     /// Create a new websocket transport based on the given transport.
+    ///
+    /// > **Note*: The given transport must be based on TCP/IP and should
+    /// > usually incorporate DNS resolution, though the latter is not
+    /// > strictly necessary if one wishes to only use the `Ws` protocol
+    /// > with known IP addresses and ports. See [`libp2p-tcp`](https://docs.rs/libp2p-tcp/)
+    /// > and [`libp2p-dns`](https://docs.rs/libp2p-dns) for constructing
+    /// > the inner transport.
     pub fn new(transport: T) -> Self {
         framed::WsConfig::new(transport).into()
     }
@@ -187,10 +194,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use libp2p_core::Multiaddr;
+    use libp2p_core::{Multiaddr, PeerId, Transport, multiaddr::Protocol};
     use libp2p_tcp as tcp;
     use futures::prelude::*;
-    use libp2p_core::{Transport, multiaddr::Protocol};
     use super::WsConfig;
 
     #[test]
@@ -230,7 +236,7 @@ mod tests {
             conn.await
         };
 
-        let outbound = ws_config.dial(addr).unwrap();
+        let outbound = ws_config.dial(addr.with(Protocol::P2p(PeerId::random().into()))).unwrap();
 
         let (a, b) = futures::join!(inbound, outbound);
         a.and(b).unwrap();


### PR DESCRIPTION
Closes https://github.com/libp2p/rust-libp2p/issues/1920, as well as, by necessity, https://github.com/libp2p/rust-libp2p/issues/1462.

This PR is based on https://github.com/libp2p/rust-libp2p/pull/1927 - a proper diff until that PR is merged can be [seen here](https://github.com/romanb/rust-libp2p/compare/trust-dns...romanb:dnsaddr).

In order to correctly resolve `/dnsaddr` addresses, the DNS transport needs to be given "fully qualified" multiaddresses when dialing, i.e. those that end with the `/p2p/...` protocol, since it chooses from the TXT records such addresses with a matching suffix of the address being dialed. So to pick the addresses for the correct peer, the `/p2p` protocol needs to be at the end of the address being dialed. This essentially goes back to #1462. So to address #1462 as well as implement `/dnsaddr` resolution,  we now make sure that dialing always uses such fully qualified addresses by appending the `/p2p` protocol as necessary in the `Network` of `libp2p-core` before giving the address for dialing to the transport. This is mostly transparent for the `PeerId`-based APIs, i.e. it is of course still possible to use a `PeerId` together with an "unqualified" address for dialing. It is just that at the end of the day, `Transport::dial()` always gets a fully-qualified address (when called from the `Network` anyway) and hence transports now  permit a trailing `/p2p` suffix (and in the case of the DNS transport, even make essential use of it).

As a side-effect, `Network::dial(addr)` and `Swarm::dial_addr(addr)` now also handle "fully-qualified" `/p2p` addresses, since the `Network` will then take the peer ID from the end of the address.

A related change as part of implementing `/dnsaddr` resolution is that `libp2p-dns` now actually tries to use all resolved addresses (well, up to a fixed maximum of dialing attempts).

The net result of these changes can be seen in the now cleaned up [`ipfs-kad` example](https://github.com/romanb/rust-libp2p/blob/dnsaddr/examples/ipfs-kad.rs), which can finally make use of `/dnsaddr/bootstrap.libp2p.io`.