### PR TITLE
Fix transport/wasm-ext fully qualified p2p multiaddr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,12 +45,13 @@
 
 - Update individual crates.
     - `libp2p-core`
+    - `libp2p-gossipsub`
+    - `libp2p-wasm-ext`
 
 ## Version 0.37.1 [2021-04-14]
 
 - Update individual crates.
     - `libp2p-swarm-derive`
-    - `libp2p-gossipsub`
 
 ## Version 0.37.0 [2021-04-13]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ libp2p-request-response = { version = "0.11.0", path = "protocols/request-respon
 libp2p-swarm = { version = "0.29.0", path = "swarm" }
 libp2p-swarm-derive = { version = "0.23.0", path = "swarm-derive" }
 libp2p-uds = { version = "0.28.0", path = "transports/uds", optional = true }
-libp2p-wasm-ext = { version = "0.28.1", path = "transports/wasm-ext", default-features = false, optional = true }
+libp2p-wasm-ext = { version = "0.28.2", path = "transports/wasm-ext", default-features = false, optional = true }
 libp2p-yamux = { version = "0.32.0", path = "muxers/yamux", optional = true }
 multiaddr = { package = "parity-multiaddr", version = "0.11.2", path = "misc/multiaddr" }
 parking_lot = "0.11.0"

--- a/transports/wasm-ext/CHANGELOG.md
+++ b/transports/wasm-ext/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.28.2 [2021-04-27]
+
+- Support dialing `Multiaddr` with `/p2p` protocol [PR
+  2058](https://github.com/libp2p/rust-libp2p/pull/2058).
+
 # 0.28.1 [2021-04-01]
 
 - Require at least js-sys v0.3.50 [PR
@@ -45,4 +50,3 @@
 - Updated dependencies.
 - Support `/dns` in the websocket implementation
   ([PR 1626](https://github.com/libp2p/rust-libp2p/pull/1626))
-

--- a/transports/wasm-ext/Cargo.toml
+++ b/transports/wasm-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-wasm-ext"
-version = "0.28.1"
+version = "0.28.2"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 edition = "2018"
 description = "Allows passing in an external transport in a WASM environment"

--- a/transports/wasm-ext/src/websockets.js
+++ b/transports/wasm-ext/src/websockets.js
@@ -31,7 +31,7 @@ export const websocket_transport = () => {
 
 /// Turns a string multiaddress into a WebSockets string URL.
 const multiaddr_to_ws = (addr) => {
-	let parsed = addr.match(/^\/(ip4|ip6|dns4|dns6|dns)\/(.*?)\/tcp\/(.*?)\/(ws|wss|x-parity-ws\/(.*)|x-parity-wss\/(.*))(\/.*|)$/);
+	let parsed = addr.match(/^\/(ip4|ip6|dns4|dns6|dns)\/(.*?)\/tcp\/(.*?)\/(ws|wss|x-parity-ws\/(.*)|x-parity-wss\/(.*))(|\/p2p\/[a-zA-Z0-9]+)$/);
 	if (parsed != null) {
 		let proto = 'wss';
 		if (parsed[4] == 'ws' || parsed[4].startsWith('x-parity-ws/')) {

--- a/transports/wasm-ext/src/websockets.js
+++ b/transports/wasm-ext/src/websockets.js
@@ -31,7 +31,7 @@ export const websocket_transport = () => {
 
 /// Turns a string multiaddress into a WebSockets string URL.
 const multiaddr_to_ws = (addr) => {
-	let parsed = addr.match(/^\/(ip4|ip6|dns4|dns6|dns)\/(.*?)\/tcp\/(.*?)\/(ws|wss|x-parity-ws\/(.*)|x-parity-wss\/(.*))$/);
+	let parsed = addr.match(/^\/(ip4|ip6|dns4|dns6|dns)\/(.*?)\/tcp\/(.*?)\/(ws|wss|x-parity-ws\/(.*)|x-parity-wss\/(.*))(\/.*|)$/);
 	if (parsed != null) {
 		let proto = 'wss';
 		if (parsed[4] == 'ws' || parsed[4].startsWith('x-parity-ws/')) {


### PR DESCRIPTION
Changes in https://github.com/libp2p/rust-libp2p/commit/45f07bf8639fd9056e4ffe52298ca113a0308951# now seem to append `/p2p/<peer>` to multiaddr passed to transports. The regex in transport/wasm-ext doesn't support this fully qualified format. Supporting extra suffixes in the regex fixes the issue, but I'm wondering if it it should match on `\/p2p\/.*` instead or just plainly accepting any suffix. Let me know what you prefer.