### PR TITLE
Add a total established connection limit

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Add `ConnectionLimit::with_max_established` (see [PR 2137]).
 
+[PR 2137]: https://github.com/libp2p/rust-libp2p/pull/2137/
+
 - Change `PublicKey::into_protobuf_encoding` to `PublicKey::to_protobuf_encoding` (see [PR 2145]).
 
 - Change `PublicKey::into_peer_id` to `PublicKey::to_peer_id` (see [PR 2145]).

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.30.0 [unreleased]
 
+- Add `ConnectionLimit::with_max_established` (see [PR 2137]).
+
 - Change `PublicKey::into_protobuf_encoding` to `PublicKey::to_protobuf_encoding` (see [PR 2145]).
 
 - Change `PublicKey::into_peer_id` to `PublicKey::to_peer_id` (see [PR 2145]).

--- a/core/src/connection/pool.rs
+++ b/core/src/connection/pool.rs
@@ -987,6 +987,9 @@ impl ConnectionCounters {
     fn check_max_established(&self, endpoint: &ConnectedPoint)
         -> Result<(), ConnectionLimit>
     {
+        // Check total connection limit
+        Self::check(self.num_established(), self.limits.max_established_total)?;
+        // Check incoming/outgoing connection limits
         match endpoint {
             ConnectedPoint::Dialer { .. } =>
                 Self::check(self.established_outgoing, self.limits.max_established_outgoing),
@@ -1031,6 +1034,7 @@ pub struct ConnectionLimits {
     max_established_incoming: Option<u32>,
     max_established_outgoing: Option<u32>,
     max_established_per_peer: Option<u32>,
+    max_established_total: Option<u32>,
 }
 
 impl ConnectionLimits {
@@ -1055,6 +1059,13 @@ impl ConnectionLimits {
     /// Configures the maximum number of concurrent established outbound connections.
     pub fn with_max_established_outgoing(mut self, limit: Option<u32>) -> Self {
         self.max_established_outgoing = limit;
+        self
+    }
+
+    /// Configures the maximum number of concurrent total established connections (inbound or
+    /// outbound).
+    pub fn with_max_established_total(mut self, limit: Option<u32>) -> Self {
+        self.max_established_total = limit;
         self
     }
 

--- a/core/src/connection/pool.rs
+++ b/core/src/connection/pool.rs
@@ -1062,11 +1062,12 @@ impl ConnectionLimits {
         self
     }
 
-    /// Configures the maximum number of concurrent established connections (both inbound and
-    /// outbound).
+    /// Configures the maximum number of concurrent established connections (both
+    /// inbound and outbound).
+    ///
     /// Note: This should be used in conjunction with
-    /// [`ConnectionLimits::with_max_established_incoming`] to prevent possible eclipse attacks (all connections being
-    /// inbound.
+    /// [`ConnectionLimits::with_max_established_incoming`] to prevent possible
+    /// eclipse attacks (all connections being inbound).
     pub fn with_max_established(mut self, limit: Option<u32>) -> Self {
         self.max_established_total = limit;
         self

--- a/core/src/connection/pool.rs
+++ b/core/src/connection/pool.rs
@@ -987,7 +987,7 @@ impl ConnectionCounters {
     fn check_max_established(&self, endpoint: &ConnectedPoint)
         -> Result<(), ConnectionLimit>
     {
-        // Check total connection limit
+        // Check total connection limit.
         Self::check(self.num_established(), self.limits.max_established_total)?;
         // Check incoming/outgoing connection limits
         match endpoint {

--- a/core/src/connection/pool.rs
+++ b/core/src/connection/pool.rs
@@ -1064,6 +1064,9 @@ impl ConnectionLimits {
 
     /// Configures the maximum number of concurrent established connections (both inbound and
     /// outbound).
+    /// Note: This should be used in conjunction with
+    /// [`ConnectionLimits::with_max_established_incoming`] to prevent possible eclipse attacks (all connections being
+    /// inbound.
     pub fn with_max_established(mut self, limit: Option<u32>) -> Self {
         self.max_established_total = limit;
         self

--- a/core/src/connection/pool.rs
+++ b/core/src/connection/pool.rs
@@ -1062,9 +1062,9 @@ impl ConnectionLimits {
         self
     }
 
-    /// Configures the maximum number of concurrent total established connections (inbound or
+    /// Configures the maximum number of concurrent established connections (both inbound and
     /// outbound).
-    pub fn with_max_established_total(mut self, limit: Option<u32>) -> Self {
+    pub fn with_max_established(mut self, limit: Option<u32>) -> Self {
         self.max_established_total = limit;
         self
     }


### PR DESCRIPTION
I think it would be useful to be able to specify a total established connection limit, rather than just incoming and outgoing limits. 

If a user wants to set an incoming limit of 10 and an outgoing limit of 5, currently, this has a maximum connection limit of 15, but the ratio of incoming to outgoing is fixed. If a user wishes to specify the total and is happy to have a variable ratio of incoming/outgoing, I think this PR is useful to enable this at the `Network` level. 

This shouldn't break anything as its an optional addition to the `ConnectionLimit` struct.