### PR TITLE
*: Prepare v0.36.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 
 # `libp2p` facade crate
 
-## Version 0.36.0 [unreleased]
+## Version 0.36.0 [2021-03-17]
 
 - Consolidate top-level utility functions for constructing development
   transports. There is now just `development_transport()` (available with default features)

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.28.0 [unreleased]
+# 0.28.0 [2021-03-17]
 
 - `Network::dial()` understands `/p2p` addresses and `Transport::dial`
   gets a "fully qualified" `/p2p` address when dialing a specific peer,

--- a/misc/multiaddr/CHANGELOG.md
+++ b/misc/multiaddr/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.11.2 [unreleased]
+# 0.11.2 [2021-03-17]
 
 - Add `Multiaddr::ends_with()`.
 

--- a/misc/multistream-select/CHANGELOG.md
+++ b/misc/multistream-select/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.10.3 [unreleased]
+# 0.10.3 [2021-03-17]
 
 - Update dependencies.
 

--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.28.0 [unreleased]
+# 0.28.0 [2021-03-17]
 
 - Update dependencies.
 

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.31.0 [unreleased]
+# 0.31.0 [2021-03-17]
 
 - Update `libp2p-core`.
 

--- a/protocols/floodsub/CHANGELOG.md
+++ b/protocols/floodsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.28.0 [unreleased]
+# 0.28.0 [2021-03-17]
 
 - Update `libp2p-swarm`.
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.29.0 [unreleased]
+# 0.29.0 [2021-03-17]
 
 - Update `libp2p-swarm`.
 

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.28.0 [unreleased]
+# 0.28.0 [2021-03-17]
 
 - Update `libp2p-swarm`.
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.29.0 [unreleased]
+# 0.29.0 [2021-03-17]
 
 - Add `KademliaCaching` and `KademliaConfig::set_caching` to configure
   whether Kademlia should track, in lookups, the closest nodes to a key

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.29.0 [unreleased]
+# 0.29.0 [2021-03-17]
 
 - Introduce `MdnsConfig` with configurable TTL of discovered peer
   records and configurable multicast query interval. The default

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.28.0 [unreleased]
+# 0.28.0 [2021-03-17]
 
 - Update `libp2p-swarm`.
 

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.1.0 [unreleased]
+# 0.1.0 [2021-03-17]
 
 - First release supporting all major features of the circuit relay v1
   specification. [PR 1838](https://github.com/libp2p/rust-libp2p/pull/1838).

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.10.0 [unreleased]
+# 0.10.0 [2021-03-17]
 
 - Update `libp2p-swarm`.
 

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.28.0 [unreleased]
+# 0.28.0 [2021-03-17]
 
 - New error variant `DialError::InvalidAddress`
 

--- a/transports/deflate/CHANGELOG.md
+++ b/transports/deflate/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.28.0 [unreleased]
+# 0.28.0 [2021-03-17]
 
 - Update `libp2p-core`.
 

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.28.0 [unreleased]
+# 0.28.0 [2021-03-17]
 
 - Update `libp2p-core`.
 

--- a/transports/noise/CHANGELOG.md
+++ b/transports/noise/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.30.0 [unreleased]
+# 0.30.0 [2021-03-17]
 
 - Update `libp2p-core`.
 

--- a/transports/plaintext/CHANGELOG.md
+++ b/transports/plaintext/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.28.0 [unreleased]
+# 0.28.0 [2021-03-17]
 
 - Update `libp2p-core`.
 

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.28.0 [unreleased]
+# 0.28.0 [2021-03-17]
 
 - Update `libp2p-core`.
 

--- a/transports/uds/CHANGELOG.md
+++ b/transports/uds/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.28.0 [unreleased]
+# 0.28.0 [2021-03-17]
 
 - Update `libp2p-core`.
 

--- a/transports/wasm-ext/CHANGELOG.md
+++ b/transports/wasm-ext/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.28.0 [unreleased]
+# 0.28.0 [2021-03-17]
 
 - Update `libp2p-core`.
 

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.29.0 [unreleased]
+# 0.29.0 [2021-03-17]
 
 - Update `libp2p-core`.
 


### PR DESCRIPTION
I would like to cut a new release once https://github.com/libp2p/rust-libp2p/pull/1927 and https://github.com/libp2p/rust-libp2p/pull/1931 are merged. What do people think? Anything else you would like to see included?