### PR TITLE
fix: Replace std::time::Instant by wasm_timer::Instant

### DIFF
--- a/protocols/gossipsub/src/peer_score.rs
+++ b/protocols/gossipsub/src/peer_score.rs
@@ -27,7 +27,8 @@ use libp2p_core::PeerId;
 use log::{debug, trace, warn};
 use std::collections::{hash_map, HashMap, HashSet};
 use std::net::IpAddr;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use wasm_timer::Instant;
 
 mod params;
 use crate::error::ValidationError;

--- a/protocols/gossipsub/src/time_cache.rs
+++ b/protocols/gossipsub/src/time_cache.rs
@@ -26,7 +26,9 @@ use std::collections::hash_map::{
     Entry::{Occupied, Vacant},
 };
 use std::collections::VecDeque;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use wasm_timer::Instant;
+
 
 struct ExpiringElement<Element> {
     /// The element that expires

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -77,7 +77,8 @@ pub use entry::*;
 use arrayvec::{self, ArrayVec};
 use bucket::KBucket;
 use std::collections::VecDeque;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use wasm_timer::Instant;
 
 /// Maximum number of k-buckets.
 const NUM_BUCKETS: usize = 256;

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -23,6 +23,7 @@ rand = "0.8.3"
 smallvec = "1.6.1"
 socket2 = { version = "0.4.0", features = ["all"] }
 void = "1.0.2"
+wasm-timer = "0.2.4"
 
 [dev-dependencies]
 async-std = "1.9.0"

--- a/protocols/mdns/src/behaviour.rs
+++ b/protocols/mdns/src/behaviour.rs
@@ -42,8 +42,9 @@ use std::{
     pin::Pin,
     task::Context,
     task::Poll,
-    time::{Duration, Instant},
+    time::Duration,
 };
+use wasm_timer::Instant;
 
 lazy_static! {
     static ref IPV4_MDNS_MULTICAST_ADDRESS: SocketAddr =


### PR DESCRIPTION
Closes #2134
Needs https://github.com/tomaka/wasm-timer/pull/17

* Just replaced the imports of `std::time::Instant` with `wasm-timer::Instant` for WASM support.
* Checked the existing uses of Instant, there is no dependency outside of the crate itself. All uses were never publicly exposed.
* I can't run the tests on my PC, it became really unstable when I tried but it fully compiled (even on wasm32 target using the https://github.com/tomaka/wasm-timer/pull/17).