### PR TITLE
protocols/kad/tests: Ignore Kademlia routing update event

### DIFF
--- a/protocols/relay/tests/lib.rs
+++ b/protocols/relay/tests/lib.rs
@@ -668,6 +668,9 @@ fn firewalled_src_discover_firewalled_dst_via_kad_and_connect_to_dst_via_routabl
                             break;
                         }
                     }
+                    SwarmEvent::Behaviour(CombinedEvent::Kad(KademliaEvent::RoutingUpdated {
+                        ..
+                    })) => {}
                     e => panic!("{:?}", e),
                 }
             }


### PR DESCRIPTION
In the `libp2p-relay` Kademlia discovery test, ignore Kademlia routing
update events when waiting for a ping from the destination node.

[Surfaced on CI](https://github.com/libp2p/rust-libp2p/pull/1992/checks?check_run_id=2087534314).