### PR TITLE
protocols/relay: Ignore IdentifyEvent::Error

### DIFF
--- a/protocols/relay/tests/lib.rs
+++ b/protocols/relay/tests/lib.rs
@@ -1112,18 +1112,15 @@ impl NetworkBehaviourEventProcess<KademliaEvent> for CombinedBehaviour {
 
 impl NetworkBehaviourEventProcess<IdentifyEvent> for CombinedBehaviour {
     fn inject_event(&mut self, event: IdentifyEvent) {
-        match event {
-            IdentifyEvent::Received {
-                peer_id,
-                info: IdentifyInfo { listen_addrs, .. },
-                ..
-            } => {
-                for addr in listen_addrs {
-                    self.kad.add_address(&peer_id, addr);
-                }
+        if let IdentifyEvent::Received {
+            peer_id,
+            info: IdentifyInfo { listen_addrs, .. },
+            ..
+        } = event
+        {
+            for addr in listen_addrs {
+                self.kad.add_address(&peer_id, addr);
             }
-            IdentifyEvent::Sent { .. } => {}
-            e => panic!("{:?}", e),
         }
     }
 }


### PR DESCRIPTION
As previously mentioned (https://github.com/libp2p/rust-libp2p/pull/1998#issuecomment-799226013), CI surfaced yet another test flake introduced with https://github.com/libp2p/rust-libp2p/pull/1838. Sorry for the trouble this might have caused on other peoples end.