### PR TITLE
.github/dependabot: Disable pull request limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 9999
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Increase pull request limit to 9999, practically disabling the limit.

I think there is lots of benefit in keeping dependencies up-to-date.

I don't think @dependabot adds much noise.