### PR TITLE
.github: Only test benchmarks, don't run them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
     - name: Run tests, with all features
       run: cargo test --workspace --all-features
 
+    - name: Run benches, with all features
+      run: cargo test --workspace --benches --all-features
+
   test-wasm:
     name: Build on WASM
     runs-on: ubuntu-latest
@@ -139,41 +142,6 @@ jobs:
       with:
         command: clippy
         args: -- -A clippy::type_complexity -A clippy::pedantic -A clippy::style
-
-  run-benchmarks:
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.8.0
-      with:
-        access_token: ${{ github.token }}
-
-    - uses: actions/checkout@v2
-
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-
-    - name: Cache CARGO_HOME
-      uses: actions/cache@v2.1.4
-      with:
-        path: ~/.cargo
-        key: cargo-home-${{ hashFiles('Cargo.toml') }}
-
-    - name: Cache cargo build
-      uses: actions/cache@v2.1.4
-      with:
-        path: target
-        key: cargo-build-target-${{ hashFiles('Cargo.toml') }}
-
-    - name: Run cargo bench
-      uses: actions-rs/cargo@v1
-      with:
-        command: bench
-        args: --workspace
 
   integration-test:
     name: Integration tests


### PR DESCRIPTION
Instead of fully executing benchmarks, i.e. running multiple iterations,
each measured and recorded, only test that they compile and run them
with a single execution to make sure they work. The benefit is a reduced
CI runtime.

Flag documentation:

> To test that the benchmarks run successfully without performing the
measurement or analysis (eg. in a CI setting), use cargo test --benches.

https://bheisler.github.io/criterion.rs/book/user_guide/command_line_options.html

The above assumes that (a) the benchmark results from CI are likely
noisy and thus (b) no one actually looks at the benchmark results.