### PR TITLE
Fix discovered event emission.

### DIFF
--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.30.2 [2021-05-06]
+
+- Fix discovered event emission.
+  [PR 2065](https://github.com/libp2p/rust-libp2p/pull/2065)
+
 # 0.30.1 [2021-04-21]
 
 - Fix timely discovery of peers after listening on a new address.

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-mdns"
 edition = "2018"
-version = "0.30.1"
+version = "0.30.2"
 description = "Implementation of the libp2p mDNS discovery method"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"

--- a/protocols/mdns/src/behaviour.rs
+++ b/protocols/mdns/src/behaviour.rs
@@ -214,8 +214,8 @@ impl Mdns {
                         } else {
                             self.discovered_nodes
                                 .push((*peer.id(), addr.clone(), new_expiration));
+                            discovered.push((*peer.id(), addr));
                         }
-                        discovered.push((*peer.id(), addr));
                     }
                 }
 

--- a/protocols/mdns/src/behaviour.rs
+++ b/protocols/mdns/src/behaviour.rs
@@ -173,6 +173,7 @@ impl Mdns {
         match packet {
             MdnsPacket::Query(query) => {
                 self.query = false;
+                log::trace!("sending response");
                 for packet in build_query_response(
                     query.query_id(),
                     *params.local_peer_id(),
@@ -350,6 +351,7 @@ impl NetworkBehaviour for Mdns {
                         None => self.send_buffer.push_front(packet),
                     }
                 } else if self.query {
+                    log::trace!("sending query");
                     self.send_buffer.push_back(build_query());
                     self.query = false;
                 } else {


### PR DESCRIPTION
mdns keeps rediscovering nodes. this PR changes that to only emit events for new nodes it discovered. In addition we make sure to only send a query if it is really needed. Some logging is added for debugging purposes.