### PR TITLE
Allow OneShotHandler's `max_dial_negotiate` limit to be configurable.

### DIFF
--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.27.1 [unreleased]
+
+- Make `OneShotHandler`s `max_dial_negotiate` limit configurable.
+  [PR 1936](https://github.com/libp2p/rust-libp2p/pull/1936).
+
 # 0.27.0 [2021-01-12]
 
 - Update dependencies.

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-swarm"
 edition = "2018"
 description = "The libp2p swarm"
-version = "0.27.0"
+version = "0.27.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/swarm/src/protocols_handler/one_shot.rs
+++ b/swarm/src/protocols_handler/one_shot.rs
@@ -47,8 +47,6 @@ where
     dial_queue: SmallVec<[TOutbound; 4]>,
     /// Current number of concurrent outbound substreams being opened.
     dial_negotiated: u32,
-    /// Maximum number of concurrent outbound substreams being opened. Value is never modified.
-    max_dial_negotiated: u32,
     /// Value to return from `connection_keep_alive`.
     keep_alive: KeepAlive,
     /// The configuration container for the handler
@@ -71,7 +69,6 @@ where
             events_out: SmallVec::new(),
             dial_queue: SmallVec::new(),
             dial_negotiated: 0,
-            max_dial_negotiated: 8,
             keep_alive: KeepAlive::Yes,
             config,
         }
@@ -204,7 +201,7 @@ where
         }
 
         if !self.dial_queue.is_empty() {
-            if self.dial_negotiated < self.max_dial_negotiated {
+            if self.dial_negotiated < self.config.max_dial_negotiated {
                 self.dial_negotiated += 1;
                 let upgrade = self.dial_queue.remove(0);
                 return Poll::Ready(
@@ -233,6 +230,8 @@ pub struct OneShotHandlerConfig {
     pub keep_alive_timeout: Duration,
     /// Timeout for outbound substream upgrades.
     pub outbound_substream_timeout: Duration,
+    /// Maximum number of concurrent outbound substreams being opened.
+    pub max_dial_negotiated: u32,
 }
 
 impl Default for OneShotHandlerConfig {
@@ -240,6 +239,7 @@ impl Default for OneShotHandlerConfig {
         OneShotHandlerConfig {
             keep_alive_timeout: Duration::from_secs(10),
             outbound_substream_timeout: Duration::from_secs(10),
+            max_dial_negotiated: 8,
         }
     }
 }


### PR DESCRIPTION
This simply moves the `max_dial_negotiated` field of `OneShotHandler` into its config (and thus making it configurable). The default is set to the formerly hard-coded value of 8.