### PR TITLE
misc/multistream-select: Add basic fuzzing

### DIFF
--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -16,6 +16,7 @@ log = "0.4"
 pin-project = "1.0.0"
 smallvec = "1.6.1"
 unsigned-varint = "0.7"
+arbitrary = { version = "1", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 async-std = "1.6.2"

--- a/misc/multistream-select/fuzz/.gitignore
+++ b/misc/multistream-select/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/misc/multistream-select/fuzz/Cargo.toml
+++ b/misc/multistream-select/fuzz/Cargo.toml
@@ -1,0 +1,35 @@
+
+[package]
+name = "multistream-select-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+futures = "0.3.1"
+arbitrary = { version = "1", features = ["derive"] }
+
+[dependencies.multistream-select]
+path = ".."
+features = ["arbitrary"]
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "dial"
+path = "fuzz_targets/dial.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "listen"
+path = "fuzz_targets/listen.rs"
+test = false
+doc = false

--- a/misc/multistream-select/fuzz/fuzz_targets/dial.rs
+++ b/misc/multistream-select/fuzz/fuzz_targets/dial.rs
@@ -1,0 +1,24 @@
+#![no_main]
+use futures::executor::block_on;
+use futures::io::Cursor;
+use futures::io::{AsyncRead, AsyncWrite};
+use libfuzzer_sys::fuzz_target;
+use multistream_select::{listener_select_proto, dialer_select_proto, Version};
+use std::io::Error;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+mod utils;
+
+fuzz_target!(|input: DialerInput| {
+    block_on(async {
+        let _ = dialer_select_proto(utils::Connection::new(input.read), input.protocols.into_iter(), input.version).await;
+    })
+});
+
+#[derive(arbitrary::Arbitrary, Debug)]
+struct DialerInput {
+    read: Vec<u8>,
+    protocols: Vec<Vec<u8>>,
+    version: Version,
+}

--- a/misc/multistream-select/fuzz/fuzz_targets/listen.rs
+++ b/misc/multistream-select/fuzz/fuzz_targets/listen.rs
@@ -1,0 +1,23 @@
+#![no_main]
+use futures::executor::block_on;
+use futures::io::Cursor;
+use futures::io::{AsyncRead, AsyncWrite};
+use libfuzzer_sys::fuzz_target;
+use multistream_select::{listener_select_proto, dialer_select_proto, Version};
+use std::io::Error;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+mod utils;
+
+fuzz_target!(|input: ListenerInput| {
+    block_on(async {
+        let _ = listener_select_proto(utils::Connection::new(input.read), input.protocols.into_iter()).await;
+    })
+});
+
+#[derive(arbitrary::Arbitrary, Debug)]
+struct ListenerInput {
+    read: Vec<u8>,
+    protocols: Vec<Vec<u8>>,
+}

--- a/misc/multistream-select/fuzz/fuzz_targets/utils.rs
+++ b/misc/multistream-select/fuzz/fuzz_targets/utils.rs
@@ -1,0 +1,49 @@
+#![no_main]
+use futures::executor::block_on;
+use futures::io::Cursor;
+use futures::io::{AsyncRead, AsyncWrite};
+use libfuzzer_sys::fuzz_target;
+use multistream_select::{listener_select_proto, dialer_select_proto, Version};
+use std::io::Error;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+pub struct Connection {
+    read: Cursor<Vec<u8>>,
+    write: Cursor<Vec<u8>>,
+}
+
+impl Connection {
+    pub fn new(data: Vec<u8>) -> Self {
+        Self {
+            read: Cursor::new(data),
+            write: Cursor::new(Vec::new()),
+        }
+    }
+}
+
+impl AsyncWrite for Connection {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, Error>> {
+        Pin::new(&mut self.write).poll_write(cx, buf)
+    }
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        Pin::new(&mut self.write).poll_flush(cx)
+    }
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        Pin::new(&mut self.write).poll_close(cx)
+    }
+}
+
+impl AsyncRead for Connection {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize, Error>> {
+        Pin::new(&mut self.read).poll_read(cx, buf)
+    }
+}

--- a/misc/multistream-select/src/lib.rs
+++ b/misc/multistream-select/src/lib.rs
@@ -101,6 +101,7 @@ pub use self::listener_select::{listener_select_proto, ListenerSelectFuture};
 
 /// Supported multistream-select versions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Version {
     /// Version 1 of the multistream-select protocol. See [1] and [2].
     ///


### PR DESCRIPTION
Exploring fuzzing for `multistream-select` crate.

Work in progress for now.

Instructions:

1. Follow installation instructions https://rust-fuzz.github.io/book/cargo-fuzz.html
2. `cargo +nightly fuzz run dial` or `cargo +nightly fuzz run listen`
3. `cargo +nightly fuzz coverage dial` or `cargo +nightly fuzz coverage listen`
4. `cargo cov -- show fuzz/target/x86_64-unknown-linux-gnu/release/dial --format=html     -instr-profile=fuzz/coverage/dial/coverage.profdata > index.html` (or replace `%s/dial/listen/g`)

Related: https://github.com/libp2p/rust-libp2p/issues/639