### PR TITLE
Make clippy "happy".

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: -- -A clippy::mutable_key_type -A clippy::type_complexity
+        args: -- -A clippy::type_complexity -A clippy::pedantic -A clippy::style
 
   run-benchmarks:
     runs-on: ubuntu-latest

--- a/core/src/network.rs
+++ b/core/src/network.rs
@@ -205,8 +205,8 @@ where
     }
 
     /// Returns the peer id of the local node.
-    pub fn local_peer_id(&self) -> PeerId {
-        self.local_peer_id
+    pub fn local_peer_id(&self) -> &PeerId {
+        &self.local_peer_id
     }
 
     /// Dials a multiaddress without expecting a particular remote peer ID.

--- a/core/src/network.rs
+++ b/core/src/network.rs
@@ -144,11 +144,10 @@ where
         local_peer_id: PeerId,
         config: NetworkConfig,
     ) -> Self {
-        let pool_local_id = local_peer_id.clone();
         Network {
             local_peer_id,
             listeners: ListenersStream::new(transport),
-            pool: Pool::new(pool_local_id, config.manager_config, config.limits),
+            pool: Pool::new(local_peer_id, config.manager_config, config.limits),
             dialing: Default::default(),
         }
     }
@@ -206,8 +205,8 @@ where
     }
 
     /// Returns the peer id of the local node.
-    pub fn local_peer_id(&self) -> &PeerId {
-        &self.local_peer_id
+    pub fn local_peer_id(&self) -> PeerId {
+        self.local_peer_id
     }
 
     /// Dials a multiaddress without expecting a particular remote peer ID.
@@ -380,7 +379,7 @@ where
         let event = match self.pool.poll(cx) {
             Poll::Pending => return Poll::Pending,
             Poll::Ready(PoolEvent::ConnectionEstablished { connection, num_established }) => {
-                if let hash_map::Entry::Occupied(mut e) = self.dialing.entry(connection.peer_id().clone()) {
+                if let hash_map::Entry::Occupied(mut e) = self.dialing.entry(connection.peer_id()) {
                     e.get_mut().retain(|s| s.current.0 != connection.id());
                     if e.get().is_empty() {
                         e.remove();
@@ -526,7 +525,7 @@ where
             if let Some(pos) = attempts.iter().position(|s| s.current.0 == id) {
                 let attempt = attempts.remove(pos);
                 let last = attempts.is_empty();
-                Some((peer.clone(), attempt, last))
+                Some((*peer, attempt, last))
             } else {
                 None
             }
@@ -545,7 +544,7 @@ where
                 if let Some(handler) = handler {
                     let next_attempt = attempt.remaining.remove(0);
                     let opts = DialingOpts {
-                        peer: peer_id.clone(),
+                        peer: peer_id,
                         handler,
                         address: next_attempt,
                         remaining: attempt.remaining

--- a/core/src/network/peer.rs
+++ b/core/src/network/peer.rs
@@ -223,7 +223,7 @@ where
         };
 
         let id = network.dial_peer(DialingOpts {
-            peer: peer_id.clone(),
+            peer: peer_id,
             handler,
             address,
             remaining: remaining.into_iter().collect(),
@@ -435,7 +435,7 @@ where
     pub fn attempt(&mut self, id: ConnectionId)
         -> Option<DialingAttempt<'_, TInEvent>>
     {
-        if let hash_map::Entry::Occupied(attempts) = self.network.dialing.entry(self.peer_id.clone()) {
+        if let hash_map::Entry::Occupied(attempts) = self.network.dialing.entry(self.peer_id) {
             if let Some(pos) = attempts.get().iter().position(|s| s.current.0 == id) {
                 if let Some(inner) = self.network.pool.get_outgoing(id) {
                     return Some(DialingAttempt { pos, inner, attempts })
@@ -662,7 +662,8 @@ impl<'a, TInEvent, TOutEvent, THandler, TTransErr, THandlerErr>
     }
 
     /// Obtains the next dialing connection, if any.
-    pub fn next<'b>(&'b mut self) -> Option<DialingAttempt<'b, TInEvent>> {
+    #[allow(clippy::should_implement_trait)]
+    pub fn next(&mut self) -> Option<DialingAttempt<'_, TInEvent>> {
         // If the number of elements reduced, the current `DialingAttempt` has been
         // aborted and iteration needs to continue from the previous position to
         // account for the removed element.
@@ -676,7 +677,7 @@ impl<'a, TInEvent, TOutEvent, THandler, TTransErr, THandlerErr>
             return None
         }
 
-        if let hash_map::Entry::Occupied(attempts) = self.dialing.entry(self.peer_id.clone()) {
+        if let hash_map::Entry::Occupied(attempts) = self.dialing.entry(*self.peer_id) {
             let id = attempts.get()[self.pos].current.0;
             if let Some(inner) = self.pool.get_outgoing(id) {
                 let conn = DialingAttempt { pos: self.pos, inner, attempts };
@@ -697,7 +698,7 @@ impl<'a, TInEvent, TOutEvent, THandler, TTransErr, THandlerErr>
             return None
         }
 
-        if let hash_map::Entry::Occupied(attempts) = self.dialing.entry(self.peer_id.clone()) {
+        if let hash_map::Entry::Occupied(attempts) = self.dialing.entry(*self.peer_id) {
             let id = attempts.get()[self.pos].current.0;
             if let Some(inner) = self.pool.get_outgoing(id) {
                 return Some(DialingAttempt { pos: self.pos, inner, attempts })

--- a/core/tests/network_dial_error.rs
+++ b/core/tests/network_dial_error.rs
@@ -69,7 +69,7 @@ fn deny_incoming_connec() {
                 multiaddr,
                 error: PendingConnectionError::Transport(_)
             }) => {
-                assert_eq!(peer_id, *swarm1.local_peer_id());
+                assert_eq!(peer_id, swarm1.local_peer_id());
                 assert_eq!(multiaddr, address);
                 return Poll::Ready(Ok(()));
             },

--- a/core/tests/network_dial_error.rs
+++ b/core/tests/network_dial_error.rs
@@ -69,7 +69,7 @@ fn deny_incoming_connec() {
                 multiaddr,
                 error: PendingConnectionError::Transport(_)
             }) => {
-                assert_eq!(peer_id, swarm1.local_peer_id());
+                assert_eq!(&peer_id, swarm1.local_peer_id());
                 assert_eq!(multiaddr, address);
                 return Poll::Ready(Ok(()));
             },

--- a/muxers/mplex/src/io.rs
+++ b/muxers/mplex/src/io.rs
@@ -321,7 +321,7 @@ where
 
         // Remove the substream, scheduling pending frames as necessary.
         match self.substreams.remove(&id) {
-            None => return,
+            None => {},
             Some(state) => {
                 // If we fell below the substream limit, notify tasks that had
                 // interest in opening an outbound substream earlier.
@@ -442,7 +442,7 @@ where
             // Read the next frame.
             match ready!(self.poll_read_frame(cx, Some(id)))? {
                 Frame::Data { data, stream_id } if stream_id.into_local() == id => {
-                    return Poll::Ready(Ok(Some(data.clone())))
+                    return Poll::Ready(Ok(Some(data)))
                 },
                 Frame::Data { stream_id, data } => {
                     // The data frame is for a different stream than the one
@@ -595,18 +595,16 @@ where
                 // this task again to have a chance at progress.
                 trace!("{}: No task to read from blocked stream. Waking current task.", self.id);
                 cx.waker().clone().wake();
+            } else if let Some(id) = stream_id {
+                // We woke some other task, but are still interested in
+                // reading `Data` frames from the current stream when unblocked.
+                debug_assert!(blocked_id != &id, "Unexpected attempt at reading a new \
+                    frame from a substream with a full buffer.");
+                let _ = NotifierRead::register_read_stream(&self.notifier_read, cx.waker(), id);
             } else {
-                if let Some(id) = stream_id {
-                    // We woke some other task, but are still interested in
-                    // reading `Data` frames from the current stream when unblocked.
-                    debug_assert!(blocked_id != &id, "Unexpected attempt at reading a new \
-                        frame from a substream with a full buffer.");
-                    let _ = NotifierRead::register_read_stream(&self.notifier_read, cx.waker(), id);
-                } else {
-                    // We woke some other task but are still interested in
-                    // reading new `Open` frames when unblocked.
-                    let _ = NotifierRead::register_next_stream(&self.notifier_read, cx.waker());
-                }
+                // We woke some other task but are still interested in
+                // reading new `Open` frames when unblocked.
+                let _ = NotifierRead::register_next_stream(&self.notifier_read, cx.waker());
             }
 
             return Poll::Pending
@@ -932,7 +930,7 @@ impl NotifierRead {
 
 impl ArcWake for NotifierRead {
     fn wake_by_ref(this: &Arc<Self>) {
-        let wakers = mem::replace(&mut *this.read_stream.lock(), Default::default());
+        let wakers = mem::take(&mut *this.read_stream.lock());
         for (_, waker) in wakers {
             waker.wake();
         }
@@ -963,7 +961,7 @@ impl NotifierWrite {
 
 impl ArcWake for NotifierWrite {
     fn wake_by_ref(this: &Arc<Self>) {
-        let wakers = mem::replace(&mut *this.pending.lock(), Default::default());
+        let wakers = mem::take(&mut *this.pending.lock());
         for waker in wakers {
             waker.wake();
         }
@@ -985,7 +983,7 @@ impl NotifierOpen {
     }
 
     fn wake_all(&mut self) {
-        let wakers = mem::replace(&mut self.pending, Default::default());
+        let wakers = mem::take(&mut self.pending);
         for waker in wakers {
             waker.wake();
         }

--- a/muxers/mplex/src/lib.rs
+++ b/muxers/mplex/src/lib.rs
@@ -106,7 +106,7 @@ where
         -> Poll<Result<Self::Substream, io::Error>>
     {
         let stream_id = ready!(self.io.lock().poll_open_stream(cx))?;
-        return Poll::Ready(Ok(Substream::new(stream_id)))
+        Poll::Ready(Ok(Substream::new(stream_id)))
     }
 
     fn destroy_outbound(&self, _substream: Self::OutboundSubstream) {

--- a/protocols/gossipsub/src/backoff.rs
+++ b/protocols/gossipsub/src/backoff.rs
@@ -78,7 +78,7 @@ impl BackoffStorage {
              backoffs_by_heartbeat: &mut Vec<HashSet<_>>,
              heartbeat_interval,
              backoff_slack| {
-                let pair = (topic.clone(), peer.clone());
+                let pair = (topic.clone(), *peer);
                 let index = (heartbeat_index.0
                     + Self::heartbeats(&time, heartbeat_interval)
                     + backoff_slack as usize)
@@ -90,12 +90,12 @@ impl BackoffStorage {
             .backoffs
             .entry(topic.clone())
             .or_insert_with(HashMap::new)
-            .entry(peer.clone())
+            .entry(*peer)
         {
             Entry::Occupied(mut o) => {
                 let (backoff, index) = o.get();
                 if backoff < &instant {
-                    let pair = (topic.clone(), peer.clone());
+                    let pair = (topic.clone(), *peer);
                     if let Some(s) = self.backoffs_by_heartbeat.get_mut(index.0) {
                         s.remove(&pair);
                     }

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -393,7 +393,7 @@ impl Default for GossipsubConfigBuilder {
                     let mut source_string = if let Some(peer_id) = message.source.as_ref() {
                         peer_id.to_base58()
                     } else {
-                        PeerId::from_bytes(&vec![0, 1, 0])
+                        PeerId::from_bytes(&[0, 1, 0])
                             .expect("Valid peer id")
                             .to_base58()
                     };

--- a/protocols/gossipsub/src/gossip_promises.rs
+++ b/protocols/gossipsub/src/gossip_promises.rs
@@ -83,7 +83,7 @@ impl GossipPromises {
         self.promises.retain(|msg, peers| {
             peers.retain(|peer_id, expires| {
                 if *expires < now {
-                    let count = result.entry(peer_id.clone()).or_insert(0);
+                    let count = result.entry(*peer_id).or_insert(0);
                     *count += 1;
                     debug!(
                         "The peer {} broke the promise to deliver message {} in time!",

--- a/protocols/gossipsub/src/mcache.rs
+++ b/protocols/gossipsub/src/mcache.rs
@@ -110,7 +110,7 @@ impl MessageCache {
                     let count = iwant_counts
                         .entry(message_id.clone())
                         .or_default()
-                        .entry(peer.clone())
+                        .entry(*peer)
                         .or_default();
                     *count += 1;
                     *count

--- a/protocols/gossipsub/src/peer_score.rs
+++ b/protocols/gossipsub/src/peer_score.rs
@@ -432,7 +432,7 @@ impl PeerScore {
     /// Adds a new ip to a peer, if the peer is not yet known creates a new peer_stats entry for it
     pub fn add_ip(&mut self, peer_id: &PeerId, ip: IpAddr) {
         trace!("Add ip for peer {}, ip: {}", peer_id, ip);
-        let peer_stats = self.peer_stats.entry(peer_id.clone()).or_default();
+        let peer_stats = self.peer_stats.entry(*peer_id).or_default();
 
         // Mark the peer as connected (currently the default is connected, but we don't want to
         // rely on the default).
@@ -443,7 +443,7 @@ impl PeerScore {
         self.peer_ips
             .entry(ip)
             .or_insert_with(HashSet::new)
-            .insert(peer_id.clone());
+            .insert(*peer_id);
     }
 
     /// Removes an ip from a peer
@@ -474,7 +474,7 @@ impl PeerScore {
     pub fn remove_peer(&mut self, peer_id: &PeerId) {
         // we only retain non-positive scores of peers
         if self.score(peer_id) > 0f64 {
-            if let hash_map::Entry::Occupied(entry) = self.peer_stats.entry(peer_id.clone()) {
+            if let hash_map::Entry::Occupied(entry) = self.peer_stats.entry(*peer_id) {
                 Self::remove_ips_for_peer(entry.get(), &mut self.peer_ips, peer_id);
                 entry.remove();
             }
@@ -692,11 +692,11 @@ impl PeerScore {
             DeliveryStatus::Unknown => {
                 // the message is being validated; track the peer delivery and wait for
                 // the Deliver/Reject notification.
-                record.peers.insert(from.clone());
+                record.peers.insert(*from);
             }
             DeliveryStatus::Valid(validated) => {
                 // mark the peer delivery time to only count a duplicate delivery once.
-                record.peers.insert(from.clone());
+                record.peers.insert(*from);
                 self.mark_duplicate_message_delivery(from, topic_hash, Some(validated));
             }
             DeliveryStatus::Invalid => {

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -117,7 +117,7 @@ impl NetworkBehaviour for Identify {
             ConnectedPoint::Listener { send_back_addr, .. } => send_back_addr.clone(),
         };
 
-        self.observed_addresses.entry(peer_id.clone()).or_default().insert(*conn, addr);
+        self.observed_addresses.entry(*peer_id).or_default().insert(*conn, addr);
     }
 
     fn inject_connection_closed(&mut self, peer_id: &PeerId, conn: &ConnectionId, _: &ConnectedPoint) {

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -35,13 +35,12 @@ use std::{fmt, io, iter, pin::Pin};
 pub struct IdentifyProtocolConfig;
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct RemoteInfo {
     /// Information about the remote.
     pub info: IdentifyInfo,
     /// Address the remote sees for us.
     pub observed_addr: Multiaddr,
-
-    _priv: ()
 }
 
 /// The substream on which a reply is expected to be sent.
@@ -80,7 +79,7 @@ where
             agent_version: Some(info.agent_version),
             protocol_version: Some(info.protocol_version),
             public_key: Some(pubkey_bytes),
-            listen_addrs: listen_addrs,
+            listen_addrs,
             observed_addr: Some(observed_addr.to_vec()),
             protocols: info.protocols
         };
@@ -158,8 +157,7 @@ where
 
             Ok(RemoteInfo {
                 info,
-                observed_addr: observed_addr.clone(),
-                _priv: ()
+                observed_addr,
             })
         })
     }

--- a/protocols/kad/src/addresses.rs
+++ b/protocols/kad/src/addresses.rs
@@ -28,6 +28,7 @@ pub struct Addresses {
     addrs: SmallVec<[Multiaddr; 6]>,
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl Addresses {
     /// Creates a new list of addresses.
     pub fn new(addr: Multiaddr) -> Addresses {

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -167,8 +167,10 @@ fn bootstrap() {
         ).into_iter()
             .map(|(_a, s)| s)
             .collect::<Vec<_>>();
+
         let swarm_ids: Vec<_> = swarms.iter()
             .map(Swarm::local_peer_id)
+            .cloned()
             .collect();
 
         let qid = swarms[0].bootstrap().unwrap();
@@ -233,7 +235,7 @@ fn query_iter() {
         let mut swarms = build_connected_nodes(num_total, 1).into_iter()
             .map(|(_a, s)| s)
             .collect::<Vec<_>>();
-        let swarm_ids: Vec<_> = swarms.iter().map(Swarm::local_peer_id).collect();
+        let swarm_ids: Vec<_> = swarms.iter().map(Swarm::local_peer_id).cloned().collect();
 
         // Ask the first peer in the list to search a random peer. The search should
         // propagate forwards through the list of peers.
@@ -393,6 +395,7 @@ fn get_record_not_found() {
 
     let swarm_ids: Vec<_> = swarms.iter()
         .map(|(_addr, swarm)| Swarm::local_peer_id(swarm))
+        .cloned()
         .collect();
 
     let (second, third) = (swarms[1].0.clone(), swarms[2].0.clone());
@@ -559,12 +562,13 @@ fn put_record() {
                     assert_eq!(r.key, expected.key);
                     assert_eq!(r.value, expected.value);
                     assert_eq!(r.expires, expected.expires);
-                    assert_eq!(r.publisher, Some(Swarm::local_peer_id(&swarms[0])));
+                    assert_eq!(r.publisher.as_ref(), Some(Swarm::local_peer_id(&swarms[0])));
 
                     let key = kbucket::Key::new(r.key.clone());
                     let mut expected = swarms.iter()
                         .skip(1)
                         .map(Swarm::local_peer_id)
+                        .cloned()
                         .collect::<Vec<_>>();
                     expected.sort_by(|id1, id2|
                         kbucket::Key::from(*id1).distance(&key).cmp(
@@ -831,6 +835,7 @@ fn add_provider() {
                     let mut expected = swarms.iter()
                         .skip(1)
                         .map(Swarm::local_peer_id)
+                        .cloned()
                         .collect::<Vec<_>>();
                     let kbucket_key = kbucket::Key::new(key);
                     expected.sort_by(|id1, id2|

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -169,7 +169,6 @@ fn bootstrap() {
             .collect::<Vec<_>>();
         let swarm_ids: Vec<_> = swarms.iter()
             .map(Swarm::local_peer_id)
-            .cloned()
             .collect();
 
         let qid = swarms[0].bootstrap().unwrap();
@@ -234,7 +233,7 @@ fn query_iter() {
         let mut swarms = build_connected_nodes(num_total, 1).into_iter()
             .map(|(_a, s)| s)
             .collect::<Vec<_>>();
-        let swarm_ids: Vec<_> = swarms.iter().map(Swarm::local_peer_id).cloned().collect();
+        let swarm_ids: Vec<_> = swarms.iter().map(Swarm::local_peer_id).collect();
 
         // Ask the first peer in the list to search a random peer. The search should
         // propagate forwards through the list of peers.
@@ -394,7 +393,6 @@ fn get_record_not_found() {
 
     let swarm_ids: Vec<_> = swarms.iter()
         .map(|(_addr, swarm)| Swarm::local_peer_id(swarm))
-        .cloned()
         .collect();
 
     let (second, third) = (swarms[1].0.clone(), swarms[2].0.clone());
@@ -466,7 +464,7 @@ fn put_record() {
             // Connect `single_swarm` to three bootnodes.
             for i in 0..3 {
                 single_swarm.1.add_address(
-                    Swarm::local_peer_id(&fully_connected_swarms[i].1),
+                    &Swarm::local_peer_id(&fully_connected_swarms[i].1),
                     fully_connected_swarms[i].0.clone(),
                 );
             }
@@ -561,13 +559,12 @@ fn put_record() {
                     assert_eq!(r.key, expected.key);
                     assert_eq!(r.value, expected.value);
                     assert_eq!(r.expires, expected.expires);
-                    assert_eq!(r.publisher.as_ref(), Some(Swarm::local_peer_id(&swarms[0])));
+                    assert_eq!(r.publisher, Some(Swarm::local_peer_id(&swarms[0])));
 
                     let key = kbucket::Key::new(r.key.clone());
                     let mut expected = swarms.iter()
                         .skip(1)
                         .map(Swarm::local_peer_id)
-                        .cloned()
                         .collect::<Vec<_>>();
                     expected.sort_by(|id1, id2|
                         kbucket::Key::from(*id1).distance(&key).cmp(
@@ -745,7 +742,7 @@ fn add_provider() {
             // Connect `single_swarm` to three bootnodes.
             for i in 0..3 {
                 single_swarm.1.add_address(
-                    Swarm::local_peer_id(&fully_connected_swarms[i].1),
+                    &Swarm::local_peer_id(&fully_connected_swarms[i].1),
                     fully_connected_swarms[i].0.clone(),
                 );
             }
@@ -834,7 +831,6 @@ fn add_provider() {
                     let mut expected = swarms.iter()
                         .skip(1)
                         .map(Swarm::local_peer_id)
-                        .cloned()
                         .collect::<Vec<_>>();
                     let kbucket_key = kbucket::Key::new(key);
                     expected.sort_by(|id1, id2|
@@ -944,8 +940,8 @@ fn disjoint_query_does_not_finish_before_all_paths_did() {
     trudy.1.store.put(record_trudy.clone()).unwrap();
 
     // Make `trudy` and `bob` known to `alice`.
-    alice.1.add_address(Swarm::local_peer_id(&trudy.1), trudy.0.clone());
-    alice.1.add_address(Swarm::local_peer_id(&bob.1), bob.0.clone());
+    alice.1.add_address(&Swarm::local_peer_id(&trudy.1), trudy.0.clone());
+    alice.1.add_address(&Swarm::local_peer_id(&bob.1), bob.0.clone());
 
     // Drop the swarm addresses.
     let (mut alice, mut bob, mut trudy) = (alice.1, bob.1, trudy.1);

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -531,7 +531,7 @@ where
             }
             KademliaHandlerIn::FindNodeReq { key, user_data } => {
                 let msg = KadRequestMsg::FindNode { key };
-                self.substreams.push(SubstreamState::OutPendingOpen(msg, Some(user_data.clone())));
+                self.substreams.push(SubstreamState::OutPendingOpen(msg, Some(user_data)));
             }
             KademliaHandlerIn::FindNodeRes {
                 closer_peers,
@@ -550,7 +550,7 @@ where
                     };
 
                     let msg = KadResponseMsg::FindNode {
-                        closer_peers: closer_peers.clone(),
+                        closer_peers,
                     };
                     self.substreams
                         .push(SubstreamState::InPendingSend(conn_id, substream, msg));
@@ -559,7 +559,7 @@ where
             KademliaHandlerIn::GetProvidersReq { key, user_data } => {
                 let msg = KadRequestMsg::GetProviders { key };
                 self.substreams
-                    .push(SubstreamState::OutPendingOpen(msg, Some(user_data.clone())));
+                    .push(SubstreamState::OutPendingOpen(msg, Some(user_data)));
             }
             KademliaHandlerIn::GetProvidersRes {
                 closer_peers,
@@ -582,8 +582,8 @@ where
                     };
 
                     let msg = KadResponseMsg::GetProviders {
-                        closer_peers: closer_peers.clone(),
-                        provider_peers: provider_peers.clone(),
+                        closer_peers,
+                        provider_peers,
                     };
                     self.substreams
                         .push(SubstreamState::InPendingSend(conn_id, substream, msg));
@@ -622,7 +622,7 @@ where
 
                     let msg = KadResponseMsg::GetValue {
                         record,
-                        closer_peers: closer_peers.clone(),
+                        closer_peers,
                     };
                     self.substreams
                         .push(SubstreamState::InPendingSend(conn_id, substream, msg));

--- a/protocols/kad/src/jobs.rs
+++ b/protocols/kad/src/jobs.rs
@@ -224,15 +224,11 @@ impl PutRecordJob {
         }
 
         if let PeriodicJobState::Running(records) = &mut self.inner.state {
-            loop {
-                if let Some(r) = records.next() {
-                    if r.is_expired(now) {
-                        store.remove(&r.key)
-                    } else {
-                        return Poll::Ready(r)
-                    }
+            for r in records {
+                if r.is_expired(now) {
+                    store.remove(&r.key)
                 } else {
-                    break
+                    return Poll::Ready(r)
                 }
             }
 
@@ -301,15 +297,11 @@ impl AddProviderJob {
         }
 
         if let PeriodicJobState::Running(keys) = &mut self.inner.state {
-            loop {
-                if let Some(r) = keys.next() {
-                    if r.is_expired(now) {
-                        store.remove_provider(&r.key, &r.provider)
-                    } else {
-                        return Poll::Ready(r)
-                    }
+            for r in keys {
+                if r.is_expired(now) {
+                    store.remove_provider(&r.key, &r.provider)
                 } else {
-                    break
+                    return Poll::Ready(r)
                 }
             }
 

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -68,6 +68,8 @@
 
 mod bucket;
 mod entry;
+#[allow(clippy::ptr_offset_with_cast)]
+#[allow(clippy::assign_op_pattern)]
 mod key;
 
 pub use entry::*;

--- a/protocols/kad/src/kbucket/bucket.rs
+++ b/protocols/kad/src/kbucket/bucket.rs
@@ -258,7 +258,7 @@ where
             }
         }
 
-        return None
+        None
     }
 
     /// Updates the status of the pending node, if any.

--- a/protocols/kad/src/query.rs
+++ b/protocols/kad/src/query.rs
@@ -207,9 +207,9 @@ impl<TInner> QueryPool<TInner> {
         }
 
         if self.queries.is_empty() {
-            return QueryPoolState::Idle
+            QueryPoolState::Idle
         } else {
-            return QueryPoolState::Waiting(None)
+            QueryPoolState::Waiting(None)
         }
     }
 }

--- a/protocols/kad/src/query/peers/closest.rs
+++ b/protocols/kad/src/query/peers/closest.rs
@@ -148,7 +148,7 @@ impl ClosestPeersIter {
             return false
         }
 
-        let key = Key::from(peer.clone());
+        let key = Key::from(*peer);
         let distance = key.distance(&self.target);
 
         // Mark the peer as succeeded.
@@ -222,7 +222,7 @@ impl ClosestPeersIter {
             return false
         }
 
-        let key = Key::from(peer.clone());
+        let key = Key::from(*peer);
         let distance = key.distance(&self.target);
 
         match self.closest_peers.entry(distance) {

--- a/protocols/kad/src/query/peers/fixed.rs
+++ b/protocols/kad/src/query/peers/fixed.rs
@@ -131,7 +131,7 @@ impl FixedPeersIter {
 
     pub fn next(&mut self) -> PeersIterState<'_> {
         match &mut self.state {
-            State::Finished => return PeersIterState::Finished,
+            State::Finished => PeersIterState::Finished,
             State::Waiting { num_waiting } => {
                 if *num_waiting >= self.parallelism.get() {
                     return PeersIterState::WaitingAtCapacity
@@ -144,7 +144,7 @@ impl FixedPeersIter {
                         } else {
                             return PeersIterState::Waiting(None)
                         }
-                        Some(p) => match self.peers.entry(p.clone()) {
+                        Some(p) => match self.peers.entry(p) {
                             Entry::Occupied(_) => {} // skip duplicates
                             Entry::Vacant(e) => {
                                 *num_waiting += 1;

--- a/protocols/kad/src/record/store/memory.rs
+++ b/protocols/kad/src/record/store/memory.rs
@@ -205,7 +205,7 @@ impl<'a> RecordStore<'a> for MemoryStore {
                 let p = providers.remove(i);
                 self.provided.remove(&p);
             }
-            if providers.len() == 0 {
+            if providers.is_empty() {
                 e.remove();
             }
         }

--- a/protocols/mdns/src/behaviour.rs
+++ b/protocols/mdns/src/behaviour.rs
@@ -201,8 +201,8 @@ impl NetworkBehaviour for Mdns {
                     if let MdnsBusyWrapper::Free(ref mut service) = self.service {
                         for packet in build_query_response(
                             query.query_id(),
-                            params.local_peer_id().clone(),
-                            params.listened_addresses().into_iter(),
+                            *params.local_peer_id(),
+                            params.listened_addresses(),
                             MDNS_RESPONSE_TTL,
                         ) {
                             service.enqueue_response(packet)
@@ -240,10 +240,10 @@ impl NetworkBehaviour for Mdns {
                             {
                                 *cur_expires = cmp::max(*cur_expires, new_expiration);
                             } else {
-                                self.discovered_nodes.push((peer.id().clone(), addr.clone(), new_expiration));
+                                self.discovered_nodes.push((*peer.id(), addr.clone(), new_expiration));
                             }
 
-                            discovered.push((peer.id().clone(), addr));
+                            discovered.push((*peer.id(), addr));
                         }
                     }
 

--- a/protocols/mdns/src/dns.rs
+++ b/protocols/mdns/src/dns.rs
@@ -114,7 +114,7 @@ pub fn build_query_response(
     let ttl = duration_to_secs(ttl);
 
     // Add a limit to 2^16-1 addresses, as the protocol limits to this number.
-    let mut addresses = addresses.take(65535);
+    let addresses = addresses.take(65535);
 
     let peer_id_bytes = encode_peer_id(&peer_id);
     debug_assert!(peer_id_bytes.len() <= 0xffff);
@@ -127,7 +127,7 @@ pub fn build_query_response(
 
     // Encode the addresses as TXT records, and multiple TXT records into a
     // response packet.
-    while let Some(addr) = addresses.next() {
+    for addr in addresses {
         let txt_to_send = format!("dnsaddr={}/p2p/{}", addr.to_string(), peer_id.to_base58());
         let mut txt_record = Vec::with_capacity(txt_to_send.len());
         match append_txt_record(&mut txt_record, &peer_id_bytes, ttl, &txt_to_send) {
@@ -203,7 +203,7 @@ pub fn build_service_discovery_response(id: u16, ttl: Duration) -> MdnsPacket {
 }
 
 /// Constructs an MDNS query response packet for an address lookup.
-fn query_response_packet(id: u16, peer_id: &Vec<u8>, records: &Vec<Vec<u8>>, ttl: u32) -> MdnsPacket {
+fn query_response_packet(id: u16, peer_id: &[u8], records: &[Vec<u8>], ttl: u32) -> MdnsPacket {
     let mut out = Vec::with_capacity(records.len() * MAX_TXT_RECORD_SIZE);
 
     append_u16(&mut out, id);
@@ -347,7 +347,7 @@ fn append_character_string(out: &mut Vec<u8>, ascii_str: &str) -> Result<(), Mdn
 }
 
 /// Appends a TXT record to `out`.
-fn append_txt_record<'a>(
+fn append_txt_record(
     out: &mut Vec<u8>,
     name: &[u8],
     ttl_secs: u32,

--- a/protocols/mdns/src/service.rs
+++ b/protocols/mdns/src/service.rs
@@ -331,7 +331,7 @@ impl MdnsPacket {
                             from,
                             query_id: packet.header.id,
                         });
-                        return Some(query);
+                        Some(query)
                     } else if packet
                         .questions
                         .iter()
@@ -344,21 +344,21 @@ impl MdnsPacket {
                                 query_id: packet.header.id,
                             },
                         );
-                        return Some(discovery);
+                        Some(discovery)
                     } else {
-                        return None;
+                        None
                     }
                 } else {
                     let resp = MdnsPacket::Response(MdnsResponse::new (
                         packet,
                         from,
                     ));
-                    return Some(resp);
+                    Some(resp)
                 }
             }
             Err(err) => {
                 warn!("Parsing mdns packet failed: {:?}", err);
-                return None;
+                None
             }
         }
     }

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -377,10 +377,10 @@ where
 
         if let Some(request) = self.try_send_request(peer, request) {
             self.pending_events.push_back(NetworkBehaviourAction::DialPeer {
-                peer_id: peer.clone(),
+                peer_id: *peer,
                 condition: DialPeerCondition::Disconnected,
             });
-            self.pending_outbound_requests.entry(peer.clone()).or_default().push(request);
+            self.pending_outbound_requests.entry(*peer).or_default().push(request);
         }
 
         request_id
@@ -409,7 +409,7 @@ where
     ///
     /// Addresses added in this way are only removed by `remove_address`.
     pub fn add_address(&mut self, peer: &PeerId, address: Multiaddr) {
-        self.addresses.entry(peer.clone()).or_default().push(address);
+        self.addresses.entry(*peer).or_default().push(address);
     }
 
     /// Removes an address of a peer previously added via `add_address`.
@@ -479,7 +479,7 @@ where
             let conn = &mut connections[ix];
             conn.pending_inbound_responses.insert(request.request_id);
             self.pending_events.push_back(NetworkBehaviourAction::NotifyHandler {
-                peer_id: peer.clone(),
+                peer_id: *peer,
                 handler: NotifyHandler::One(conn.id),
                 event: request
             });
@@ -576,7 +576,7 @@ where
             ConnectedPoint::Dialer { address } => Some(address.clone()),
             ConnectedPoint::Listener { .. } => None
         };
-        self.connected.entry(peer.clone())
+        self.connected.entry(*peer)
             .or_default()
             .push(Connection::new(*conn, address));
     }
@@ -597,7 +597,7 @@ where
         for request_id in connection.pending_outbound_responses {
             self.pending_events.push_back(NetworkBehaviourAction::GenerateEvent(
                 RequestResponseEvent::InboundFailure {
-                    peer: peer_id.clone(),
+                    peer: *peer_id,
                     request_id,
                     error: InboundFailure::ConnectionClosed
                 }
@@ -608,7 +608,7 @@ where
         for request_id in connection.pending_inbound_responses {
             self.pending_events.push_back(NetworkBehaviourAction::GenerateEvent(
                 RequestResponseEvent::OutboundFailure {
-                    peer: peer_id.clone(),
+                    peer: *peer_id,
                     request_id,
                     error: OutboundFailure::ConnectionClosed
                 }
@@ -631,7 +631,7 @@ where
             for request in pending {
                 self.pending_events.push_back(NetworkBehaviourAction::GenerateEvent(
                     RequestResponseEvent::OutboundFailure {
-                        peer: peer.clone(),
+                        peer: *peer,
                         request_id: request.request_id,
                         error: OutboundFailure::DialFailure
                     }
@@ -660,10 +660,10 @@ where
                         RequestResponseEvent::Message { peer, message }));
             }
             RequestResponseHandlerEvent::Request { request_id, request, sender } => {
-                let channel = ResponseChannel { request_id, peer: peer.clone(), sender };
+                let channel = ResponseChannel { request_id, peer, sender };
                 let message = RequestResponseMessage::Request { request_id, request, channel };
                 self.pending_events.push_back(NetworkBehaviourAction::GenerateEvent(
-                    RequestResponseEvent::Message { peer: peer.clone(), message }
+                    RequestResponseEvent::Message { peer, message }
                 ));
 
                 match self.get_connection_mut(&peer, connection) {
@@ -675,7 +675,7 @@ where
                     None => {
                         self.pending_events.push_back(NetworkBehaviourAction::GenerateEvent(
                             RequestResponseEvent::InboundFailure {
-                                peer: peer.clone(),
+                                peer,
                                 request_id,
                                 error: InboundFailure::ConnectionClosed
                             }

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -383,7 +383,7 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                 let handler = me.behaviour.new_handler()
                     .into_node_handler_builder()
                     .with_substream_upgrade_protocol_override(me.substream_upgrade_protocol_override);
-                me.network.peer(peer_id.clone())
+                me.network.peer(*peer_id)
                     .dial(first, addrs, handler)
                     .map(|_| ())
                     .map_err(DialError::ConnectionLimit)
@@ -407,8 +407,8 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
     }
 
     /// Returns the peer ID of the swarm passed as parameter.
-    pub fn local_peer_id(me: &Self) -> &PeerId {
-        &me.network.local_peer_id()
+    pub fn local_peer_id(me: &Self) -> PeerId {
+        me.network.local_peer_id()
     }
 
     /// Returns an iterator for [`AddressRecord`]s of external addresses
@@ -451,7 +451,7 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
     /// Any incoming connection and any dialing attempt will immediately be rejected.
     /// This function has no effect if the peer is already banned.
     pub fn ban_peer_id(me: &mut Self, peer_id: PeerId) {
-        if me.banned_peers.insert(peer_id.clone()) {
+        if me.banned_peers.insert(peer_id) {
             if let Some(peer) = me.network.peer(peer_id).into_connected() {
                 peer.disconnect();
             }
@@ -504,7 +504,7 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
             match this.network.poll(cx) {
                 Poll::Pending => network_not_ready = true,
                 Poll::Ready(NetworkEvent::ConnectionEvent { connection, event }) => {
-                    let peer = connection.peer_id().clone();
+                    let peer = connection.peer_id();
                     let connection = connection.id();
                     this.behaviour.inject_event(peer, connection, event);
                 },
@@ -514,10 +514,10 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                     this.behaviour.inject_address_change(&peer, &connection, &old_endpoint, &new_endpoint);
                 },
                 Poll::Ready(NetworkEvent::ConnectionEstablished { connection, num_established }) => {
-                    let peer_id = connection.peer_id().clone();
+                    let peer_id = connection.peer_id();
                     let endpoint = connection.endpoint().clone();
                     if this.banned_peers.contains(&peer_id) {
-                        this.network.peer(peer_id.clone())
+                        this.network.peer(peer_id)
                             .into_connected()
                             .expect("the Network just notified us that we were connected; QED")
                             .disconnect();
@@ -645,7 +645,7 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
             // before polling the behaviour again. If the targeted peer
             // meanwhie disconnected, the event is discarded.
             if let Some((peer_id, handler, event)) = this.pending_event.take() {
-                if let Some(mut peer) = this.network.peer(peer_id.clone()).into_connected() {
+                if let Some(mut peer) = this.network.peer(peer_id).into_connected() {
                     match handler {
                         PendingNotifyHandler::One(conn_id) =>
                             if let Some(mut conn) = peer.connection(conn_id) {
@@ -706,7 +706,7 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                             log::trace!("Condition for new dialing attempt to {:?} not met: {:?}",
                                 peer_id, condition);
                             let self_listening = &this.listened_addrs;
-                            if let Some(mut peer) = this.network.peer(peer_id.clone()).into_dialing() {
+                            if let Some(mut peer) = this.network.peer(peer_id).into_dialing() {
                                 let addrs = this.behaviour.addresses_of_peer(peer.id());
                                 let mut attempt = peer.some_attempt();
                                 for a in addrs {
@@ -719,7 +719,7 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                     }
                 },
                 Poll::Ready(NetworkBehaviourAction::NotifyHandler { peer_id, handler, event }) => {
-                    if let Some(mut peer) = this.network.peer(peer_id.clone()).into_connected() {
+                    if let Some(mut peer) = this.network.peer(peer_id).into_connected() {
                         match handler {
                             NotifyHandler::One(connection) => {
                                 if let Some(mut conn) = peer.connection(connection) {
@@ -743,7 +743,7 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
                 },
                 Poll::Ready(NetworkBehaviourAction::ReportObservedAddr { address, score }) => {
                     for addr in this.network.address_translation(&address) {
-                        if this.external_addrs.iter().all(|a| &a.addr != &addr) {
+                        if this.external_addrs.iter().all(|a| a.addr != addr) {
                             this.behaviour.inject_new_external_addr(&addr);
                         }
                         this.external_addrs.add(addr, score);
@@ -898,7 +898,7 @@ impl<'a> PollParameters for SwarmPollParameters<'a> {
     }
 
     fn local_peer_id(&self) -> &PeerId {
-        self.local_peer_id
+        &self.local_peer_id
     }
 }
 
@@ -925,7 +925,7 @@ where TBehaviour: NetworkBehaviour,
     ) -> Self {
         SwarmBuilder {
             local_peer_id,
-            transport: transport,
+            transport,
             behaviour,
             network_config: Default::default(),
             substream_upgrade_protocol_override: None,

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -407,7 +407,7 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
     }
 
     /// Returns the peer ID of the swarm passed as parameter.
-    pub fn local_peer_id(me: &Self) -> PeerId {
+    pub fn local_peer_id(me: &Self) -> &PeerId {
         me.network.local_peer_id()
     }
 

--- a/swarm/src/protocols_handler/multi.rs
+++ b/swarm/src/protocols_handler/multi.rs
@@ -106,11 +106,11 @@ where
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
         let (upgrade, info, timeout, version) = self.handlers.iter()
-            .map(|(k, h)| {
-                let p = h.listen_protocol();
-                let t = *p.timeout();
-                let (v, u, i) = p.into_upgrade();
-                (k.clone(), (v, u, i, t))
+            .map(|(key, handler)| {
+                let proto = handler.listen_protocol();
+                let timeout = *proto.timeout();
+                let (version, upgrade, info) = proto.into_upgrade();
+                (key.clone(), (version, upgrade, info, timeout))
             })
             .fold((Upgrade::new(), Info::new(), Duration::from_secs(0), None),
                 |(mut upg, mut inf, mut timeout, mut version), (k, (v, u, i, t))| {

--- a/swarm/src/protocols_handler/node_handler.rs
+++ b/swarm/src/protocols_handler/node_handler.rs
@@ -245,7 +245,7 @@ where
         match endpoint {
             SubstreamEndpoint::Listener => {
                 let protocol = self.handler.listen_protocol();
-                let timeout = protocol.timeout().clone();
+                let timeout = *protocol.timeout();
                 let (_, upgrade, user_data) = protocol.into_upgrade();
                 let upgrade = upgrade::apply_inbound(substream, SendWrapper(upgrade));
                 let timeout = Delay::new(timeout);
@@ -334,7 +334,7 @@ where
             }
             Poll::Ready(ProtocolsHandlerEvent::OutboundSubstreamRequest { protocol }) => {
                 let id = self.unique_dial_upgrade_id;
-                let timeout = protocol.timeout().clone();
+                let timeout = *protocol.timeout();
                 self.unique_dial_upgrade_id += 1;
                 let (version, upgrade, info) = protocol.into_upgrade();
                 self.queued_dial_upgrades.push((id, (version, SendWrapper(upgrade))));

--- a/swarm/src/protocols_handler/select.rs
+++ b/swarm/src/protocols_handler/select.rs
@@ -110,7 +110,7 @@ where
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
         let proto1 = self.proto1.listen_protocol();
         let proto2 = self.proto2.listen_protocol();
-        let timeout = std::cmp::max(proto1.timeout(), proto2.timeout()).clone();
+        let timeout = *std::cmp::max(proto1.timeout(), proto2.timeout());
         let (_, u1, i1) = proto1.into_upgrade();
         let (_, u2, i2) = proto2.into_upgrade();
         let choice = SelectUpgrade::new(SendWrapper(u1), SendWrapper(u2));

--- a/swarm/src/toggle.rs
+++ b/swarm/src/toggle.rs
@@ -241,7 +241,7 @@ where
                 .expect("Can't receive an inbound substream if disabled; QED")
                 .inject_fully_negotiated_inbound(out, info)
         } else {
-            panic!("Unpexpected Either::Right in enabled `inject_fully_negotiated_inbound`.")
+            panic!("Unexpected Either::Right in enabled `inject_fully_negotiated_inbound`.")
         }
     }
 

--- a/transports/noise/src/error.rs
+++ b/transports/noise/src/error.rs
@@ -24,6 +24,7 @@ use std::{error::Error, fmt, io};
 
 /// libp2p_noise error type.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum NoiseError {
     /// An I/O error has been encountered.
     Io(io::Error),
@@ -38,8 +39,6 @@ pub enum NoiseError {
     InvalidPayload(prost::DecodeError),
     /// A signature was required and could not be created.
     SigningError(identity::error::SigningError),
-    #[doc(hidden)]
-    __Nonexhaustive
 }
 
 impl fmt::Display for NoiseError {
@@ -51,7 +50,6 @@ impl fmt::Display for NoiseError {
             NoiseError::InvalidPayload(e) => write!(f, "{}", e),
             NoiseError::AuthenticationFailed => f.write_str("Authentication failed"),
             NoiseError::SigningError(e) => write!(f, "{}", e),
-            NoiseError::__Nonexhaustive => f.write_str("__Nonexhaustive")
         }
     }
 }
@@ -65,7 +63,6 @@ impl Error for NoiseError {
             NoiseError::AuthenticationFailed => None,
             NoiseError::InvalidPayload(e) => Some(e),
             NoiseError::SigningError(e) => Some(e),
-            NoiseError::__Nonexhaustive => None
         }
     }
 }

--- a/transports/noise/src/io.rs
+++ b/transports/noise/src/io.rs
@@ -115,7 +115,7 @@ impl<T: AsyncWrite + Unpin> AsyncWrite for NoiseOutput<T> {
         this.send_offset += n;
         trace!("write: buffered {} bytes", this.send_offset);
 
-        return Poll::Ready(Ok(n))
+        Poll::Ready(Ok(n))
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/transports/noise/src/io/framed.rs
+++ b/transports/noise/src/io/framed.rs
@@ -27,7 +27,6 @@ use crate::io::NoiseOutput;
 use futures::ready;
 use futures::prelude::*;
 use log::{debug, trace};
-use snow;
 use std::{fmt, io, pin::Pin, task::{Context, Poll}};
 
 /// Max. size of a noise message.
@@ -261,9 +260,9 @@ where
                 WriteState::Ready => {
                     return Poll::Ready(Ok(()));
                 }
-                WriteState::WriteLen { len, mut buf, mut off } => {
+                WriteState::WriteLen { len, buf, mut off } => {
                     trace!("write: frame len ({}, {:?}, {}/2)", len, buf, off);
-                    match write_frame_len(&mut this.io, cx, &mut buf, &mut off) {
+                    match write_frame_len(&mut this.io, cx, &buf, &mut off) {
                         Poll::Ready(Ok(true)) => (),
                         Poll::Ready(Ok(false)) => {
                             trace!("write: eof");
@@ -324,12 +323,12 @@ where
                     buf: u16::to_be_bytes(n as u16),
                     off: 0
                 };
-                return Ok(())
+                Ok(())
             }
             Err(e) => {
                 log::error!("encryption error: {:?}", e);
                 this.write_state = WriteState::EncErr;
-                return Err(io::ErrorKind::InvalidData.into())
+                Err(io::ErrorKind::InvalidData.into())
             }
         }
     }

--- a/transports/wasm-ext/src/lib.rs
+++ b/transports/wasm-ext/src/lib.rs
@@ -484,11 +484,7 @@ impl Drop for Connection {
 /// Returns true if `err` is an error about an address not being supported.
 fn is_not_supported_error(err: &JsValue) -> bool {
     if let Some(err) = err.dyn_ref::<js_sys::Error>() {
-        if String::from(err.name()) == "NotSupportedError" {
-            true
-        } else {
-            false
-        }
+        err.name() == "NotSupportedError"
     } else {
         false
     }

--- a/transports/websocket/src/tls.rs
+++ b/transports/websocket/src/tls.rs
@@ -130,6 +130,7 @@ pub(crate) fn dns_name_ref(name: &str) -> Result<webpki::DNSNameRef<'_>, Error> 
 
 /// TLS related errors.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// An underlying I/O error.
     Io(io::Error),
@@ -137,9 +138,6 @@ pub enum Error {
     Tls(Box<dyn std::error::Error + Send + Sync>),
     /// The DNS name was invalid.
     InvalidDnsName(String),
-
-    #[doc(hidden)]
-    __Nonexhaustive
 }
 
 impl fmt::Display for Error {
@@ -148,7 +146,6 @@ impl fmt::Display for Error {
             Error::Io(e) => write!(f, "i/o error: {}", e),
             Error::Tls(e) => write!(f, "tls error: {}", e),
             Error::InvalidDnsName(n) => write!(f, "invalid DNS name: {}", n),
-            Error::__Nonexhaustive => f.write_str("__Nonexhaustive")
         }
     }
 }
@@ -158,7 +155,7 @@ impl std::error::Error for Error {
         match self {
             Error::Io(e) => Some(e),
             Error::Tls(e) => Some(&**e),
-            Error::InvalidDnsName(_) | Error::__Nonexhaustive => None
+            Error::InvalidDnsName(_) => None
         }
     }
 }


### PR DESCRIPTION
Address all clippy complaints that are not purely stylistic (or even have corner cases with false positives). Ignore all "style" and "pedantic" lints. Closes #1888. There was quite a bit of unnecessary cloning, not just of peer IDs. 