### PR TITLE
Update to yamux-0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@
 
 # `libp2p` facade crate
 
+## Version 0.35.1 [unreleased]
+
+- Update `libp2p-yamux` to latest patch version.
+
 ## Version 0.35.0 [2021-02-15]
 
 - Use `libp2p-swarm-derive`, the former `libp2p-core-derive`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p"
 edition = "2018"
 description = "Peer-to-peer networking library"
-version = "0.35.0"
+version = "0.35.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -76,7 +76,7 @@ libp2p-swarm = { version = "0.27.2", path = "swarm" }
 libp2p-swarm-derive = { version = "0.22.0", path = "swarm-derive" }
 libp2p-uds = { version = "0.27.0", path = "transports/uds", optional = true }
 libp2p-wasm-ext = { version = "0.27.0", path = "transports/wasm-ext", optional = true }
-libp2p-yamux = { version = "0.30.0", path = "muxers/yamux", optional = true }
+libp2p-yamux = { version = "0.30.1", path = "muxers/yamux", optional = true }
 multiaddr = { package = "parity-multiaddr", version = "0.11.1", path = "misc/multiaddr" }
 parking_lot = "0.11.0"
 pin-project = "1.0.0"

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.30.1 [unreleased]
+
+- Update `yamux` to `0.8.1`.
+
 # 0.30.0 [2021-01-12]
 
 - Update dependencies.

--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-yamux"
 edition = "2018"
 description = "Yamux multiplexing protocol for libp2p"
-version = "0.30.0"
+version = "0.30.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -14,4 +14,4 @@ futures = "0.3.1"
 libp2p-core = { version = "0.27.0", path = "../../core" }
 parking_lot = "0.11"
 thiserror = "1.0"
-yamux = "0.8.0"
+yamux = "0.8.1"


### PR DESCRIPTION
This PR updates `libp2p-yamux` to use `yamux-0.8.1` in preparation for `yamux-0.9` (see https://github.com/paritytech/yamux/pull/115). Once this upgrade is released in `libp2p-0.35.1`, a PR for a libp2p update for substrate follows.