### PR TITLE
[swarm] Remove substream-specific protocol negotiation version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,17 +62,17 @@ bytes = "1"
 futures = "0.3.1"
 lazy_static = "1.2"
 libp2p-core = { version = "0.27.1", path = "core" }
-libp2p-floodsub = { version = "0.27.0", path = "protocols/floodsub", optional = true }
-libp2p-gossipsub = { version = "0.28.0", path = "./protocols/gossipsub", optional = true }
-libp2p-identify = { version = "0.27.0", path = "protocols/identify", optional = true }
-libp2p-kad = { version = "0.28.1", path = "protocols/kad", optional = true }
+libp2p-floodsub = { version = "0.28.0", path = "protocols/floodsub", optional = true }
+libp2p-gossipsub = { version = "0.29.0", path = "./protocols/gossipsub", optional = true }
+libp2p-identify = { version = "0.28.0", path = "protocols/identify", optional = true }
+libp2p-kad = { version = "0.29.0", path = "protocols/kad", optional = true }
 libp2p-mplex = { version = "0.27.1", path = "muxers/mplex", optional = true }
 libp2p-noise = { version = "0.29.0", path = "transports/noise", optional = true }
-libp2p-ping = { version = "0.27.0", path = "protocols/ping", optional = true }
+libp2p-ping = { version = "0.28.0", path = "protocols/ping", optional = true }
 libp2p-plaintext = { version = "0.27.1", path = "transports/plaintext", optional = true }
 libp2p-pnet = { version = "0.20.0", path = "transports/pnet", optional = true }
-libp2p-request-response = { version = "0.9.1", path = "protocols/request-response", optional = true }
-libp2p-swarm = { version = "0.27.2", path = "swarm" }
+libp2p-request-response = { version = "0.10.0", path = "protocols/request-response", optional = true }
+libp2p-swarm = { version = "0.28.0", path = "swarm" }
 libp2p-swarm-derive = { version = "0.22.0", path = "swarm-derive" }
 libp2p-uds = { version = "0.27.0", path = "transports/uds", optional = true }
 libp2p-wasm-ext = { version = "0.27.0", path = "transports/wasm-ext", optional = true }
@@ -86,7 +86,7 @@ wasm-timer = "0.2.4"
 [target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")))'.dependencies]
 libp2p-deflate = { version = "0.27.1", path = "transports/deflate", optional = true }
 libp2p-dns = { version = "0.27.0", path = "transports/dns", optional = true }
-libp2p-mdns = { version = "0.28.1", path = "protocols/mdns", optional = true }
+libp2p-mdns = { version = "0.29.0", path = "protocols/mdns", optional = true }
 libp2p-tcp = { version = "0.27.1", path = "transports/tcp", optional = true }
 libp2p-websocket = { version = "0.28.0", path = "transports/websocket", optional = true }
 

--- a/protocols/floodsub/CHANGELOG.md
+++ b/protocols/floodsub/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.28.0 [unreleased]
+
+- Update `libp2p-swarm`.
+
 # 0.27.0 [2021-01-12]
 
 - Update dependencies.

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-floodsub"
 edition = "2018"
 description = "Floodsub protocol for libp2p"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -14,7 +14,7 @@ cuckoofilter = "0.5.0"
 fnv = "1.0"
 futures = "0.3.1"
 libp2p-core = { version = "0.27.0", path = "../../core" }
-libp2p-swarm = { version = "0.27.0", path = "../../swarm" }
+libp2p-swarm = { version = "0.28.0", path = "../../swarm" }
 log = "0.4"
 prost = "0.7"
 rand = "0.7"

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.29.0 [unreleased]
+
+- Update `libp2p-swarm`.
+
 # 0.28.0 [2021-02-15]
 
 - Prevent non-published messages being added to caches.

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-gossipsub"
 edition = "2018"
 description = "Gossipsub protocol for libp2p"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Age Manning <Age@AgeManning.com>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -10,7 +10,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-libp2p-swarm = { version = "0.27.0", path = "../../swarm" }
+libp2p-swarm = { version = "0.28.0", path = "../../swarm" }
 libp2p-core = { version = "0.27.0", path = "../../core" }
 bytes = "1.0"
 byteorder = "1.3.4"

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.28.0 [unreleased]
+
+- Update `libp2p-swarm`.
+
 # 0.27.0 [2021-01-12]
 
 - Update dependencies.

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-identify"
 edition = "2018"
 description = "Nodes identifcation protocol for libp2p"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 futures = "0.3.1"
 libp2p-core = { version = "0.27.0", path = "../../core" }
-libp2p-swarm = { version = "0.27.0", path = "../../swarm" }
+libp2p-swarm = { version = "0.28.0", path = "../../swarm" }
 log = "0.4.1"
 prost = "0.7"
 smallvec = "1.0"

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.29.0 [unreleased]
+
+- Update `libp2p-swarm`.
+
 # 0.28.1 [2021-02-15]
 
 - Update dependencies.

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-kad"
 edition = "2018"
 description = "Kademlia protocol for libp2p"
-version = "0.28.1"
+version = "0.29.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -18,7 +18,7 @@ asynchronous-codec = "0.6"
 futures = "0.3.1"
 log = "0.4"
 libp2p-core = { version = "0.27.0", path = "../../core" }
-libp2p-swarm = { version = "0.27.0", path = "../../swarm" }
+libp2p-swarm = { version = "0.28.0", path = "../../swarm" }
 prost = "0.7"
 rand = "0.7.2"
 sha2 = "0.9.1"

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.29.0 [unreleased]
+
+- Update `libp2p-swarm`.
+
 # 0.28.1 [2021-02-15]
 
 - Update dependencies.

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-mdns"
 edition = "2018"
-version = "0.28.1"
+version = "0.29.0"
 description = "Implementation of the libp2p mDNS discovery method"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
@@ -17,7 +17,7 @@ futures = "0.3.8"
 if-watch = "0.1.8"
 lazy_static = "1.4.0"
 libp2p-core = { version = "0.27.0", path = "../../core" }
-libp2p-swarm = { version = "0.27.0", path = "../../swarm" }
+libp2p-swarm = { version = "0.28.0", path = "../../swarm" }
 log = "0.4.11"
 rand = "0.7.3"
 smallvec = "1.5.0"

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.28.0 [unreleased]
+
+- Update `libp2p-swarm`.
+
 # 0.27.0 [2021-01-12]
 
 - Update dependencies.

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-ping"
 edition = "2018"
 description = "Ping protocol for libp2p"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 futures = "0.3.1"
 libp2p-core = { version = "0.27.0", path = "../../core" }
-libp2p-swarm = { version = "0.27.0", path = "../../swarm" }
+libp2p-swarm = { version = "0.28.0", path = "../../swarm" }
 log = "0.4.1"
 rand = "0.7.2"
 void = "1.0"

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.0 [unreleased]
+
+- Update `libp2p-swarm`.
+
 # 0.9.1 [2021-02-15]
 
 - Make `is_pending_outbound` return true on pending connection.

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-request-response"
 edition = "2018"
 description = "Generic Request/Response Protocols"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -14,7 +14,7 @@ async-trait = "0.1"
 bytes = "1"
 futures = "0.3.1"
 libp2p-core = { version = "0.27.0", path = "../../core" }
-libp2p-swarm = { version = "0.27.0", path = "../../swarm" }
+libp2p-swarm = { version = "0.28.0", path = "../../swarm" }
 log = "0.4.11"
 lru = "0.6"
 minicbor = { version = "0.7", features = ["std", "derive"] }

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.28.0 [unreleased]
+
+- Remove the option for a substream-specific multistream select protocol override.
+  The override at this granularity is no longer deemed useful, in particular because
+  it can usually not be configured for existing protocols like `libp2p-kad` and others.
+  There is a `Swarm`-scoped configuration for this version available since
+  [1858](https://github.com/libp2p/rust-libp2p/pull/1858).
+
 # 0.27.2 [2021-02-04]
 
 - Have `ToggleProtoHandler` ignore listen upgrade errors when disabled.

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-swarm"
 edition = "2018"
 description = "The libp2p swarm"
-version = "0.27.2"
+version = "0.28.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/swarm/src/protocols_handler/multi.rs
+++ b/swarm/src/protocols_handler/multi.rs
@@ -37,7 +37,7 @@ use crate::upgrade::{
 };
 use futures::{future::BoxFuture, prelude::*};
 use libp2p_core::{ConnectedPoint, Multiaddr, PeerId};
-use libp2p_core::upgrade::{self, ProtocolName, UpgradeError, NegotiationError, ProtocolError};
+use libp2p_core::upgrade::{ProtocolName, UpgradeError, NegotiationError, ProtocolError};
 use rand::Rng;
 use std::{
     cmp,
@@ -84,7 +84,7 @@ where
         I: IntoIterator<Item = (K, H)>
     {
         let m = MultiHandler { handlers: HashMap::from_iter(iter) };
-        uniq_proto_names(m.handlers.values().map(|h| h.listen_protocol().into_upgrade().1))?;
+        uniq_proto_names(m.handlers.values().map(|h| h.listen_protocol().into_upgrade().0))?;
         Ok(m)
     }
 }
@@ -105,34 +105,22 @@ where
     type OutboundOpenInfo = (K, <H as ProtocolsHandler>::OutboundOpenInfo);
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
-        let (upgrade, info, timeout, version) = self.handlers.iter()
+        let (upgrade, info, timeout) = self.handlers.iter()
             .map(|(key, handler)| {
                 let proto = handler.listen_protocol();
                 let timeout = *proto.timeout();
-                let (version, upgrade, info) = proto.into_upgrade();
-                (key.clone(), (version, upgrade, info, timeout))
+                let (upgrade, info) = proto.into_upgrade();
+                (key.clone(), (upgrade, info, timeout))
             })
-            .fold((Upgrade::new(), Info::new(), Duration::from_secs(0), None),
-                |(mut upg, mut inf, mut timeout, mut version), (k, (v, u, i, t))| {
+            .fold((Upgrade::new(), Info::new(), Duration::from_secs(0)),
+                |(mut upg, mut inf, mut timeout), (k, (u, i, t))| {
                     upg.upgrades.push((k.clone(), u));
                     inf.infos.push((k, i));
                     timeout = cmp::max(timeout, t);
-                    version = version.map_or(Some(v), |vv|
-                        if v != vv {
-                            // Different upgrade (i.e. protocol negotiation) protocol
-                            // versions are usually incompatible and not negotiated
-                            // themselves, so a protocol upgrade may fail.
-                            log::warn!("Differing upgrade versions. Defaulting to V1.");
-                            Some(upgrade::Version::V1)
-                        } else {
-                            Some(v)
-                        });
-                    (upg, inf, timeout, version)
+                    (upg, inf, timeout)
                 }
             );
-        SubstreamProtocol::new(upgrade, info)
-            .with_timeout(timeout)
-            .with_upgrade_protocol(version.unwrap_or(upgrade::Version::V1))
+        SubstreamProtocol::new(upgrade, info).with_timeout(timeout)
     }
 
     fn inject_fully_negotiated_outbound (

--- a/swarm/src/protocols_handler/multi.rs
+++ b/swarm/src/protocols_handler/multi.rs
@@ -76,9 +76,6 @@ where
     /// Create and populate a `MultiHandler` from the given handler iterator.
     ///
     /// It is an error for any two protocols handlers to share the same protocol name.
-    ///
-    /// > **Note**: All handlers should use the same [`upgrade::Version`] for
-    /// > the inbound and outbound [`SubstreamProtocol`]s.
     pub fn try_from_iter<I>(iter: I) -> Result<Self, DuplicateProtonameError>
     where
         I: IntoIterator<Item = (K, H)>
@@ -303,9 +300,6 @@ where
     /// Create and populate an `IntoMultiHandler` from the given iterator.
     ///
     /// It is an error for any two protocols handlers to share the same protocol name.
-    ///
-    /// > **Note**: All handlers should use the same [`upgrade::Version`] for
-    /// > the inbound and outbound [`SubstreamProtocol`]s.
     pub fn try_from_iter<I>(iter: I) -> Result<Self, DuplicateProtonameError>
     where
         I: IntoIterator<Item = (K, H)>

--- a/swarm/src/protocols_handler/select.rs
+++ b/swarm/src/protocols_handler/select.rs
@@ -111,8 +111,8 @@ where
         let proto1 = self.proto1.listen_protocol();
         let proto2 = self.proto2.listen_protocol();
         let timeout = *std::cmp::max(proto1.timeout(), proto2.timeout());
-        let (_, u1, i1) = proto1.into_upgrade();
-        let (_, u2, i2) = proto2.into_upgrade();
+        let (u1, i1) = proto1.into_upgrade();
+        let (u2, i2) = proto2.into_upgrade();
         let choice = SelectUpgrade::new(SendWrapper(u1), SendWrapper(u2));
         SubstreamProtocol::new(choice, (i1, i2)).with_timeout(timeout)
     }


### PR DESCRIPTION
Remove the option for a substream-specific multistream select protocol version override. The override at this granularity is no longer deemed useful (and probably never was), in particular because it can usually not be configured for existing protocols like `libp2p-kad` and others. There is a `Swarm`-scoped configuration for this version available since [1858](https://github.com/libp2p/rust-libp2p/pull/1858).

Closes #1859.