### PR TITLE
[identify] Add configurable automatic push on listen addr changes.

### DIFF
--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 0.29.0 [unreleased]
 
+- Add support for configurable automatic push to connected peers
+  on listen addr changes. Disabled by default.
+  [PR 2004](https://github.com/libp2p/rust-libp2p/pull/2004)
+
 - Implement the `/ipfs/id/push/1.0.0` protocol.
   cf. https://github.com/libp2p/specs/tree/master/identify#identifypush
   [PR 1999](https://github.com/libp2p/rust-libp2p/pull/1999)

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -107,6 +107,16 @@ pub struct IdentifyConfig {
     ///
     /// Defaults to 5 minutes.
     pub interval: Duration,
+
+    /// Whether new or expired listen addresses of the local node should
+    /// trigger an active push of an identify message to all connected peers.
+    ///
+    /// Enabling this option can result in connected peers being informed
+    /// earlier about new or expired listen addresses of the local node,
+    /// i.e. before the next periodic identify request with each peer.
+    ///
+    /// Disabled by default.
+    pub push_listen_addr_updates: bool,
 }
 
 impl IdentifyConfig {
@@ -119,6 +129,7 @@ impl IdentifyConfig {
             local_public_key,
             initial_delay: Duration::from_millis(500),
             interval: Duration::from_secs(5 * 60),
+            push_listen_addr_updates: false,
         }
     }
 
@@ -139,6 +150,14 @@ impl IdentifyConfig {
     /// sent to peers after the initial request.
     pub fn with_interval(mut self, d: Duration) -> Self {
         self.interval = d;
+        self
+    }
+
+    /// Configures whether new or expired listen addresses of the local
+    /// node should trigger an active push of an identify message to all
+    /// connected peers.
+    pub fn with_push_listen_addr_updates(mut self, b: bool) -> Self {
+        self.push_listen_addr_updates = b;
         self
     }
 }
@@ -212,6 +231,18 @@ impl NetworkBehaviour for Identify {
     fn inject_disconnected(&mut self, peer_id: &PeerId) {
         self.connected.remove(peer_id);
         self.pending_push.remove(peer_id);
+    }
+
+    fn inject_new_listen_addr(&mut self, _addr: &Multiaddr) {
+        if self.config.push_listen_addr_updates {
+            self.pending_push.extend(self.connected.keys());
+        }
+    }
+
+    fn inject_expired_listen_addr(&mut self, _addr: &Multiaddr) {
+        if self.config.push_listen_addr_updates {
+            self.pending_push.extend(self.connected.keys());
+        }
     }
 
     fn inject_event(

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -213,7 +213,7 @@ impl NetworkBehaviour for Identify {
             ConnectedPoint::Listener { send_back_addr, .. } => send_back_addr.clone(),
         };
 
-        self.connected.entry(*peer_id).or_default().insert(*conn, addr.clone());
+        self.connected.entry(*peer_id).or_default().insert(*conn, addr);
     }
 
     fn inject_connection_closed(&mut self, peer_id: &PeerId, conn: &ConnectionId, _: &ConnectedPoint) {
@@ -372,7 +372,7 @@ impl NetworkBehaviour for Identify {
                             Poll::Ready(Err(err)) => {
                                 let event = IdentifyEvent::Error {
                                     peer_id: peer,
-                                    error: ProtocolsHandlerUpgrErr::Upgrade(UpgradeError::Apply(err.into()))
+                                    error: ProtocolsHandlerUpgrErr::Upgrade(UpgradeError::Apply(err))
                                 };
                                 return Poll::Ready(NetworkBehaviourAction::GenerateEvent(event));
                             },


### PR DESCRIPTION
This PR picks up a suggestion of @mxinden from https://github.com/libp2p/rust-libp2p/pull/1999#pullrequestreview-614608033. When a new or expired listen address is reported by the `Swarm`, it can result in an active push of an identify message to all connected peers. Two points worth noting:

  1. I've made this behaviour configurable and _disabled_ it by default. I think that having such new features opt-in initially avoids surprises and allows selective experimentation in a more controlled manner. Also, since listen addresses are often not directly reachable due to NAT, it may be better if it is selectively enabled for those nodes who are known to be deployed with publicly reachable listen addresses. Lastly, if there are potentially _a lot_ of connected peers, this kind of active push may cause quite a traffic burst. If it proves beneficial over time without any downsides, it can still be made the default later. However, I generally think that active pushes are more likely to be useful if they are targeted to specific subsets of peers.
  2. I have not included `inject_new_external_addr` as a trigger for an automatic push. I am somewhat concerned that, given that these addresses are reported by remote peers, it would make it too easy to remotely make a node spam all its connected peers with messages, possibly even with invalid data, since this would essentially provide a remote trigger for a kind of broadcast. One could of course add defensive measures via some form of throttling, but at least a naive implementation, as I've done here for `inject_new_listen_addr` and `inject_expired_listen_addr`, seems to be too easy to abuse.