### PR TITLE
core/identity: Encode and decode for Ed25519 SecretKey.

### DIFF
--- a/core/src/identity/ed25519.rs
+++ b/core/src/identity/ed25519.rs
@@ -230,12 +230,7 @@ mod tests {
         fn prop() -> bool {
             let sk = SecretKey::generate();
             let sk_after = SecretKey::decode(sk.encode()).unwrap();
-            for i in 0..32 {
-                if sk.0.to_bytes()[i] != sk_after.0.to_bytes()[i] {
-                    return false;
-                }
-            }
-            true
+            sk.0.to_bytes() == sk_after.0.to_bytes()
         }
         QuickCheck::new().tests(10).quickcheck(prop as fn() -> _);
     }

--- a/core/src/identity/ed25519.rs
+++ b/core/src/identity/ed25519.rs
@@ -20,12 +20,12 @@
 
 //! Ed25519 keys.
 
+use super::error::DecodingError;
+use core::fmt;
 use ed25519_dalek::{self as ed25519, Signer as _, Verifier as _};
 use rand::RngCore;
 use std::convert::TryFrom;
-use super::error::DecodingError;
 use zeroize::Zeroize;
-use core::fmt;
 
 /// An Ed25519 keypair.
 pub struct Keypair(ed25519::Keypair);
@@ -47,7 +47,10 @@ impl Keypair {
     /// zeroing the input on success.
     pub fn decode(kp: &mut [u8]) -> Result<Keypair, DecodingError> {
         ed25519::Keypair::from_bytes(kp)
-            .map(|k| { kp.zeroize(); Keypair(k) })
+            .map(|k| {
+                kp.zeroize();
+                Keypair(k)
+            })
             .map_err(|e| DecodingError::new("Ed25519 keypair").source(e))
     }
 
@@ -70,7 +73,9 @@ impl Keypair {
 
 impl fmt::Debug for Keypair {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Keypair").field("public", &self.0.public).finish()
+        f.debug_struct("Keypair")
+            .field("public", &self.0.public)
+            .finish()
     }
 }
 
@@ -78,7 +83,8 @@ impl Clone for Keypair {
     fn clone(&self) -> Keypair {
         let mut sk_bytes = self.0.secret.to_bytes();
         let secret = SecretKey::from_bytes(&mut sk_bytes)
-            .expect("ed25519::SecretKey::from_bytes(to_bytes(k)) != k").0;
+            .expect("ed25519::SecretKey::from_bytes(to_bytes(k)) != k")
+            .0;
         let public = ed25519::PublicKey::from_bytes(&self.0.public.to_bytes())
             .expect("ed25519::PublicKey::from_bytes(to_bytes(k)) != k");
         Keypair(ed25519::Keypair { secret, public })
@@ -97,7 +103,10 @@ impl From<SecretKey> for Keypair {
     fn from(sk: SecretKey) -> Keypair {
         let secret: ed25519::ExpandedSecretKey = (&sk.0).into();
         let public = ed25519::PublicKey::from(&secret);
-        Keypair(ed25519::Keypair { secret: sk.0, public })
+        Keypair(ed25519::Keypair {
+            secret: sk.0,
+            public,
+        })
     }
 }
 
@@ -118,7 +127,9 @@ impl fmt::Debug for PublicKey {
 impl PublicKey {
     /// Verify the Ed25519 signature on a message using the public key.
     pub fn verify(&self, msg: &[u8], sig: &[u8]) -> bool {
-        ed25519::Signature::try_from(sig).and_then(|s| self.0.verify(msg, &s)).is_ok()
+        ed25519::Signature::try_from(sig)
+            .and_then(|s| self.0.verify(msg, &s))
+            .is_ok()
     }
 
     /// Encode the public key into a byte array in compressed form, i.e.
@@ -148,8 +159,7 @@ impl AsRef<[u8]> for SecretKey {
 impl Clone for SecretKey {
     fn clone(&self) -> SecretKey {
         let mut sk_bytes = self.0.to_bytes();
-        Self::from_bytes(&mut sk_bytes)
-            .expect("ed25519::SecretKey::from_bytes(to_bytes(k)) != k")
+        Self::from_bytes(&mut sk_bytes).expect("ed25519::SecretKey::from_bytes(to_bytes(k)) != k")
     }
 }
 
@@ -164,8 +174,11 @@ impl SecretKey {
     pub fn generate() -> SecretKey {
         let mut bytes = [0u8; 32];
         rand::thread_rng().fill_bytes(&mut bytes);
-        SecretKey(ed25519::SecretKey::from_bytes(&bytes)
-            .expect("this returns `Err` only if the length is wrong; the length is correct; qed"))
+        SecretKey(
+            ed25519::SecretKey::from_bytes(&bytes).expect(
+                "this returns `Err` only if the length is wrong; the length is correct; qed",
+            ),
+        )
     }
 
     /// Create an Ed25519 secret key from a byte slice, zeroing the input on success.
@@ -178,6 +191,18 @@ impl SecretKey {
         sk_bytes.zeroize();
         Ok(SecretKey(secret))
     }
+
+    /// View the secret key as bytes.
+    pub fn encode(&self) -> &[u8; 32] {
+        self.0.as_bytes()
+    }
+
+    /// Decode a private key from a byte array as produced by `encode`.
+    pub fn decode(k: &[u8]) -> Result<SecretKey, DecodingError> {
+        ed25519::SecretKey::from_bytes(k)
+            .map_err(|e| DecodingError::new("Ed25519 secret key").source(e))
+            .map(SecretKey)
+    }
 }
 
 #[cfg(test)]
@@ -186,9 +211,7 @@ mod tests {
     use quickcheck::*;
 
     fn eq_keypairs(kp1: &Keypair, kp2: &Keypair) -> bool {
-        kp1.public() == kp2.public()
-            &&
-        kp1.0.secret.as_bytes() == kp2.0.secret.as_bytes()
+        kp1.public() == kp2.public() && kp1.0.secret.as_bytes() == kp2.0.secret.as_bytes()
     }
 
     #[test]
@@ -197,9 +220,22 @@ mod tests {
             let kp1 = Keypair::generate();
             let mut kp1_enc = kp1.encode();
             let kp2 = Keypair::decode(&mut kp1_enc).unwrap();
-            eq_keypairs(&kp1, &kp2)
-                &&
-            kp1_enc.iter().all(|b| *b == 0)
+            eq_keypairs(&kp1, &kp2) && kp1_enc.iter().all(|b| *b == 0)
+        }
+        QuickCheck::new().tests(10).quickcheck(prop as fn() -> _);
+    }
+
+    #[test]
+    fn ed25519_secret_encode_decode() {
+        fn prop() -> bool {
+            let sk = SecretKey::generate();
+            let sk_after = SecretKey::decode(sk.encode()).unwrap();
+            for i in 0..32 {
+                if sk.0.to_bytes()[i] != sk_after.0.to_bytes()[i] {
+                    return false;
+                }
+            }
+            true
         }
         QuickCheck::new().tests(10).quickcheck(prop as fn() -> _);
     }
@@ -210,9 +246,7 @@ mod tests {
             let kp1 = Keypair::generate();
             let mut sk = kp1.0.secret.to_bytes();
             let kp2 = Keypair::from(SecretKey::from_bytes(&mut sk).unwrap());
-            eq_keypairs(&kp1, &kp2)
-                &&
-            sk == [0u8; 32]
+            eq_keypairs(&kp1, &kp2) && sk == [0u8; 32]
         }
         QuickCheck::new().tests(10).quickcheck(prop as fn() -> _);
     }


### PR DESCRIPTION
It is odd how the ed25519 PublicKeys come with `.encode()` and `.decode()` methods, but the PrivateKeys do not. So, this PR adds similar functionality to the ed25519 SecretKey struct. The encode method returns a `&[u8; 32]` to view the SecretKey as bytes, and the `decode` method converts the output of `encode()` back into an ed25519 SecretKey. Also, wrote a passing test for this functionality.