### PR TITLE
README: Remove dead-link badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 <a href="http://libp2p.io/"><img src="https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square" /></a>
 <a href="http://webchat.freenode.net/?channels=%23libp2p"><img src="https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square" /></a>
-<a href="https://riot.permaweb.io/#/room/#libp2p:permaweb.io"><img src="https://img.shields.io/badge/matrix-%23libp2p%3Apermaweb.io-blue.svg?style=flat-square" /> </a>
-  <a href="https://discord.gg/66KBrm2"><img src="https://img.shields.io/discord/475789330380488707?color=blueviolet&label=discord&style=flat-square" /></a>
 [![dependency status](https://deps.rs/repo/github/libp2p/rust-libp2p/status.svg?style=flat-square)](https://deps.rs/repo/github/libp2p/rust-libp2p)
 
 This repository is the central place for Rust development of the [libp2p](https://libp2p.io) spec.


### PR DESCRIPTION
Links to the libp2p matrix and discord channels are broken. Instead of replacing them, I suggest to remove them for the following reasons:

- We already have Github issues for Rust specific questions.
- We already have the forum (https://discuss.libp2p.io) for general libp2p questions. 
- As far as I know, none of the core maintainers are active in the matrix nor discord channel, thus not being able to help out.

Closes https://github.com/libp2p/rust-libp2p/issues/1948