### PR TITLE
swarm/behaviour: Document inject_connected called for first only

### DIFF
--- a/swarm/src/behaviour.rs
+++ b/swarm/src/behaviour.rs
@@ -82,21 +82,21 @@ pub trait NetworkBehaviour: Send + 'static {
     /// address should be the most likely to be reachable.
     fn addresses_of_peer(&mut self, peer_id: &PeerId) -> Vec<Multiaddr>;
 
-    /// Indicates the behaviour that we connected to the node with the given peer id.
+    /// Indicate to the behaviour that we connected to the node with the given peer id.
     ///
     /// This node now has a handler (as spawned by `new_handler`) running in the background.
     ///
-    /// This method is only called when the connection to the peer is
-    /// established, preceded by `inject_connection_established`.
+    /// This method is only called when the first connection to the peer is established, preceded by
+    /// [`inject_connection_established`](NetworkBehaviour::inject_connection_established).
     fn inject_connected(&mut self, peer_id: &PeerId);
 
-    /// Indicates the behaviour that we disconnected from the node with the given peer id.
+    /// Indicates to the behaviour that we disconnected from the node with the given peer id.
     ///
     /// There is no handler running anymore for this node. Any event that has been sent to it may
     /// or may not have been processed by the handler.
     ///
-    /// This method is only called when the last established connection to the peer
-    /// is closed, preceded by `inject_connection_closed`.
+    /// This method is only called when the last established connection to the peer is closed,
+    /// preceded by [`inject_connection_closed`](NetworkBehaviour::inject_connection_closed).
     fn inject_disconnected(&mut self, peer_id: &PeerId);
 
     /// Informs the behaviour about a newly established connection to a peer.


### PR DESCRIPTION
`NetworkBehaviour::inject_connected` is called for the first established
connection to a peer only. See `swarm/src/lib.rs`:

```rust
this.behaviour.inject_connection_established(&peer_id, &connection.id(), &endpoint);
if num_established.get() == 1 {
    this.behaviour.inject_connected(&peer_id);
}
```

This commit adjusts the documentation accordingly.