### PR TITLE
[libp2p-deflate] Ensure read buffer is initialised.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ smallvec = "1.0"
 wasm-timer = "0.2.4"
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")))'.dependencies]
-libp2p-deflate = { version = "0.27.0", path = "protocols/deflate", optional = true }
+libp2p-deflate = { version = "0.27.1", path = "protocols/deflate", optional = true }
 libp2p-dns = { version = "0.27.0", path = "transports/dns", optional = true }
 libp2p-mdns = { version = "0.28.0", path = "protocols/mdns", optional = true }
 libp2p-tcp = { version = "0.27.0", path = "transports/tcp", optional = true }

--- a/protocols/deflate/CHANGELOG.md
+++ b/protocols/deflate/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.27.1 [2021-01-27]
+
+- Ensure read buffers are initialised.
+  [PR 1933](https://github.com/libp2p/rust-libp2p/pull/1933).
+
 # 0.27.0 [2021-01-12]
 
 - Update dependencies.

--- a/protocols/deflate/Cargo.toml
+++ b/protocols/deflate/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-deflate"
 edition = "2018"
 description = "Deflate encryption protocol for libp2p"
-version = "0.27.0"
+version = "0.27.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/deflate/src/lib.rs
+++ b/protocols/deflate/src/lib.rs
@@ -133,10 +133,7 @@ impl<S> AsyncRead for DeflateOutput<S>
         loop {
             // Read from `self.inner` into `self.read_interm` if necessary.
             if this.read_interm.is_empty() && !this.inner_read_eof {
-                unsafe {
-                    this.read_interm.reserve(256);
-                    this.read_interm.set_len(this.read_interm.capacity());
-                }
+                this.read_interm.resize(this.read_interm.capacity() + 256, 0);
 
                 match AsyncRead::poll_read(Pin::new(&mut this.inner), cx, &mut this.read_interm) {
                     Poll::Ready(Ok(0)) => {


### PR DESCRIPTION
Addresses https://github.com/libp2p/rust-libp2p/issues/1932, i.e. the possibility to read uninitialised memory.