### PR TITLE
fix(deps): update libsecp256k1

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,7 +18,7 @@ fnv = "1.0"
 futures = { version = "0.3.1", features = ["executor", "thread-pool"] }
 futures-timer = "3"
 lazy_static = "1.2"
-libsecp256k1 = { version = "0.3.1", optional = true }
+libsecp256k1 = { version = "0.4.0", optional = true }
 log = "0.4"
 multiaddr = { package = "parity-multiaddr", version = "0.11", path = "../misc/multiaddr" }
 multihash = { version = "0.13", default-features = false, features = ["std", "multihash-impl", "identity", "sha2"] }


### PR DESCRIPTION
This PR merely updates `libsecp256k1` and closes #1980