### PR TITLE
README: Link to Code of Conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ The main components of this repository are structured as follows:
   * `examples/`: Worked examples of built-in application protocols (see `protocols/`)
     with common `Transport` configurations.
 
+## Community Guidelines
+
+The libp2p project operates under the [IPFS Code of
+Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+
+> tl;dr
+>
+> - Be respectful.
+> - We're here to help: abuse@ipfs.io
+> - Abusive behavior is never tolerated.
+> - Violations of this code may result in swift and permanent expulsion from the
+>   IPFS [and libp2p] community.
+> - "Too long, didn't read" is not a valid excuse for not knowing what is in
+>   this document.
+
 ## Notable users
 
 (open a pull request if you want your project to be added here)


### PR DESCRIPTION
I am proposing to link to the IPFS Code of Conduct in our README to make sure work on rust-libp2p is happening in a friendly and respectful environment.

Please get involved in case you have any suggestions or comments, either here in public or via a private mail.