### PR TITLE
README: Remove freenode IRC link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Central repository for work on libp2p
 
 <a href="http://libp2p.io/"><img src="https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square" /></a>
-<a href="http://webchat.freenode.net/?channels=%23libp2p"><img src="https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square" /></a>
 [![dependency status](https://deps.rs/repo/github/libp2p/rust-libp2p/status.svg?style=flat-square)](https://deps.rs/repo/github/libp2p/rust-libp2p)
 
 This repository is the central place for Rust development of the [libp2p](https://libp2p.io) spec.


### PR DESCRIPTION
This pull request removes the IRC link to freenode on the main README.md. This is motivated by:

1. I am not monitoring this channel. Unless someone else from the rust-libp2p community is, removing it should reduce disappointment for newcomers.
2. IPFS moving away from freenode (see https://github.com/ipfs/ipfs-docs/pull/787).