### PR TITLE
protocols/streaming-response

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ default = [
     "pnet",
     "relay",
     "request-response",
+    "streaming",
     "secp256k1",
     "tcp-async-io",
     "uds",
@@ -47,6 +48,7 @@ plaintext = ["libp2p-plaintext"]
 pnet = ["libp2p-pnet"]
 relay = ["libp2p-relay"]
 request-response = ["libp2p-request-response"]
+streaming = ["libp2p-streaming"]
 tcp-async-io = ["libp2p-tcp", "libp2p-tcp/async-io"]
 tcp-tokio = ["libp2p-tcp", "libp2p-tcp/tokio"]
 uds = ["libp2p-uds"]
@@ -76,6 +78,7 @@ libp2p-plaintext = { version = "0.30.0", path = "transports/plaintext", optional
 libp2p-pnet = { version = "0.21.0", path = "transports/pnet", optional = true }
 libp2p-relay = { version = "0.4.0", path = "protocols/relay", optional = true }
 libp2p-request-response = { version = "0.13.0", path = "protocols/request-response", optional = true }
+libp2p-streaming = { version = "0.1.0", path = "protocols/streaming", optional = true }
 libp2p-swarm = { version = "0.31.0", path = "swarm" }
 libp2p-swarm-derive = { version = "0.24.0", path = "swarm-derive" }
 libp2p-uds = { version = "0.30.0", path = "transports/uds", optional = true }

--- a/protocols/streaming/Cargo.toml
+++ b/protocols/streaming/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "libp2p-streaming"
+edition = "2018"
+description = "Generic Streaming Protocol"
+version = "0.1.0"
+authors = ["Oliver Wangler <oliver@wngr.de>", "Parity Technologies <admin@parity.io>"]
+license = "MIT"
+repository = "https://github.com/libp2p/rust-libp2p"
+keywords = ["peer-to-peer", "libp2p", "networking"]
+categories = ["network-programming", "asynchronous"]
+
+[dependencies]
+futures = "0.3.1"
+libp2p-core = { version = "0.30.0", path = "../../core" }
+libp2p-swarm = { version = "0.31.0", path = "../../swarm" }
+serde = { version = "1.0.127", features = ["derive"] }
+smallvec = "1.6.1"
+thiserror = "1.0.25"
+tracing = "0.1.26"
+
+[dev-dependencies]
+anyhow = "1.0.42"
+async-std = { version = "1.9.0", features = ["attributes"] }
+asynchronous-codec = { version ="0.6.0", features = ["cbor"] }
+libp2p = { path = "../../" }
+libp2p-noise = { path = "../../transports/noise" }
+libp2p-swarm-derive = { path = "../../swarm-derive" }
+libp2p-tcp = { path = "../../transports/tcp" }
+libp2p-yamux = { path = "../../muxers/yamux" }
+tracing-log = "0.1.2"
+tracing-subscriber = "0.2.19"

--- a/protocols/streaming/src/handler.rs
+++ b/protocols/streaming/src/handler.rs
@@ -1,0 +1,306 @@
+use futures::future;
+use libp2p_core::{
+    upgrade::NegotiationError, InboundUpgrade, OutboundUpgrade, UpgradeError, UpgradeInfo,
+};
+use libp2p_swarm::{
+    protocols_handler::InboundUpgradeSend, KeepAlive, NegotiatedSubstream, ProtocolsHandler,
+    ProtocolsHandlerEvent, ProtocolsHandlerUpgrErr, SubstreamProtocol,
+};
+use smallvec::SmallVec;
+use std::{
+    collections::VecDeque,
+    convert::Infallible,
+    marker::PhantomData,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    task::Poll,
+    time::Instant,
+};
+
+use crate::{
+    InboundStreamId, OutboundStreamId, StreamHandle, StreamingCodec, StreamingConfig,
+    EMPTY_QUEUE_SHRINK_THRESHOLD,
+};
+
+pub(crate) type RefCount = Arc<PhantomData<u8>>;
+#[derive(Debug)]
+pub enum StreamId {
+    Inbound(InboundStreamId),
+    Outbound(OutboundStreamId),
+}
+pub struct StreamingProtocolsHandler<T: StreamingCodec> {
+    config: StreamingConfig,
+    /// The current connection keep-alive.
+    keep_alive: KeepAlive,
+    /// Queue of events to emit in `poll()`.
+    pending_events: VecDeque<StreamingProtocolsHandlerEvent<T>>,
+    /// Outbound upgrades waiting to be emitted as an `OutboundSubstreamRequest`.
+    outbound: VecDeque<OutboundStreamId>,
+    /// Live streams.
+    open_streams: SmallVec<[(StreamId, RefCount); 2]>,
+    /// Counter for inbound stream ids.
+    inbound_stream_id: Arc<AtomicU64>,
+    /// A pending fatal error that results in the connection being closed.
+    pending_error: Option<ProtocolsHandlerUpgrErr<std::convert::Infallible>>,
+    _codec: PhantomData<T>,
+}
+
+impl<T: StreamingCodec> StreamingProtocolsHandler<T> {
+    pub(crate) fn new(inbound_stream_id: Arc<AtomicU64>, config: StreamingConfig) -> Self {
+        Self {
+            config,
+            keep_alive: KeepAlive::Yes,
+            pending_events: VecDeque::default(),
+            outbound: VecDeque::default(),
+            inbound_stream_id,
+            open_streams: Default::default(),
+            pending_error: None,
+            _codec: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum StreamingProtocolsHandlerEvent<T: StreamingCodec> {
+    NewIncoming {
+        id: InboundStreamId,
+        stream: StreamHandle<T::Upgrade>,
+    },
+    StreamOpened {
+        id: OutboundStreamId,
+        stream: StreamHandle<T::Upgrade>,
+    },
+    InboundStreamClosed {
+        id: InboundStreamId,
+    },
+    OutboundStreamClosed {
+        id: OutboundStreamId,
+    },
+    OutboundTimeout(OutboundStreamId),
+    OutboundUnsupportedProtocols(OutboundStreamId),
+    InboundTimeout(InboundStreamId),
+    InboundUnsupportedProtocols(InboundStreamId),
+}
+
+#[derive(Debug, Default)]
+pub struct StreamingProtocol<T: StreamingCodec> {
+    _codec: PhantomData<T>,
+}
+impl<T: StreamingCodec> StreamingProtocol<T> {
+    fn new() -> Self {
+        Self {
+            _codec: Default::default(),
+        }
+    }
+}
+
+impl<T: StreamingCodec> UpgradeInfo for StreamingProtocol<T> {
+    type Info = T::Protocol;
+
+    type InfoIter = std::iter::Once<Self::Info>;
+
+    fn protocol_info(&self) -> Self::InfoIter {
+        // must start with '/'
+        std::iter::once(T::protocol_name())
+    }
+}
+
+impl<T: StreamingCodec> InboundUpgrade<NegotiatedSubstream> for StreamingProtocol<T> {
+    type Output = T::Upgrade;
+
+    type Error = std::convert::Infallible;
+
+    type Future = future::Ready<Result<Self::Output, Self::Error>>;
+
+    fn upgrade_inbound(self, io: NegotiatedSubstream, _: Self::Info) -> Self::Future {
+        future::ok(T::upgrade(io))
+    }
+}
+
+impl<T: StreamingCodec> OutboundUpgrade<NegotiatedSubstream> for StreamingProtocol<T> {
+    type Output = T::Upgrade;
+
+    type Error = std::convert::Infallible;
+
+    type Future = future::Ready<Result<Self::Output, Self::Error>>;
+
+    fn upgrade_outbound(self, io: NegotiatedSubstream, _: Self::Info) -> Self::Future {
+        future::ok(T::upgrade(io))
+    }
+}
+
+impl<T: StreamingCodec + Send + 'static> ProtocolsHandler for StreamingProtocolsHandler<T> {
+    type InEvent = OutboundStreamId;
+
+    type OutEvent = StreamingProtocolsHandlerEvent<T>;
+
+    type Error = ProtocolsHandlerUpgrErr<Infallible>;
+
+    type InboundProtocol = StreamingProtocol<T>;
+
+    type OutboundProtocol = StreamingProtocol<T>;
+
+    type InboundOpenInfo = InboundStreamId;
+
+    type OutboundOpenInfo = OutboundStreamId;
+
+    fn listen_protocol(
+        &self,
+    ) -> libp2p_swarm::SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
+        let stream_id = InboundStreamId(self.inbound_stream_id.fetch_add(1, Ordering::Relaxed));
+        tracing::trace!("new listen_protocol with stream_id {:?}", stream_id);
+        SubstreamProtocol::new(StreamingProtocol::new(), stream_id)
+    }
+
+    fn inject_fully_negotiated_inbound(&mut self, handle: T::Upgrade, info: Self::InboundOpenInfo) {
+        tracing::trace!("New Inbound stream {:?}", info);
+        self.keep_alive = KeepAlive::Yes;
+        let marker: RefCount = Default::default();
+        let marker_c = marker.clone();
+        self.open_streams.push((StreamId::Inbound(info), marker));
+        let ev = StreamingProtocolsHandlerEvent::NewIncoming {
+            id: info,
+            stream: StreamHandle::new(handle, marker_c),
+        };
+        self.pending_events.push_back(ev);
+    }
+
+    fn inject_fully_negotiated_outbound(
+        &mut self,
+        handle: T::Upgrade,
+        info: Self::OutboundOpenInfo,
+    ) {
+        tracing::trace!("New outbound stream {:?}", info);
+
+        self.keep_alive = KeepAlive::Yes;
+        let marker: RefCount = Default::default();
+        let marker_c = marker.clone();
+        self.open_streams.push((StreamId::Outbound(info), marker));
+        let ev = StreamingProtocolsHandlerEvent::StreamOpened {
+            id: info,
+            stream: StreamHandle::new(handle, marker_c),
+        };
+        self.pending_events.push_back(ev);
+    }
+
+    fn inject_event(&mut self, event: Self::InEvent) {
+        tracing::trace!("inject_event {:?}", event);
+        self.keep_alive = KeepAlive::Yes;
+        self.outbound.push_back(event);
+    }
+
+    fn inject_dial_upgrade_error(
+        &mut self,
+        info: Self::OutboundOpenInfo,
+        err: ProtocolsHandlerUpgrErr<std::convert::Infallible>,
+    ) {
+        match err {
+            ProtocolsHandlerUpgrErr::Timeout => {
+                self.pending_events
+                    .push_back(StreamingProtocolsHandlerEvent::OutboundTimeout(info));
+            }
+            ProtocolsHandlerUpgrErr::Upgrade(UpgradeError::Select(NegotiationError::Failed)) => {
+                self.pending_events
+                    .push_back(StreamingProtocolsHandlerEvent::OutboundUnsupportedProtocols(info))
+            }
+            _ => {
+                self.pending_error = Some(err);
+            }
+        }
+    }
+
+    fn connection_keep_alive(&self) -> libp2p_swarm::KeepAlive {
+        self.keep_alive
+    }
+
+    fn inject_listen_upgrade_error(
+        &mut self,
+        info: Self::InboundOpenInfo,
+        err: ProtocolsHandlerUpgrErr<<Self::InboundProtocol as InboundUpgradeSend>::Error>,
+    ) {
+        match err {
+            ProtocolsHandlerUpgrErr::Timeout => {
+                self.pending_events
+                    .push_back(StreamingProtocolsHandlerEvent::InboundTimeout(info));
+            }
+            ProtocolsHandlerUpgrErr::Upgrade(UpgradeError::Select(NegotiationError::Failed)) => {
+                self.pending_events.push_back(
+                    StreamingProtocolsHandlerEvent::InboundUnsupportedProtocols(info),
+                )
+            }
+            _ => {
+                self.pending_error = Some(err);
+            }
+        }
+    }
+
+    fn poll(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<
+        libp2p_swarm::ProtocolsHandlerEvent<
+            Self::OutboundProtocol,
+            Self::OutboundOpenInfo,
+            Self::OutEvent,
+            Self::Error,
+        >,
+    > {
+        if let Some(err) = self.pending_error.take() {
+            return Poll::Ready(ProtocolsHandlerEvent::Close(err));
+        }
+
+        {
+            // Check open streams
+            let open_streams = &mut self.open_streams;
+            let pending_events = &mut self.pending_events;
+            open_streams.retain(|(id, marker)| {
+                if Arc::strong_count(marker) == 1 {
+                    tracing::debug!("Stream {:?} was dropped", id);
+                    let ev = match *id {
+                        StreamId::Inbound(id) => {
+                            StreamingProtocolsHandlerEvent::InboundStreamClosed { id }
+                        }
+                        StreamId::Outbound(id) => {
+                            StreamingProtocolsHandlerEvent::OutboundStreamClosed { id }
+                        }
+                    };
+                    pending_events.push_back(ev);
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+
+        // Drain pending events.
+        if let Some(event) = self.pending_events.pop_front() {
+            return Poll::Ready(ProtocolsHandlerEvent::Custom(event));
+        } else if self.pending_events.capacity() > EMPTY_QUEUE_SHRINK_THRESHOLD {
+            self.pending_events.shrink_to_fit();
+        }
+        // Emit outbound requests.
+        if let Some(info) = self.outbound.pop_front() {
+            return Poll::Ready(ProtocolsHandlerEvent::OutboundSubstreamRequest {
+                protocol: SubstreamProtocol::new(StreamingProtocol::new(), info)
+                    .with_timeout(self.config.substream_timeout),
+            });
+        }
+
+        debug_assert!(self.outbound.is_empty());
+
+        if self.outbound.capacity() > EMPTY_QUEUE_SHRINK_THRESHOLD {
+            self.outbound.shrink_to_fit();
+        }
+
+        if self.keep_alive.is_yes() && self.open_streams.is_empty() {
+            // No open streams but there may be outbound upgrades.
+            let until =
+                Instant::now() + self.config.substream_timeout + self.config.keep_alive_timeout;
+            self.keep_alive = KeepAlive::Until(until);
+        }
+
+        Poll::Pending
+    }
+}

--- a/protocols/streaming/src/lib.rs
+++ b/protocols/streaming/src/lib.rs
@@ -1,0 +1,547 @@
+//! Basic building block for easier building of libp2p protocols. The streaming protocol provides
+//! the functionality to establish a bi-directional stream to a remote peer including dialing. In
+//! essence, it provides a generic way to write a custom protocol using an opinionated
+//! [`NetworkBehaviour`].  The [`Streaming`] behaviour can be constructed with a custom
+//! [`StreamingCodec`], which provides a custom protocol definition.
+//!
+//! ```
+//! use libp2p_streaming::{IdentityCodec, Streaming};
+//!
+//! let behaviour = Streaming::<IdentityCodec>::default();
+//! ```
+pub use handler::StreamId;
+use handler::{RefCount, StreamingProtocolsHandler, StreamingProtocolsHandlerEvent};
+use libp2p_core::{connection::ConnectionId, ConnectedPoint, Multiaddr, PeerId, ProtocolName};
+use libp2p_swarm::{
+    DialPeerCondition, NegotiatedSubstream, NetworkBehaviour, NetworkBehaviourAction, NotifyHandler,
+};
+use smallvec::SmallVec;
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+    sync::{atomic::AtomicU64, Arc},
+    task::Poll,
+    time::Duration,
+};
+
+mod handler;
+
+pub struct Streaming<T: StreamingCodec> {
+    /// Pending events to return from `poll`
+    pending_events: VecDeque<NetworkBehaviourAction<OutboundStreamId, StreamingEvent<T>>>,
+    /// The next (inbound) stream ID
+    next_inbound_id: Arc<AtomicU64>,
+    /// The next outbound stream ID
+    next_stream_id: OutboundStreamId,
+    /// The currently connected peers, their pending outbound and
+    /// inbound requests and their known, reachable addresses, if any.
+    connected: HashMap<PeerId, SmallVec<[Connection; 2]>>,
+    /// Externally managed addresses via `add_address` and
+    /// `remove_address`.
+    addresses: HashMap<PeerId, SmallVec<[Multiaddr; 6]>>,
+    /// Requests that have not yet been sent and are waiting for a
+    /// connection to be established.
+    pending_outbound_requests: HashMap<PeerId, SmallVec<[OutboundStreamId; 10]>>,
+    config: StreamingConfig,
+    _codec: PhantomData<T>,
+}
+impl<T: StreamingCodec> Streaming<T> {
+    pub fn new(config: StreamingConfig) -> Self {
+        Self {
+            config,
+            ..Default::default()
+        }
+    }
+}
+#[derive(Clone, Debug)]
+pub struct StreamingConfig {
+    /// The keep-alive timeout of idle connections. A connection is considered idle if there are no
+    /// substreams.
+    keep_alive_timeout: Duration,
+    /// The timeout for inbound and outbound substreams .
+    substream_timeout: Duration,
+}
+impl StreamingConfig {
+    pub fn new(keep_alive_timeout: Duration, substream_timeout: Duration) -> Self {
+        Self {
+            keep_alive_timeout,
+            substream_timeout,
+        }
+    }
+}
+impl Default for StreamingConfig {
+    fn default() -> Self {
+        Self {
+            keep_alive_timeout: Duration::from_millis(10_000),
+            substream_timeout: Duration::from_millis(5_000),
+        }
+    }
+}
+impl<T: StreamingCodec> Default for Streaming<T> {
+    fn default() -> Self {
+        Self {
+            pending_events: Default::default(),
+            next_inbound_id: Default::default(),
+            next_stream_id: Default::default(),
+            connected: Default::default(),
+            addresses: Default::default(),
+            pending_outbound_requests: Default::default(),
+            config: Default::default(),
+            _codec: Default::default(),
+        }
+    }
+}
+
+struct Connection {
+    id: ConnectionId,
+    address: Option<Multiaddr>,
+    pending_outbound: HashSet<OutboundStreamId>,
+    pending_inbound: HashSet<InboundStreamId>,
+}
+
+impl Connection {
+    fn new(id: ConnectionId, address: Option<Multiaddr>) -> Self {
+        Self {
+            id,
+            address,
+            pending_outbound: Default::default(),
+            pending_inbound: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct InboundStreamId(u64);
+
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct OutboundStreamId(u64);
+#[derive(Debug)]
+/// Handle associated with an upgraded connection to a remote peer.  The handle can be dereferenced
+/// yielding the wrapped &mut T.
+pub struct StreamHandle<T> {
+    /// The wrapped value.
+    inner: T,
+    /// Reference counter to indicate whether a connection should be kept alive or not.
+    marker: RefCount,
+}
+impl<T> StreamHandle<T> {
+    fn new(inner: T, marker: RefCount) -> Self {
+        Self { inner, marker }
+    }
+}
+impl<T> Deref for StreamHandle<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<T> DerefMut for StreamHandle<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+/// Implement this trait to provide a custom StreamingCodec. If you're just interested in the raw
+/// bytes (yielding a handle which implements both [`AsyncRead`](futures::io::AsyncRead) and
+/// [`AsyncWrite`](futures::io::AsyncWrite)), use [`IdentityCodec`].
+pub trait StreamingCodec {
+    type Protocol: ProtocolName + Send + Clone;
+    type Upgrade: Send;
+
+    fn upgrade(io: NegotiatedSubstream) -> Self::Upgrade;
+    fn protocol_name() -> Self::Protocol;
+}
+
+#[derive(Debug)]
+/// Codec providing the raw bytes. The resulting [`StreamHandle`] can be derefenced yielding an
+/// [`AsyncRead`](futures::io::AsyncRead) and [`AsyncWrite`](futures::io::AsyncWrite)
+/// implementation.
+pub struct IdentityCodec;
+impl StreamingCodec for IdentityCodec {
+    type Protocol = &'static [u8];
+
+    type Upgrade = NegotiatedSubstream;
+
+    fn upgrade(io: NegotiatedSubstream) -> Self::Upgrade {
+        io
+    }
+
+    fn protocol_name() -> Self::Protocol {
+        b"/streaming/bytes/1.0.0"
+    }
+}
+
+// Exposed swarm events
+#[derive(Debug)]
+pub enum StreamingEvent<T: StreamingCodec> {
+    // New connection from remote
+    NewIncoming {
+        peer_id: PeerId,
+        id: InboundStreamId,
+        stream: StreamHandle<T::Upgrade>,
+    },
+    StreamOpened {
+        peer_id: PeerId,
+        id: OutboundStreamId,
+        stream: StreamHandle<T::Upgrade>,
+    },
+    StreamClosed {
+        peer_id: PeerId,
+        id: StreamId,
+    },
+    OutboundFailure {
+        peer_id: PeerId,
+        id: OutboundStreamId,
+        error: OutboundFailure,
+    },
+    InboundFailure {
+        peer_id: PeerId,
+        id: InboundStreamId,
+        error: InboundFailure,
+    },
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum OutboundFailure {
+    #[error("Unable to dial remote.")]
+    DialFailure,
+    #[error("Hit timeout when trying to reach remote.")]
+    Timeout,
+    #[error("Connection closed.")]
+    ConnectionClosed,
+    #[error("Outbound upgrade failed due to the remote not supporting the protocol.")]
+    UnsupportedProtocols,
+}
+#[derive(thiserror::Error, Debug)]
+pub enum InboundFailure {
+    #[error("Connection closed.")]
+    ConnectionClosed,
+    #[error("Timeout.")]
+    Timeout,
+    #[error("Inbound upgrade failed due to the remote not supporting the protocol.")]
+    UnsupportedProtocols,
+}
+
+impl<T: StreamingCodec> Streaming<T> {
+    /// Establish an outbound stream. If the given [`PeerId`] is not yet connected, a dialing
+    /// attempt will be initiated. The remote's address needs to be added first through
+    /// [`add_address`].
+    pub fn open_stream(&mut self, peer_id: PeerId) -> OutboundStreamId {
+        let stream_id = self.next_stream_id();
+        tracing::trace!(%peer_id, ?stream_id, "Opening stream");
+        if !self.try_open(peer_id, stream_id) {
+            self.pending_events
+                .push_back(NetworkBehaviourAction::DialPeer {
+                    peer_id,
+                    condition: DialPeerCondition::Disconnected,
+                });
+            self.pending_outbound_requests
+                .entry(peer_id)
+                .or_default()
+                .push(stream_id);
+        }
+        stream_id
+    }
+    fn try_open(&mut self, peer_id: PeerId, id: OutboundStreamId) -> bool {
+        if let Some(connections) = self.connected.get_mut(&peer_id) {
+            if connections.is_empty() {
+                self.connected.remove(&peer_id);
+                return false;
+            }
+
+            // Use a random connection
+            let ix = (id.0 as usize) % connections.len();
+            let conn = &mut connections[ix];
+            conn.pending_outbound.insert(id);
+            self.pending_events
+                .push_back(NetworkBehaviourAction::NotifyHandler {
+                    peer_id,
+                    handler: NotifyHandler::One(conn.id),
+                    event: id,
+                });
+            true
+        } else {
+            false
+        }
+    }
+
+    fn next_stream_id(&mut self) -> OutboundStreamId {
+        let stream_id = self.next_stream_id;
+        self.next_stream_id.0 += 1;
+        stream_id
+    }
+
+    /// Adds a known address for a peer that can be used for
+    /// dialing attempts by the `Swarm`, i.e. is returned
+    /// by [`NetworkBehaviour::addresses_of_peer`].
+    ///
+    /// Addresses added in this way are only removed by `remove_address`.
+    pub fn add_address(&mut self, peer: PeerId, address: Multiaddr) {
+        self.addresses.entry(peer).or_default().push(address);
+    }
+
+    /// Removes an address of a peer previously added via [`add_address`].
+    pub fn remove_address(&mut self, peer: PeerId, address: &Multiaddr) {
+        let mut last = false;
+        if let Some(addresses) = self.addresses.get_mut(&peer) {
+            addresses.retain(|a| a != address);
+            last = addresses.is_empty();
+        }
+        if last {
+            self.addresses.remove(&peer);
+        }
+    }
+
+    fn get_connection_mut(
+        &mut self,
+        peer: &PeerId,
+        connection: ConnectionId,
+    ) -> Option<&mut Connection> {
+        self.connected
+            .get_mut(peer)
+            .and_then(|connections| connections.iter_mut().find(|c| c.id == connection))
+    }
+
+    fn remove_pending_outbound(
+        &mut self,
+        peer: &PeerId,
+        connection: ConnectionId,
+        id: OutboundStreamId,
+    ) -> bool {
+        self.get_connection_mut(peer, connection)
+            .map(|c| c.pending_outbound.remove(&id))
+            .unwrap_or(false)
+    }
+
+    fn remove_pending_inbound(
+        &mut self,
+        peer: &PeerId,
+        connection: ConnectionId,
+        id: InboundStreamId,
+    ) -> bool {
+        self.get_connection_mut(peer, connection)
+            .map(|c| c.pending_inbound.remove(&id))
+            .unwrap_or(false)
+    }
+}
+
+impl<T: StreamingCodec + Send + 'static> NetworkBehaviour for Streaming<T> {
+    type ProtocolsHandler = StreamingProtocolsHandler<T>;
+
+    type OutEvent = StreamingEvent<T>;
+
+    fn new_handler(&mut self) -> Self::ProtocolsHandler {
+        tracing::trace!("new_handler");
+        StreamingProtocolsHandler::new(self.next_inbound_id.clone(), self.config.clone())
+    }
+
+    fn addresses_of_peer(&mut self, peer: &PeerId) -> Vec<Multiaddr> {
+        let mut addresses = Vec::new();
+        if let Some(connections) = self.connected.get(peer) {
+            addresses.extend(connections.iter().filter_map(|c| c.address.clone()))
+        }
+        if let Some(more) = self.addresses.get(peer) {
+            addresses.extend(more.into_iter().cloned());
+        }
+        addresses
+    }
+
+    fn inject_connected(&mut self, peer: &PeerId) {
+        if let Some(pending) = self.pending_outbound_requests.remove(peer) {
+            for request in pending {
+                let sent_request = self.try_open(*peer, request);
+                assert!(sent_request);
+            }
+        }
+    }
+
+    fn inject_connection_established(
+        &mut self,
+        peer: &PeerId,
+        conn: &ConnectionId,
+        endpoint: &ConnectedPoint,
+    ) {
+        let address = match endpoint {
+            ConnectedPoint::Dialer { address } => Some(address.clone()),
+            ConnectedPoint::Listener { .. } => None,
+        };
+        self.connected
+            .entry(*peer)
+            .or_default()
+            .push(Connection::new(*conn, address));
+    }
+
+    fn inject_connection_closed(
+        &mut self,
+        peer_id: &PeerId,
+        conn: &ConnectionId,
+        _: &ConnectedPoint,
+    ) {
+        let connections = self
+            .connected
+            .get_mut(peer_id)
+            .expect("Expected some established connection to peer before closing.");
+
+        let connection = connections
+            .iter()
+            .position(|c| &c.id == conn)
+            .map(|p: usize| connections.remove(p))
+            .expect("Expected connection to be established before closing.");
+
+        if connections.is_empty() {
+            self.connected.remove(peer_id);
+        }
+
+        for id in connection.pending_inbound {
+            self.pending_events
+                .push_back(NetworkBehaviourAction::GenerateEvent(
+                    StreamingEvent::InboundFailure {
+                        peer_id: *peer_id,
+                        id,
+                        error: InboundFailure::ConnectionClosed,
+                    },
+                ));
+        }
+
+        for id in connection.pending_outbound {
+            self.pending_events
+                .push_back(NetworkBehaviourAction::GenerateEvent(
+                    StreamingEvent::OutboundFailure {
+                        peer_id: *peer_id,
+                        id,
+                        error: OutboundFailure::ConnectionClosed,
+                    },
+                ));
+        }
+    }
+
+    fn inject_disconnected(&mut self, peer: &PeerId) {
+        self.connected.remove(peer);
+    }
+
+    fn inject_dial_failure(&mut self, peer: &PeerId) {
+        // Consider any pending outgoing requests to that peer failed.
+        if let Some(pending) = self.pending_outbound_requests.remove(peer) {
+            for id in pending {
+                self.pending_events
+                    .push_back(NetworkBehaviourAction::GenerateEvent(
+                        StreamingEvent::OutboundFailure {
+                            peer_id: *peer,
+                            id,
+                            error: OutboundFailure::DialFailure,
+                        },
+                    ));
+            }
+        }
+    }
+
+    fn inject_event(
+        &mut self,
+        peer_id: libp2p_core::PeerId,
+        connection_id: libp2p_core::connection::ConnectionId,
+        event: StreamingProtocolsHandlerEvent<T>,
+    ) {
+        let ev = match event {
+            StreamingProtocolsHandlerEvent::NewIncoming { id, stream } => {
+                match self.get_connection_mut(&peer_id, connection_id) {
+                    Some(connection) => {
+                        let inserted = connection.pending_inbound.insert(id);
+                        debug_assert!(inserted, "Expect id of new request to be unknown.");
+                        StreamingEvent::NewIncoming {
+                            peer_id,
+                            id,
+                            stream,
+                        }
+                    }
+                    // Connection was immediately closed.
+                    None => StreamingEvent::InboundFailure {
+                        peer_id,
+                        id,
+                        error: InboundFailure::ConnectionClosed,
+                    },
+                }
+            }
+            StreamingProtocolsHandlerEvent::StreamOpened { id, stream } => {
+                StreamingEvent::StreamOpened {
+                    id,
+                    peer_id,
+                    stream,
+                }
+            }
+            StreamingProtocolsHandlerEvent::OutboundTimeout(id) => {
+                let removed = self.remove_pending_outbound(&peer_id, connection_id, id);
+                debug_assert!(removed, "Expect id to be pending before request times out.");
+
+                StreamingEvent::OutboundFailure {
+                    peer_id,
+                    id,
+                    error: OutboundFailure::Timeout,
+                }
+            }
+            StreamingProtocolsHandlerEvent::OutboundUnsupportedProtocols(id) => {
+                let removed = self.remove_pending_outbound(&peer_id, connection_id, id);
+                debug_assert!(
+                    removed,
+                    "Expect id to be pending before request is rejected."
+                );
+
+                StreamingEvent::OutboundFailure {
+                    peer_id,
+                    id,
+                    error: OutboundFailure::UnsupportedProtocols,
+                }
+            }
+            StreamingProtocolsHandlerEvent::InboundTimeout(id) => StreamingEvent::InboundFailure {
+                peer_id,
+                id,
+                error: InboundFailure::Timeout,
+            },
+            StreamingProtocolsHandlerEvent::InboundUnsupportedProtocols(id) => {
+                StreamingEvent::InboundFailure {
+                    peer_id,
+                    id,
+                    error: InboundFailure::UnsupportedProtocols,
+                }
+            }
+            StreamingProtocolsHandlerEvent::InboundStreamClosed { id } => {
+                self.remove_pending_inbound(&peer_id, connection_id, id);
+                StreamingEvent::StreamClosed {
+                    peer_id,
+                    id: StreamId::Inbound(id),
+                }
+            }
+            StreamingProtocolsHandlerEvent::OutboundStreamClosed { id } => {
+                self.remove_pending_outbound(&peer_id, connection_id, id);
+                StreamingEvent::StreamClosed {
+                    peer_id,
+                    id: StreamId::Outbound(id),
+                }
+            }
+        };
+
+        self.pending_events
+            .push_back(NetworkBehaviourAction::GenerateEvent(ev));
+    }
+
+    fn poll(
+        &mut self,
+        _: &mut std::task::Context<'_>,
+        _: &mut impl libp2p_swarm::PollParameters,
+    ) -> std::task::Poll<libp2p_swarm::NetworkBehaviourAction<OutboundStreamId, Self::OutEvent>>
+    {
+        if let Some(ev) = self.pending_events.pop_front() {
+            return Poll::Ready(ev);
+        } else if self.pending_events.capacity() > EMPTY_QUEUE_SHRINK_THRESHOLD {
+            self.pending_events.shrink_to_fit();
+        }
+
+        Poll::Pending
+    }
+}
+
+/// Internal threshold for when to shrink the capacity of empty
+/// queues. If the capacity of an empty queue exceeds this threshold,
+/// the associated memory is released.
+const EMPTY_QUEUE_SHRINK_THRESHOLD: usize = 100;

--- a/protocols/streaming/tests/codec.rs
+++ b/protocols/streaming/tests/codec.rs
@@ -1,0 +1,120 @@
+use async_std::future::timeout;
+use asynchronous_codec::{CborCodec, Framed};
+use common::{mk_transport, setup_logger};
+use futures::{channel::mpsc, SinkExt, StreamExt};
+use libp2p_streaming::{Streaming, StreamingCodec};
+use libp2p_swarm::{NegotiatedSubstream, Swarm, SwarmEvent};
+use serde::{Deserialize, Serialize};
+///! Simple example demonstrating a custom codec.
+use std::time::Duration;
+
+mod common;
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+struct Ping(Vec<u8>);
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+struct Pong(Vec<u8>);
+#[derive(Debug)]
+struct PingCodec;
+impl StreamingCodec for PingCodec {
+    type Protocol = &'static [u8];
+
+    type Upgrade = Framed<NegotiatedSubstream, CborCodec<Ping, Pong>>;
+
+    fn upgrade(io: NegotiatedSubstream) -> Self::Upgrade {
+        Framed::new(io, CborCodec::new())
+    }
+
+    fn protocol_name() -> Self::Protocol {
+        b"/streaming/ping/1.0.0"
+    }
+}
+
+#[derive(Debug)]
+struct PongCodec;
+impl StreamingCodec for PongCodec {
+    type Protocol = &'static [u8];
+
+    type Upgrade = Framed<NegotiatedSubstream, CborCodec<Pong, Ping>>;
+
+    fn upgrade(io: NegotiatedSubstream) -> Self::Upgrade {
+        Framed::new(io, CborCodec::new())
+    }
+
+    fn protocol_name() -> Self::Protocol {
+        b"/streaming/ping/1.0.0"
+    }
+}
+
+#[async_std::test]
+async fn codec() -> anyhow::Result<()> {
+    setup_logger();
+
+    let (peer1_id, trans) = mk_transport();
+
+    let mut swarm1 = Swarm::new(trans, Streaming::<PingCodec>::default(), peer1_id);
+
+    let (peer2_id, trans) = mk_transport();
+    let mut swarm2 = Swarm::new(trans, Streaming::<PongCodec>::default(), peer2_id);
+
+    let addr = "/ip4/127.0.0.1/tcp/0".parse().unwrap();
+    swarm1.listen_on(addr).unwrap();
+
+    let (mut tx_addr, mut rx_addr) = mpsc::channel(1);
+    async_std::task::spawn(async move {
+        while let Some(ev) = swarm1.next().await {
+            tracing::info!("swarm1: {:?}", ev);
+            match ev {
+                SwarmEvent::NewListenAddr { address, .. } => {
+                    tx_addr.send(address).await.unwrap();
+                }
+                SwarmEvent::ListenerError { error, .. } => panic!("{}", error),
+                SwarmEvent::Behaviour(libp2p_streaming::StreamingEvent::NewIncoming {
+                    peer_id,
+                    mut stream,
+                    ..
+                }) => {
+                    assert_eq!(peer_id, peer2_id);
+                    stream.send(Ping(b"Hello".to_vec())).await.unwrap();
+
+                    let out = stream.next().await.unwrap().unwrap();
+                    assert_eq!(out, Pong(b"World!".to_vec()));
+                    break;
+                }
+                _ => {}
+            }
+        }
+    });
+
+    let addr = rx_addr.next().await.unwrap();
+    swarm2.behaviour_mut().add_address(peer1_id, addr.clone());
+
+    let stream_id = swarm2.behaviour_mut().open_stream(peer1_id);
+    while let Some(ev) = timeout(Duration::from_secs(5), swarm2.next())
+        .await
+        .unwrap()
+    {
+        tracing::info!("swarm2: {:?}", ev);
+        match ev {
+            SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                assert_eq!(peer1_id, peer_id);
+            }
+            SwarmEvent::Behaviour(libp2p_streaming::StreamingEvent::StreamOpened {
+                id,
+                peer_id,
+                mut stream,
+            }) => {
+                assert_eq!(peer1_id, peer_id);
+                assert_eq!(id, stream_id);
+                let out = stream.next().await.unwrap().unwrap();
+                assert_eq!(out, Ping(b"Hello".to_vec()));
+
+                stream.send(Pong(b"World".to_vec())).await.unwrap();
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}

--- a/protocols/streaming/tests/common/mod.rs
+++ b/protocols/streaming/tests/common/mod.rs
@@ -1,0 +1,37 @@
+use libp2p_core::{
+    identity,
+    muxing::StreamMuxerBox,
+    transport::{self, Transport},
+    upgrade, PeerId,
+};
+use libp2p_noise::{Keypair, NoiseConfig, X25519Spec};
+use libp2p_tcp::TcpConfig;
+use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
+
+pub fn mk_transport() -> (PeerId, transport::Boxed<(PeerId, StreamMuxerBox)>) {
+    let id_keys = identity::Keypair::generate_ed25519();
+    let peer_id = id_keys.public().into();
+    let noise_keys = Keypair::<X25519Spec>::new()
+        .into_authentic(&id_keys)
+        .unwrap();
+    (
+        peer_id,
+        TcpConfig::new()
+            .nodelay(true)
+            .upgrade(upgrade::Version::V1)
+            .authenticate(NoiseConfig::xx(noise_keys).into_authenticated())
+            .multiplex(libp2p_yamux::YamuxConfig::default())
+            .boxed(),
+    )
+}
+
+pub fn setup_logger() {
+    tracing_log::LogTracer::init().ok();
+    let env = std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_| "info".to_owned());
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_span_events(FmtSpan::ACTIVE | FmtSpan::CLOSE)
+        .with_env_filter(EnvFilter::new(env))
+        .with_writer(std::io::stderr)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).ok();
+}

--- a/protocols/streaming/tests/smoke.rs
+++ b/protocols/streaming/tests/smoke.rs
@@ -1,0 +1,85 @@
+use async_std::prelude::*;
+use common::{mk_transport, setup_logger};
+use futures::{channel::mpsc, SinkExt, StreamExt};
+use libp2p_streaming::{IdentityCodec, Streaming};
+use libp2p_swarm::{Swarm, SwarmEvent};
+
+mod common;
+
+#[async_std::test]
+async fn smoke() -> anyhow::Result<()> {
+    setup_logger();
+
+    let (peer1_id, trans) = mk_transport();
+
+    let mut swarm1 = Swarm::new(trans, Streaming::<IdentityCodec>::default(), peer1_id);
+
+    let (peer2_id, trans) = mk_transport();
+    let mut swarm2 = Swarm::new(trans, Streaming::<IdentityCodec>::default(), peer2_id);
+
+    let addr = "/ip4/127.0.0.1/tcp/0".parse().unwrap();
+    swarm1.listen_on(addr).unwrap();
+
+    let (mut tx_addr, mut rx_addr) = mpsc::channel(1);
+    async_std::task::spawn(async move {
+        while let Some(ev) = swarm1.next().await {
+            match ev {
+                SwarmEvent::NewListenAddr { address, .. } => {
+                    tx_addr.send(address).await.unwrap();
+                }
+                SwarmEvent::ListenerError { error, .. } => panic!("{}", error),
+                SwarmEvent::Behaviour(libp2p_streaming::StreamingEvent::NewIncoming {
+                    peer_id,
+                    mut stream,
+                    ..
+                }) => {
+                    assert_eq!(peer_id, peer2_id);
+                    stream.write_all(b"Hello").await.unwrap();
+                    stream.flush().await.unwrap();
+
+                    let mut out = vec![0; 32];
+                    let n = stream.read(&mut out).await.unwrap();
+                    out.truncate(n);
+                    assert_eq!(out, b"World!");
+                    break;
+                }
+                x => {
+                    tracing::info!("swarm1: {:?}", x);
+                }
+            };
+        }
+    });
+
+    let addr = rx_addr.next().await.unwrap();
+    swarm2.behaviour_mut().add_address(peer1_id, addr.clone());
+    let stream_id = swarm2.behaviour_mut().open_stream(peer1_id);
+
+    while let Some(ev) = swarm2.next().await {
+        match ev {
+            SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                assert_eq!(peer1_id, peer_id);
+            }
+            SwarmEvent::Behaviour(libp2p_streaming::StreamingEvent::StreamOpened {
+                id,
+                peer_id,
+                mut stream,
+            }) => {
+                assert_eq!(peer1_id, peer_id);
+                assert_eq!(id, stream_id);
+                let mut out = vec![0; 32];
+                let n = stream.read(&mut out).await.unwrap();
+                out.truncate(n);
+                assert_eq!(out, b"Hello");
+
+                stream.write_all(b"World!").await.unwrap();
+                stream.flush().await.unwrap();
+                break;
+            }
+            x => {
+                tracing::info!("swarm2: {:?}", x);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/protocols/streaming/tests/streaming.rs
+++ b/protocols/streaming/tests/streaming.rs
@@ -1,0 +1,149 @@
+use async_std::task::sleep;
+use asynchronous_codec::{CborCodec, Framed};
+use common::{mk_transport, setup_logger};
+use futures::{channel::mpsc, SinkExt, StreamExt};
+use libp2p_streaming::{Streaming, StreamingCodec, StreamingConfig, StreamingEvent};
+use libp2p_swarm::{NegotiatedSubstream, Swarm, SwarmEvent};
+use serde::{Deserialize, Serialize};
+use std::time::{Duration, Instant};
+
+mod common;
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+struct RequestTicker;
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+struct ResponseTicker(Duration);
+
+#[derive(Debug)]
+struct RequestCodec;
+impl StreamingCodec for RequestCodec {
+    type Protocol = &'static [u8];
+
+    type Upgrade = Framed<NegotiatedSubstream, CborCodec<RequestTicker, ResponseTicker>>;
+
+    fn upgrade(io: NegotiatedSubstream) -> Self::Upgrade {
+        Framed::new(io, CborCodec::<RequestTicker, ResponseTicker>::new())
+    }
+
+    fn protocol_name() -> Self::Protocol {
+        b"/streaming/ticker/1.0.0"
+    }
+}
+#[derive(Debug)]
+struct ResponseCodec;
+impl StreamingCodec for ResponseCodec {
+    type Protocol = &'static [u8];
+
+    type Upgrade = Framed<NegotiatedSubstream, CborCodec<ResponseTicker, RequestTicker>>;
+
+    fn upgrade(io: NegotiatedSubstream) -> Self::Upgrade {
+        Framed::new(io, CborCodec::<ResponseTicker, RequestTicker>::new())
+    }
+
+    fn protocol_name() -> Self::Protocol {
+        b"/streaming/ticker/1.0.0"
+    }
+}
+
+#[async_std::test]
+async fn ticker() -> anyhow::Result<()> {
+    setup_logger();
+
+    let (peer1_id, trans) = mk_transport();
+
+    let config = StreamingConfig::new(Duration::from_millis(50), Duration::from_millis(100));
+    let mut swarm1 = Swarm::new(
+        trans,
+        Streaming::<RequestCodec>::new(config.clone()),
+        peer1_id,
+    );
+
+    let (peer2_id, trans) = mk_transport();
+    let mut swarm2 = Swarm::new(trans, Streaming::<ResponseCodec>::new(config), peer2_id);
+
+    let addr = "/ip4/127.0.0.1/tcp/0".parse().unwrap();
+    swarm1.listen_on(addr).unwrap();
+
+    let (mut tx_addr, mut rx_addr) = mpsc::channel(1);
+    let (tx, mut rx) = mpsc::channel(1);
+    let swarm1_handle = async_std::task::spawn(async move {
+        while let Some(ev) = swarm1.next().await {
+            tracing::info!("swarm1: {:?}", ev);
+            match ev {
+                SwarmEvent::NewListenAddr { address, .. } => {
+                    tx_addr.send(address).await.unwrap();
+                }
+                SwarmEvent::ListenerError { error, .. } => panic!("{}", error),
+                SwarmEvent::Behaviour(libp2p_streaming::StreamingEvent::NewIncoming {
+                    peer_id,
+                    mut stream,
+                    ..
+                }) => {
+                    assert_eq!(peer_id, peer2_id);
+                    stream.send(RequestTicker).await.unwrap();
+
+                    let mut txc = tx.clone();
+                    async_std::task::spawn(async move {
+                        let mut i = 0usize;
+                        while let Some(Ok(x)) = stream.next().await {
+                            tracing::info!("{}", x.0.as_millis());
+                            i += 1;
+                        }
+                        txc.send(i).await.unwrap();
+                    });
+                }
+                SwarmEvent::ConnectionClosed { peer_id, .. } => {
+                    assert_eq!(peer_id, peer2_id);
+                }
+                SwarmEvent::Behaviour(StreamingEvent::InboundFailure { peer_id, .. }) => {
+                    assert_eq!(peer_id, peer2_id);
+                    break;
+                }
+                _ => {}
+            }
+        }
+    });
+
+    let addr = rx_addr.next().await.unwrap();
+    swarm2.behaviour_mut().add_address(peer1_id, addr.clone());
+
+    let stream_id = swarm2.behaviour_mut().open_stream(peer1_id);
+    while let Some(ev) = swarm2.next().await {
+        tracing::info!("swarm2: {:?}", ev);
+        match ev {
+            SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                assert_eq!(peer1_id, peer_id);
+            }
+            SwarmEvent::Behaviour(libp2p_streaming::StreamingEvent::StreamOpened {
+                id,
+                peer_id,
+                mut stream,
+            }) => {
+                assert_eq!(peer1_id, peer_id);
+                assert_eq!(id, stream_id);
+                let out = stream.next().await.unwrap().unwrap();
+                assert_eq!(out, RequestTicker);
+
+                async_std::task::spawn(async move {
+                    let start = Instant::now();
+                    for _ in 0..10 {
+                        stream.send(ResponseTicker(start.elapsed())).await.unwrap();
+                        sleep(Duration::from_millis(50)).await;
+                    }
+                    stream.close().await.unwrap();
+                });
+            }
+            SwarmEvent::ConnectionClosed { peer_id, .. } => {
+                assert_eq!(peer_id, peer1_id);
+                assert_eq!(rx.next().await.unwrap(), 10);
+                break;
+            }
+
+            _ => {}
+        }
+    }
+    swarm1_handle.await;
+
+    // TODO: assert streamclosed message
+    Ok(())
+}


### PR DESCRIPTION
this adds a `streaming-response` crate, which provides a `NetworkBehaviour` similar
to the `request-response` protocol to have a generic messaging mechanism
between two peers. The most notable difference to `request-response` and
the main motivation for its implementation is to provide an open-ended
streaming mechanism for the responses: a consumer's request can result
in any number of individual response frames, until said stream is
finalized. Conceptually, it is somewhat similar to grpc streaming.

Posting this here as a draft PR for discussion, whether you would be willing
to accept such a dedicated crate, or whether it would make sense to fold this into
`request-response`.

Related discussions #1727 #1942