### PR TITLE
Parsing mDNS packet failure: warn -> debug

### DIFF
--- a/protocols/mdns/src/service.rs
+++ b/protocols/mdns/src/service.rs
@@ -25,7 +25,7 @@ use futures::{prelude::*, select};
 use if_watch::{IfEvent, IfWatcher};
 use lazy_static::lazy_static;
 use libp2p_core::{multiaddr::{Multiaddr, Protocol}, PeerId};
-use log::warn;
+use log::debug;
 use socket2::{Socket, Domain, Type};
 use std::{convert::TryFrom, fmt, io, net::{IpAddr, Ipv4Addr, UdpSocket, SocketAddr}, str, time::{Duration, Instant}};
 
@@ -357,7 +357,7 @@ impl MdnsPacket {
                 }
             }
             Err(err) => {
-                warn!("Parsing mdns packet failed: {:?}", err);
+                debug!("Parsing mdns packet failed: {:?}", err);
                 None
             }
         }


### PR DESCRIPTION
Considering that any software running on the local network of a machine can emit invalid mDNS packets, failing to parse a packet is a normal situation, and it feels exaggerated to emit a warning.