### PR TITLE
[core] Shorten and unify Debug impls of public keys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ atomic = "0.5.0"
 bytes = "1"
 futures = "0.3.1"
 lazy_static = "1.2"
-libp2p-core = { version = "0.27.1", path = "core",  default-features = false }
+libp2p-core = { version = "0.27.2", path = "core",  default-features = false }
 libp2p-floodsub = { version = "0.28.0", path = "protocols/floodsub", optional = true }
 libp2p-gossipsub = { version = "0.29.0", path = "./protocols/gossipsub", optional = true }
 libp2p-identify = { version = "0.28.0", path = "protocols/identify", optional = true }

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.2 [unreleased]
+
+- Shorten and unify `Debug` impls of public keys.
+
 # 0.27.1 [2021-02-15]
 
 - Update dependencies.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-core"
 edition = "2018"
 description = "Core traits and structs of libp2p"
-version = "0.27.1"
+version = "0.27.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/core/src/identity/ed25519.rs
+++ b/core/src/identity/ed25519.rs
@@ -102,8 +102,18 @@ impl From<SecretKey> for Keypair {
 }
 
 /// An Ed25519 public key.
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct PublicKey(ed25519::PublicKey);
+
+impl fmt::Debug for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("PublicKey(compressed): ")?;
+        for byte in self.0.as_bytes() {
+            write!(f, "{:x}", byte)?;
+        }
+        Ok(())
+    }
+}
 
 impl PublicKey {
     /// Verify the Ed25519 signature on a message using the public key.

--- a/core/src/identity/rsa.rs
+++ b/core/src/identity/rsa.rs
@@ -26,7 +26,7 @@ use super::error::*;
 use ring::rand::SystemRandom;
 use ring::signature::{self, RsaKeyPair, RSA_PKCS1_SHA256, RSA_PKCS1_2048_8192_SHA256};
 use ring::signature::KeyPair;
-use std::{fmt::{self, Write}, sync::Arc};
+use std::{fmt, sync::Arc};
 use zeroize::Zeroize;
 
 /// An RSA keypair.
@@ -109,16 +109,11 @@ impl PublicKey {
 
 impl fmt::Debug for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let bytes = &self.0;
-        let mut hex = String::with_capacity(bytes.len() * 2);
-
-        for byte in bytes {
-            write!(hex, "{:02x}", byte).expect("Can't fail on writing to string");
+        f.write_str("PublicKey(PKCS1): ")?;
+        for byte in &self.0 {
+            write!(f, "{:x}", byte)?;
         }
-
-        f.debug_struct("PublicKey")
-            .field("pkcs1", &hex)
-            .finish()
+        Ok(())
     }
 }
 

--- a/core/src/identity/secp256k1.rs
+++ b/core/src/identity/secp256k1.rs
@@ -151,8 +151,18 @@ impl SecretKey {
 }
 
 /// A Secp256k1 public key.
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct PublicKey(secp256k1::PublicKey);
+
+impl fmt::Debug for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("PublicKey(compressed): ")?;
+        for byte in &self.encode() {
+            write!(f, "{:x}", byte)?;
+        }
+        Ok(())
+    }
+}
 
 impl PublicKey {
     /// Verify the Secp256k1 signature on a message using the public key.


### PR DESCRIPTION
This PR is just a small update to the `Debug` impls of public key types. Specifically, ed25519 `PublicKey` and secp256k1 `PublicKey` get a new, shorter `Debug` impl, rather than a derived one (which dumps details that are usually not relevant for a libp2p user), while RSAs `PublicKey` is just aligned with the others for uniformity of the syntax. Closes #1939.