### PR TITLE
[libp2p-core-derive -> libp2p-swarm-derive] Rename and move crate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 # Version 0.35.0 [unreleased]
 
+- Use `libp2p-swarm-derive`, the former `libp2p-core-derive`.
+
 - Update `libp2p-gossipsub` and `libp2p-request-response`.
 
 # Version 0.34.0 [2021-01-12]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ bytes = "1"
 futures = "0.3.1"
 lazy_static = "1.2"
 libp2p-core = { version = "0.27.0", path = "core" }
-libp2p-core-derive = { version = "0.21.0", path = "misc/core-derive" }
 libp2p-floodsub = { version = "0.27.0", path = "protocols/floodsub", optional = true }
 libp2p-gossipsub = { version = "0.28.0", path = "./protocols/gossipsub", optional = true }
 libp2p-identify = { version = "0.27.0", path = "protocols/identify", optional = true }
@@ -74,6 +73,7 @@ libp2p-plaintext = { version = "0.27.0", path = "protocols/plaintext", optional 
 libp2p-pnet = { version = "0.20.0", path = "protocols/pnet", optional = true }
 libp2p-request-response = { version = "0.9.1", path = "protocols/request-response", optional = true }
 libp2p-swarm = { version = "0.27.0", path = "swarm" }
+libp2p-swarm-derive = { version = "0.22.0", path = "swarm-derive" }
 libp2p-uds = { version = "0.27.0", path = "transports/uds", optional = true }
 libp2p-wasm-ext = { version = "0.27.0", path = "transports/wasm-ext", optional = true }
 libp2p-yamux = { version = "0.30.0", path = "muxers/yamux", optional = true }
@@ -98,7 +98,6 @@ tokio = { version = "1.0.1", features = ["io-util", "io-std", "macros", "rt", "r
 [workspace]
 members = [
     "core",
-    "misc/core-derive",
     "misc/multiaddr",
     "misc/multistream-select",
     "misc/peer-id-generator",
@@ -117,6 +116,7 @@ members = [
     "protocols/request-response",
     "protocols/secio",
     "swarm",
+    "swarm-derive",
     "transports/dns",
     "transports/tcp",
     "transports/uds",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,7 @@ pub use self::core::{
     transport::TransportError,
     upgrade::{InboundUpgrade, InboundUpgradeExt, OutboundUpgrade, OutboundUpgradeExt}
 };
-pub use libp2p_core_derive::NetworkBehaviour;
+pub use libp2p_swarm_derive::NetworkBehaviour;
 pub use self::multiaddr::{Multiaddr, multiaddr as build_multiaddr};
 pub use self::simple::SimpleProtocol;
 pub use self::swarm::Swarm;

--- a/swarm-derive/CHANGELOG.md
+++ b/swarm-derive/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.22.0 [unreleased]
+
+- Rename the crate to `libp2p-swarm-derive`.
+
 # 0.21.0 [2020-11-25]
 
 - Update for compatibility with `libp2p-swarm-0.25`.

--- a/swarm-derive/Cargo.toml
+++ b/swarm-derive/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "libp2p-core-derive"
+name = "libp2p-swarm-derive"
 edition = "2018"
 description = "Procedural macros of libp2p-core"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -17,4 +17,4 @@ syn = { version = "1.0.8", default-features = false, features = ["clone-impls", 
 quote = "1.0"
 
 [dev-dependencies]
-libp2p = { path = "../.." }
+libp2p = { path = "../" }

--- a/swarm-derive/src/lib.rs
+++ b/swarm-derive/src/lib.rs
@@ -20,8 +20,6 @@
 
 #![recursion_limit = "256"]
 
-
-
 use quote::quote;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput, Data, DataStruct, Ident};

--- a/swarm-derive/tests/test.rs
+++ b/swarm-derive/tests/test.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use libp2p_core_derive::*;
+use libp2p_swarm_derive::*;
 
 /// Small utility to check that a type implements `NetworkBehaviour`.
 #[allow(dead_code)]
@@ -291,15 +291,15 @@ fn event_process_false() {
         identify: libp2p::identify::Identify,
     }
 
-    #[allow(dead_code)]
+    #[allow(dead_code, unreachable_code)]
     fn bar() {
         require_net_behaviour::<Foo>();
 
-        let mut swarm: libp2p::Swarm<Foo> = unimplemented!();
+        let mut _swarm: libp2p::Swarm<Foo> = unimplemented!();
 
         // check that the event is bubbled up all the way to swarm
         let _ = async {
-            match swarm.next().await {
+            match _swarm.next().await {
                 BehaviourOutEvent::Ping(_) => {},
                 BehaviourOutEvent::Identify(_) => {},
             }


### PR DESCRIPTION
This PR renames and moves `libp2p-core-derive` as `libp2p-swarm-derive`. This was a small left-over from the extraction of `libp2p-swarm` from `libp2p-core` in https://github.com/libp2p/rust-libp2p/pull/1188, i.e. the `NetworkBehaviour` used to be in `libp2p-core` but since the `derive(NetworkBehaviour)` is now `libp2p-swarm`-specific, rebranding `libp2p-core-derive` as `libp2p-swarm-derive` seems sensible.