### PR TITLE
protocols/identify: Emit Push event after successful identification push

### DIFF
--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -8,6 +8,9 @@
   cf. https://github.com/libp2p/specs/tree/master/identify#identifypush
   [PR 1999](https://github.com/libp2p/rust-libp2p/pull/1999)
 
+- Emit `IdentifyEvent::Pushed` event after successfully pushing identification
+  information to peer.
+
 # 0.28.0 [2021-03-17]
 
 - Update `libp2p-swarm`.

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -9,7 +9,8 @@
   [PR 1999](https://github.com/libp2p/rust-libp2p/pull/1999)
 
 - Emit `IdentifyEvent::Pushed` event after successfully pushing identification
-  information to peer.
+  information to peer [PR
+  2030](https://github.com/libp2p/rust-libp2p/pull/2030).
 
 # 0.28.0 [2021-03-17]
 

--- a/protocols/identify/src/handler.rs
+++ b/protocols/identify/src/handler.rs
@@ -79,6 +79,8 @@ pub struct IdentifyHandler {
 pub enum IdentifyHandlerEvent {
     /// We obtained identification information from the remote.
     Identified(IdentifyInfo),
+    /// We actively pushed our identification information to the remote.
+    IdentificationPushed,
     /// We received a request for identification.
     Identify(ReplySubstream<NegotiatedSubstream>),
     /// Failed to identify the remote.
@@ -149,7 +151,8 @@ impl ProtocolsHandler for IdentifyHandler {
                         IdentifyHandlerEvent::Identified(remote_info)));
                 self.keep_alive = KeepAlive::No;
             }
-            EitherOutput::Second(()) => {}
+            EitherOutput::Second(()) => self.events.push(
+                    ProtocolsHandlerEvent::Custom(IdentifyHandlerEvent::IdentificationPushed))
         }
     }
 

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -266,6 +266,13 @@ impl NetworkBehaviour for Identify {
                         score: AddressScore::Finite(1),
                     });
             }
+            IdentifyHandlerEvent::IdentificationPushed => {
+                self.events.push_back(
+                    NetworkBehaviourAction::GenerateEvent(
+                        IdentifyEvent::Pushed {
+                            peer_id,
+                        }));
+            }
             IdentifyHandlerEvent::Identify(sender) => {
                 let observed = self.connected.get(&peer_id)
                     .and_then(|addrs| addrs.get(&connection))
@@ -390,15 +397,22 @@ impl NetworkBehaviour for Identify {
 /// Event emitted  by the `Identify` behaviour.
 #[derive(Debug)]
 pub enum IdentifyEvent {
-    /// Identifying information has been received from a peer.
+    /// Identification information has been received from a peer.
     Received {
         /// The peer that has been identified.
         peer_id: PeerId,
         /// The information provided by the peer.
         info: IdentifyInfo,
     },
-    /// Identifying information of the local node has been sent to a peer.
+    /// Identification information of the local node has been sent to a peer in
+    /// response to an identification request.
     Sent {
+        /// The peer that the information has been sent to.
+        peer_id: PeerId,
+    },
+    /// Identification information of the local node has been actively pushed to
+    /// a peer.
+    Pushed {
         /// The peer that the information has been sent to.
         peer_id: PeerId,
     },


### PR DESCRIPTION
> Emit `IdentifyEvent::Pushed` event after successfully pushing identification
  information to peer.

Small follow up on past discussion https://github.com/libp2p/rust-libp2p/pull/1999#discussion_r597082362.