### PR TITLE
README: Remove compatibility warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 
 This repository is the central place for Rust development of the [libp2p](https://libp2p.io) spec.
 
-**Warning**: While we are trying our best to be compatible with other libp2p implementations, we
-cannot guarantee that this is the case considering the lack of a precise libp2p specifications.
-
 ## Getting started
 
 - **Main documentation** can be found on https://docs.rs/libp2p.


### PR DESCRIPTION
With the ethereum 2 [lighthouse client] and the Filecoin [forest client]
we have two rust-libp2p users demonstrating compatibility of the
rust-libp2p library with other libp2p implementations on a daily basis
on their corresponding live networks.

That in mind the compatibility warning is out of date. While we could do
better, especially in regards to automated compatibility testing across
implementations, rust-libp2p is in fact compatible with the libp2p
specification as well as other libp2p implementations.

[lighthouse client]: https://github.com/sigp/lighthouse

[forest client]: https://github.com/ChainSafe/forest

//CC @adlrocha