### PR TITLE
[kad] Provide a targeted store operation.

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,10 +1,17 @@
 # 0.29.0 [unreleased]
 
+- Add `KademliaCaching` and `KademliaConfig::set_caching` to configure
+  whether Kademlia should track, in lookups, the closest nodes to a key
+  that did not return a record, via `GetRecordOk::cache_candidates`.
+  As before, if a lookup used a quorum of 1, these candidates will
+  automatically be sent the found record. Otherwise, with a lookup
+  quorum of > 1, the candidates can be used with `Kademlia::put_record_to`
+  after selecting one of the return records to cache. As is the current
+  behaviour, caching is enabled by default with a `max_peers` of 1, i.e.
+  it only tracks the closest node to the key that did not return a record.
+
 - Add `Kademlia::put_record_to` for storing a record at specific nodes,
-  e.g. for write-back caching after a successful read. In that context,
-  peers that were queried in a successful `Kademlia::get_record` operation but
-  did not return a record are now returned in the `GetRecordOk::cache_candidates`
-  list of peer IDs.
+  e.g. for write-back caching after a successful read with quorum > 1.
 
 - Update `libp2p-swarm`.
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 0.29.0 [unreleased]
 
+- Add `Kademlia::put_record_to` for storing a record at specific nodes,
+  e.g. for write-back caching after a successful read. In that context,
+  peers that were queried in a successful `Kademlia::get_record` operation but
+  did not return a record are now returned in the `GetRecordOk::no_record`
+  list of peer IDs.
+
 - Update `libp2p-swarm`.
 
 # 0.28.1 [2021-02-15]

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Add `Kademlia::put_record_to` for storing a record at specific nodes,
   e.g. for write-back caching after a successful read. In that context,
   peers that were queried in a successful `Kademlia::get_record` operation but
-  did not return a record are now returned in the `GetRecordOk::no_record`
+  did not return a record are now returned in the `GetRecordOk::cache_candidates`
   list of peer IDs.
 
 - Update `libp2p-swarm`.

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -2466,7 +2466,7 @@ pub enum QueryInfo {
         records: Vec<PeerRecord>,
         /// The number of records to look for.
         quorum: NonZeroUsize,
-        /// The peers what were queried but did not return a record for the `key`.
+        /// The peers that were queried but did not return a record for the `key`.
         no_record: Vec<PeerId>,
         /// The closest peer to `key` that did not return a record.
         ///

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -643,7 +643,9 @@ fn get_record() {
 
     let record = Record::new(random_multihash(), vec![4,5,6]);
 
-    swarms[1].store.put(record.clone()).unwrap();
+    let expected_no_record = *Swarm::local_peer_id(&swarms[1]);
+
+    swarms[2].store.put(record.clone()).unwrap();
     let qid = swarms[0].get_record(&record.key, Quorum::One);
 
     block_on(
@@ -653,12 +655,13 @@ fn get_record() {
                     match swarm.poll_next_unpin(ctx) {
                         Poll::Ready(Some(KademliaEvent::QueryResult {
                             id,
-                            result: QueryResult::GetRecord(Ok(GetRecordOk { records })),
+                            result: QueryResult::GetRecord(Ok(GetRecordOk { records, no_record })),
                             ..
                         })) => {
                             assert_eq!(id, qid);
                             assert_eq!(records.len(), 1);
                             assert_eq!(records.first().unwrap().record, record);
+                            assert_eq!(no_record, vec![expected_no_record]);
                             return Poll::Ready(());
                         }
                         // Ignore any other event.
@@ -699,7 +702,7 @@ fn get_record_many() {
                     match swarm.poll_next_unpin(ctx) {
                         Poll::Ready(Some(KademliaEvent::QueryResult {
                             id,
-                            result: QueryResult::GetRecord(Ok(GetRecordOk { records })),
+                            result: QueryResult::GetRecord(Ok(GetRecordOk { records, .. })),
                             ..
                         })) => {
                             assert_eq!(id, qid);

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -39,7 +39,14 @@ mod dht_proto {
 }
 
 pub use addresses::Addresses;
-pub use behaviour::{Kademlia, KademliaBucketInserts, KademliaConfig, KademliaEvent, Quorum};
+pub use behaviour::{
+    Kademlia,
+    KademliaBucketInserts,
+    KademliaConfig,
+    KademliaCaching,
+    KademliaEvent,
+    Quorum
+};
 pub use behaviour::{
     QueryRef,
     QueryMut,


### PR DESCRIPTION
This PR adds `Kademlia::put_record_to` for storing a record at specific nodes, e.g. for write-back caching after a successful read. In that context, peers that were queried in a successful `Kademlia::get_record` operation but did not return a record are now returned in the `GetRecordOk::no_record` list of peer IDs as additional information which may be used to choose which of these peers to send (one of) the found records to.

The motivation for this PR originates in the discussion at https://github.com/libp2p/rust-libp2p/issues/1577, i.e. the inability for libp2p-kad itself to do write-back caching of records after successful lookups when a quorum > 1 is used. It is deemed best and the most flexible to provide the means to do so on the API. There may be other use-cases for targeted store operations as well. That is to say, `Kademlia::put_record_to` is intended as to augment the use of `Kademlia::put_record` with occasional targeted store operations, not as a replacement. Though if someone wishes to only use `Kademlia::put_record_to`, that can obviously be done, the resulting DHT then just no longer has the properties attributed to Kademlia.

I'm not sure if it would be worthwhile to be able to configure (i.e. enable/disable) the default behaviour of write-back caching upon lookups with a quorum of 1. Maybe some users would like full control over that behaviour by disabling it and doing any such writes themselves via `Kademlia::put_record_to`. Feedback appreciated.