### PR TITLE
*: patch prost / prost-build version to v0.8

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,7 +25,7 @@ multihash = { version = "0.13", default-features = false, features = ["std", "mu
 multistream-select = { version = "0.10", path = "../misc/multistream-select" }
 parking_lot = "0.11.0"
 pin-project = "1.0.0"
-prost = "0.7"
+prost = "0.8"
 rand = "0.7"
 rw-stream-sink = "0.2.0"
 sha2 = "0.9.1"
@@ -50,7 +50,7 @@ quickcheck = "0.9.0"
 wasm-timer = "0.2"
 
 [build-dependencies]
-prost-build = "0.7"
+prost-build = "0.8"
 
 [features]
 default = ["secp256k1"]

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -16,9 +16,9 @@ futures = "0.3.1"
 libp2p-core = { version = "0.29.0", path = "../../core" }
 libp2p-swarm = { version = "0.30.0", path = "../../swarm" }
 log = "0.4"
-prost = "0.7"
+prost = "0.8"
 rand = "0.7"
 smallvec = "1.6.1"
 
 [build-dependencies]
-prost-build = "0.7"
+prost-build = "0.8"

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4.11"
 sha2 = "0.9.1"
 base64 = "0.13.0"
 smallvec = "1.6.1"
-prost = "0.7"
+prost = "0.8"
 hex_fmt = "0.3.0"
 regex = "1.4.0"
 
@@ -40,4 +40,4 @@ hex = "0.4.2"
 derive_builder = "0.10.0"
 
 [build-dependencies]
-prost-build = "0.7"
+prost-build = "0.8"

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.1"
 libp2p-core = { version = "0.29.0", path = "../../core" }
 libp2p-swarm = { version = "0.30.0", path = "../../swarm" }
 log = "0.4.1"
-prost = "0.7"
+prost = "0.8"
 smallvec = "1.6.1"
 wasm-timer = "0.2"
 
@@ -26,4 +26,4 @@ libp2p-noise = { path = "../../transports/noise" }
 libp2p-tcp = { path = "../../transports/tcp" }
 
 [build-dependencies]
-prost-build = "0.7"
+prost-build = "0.8"

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -19,7 +19,7 @@ futures = "0.3.1"
 log = "0.4"
 libp2p-core = { version = "0.29.0", path = "../../core" }
 libp2p-swarm = { version = "0.30.0", path = "../../swarm" }
-prost = "0.7"
+prost = "0.8"
 rand = "0.7.2"
 sha2 = "0.9.1"
 smallvec = "1.6.1"
@@ -35,4 +35,4 @@ libp2p-yamux = { path = "../../muxers/yamux" }
 quickcheck = "0.9.0"
 
 [build-dependencies]
-prost-build = "0.7"
+prost-build = "0.8"

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -18,7 +18,7 @@ libp2p-core = { version = "0.29", path = "../../core" }
 libp2p-swarm = { version = "0.30", path = "../../swarm" }
 log = "0.4"
 pin-project = "1"
-prost = "0.7"
+prost = "0.8"
 rand = "0.7"
 smallvec = "1.6.1"
 unsigned-varint = { version = "0.7", features = ["asynchronous_codec"] }
@@ -26,7 +26,7 @@ void = "1"
 wasm-timer = "0.2"
 
 [build-dependencies]
-prost-build = "0.7"
+prost-build = "0.8"
 
 [dev-dependencies]
 env_logger = "0.8.3"

--- a/transports/noise/Cargo.toml
+++ b/transports/noise/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.1"
 lazy_static = "1.2"
 libp2p-core = { version = "0.29.0", path = "../../core" }
 log = "0.4"
-prost = "0.7"
+prost = "0.8"
 rand = "0.8.3"
 sha2 = "0.9.1"
 static_assertions = "1"
@@ -35,4 +35,4 @@ quickcheck = "0.9.0"
 sodiumoxide = "0.2.5"
 
 [build-dependencies]
-prost-build = "0.7"
+prost-build = "0.8"

--- a/transports/plaintext/Cargo.toml
+++ b/transports/plaintext/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3.1"
 asynchronous-codec = "0.6"
 libp2p-core = { version = "0.29.0", path = "../../core" }
 log = "0.4.8"
-prost = "0.7"
+prost = "0.8"
 unsigned-varint = { version = "0.7", features = ["asynchronous_codec"] }
 void = "1.0.2"
 
@@ -25,4 +25,4 @@ quickcheck = "0.9.0"
 rand = "0.7"
 
 [build-dependencies]
-prost-build = "0.7"
+prost-build = "0.8"


### PR DESCRIPTION
Update `prost` and `prost-build` from v0.7 to v0.8. 
`prost-build` v0.7 depends on outdated version of `prost-types` with the issue https://github.com/tokio-rs/prost/issues/438:
>  Conversion from prost_types::Timestamp to SystemTime can cause an overflow and panic

cc: https://github.com/iotaledger/stronghold.rs/issues/228