### PR TITLE
*: Prepare v0.37.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 
 # `libp2p` facade crate
 
-## Version 0.37.0 [unreleased]
+## Version 0.37.0 [2021-04-13]
 
 - Update individual crates.
     - `libp2p-core`

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.28.2 [unreleased]
+# 0.28.2 [2021-04-13]
 
 - Update dependencies.
 

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.32.0 [unreleased]
+# 0.32.0 [2021-04-13]
 
 - Update to `yamux` `v0.9.0` [PR
   1960](https://github.com/libp2p/rust-libp2p/pull/1960).

--- a/protocols/floodsub/CHANGELOG.md
+++ b/protocols/floodsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.29.0 [unreleased]
+# 0.29.0 [2021-04-13]
 
 - Update `libp2p-swarm`.
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.30.0 [unreleased]
+# 0.30.0 [2021-04-13]
 
 - Update `libp2p-swarm`.
 

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.29.0 [unreleased]
+# 0.29.0 [2021-04-13]
 
 - Add support for configurable automatic push to connected peers
   on listen addr changes. Disabled by default.

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.30.0 [unreleased]
+# 0.30.0 [2021-04-13]
 
 - Update `libp2p-swarm`.
 

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.30.0 [unreleased]
+# 0.30.0 [2021-04-13]
 
 - Derive `Debug` and `Clone` for `MdnsConfig`.
 

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.29.0 [unreleased]
+# 0.29.0 [2021-04-13]
 
 - Update `libp2p-swarm`.
 

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.2.0 [unreleased]
+# 0.2.0 [2021-04-13]
 
 - Update `libp2p-swarm`.
 

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.11.0 [unreleased]
+# 0.11.0 [2021-04-13]
 
 - Update `libp2p-swarm`.
 - Implement `std::error::Error` for `InboundFailure` and `OutboundFailure` [PR

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.29.0 [unreleased]
+# 0.29.0 [2021-04-13]
 
 - Remove `Deref` and `DerefMut` implementations previously dereferencing to the
   `NetworkBehaviour` on `Swarm`. Instead one can access the `NetworkBehaviour`


### PR DESCRIPTION
I would like to cut `libp2p` `v0.37.0`. Any objections? Anything you would like to see included which is not in `master` today?

I would suggest releasing https://github.com/libp2p/rust-libp2p/pull/2043 as a separate bug-fix release.