### PR TITLE
transports/dns: Require smallvec >= 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 ## Version 0.37.0 [unreleased]
 
 - Update individual crates.
+    - `libp2p-dns`
     - `libp2p-floodsub`
     - `libp2p-gossipsub`
     - `libp2p-kad`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ wasm-timer = "0.2.4"
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")))'.dependencies]
 libp2p-deflate = { version = "0.28.0", path = "transports/deflate", optional = true }
-libp2p-dns = { version = "0.28.0", path = "transports/dns", optional = true, default-features = false }
+libp2p-dns = { version = "0.28.1", path = "transports/dns", optional = true, default-features = false }
 libp2p-mdns = { version = "0.30.0", path = "protocols/mdns", optional = true }
 libp2p-tcp = { version = "0.28.0", path = "transports/tcp", default-features = false, optional = true }
 libp2p-websocket = { version = "0.29.0", path = "transports/websocket", optional = true }

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.28.1 [unreleased]
+
+- Update dependencies.
+
 # 0.28.0 [2021-03-17]
 
 - Update `libp2p-core`.

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-dns"
 edition = "2018"
 description = "DNS transport implementation for libp2p"
-version = "0.28.0"
+version = "0.28.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -15,7 +15,7 @@ log = "0.4.1"
 futures = "0.3.1"
 trust-dns-resolver = { version = "0.20", default-features = false, features = ["system-config"] }
 async-std-resolver = { version = "0.20", optional = true }
-smallvec = "1.6"
+smallvec = "1.6.1"
 
 [dev-dependencies]
 env_logger = "0.6"


### PR DESCRIPTION
Follow up to https://github.com/libp2p/rust-libp2p/pull/1994/:

> Versions <1.6.1 are vulnerable to a buffer overflow. See
> https://rustsec.org/advisories/RUSTSEC-2021-0003.html for details.