### PR TITLE
*: Drop generic wasm32-unknown-unknown support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
-        target: wasm32-wasmi
+        target: wasm32-wasi
 
     - name: Install a recent version of clang
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,18 +53,6 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Install Rust wasm32-unknown-unknown
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: wasm32-unknown-unknown
-
-    - name: Install Rust wasm32-wasi
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: wasm32-wasi
-
     - name: Install a recent version of clang
       run: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
@@ -87,10 +75,22 @@ jobs:
         path: target
         key: wasm-cargo-build-target-${{ hashFiles('Cargo.toml') }}
 
+    - name: Install Rust wasm32-unknown-unknown
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: wasm32-unknown-unknown
+
     - name: Build on wasm32-unknown-emscripten
       # TODO: also run `cargo test`
       # TODO: ideally we would build `--workspace`, but not all crates compile for WASM
       run: cargo build --target=wasm32-unknown-emscripten
+
+    - name: Install Rust wasm32-wasi
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: wasm32-wasi
 
     - name: Build on wasm32-wasi
       # TODO: also run `cargo test`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,16 +53,6 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Install a recent version of clang
-      run: |
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-        echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" >> /etc/apt/sources.list
-        apt-get update
-        apt-get install -y clang-10
-
-    - name: Install CMake
-      run: apt-get install -y cmake
-
     - name: Install Rust wasm32-unknown-emscripten
       uses: actions-rs/toolchain@v1
       with:
@@ -76,6 +66,16 @@ jobs:
         toolchain: stable
         target: wasm32-wasi
         override: true
+
+    - name: Install a recent version of clang
+      run: |
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+        echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" >> /etc/apt/sources.list
+        apt-get update
+        apt-get install -y clang-10
+
+    - name: Install CMake
+      run: apt-get install -y cmake
 
     - name: Cache CARGO_HOME
       uses: actions/cache@v2.1.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,20 @@ jobs:
     - name: Install CMake
       run: apt-get install -y cmake
 
+    - name: Install Rust wasm32-unknown-emscripten
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: wasm32-unknown-emscripten
+        override: true
+
+    - name: Install Rust wasm32-wasi
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: wasm32-wasi
+        override: true
+
     - name: Cache CARGO_HOME
       uses: actions/cache@v2.1.4
       with:
@@ -75,24 +89,10 @@ jobs:
         path: target
         key: wasm-cargo-build-target-${{ hashFiles('Cargo.toml') }}
 
-    - name: Install Rust wasm32-unknown-unknown
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: wasm32-unknown-unknown
-        override: true
-
     - name: Build on wasm32-unknown-emscripten
       # TODO: also run `cargo test`
       # TODO: ideally we would build `--workspace`, but not all crates compile for WASM
       run: cargo build --target=wasm32-unknown-emscripten
-
-    - name: Install Rust wasm32-wasi
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: wasm32-wasi
-        override: true
 
     - name: Build on wasm32-wasi
       # TODO: also run `cargo test`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
       with:
         toolchain: stable
         target: wasm32-unknown-unknown
+        override: true
 
     - name: Build on wasm32-unknown-emscripten
       # TODO: also run `cargo test`
@@ -91,6 +92,7 @@ jobs:
       with:
         toolchain: stable
         target: wasm32-wasi
+        override: true
 
     - name: Build on wasm32-wasi
       # TODO: also run `cargo test`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
-        target: wasm32-unknown-unknown
+        target: wasm32-unknown-unknown, wasm32-wasmi
         override: true
 
     - name: Install a recent version of clang
@@ -82,10 +82,15 @@ jobs:
         path: target
         key: wasm-cargo-build-target-${{ hashFiles('Cargo.toml') }}
 
-    - name: Build on WASM
+    - name: Build on wasm32-unknown-emscripten
       # TODO: also run `cargo test`
       # TODO: ideally we would build `--workspace`, but not all crates compile for WASM
-      run: cargo build --target=wasm32-unknown-unknown
+      run: cargo build --target=wasm32-unknown-emscripten
+
+    - name: Build on wasm32-wasi
+      # TODO: also run `cargo test`
+      # TODO: ideally we would build `--workspace`, but not all crates compile for WASM
+      run: cargo build --target=wasm32-wasi
 
   check-rustdoc-links:
     name: Check rustdoc intra-doc links

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,17 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Install Rust
+    - name: Install Rust wasm32-unknown-unknown
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
-        target: wasm32-unknown-unknown, wasm32-wasmi
-        override: true
+        target: wasm32-unknown-unknown
+
+    - name: Install Rust wasm32-wasi
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: wasm32-wasmi
 
     - name: Install a recent version of clang
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@
     - `libp2p-request-response`
     - `libp2p-swarm`
     - `libp2p-wasm-ext`
+    
+- Drop support for `wasm32-unknown-unknown` in favor of
+  `wasm32-unknown-emscripten` and `wasm32-wasi` [PR
+  2038](https://github.com/libp2p/rust-libp2p/pull/2038).
 
 ## Version 0.36.0 [2021-03-17]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ env_logger = "0.8.1"
 tokio = { version = "1.0.1", features = ["io-util", "io-std", "macros", "rt", "rt-multi-thread"] }
 
 [workspace]
+resolver = "2"
 members = [
     "core",
     "misc/multiaddr",


### PR DESCRIPTION
With `rand` `v0.8.0` platform support changed [1] due to its upgrade to
`getrandom` `v0.2`. With `getrandom` `v0.2` `wasm32-unknown-unknown` is no
longer supported out of the box:

> This crate fully supports the wasm32-wasi and wasm32-unknown-emscripten
> targets. However, the wasm32-unknown-unknown target is not automatically
> supported since, from the target name alone, we cannot deduce which JavaScript
> interface is in use (or if JavaScript is available at all).
>
> Instead, if the "js" Cargo feature is enabled, this crate will assume that you
> are building for an environment containing JavaScript, and will call the
> appropriate methods. Both web browser (main window and Web Workers) and
> Node.js environments are supported, invoking the methods described above using
> the wasm-bindgen toolchain.
>
> This feature has no effect on targets other than wasm32-unknown-unknown.

This commit drops support for wasm32-unknown-unknown in favor of the two more
specific targets wasm32-wasi and wasm32-unknown-emscripten.

Note on `resolver = "2"`: The new resolver is required to prevent features
being mixed, more specifically to prevent libp2p-noise to build with the
`ring-resolver` feature. See [3] for details.

---

[1] https://github.com/rust-random/rand/blob/master/CHANGELOG.md#platform-support
[2] https://docs.rs/getrandom/0.2.2/getrandom/#webassembly-support
[3] https://doc.rust-lang.org/nightly/cargo/reference/features.html#feature-resolver-version-2