### PR TITLE
Add the ability for the behaviour to disconnect a peer

### DIFF
--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -3202,6 +3202,9 @@ where
                 NetworkBehaviourAction::ReportObservedAddr { address, score } => {
                     NetworkBehaviourAction::ReportObservedAddr { address, score }
                 }
+                NetworkBehaviourAction::DisconnectPeer { peer_id, handler } => {
+                    NetworkBehaviourAction::DisconnectPeer { peer_id, handler }
+                }
             });
         }
 

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -3202,8 +3202,8 @@ where
                 NetworkBehaviourAction::ReportObservedAddr { address, score } => {
                     NetworkBehaviourAction::ReportObservedAddr { address, score }
                 }
-                NetworkBehaviourAction::CloseConnection { peer_id, handler } => {
-                    NetworkBehaviourAction::CloseConnection { peer_id, handler }
+                NetworkBehaviourAction::CloseConnection { peer_id, connection } => {
+                    NetworkBehaviourAction::CloseConnection { peer_id, connection }
                 }
             });
         }

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -3202,8 +3202,8 @@ where
                 NetworkBehaviourAction::ReportObservedAddr { address, score } => {
                     NetworkBehaviourAction::ReportObservedAddr { address, score }
                 }
-                NetworkBehaviourAction::DisconnectPeer { peer_id, handler } => {
-                    NetworkBehaviourAction::DisconnectPeer { peer_id, handler }
+                NetworkBehaviourAction::CloseConnection { peer_id, handler } => {
+                    NetworkBehaviourAction::CloseConnection { peer_id, handler }
                 }
             });
         }

--- a/protocols/request-response/src/throttled.rs
+++ b/protocols/request-response/src/throttled.rs
@@ -658,8 +658,8 @@ where
                     NetworkBehaviourAction::NotifyHandler { peer_id, handler, event },
                 | NetworkBehaviourAction::ReportObservedAddr { address, score } =>
                     NetworkBehaviourAction::ReportObservedAddr { address, score },
-                | NetworkBehaviourAction::CloseConnection { peer_id, handler } =>
-                    NetworkBehaviourAction::CloseConnection { peer_id, handler }
+                | NetworkBehaviourAction::CloseConnection { peer_id, connection } =>
+                    NetworkBehaviourAction::CloseConnection { peer_id, connection }
             };
 
             return Poll::Ready(event)

--- a/protocols/request-response/src/throttled.rs
+++ b/protocols/request-response/src/throttled.rs
@@ -657,7 +657,9 @@ where
                 | NetworkBehaviourAction::NotifyHandler { peer_id, handler, event } =>
                     NetworkBehaviourAction::NotifyHandler { peer_id, handler, event },
                 | NetworkBehaviourAction::ReportObservedAddr { address, score } =>
-                    NetworkBehaviourAction::ReportObservedAddr { address, score }
+                    NetworkBehaviourAction::ReportObservedAddr { address, score },
+                | NetworkBehaviourAction::DisconnectPeer { peer_id, handler } =>
+                    NetworkBehaviourAction::DisconnectPeer { peer_id, handler }
             };
 
             return Poll::Ready(event)

--- a/protocols/request-response/src/throttled.rs
+++ b/protocols/request-response/src/throttled.rs
@@ -658,8 +658,8 @@ where
                     NetworkBehaviourAction::NotifyHandler { peer_id, handler, event },
                 | NetworkBehaviourAction::ReportObservedAddr { address, score } =>
                     NetworkBehaviourAction::ReportObservedAddr { address, score },
-                | NetworkBehaviourAction::DisconnectPeer { peer_id, handler } =>
-                    NetworkBehaviourAction::DisconnectPeer { peer_id, handler }
+                | NetworkBehaviourAction::CloseConnection { peer_id, handler } =>
+                    NetworkBehaviourAction::CloseConnection { peer_id, handler }
             };
 
             return Poll::Ready(event)

--- a/swarm-derive/src/lib.rs
+++ b/swarm-derive/src/lib.rs
@@ -479,8 +479,8 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
                     std::task::Poll::Ready(#network_behaviour_action::ReportObservedAddr { address, score }) => {
                         return std::task::Poll::Ready(#network_behaviour_action::ReportObservedAddr { address, score });
                     }
-                    std::task::Poll::Ready(#network_behaviour_action::CloseConnection { peer_id, handler }) => {
-                        return std::task::Poll::Ready(#network_behaviour_action::CloseConnection { peer_id, handler });
+                    std::task::Poll::Ready(#network_behaviour_action::CloseConnection { peer_id, connection }) => {
+                        return std::task::Poll::Ready(#network_behaviour_action::CloseConnection { peer_id, connection });
                     }
                     std::task::Poll::Pending => break,
                 }

--- a/swarm-derive/src/lib.rs
+++ b/swarm-derive/src/lib.rs
@@ -479,8 +479,8 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
                     std::task::Poll::Ready(#network_behaviour_action::ReportObservedAddr { address, score }) => {
                         return std::task::Poll::Ready(#network_behaviour_action::ReportObservedAddr { address, score });
                     }
-                    std::task::Poll::Ready(#network_behaviour_action::DisconnectPeer { peer_id, handler }) => {
-                        return std::task::Poll::Ready(#network_behaviour_action::DisconnectPeer { peer_id, handler });
+                    std::task::Poll::Ready(#network_behaviour_action::CloseConnection { peer_id, handler }) => {
+                        return std::task::Poll::Ready(#network_behaviour_action::CloseConnection { peer_id, handler });
                     }
                     std::task::Poll::Pending => break,
                 }

--- a/swarm-derive/src/lib.rs
+++ b/swarm-derive/src/lib.rs
@@ -479,6 +479,9 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
                     std::task::Poll::Ready(#network_behaviour_action::ReportObservedAddr { address, score }) => {
                         return std::task::Poll::Ready(#network_behaviour_action::ReportObservedAddr { address, score });
                     }
+                    std::task::Poll::Ready(#network_behaviour_action::DisconnectPeer { peer_id, handler }) => {
+                        return std::task::Poll::Ready(#network_behaviour_action::DisconnectPeer { peer_id, handler });
+                    }
                     std::task::Poll::Pending => break,
                 }
             }

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -15,7 +15,12 @@
 
   See [PR 2100] for details.
 
+- Add `ExpandedSwarm::disconnect_peer_id` and
+  `NetworkBehaviourAction::CloseConnection` to close connections to a specific
+  peer via an `ExpandedSwarm` or `NetworkBehaviour`. See [PR 2110] for details.
+
 [PR 2100]: https://github.com/libp2p/rust-libp2p/pull/2100
+[PR 2110]: https://github.com/libp2p/rust-libp2p/pull/2110/
 
 # 0.29.0 [2021-04-13]
 

--- a/swarm/src/behaviour.rs
+++ b/swarm/src/behaviour.rs
@@ -294,13 +294,13 @@ pub enum NetworkBehaviourAction<TInEvent, TOutEvent> {
         score: AddressScore,
     },
 
-    /// Instructs the `Swarm` to initiate a graceful close of the connection
-    /// with a peer.
-    DisconnectPeer {
+    /// Instructs the `Swarm` to initiate a graceful close of one or all connections
+    /// with the given peer.
+    CloseConnection {
         /// The peer to disconnect.
         peer_id: PeerId,
         /// The ID of the connection whose `ProtocolsHandler` to disconnect.
-        handler: DisconnectPeerHandler,
+        handler: CloseConnection,
     }
 }
 
@@ -322,8 +322,8 @@ impl<TInEvent, TOutEvent> NetworkBehaviourAction<TInEvent, TOutEvent> {
                 },
             NetworkBehaviourAction::ReportObservedAddr { address, score } =>
                 NetworkBehaviourAction::ReportObservedAddr { address, score },
-            NetworkBehaviourAction::DisconnectPeer { peer_id, handler } => {
-                NetworkBehaviourAction::DisconnectPeer { peer_id, handler }
+            NetworkBehaviourAction::CloseConnection { peer_id, handler } => {
+                NetworkBehaviourAction::CloseConnection { peer_id, handler }
             }
         }
     }
@@ -341,8 +341,8 @@ impl<TInEvent, TOutEvent> NetworkBehaviourAction<TInEvent, TOutEvent> {
                 NetworkBehaviourAction::NotifyHandler { peer_id, handler, event },
             NetworkBehaviourAction::ReportObservedAddr { address, score } =>
                 NetworkBehaviourAction::ReportObservedAddr { address, score },
-            NetworkBehaviourAction::DisconnectPeer { peer_id, handler } =>
-                NetworkBehaviourAction::DisconnectPeer { peer_id, handler }
+            NetworkBehaviourAction::CloseConnection { peer_id, handler } =>
+                NetworkBehaviourAction::CloseConnection { peer_id, handler }
         }
     }
 }
@@ -390,15 +390,15 @@ impl Default for DialPeerCondition {
 
 /// The options which connection handlers to disconnect.
 #[derive(Debug, Clone)]
-pub enum DisconnectPeerHandler {
-    /// Disconnect a particular connection handler.
+pub enum CloseConnection {
+    /// Disconnect a particular connection.
     One(ConnectionId),
-    /// Disconnect all connection handlers.
+    /// Disconnect all connections.
     All,
 }
 
-impl Default for DisconnectPeerHandler {
+impl Default for CloseConnection {
     fn default() -> Self {
-        DisconnectPeerHandler::All
+        CloseConnection::All
     }
 }

--- a/swarm/src/behaviour.rs
+++ b/swarm/src/behaviour.rs
@@ -293,6 +293,15 @@ pub enum NetworkBehaviourAction<TInEvent, TOutEvent> {
         /// relative to other observed addresses.
         score: AddressScore,
     },
+
+    /// Instructs the `Swarm` to initiate a graceful close of the connection
+    /// with a peer.
+    DisconnectPeer {
+        /// The peer to disconnect.
+        peer_id: PeerId,
+        /// The ID of the connection whose `ProtocolsHandler` to disconnect.
+        handler: DisconnectPeerHandler,
+    }
 }
 
 impl<TInEvent, TOutEvent> NetworkBehaviourAction<TInEvent, TOutEvent> {
@@ -312,7 +321,10 @@ impl<TInEvent, TOutEvent> NetworkBehaviourAction<TInEvent, TOutEvent> {
                     event: f(event)
                 },
             NetworkBehaviourAction::ReportObservedAddr { address, score } =>
-                NetworkBehaviourAction::ReportObservedAddr { address, score }
+                NetworkBehaviourAction::ReportObservedAddr { address, score },
+            NetworkBehaviourAction::DisconnectPeer { peer_id, handler } => {
+                NetworkBehaviourAction::DisconnectPeer { peer_id, handler }
+            }
         }
     }
 
@@ -328,7 +340,9 @@ impl<TInEvent, TOutEvent> NetworkBehaviourAction<TInEvent, TOutEvent> {
             NetworkBehaviourAction::NotifyHandler { peer_id, handler, event } =>
                 NetworkBehaviourAction::NotifyHandler { peer_id, handler, event },
             NetworkBehaviourAction::ReportObservedAddr { address, score } =>
-                NetworkBehaviourAction::ReportObservedAddr { address, score }
+                NetworkBehaviourAction::ReportObservedAddr { address, score },
+            NetworkBehaviourAction::DisconnectPeer { peer_id, handler } =>
+                NetworkBehaviourAction::DisconnectPeer { peer_id, handler }
         }
     }
 }
@@ -371,5 +385,20 @@ pub enum DialPeerCondition {
 impl Default for DialPeerCondition {
     fn default() -> Self {
         DialPeerCondition::Disconnected
+    }
+}
+
+/// The options which connection handlers to disconnect.
+#[derive(Debug, Clone)]
+pub enum DisconnectPeerHandler {
+    /// Disconnect a particular connection handler.
+    One(ConnectionId),
+    /// Disconnect all connection handlers.
+    All,
+}
+
+impl Default for DisconnectPeerHandler {
+    fn default() -> Self {
+        DisconnectPeerHandler::All
     }
 }

--- a/swarm/src/behaviour.rs
+++ b/swarm/src/behaviour.rs
@@ -299,11 +299,11 @@ pub enum NetworkBehaviourAction<TInEvent, TOutEvent> {
     ///
     /// Note: Closing a connection via
     /// [`NetworkBehaviourAction::CloseConnection`] does not inform the
-    /// corresponding [`ProtocolsHandler`](s).
+    /// corresponding [`ProtocolsHandler`].
     /// Closing a connection via a [`ProtocolsHandler`] can be done
     /// either in a collaborative manner across [`ProtocolsHandler`]s
     /// with [`ProtocolsHandler::connection_keep_alive`] or directly with
-    /// [`ProtocolsHandlerEvent::Close`].
+    /// [`ProtocolsHandlerEvent::Close`](crate::ProtocolsHandlerEvent::Close).
     CloseConnection {
         /// The peer to disconnect.
         peer_id: PeerId,

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -469,7 +469,7 @@ where TBehaviour: NetworkBehaviour<ProtocolsHandler = THandler>,
     /// Returns `Ok(())` if there was one or more established connections to the peer.
     ///
     /// Note: Closing a connection via [`ExpandedSwarm::disconnect_peer_id`] does
-    /// not inform the corresponding [`ProtocolsHandler`](s).
+    /// not inform the corresponding [`ProtocolsHandler`].
     /// Closing a connection via a [`ProtocolsHandler`] can be done either in a
     /// collaborative manner across [`ProtocolsHandler`]s
     /// with [`ProtocolsHandler::connection_keep_alive`] or directly with

--- a/swarm/src/test.rs
+++ b/swarm/src/test.rs
@@ -167,6 +167,8 @@ where
         self.inject_listener_closed = Vec::new();
         self.poll = 0;
     }
+
+    pub fn inner(&mut self) -> &mut TInner { &mut self.inner }
 }
 
 impl<TInner> NetworkBehaviour for CallTraceBehaviour<TInner>


### PR DESCRIPTION
Currently, we use a custom version of the [rust-libp2p](https://github.com/KomodoPlatform/rust-libp2p/tree/master) crate in the https://github.com/KomodoPlatform/atomicDEX-API project that allows us to disconnect peers from the network behaviour.
I would like to propose this functionality to allow the users to build their custom behaviors with the ability to disconnect peers.
Please look at the example of using `NetworkBehaviourAction::DisconnectPeer'`: https://github.com/KomodoPlatform/atomicDEX-API/blob/mm2.1/mm2src/mm2_libp2p/src/adex_ping.rs#L27

* Add 'NetworkBehaviourAction::DisconnectPeer'
* Add 'ExpandedSwarm::disconnect_peer_id'
* Add 'test_swarm_disconnect', 'test_behaviour_disconnect_all', 'test_behaviour_disconnect_one'