### PR TITLE
Fix mdns taking a long time to discover peers.

### DIFF
--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.30.1 [2021-04-21]
 
 - Fix timely discovery of peers after listening on a new address.
+  [PR 2053](https://github.com/libp2p/rust-libp2p/pull/2053/)
 
 # 0.30.0 [2021-04-13]
 

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.30.1 [2021-04-21]
+
+- Fix timely discovery of peers after listening on a new address.
+
 # 0.30.0 [2021-04-13]
 
 - Derive `Debug` and `Clone` for `MdnsConfig`.

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-mdns"
 edition = "2018"
-version = "0.30.0"
+version = "0.30.1"
 description = "Implementation of the libp2p mDNS discovery method"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"

--- a/protocols/mdns/src/behaviour.rs
+++ b/protocols/mdns/src/behaviour.rs
@@ -27,6 +27,7 @@ use lazy_static::lazy_static;
 use libp2p_core::{
     address_translation, connection::ConnectionId, multiaddr::Protocol, Multiaddr, PeerId,
 };
+use libp2p_core::connection::ListenerId;
 use libp2p_swarm::{
     protocols_handler::DummyProtocolsHandler, NetworkBehaviour, NetworkBehaviourAction,
     PollParameters, ProtocolsHandler,
@@ -267,6 +268,10 @@ impl NetworkBehaviour for Mdns {
         ev: <Self::ProtocolsHandler as ProtocolsHandler>::OutEvent,
     ) {
         void::unreachable(ev)
+    }
+
+    fn inject_new_listen_addr(&mut self, _id: ListenerId, _addr: &Multiaddr) {
+        self.send_buffer.push_back(build_query());
     }
 
     fn poll(


### PR DESCRIPTION
If you start listening after mdns joined a multicast group, the peers may not discover eachother until the 5min timeout expires.