### PR TITLE
(suggestion) Make RecordStore associated types IntoIterator instead of Iterator

### DIFF
--- a/protocols/kad/src/jobs.rs
+++ b/protocols/kad/src/jobs.rs
@@ -197,6 +197,7 @@ impl PutRecordJob {
         if self.inner.is_ready(cx, now) {
             let publish = self.next_publish.map_or(false, |t_pub| now >= t_pub);
             let records = store.records()
+                .into_iter()
                 .filter_map(|r| {
                     let is_publisher = r.publisher.as_ref() == Some(&self.local_id);
                     if self.skipped.contains(&r.key) || (!publish && is_publisher) {
@@ -290,6 +291,7 @@ impl AddProviderJob {
     {
         if self.inner.is_ready(cx, now) {
             let records = store.provided()
+                .into_iter()
                 .map(|r| r.into_owned())
                 .collect::<Vec<_>>()
                 .into_iter();

--- a/protocols/kad/src/record/store.rs
+++ b/protocols/kad/src/record/store.rs
@@ -60,8 +60,8 @@ pub enum Error {
 ///      to the closest nodes to the key.
 ///
 pub trait RecordStore<'a> {
-    type RecordsIter: Iterator<Item = Cow<'a, Record>>;
-    type ProvidedIter: Iterator<Item = Cow<'a, ProviderRecord>>;
+    type RecordsIter: IntoIterator<Item = Cow<'a, Record>>;
+    type ProvidedIter: IntoIterator<Item = Cow<'a, ProviderRecord>>;
 
     /// Gets a record from the store, given its key.
     fn get(&'a self, k: &Key) -> Option<Cow<'_, Record>>;


### PR DESCRIPTION
The idea behind this pull request:

```diff
--- a/protocols/kad/src/record/store.rs                               
+++ b/protocols/kad/src/record/store.rs                               
@@ -60,8 +60,8 @@ pub enum Error {                                    
 ///      to the closest nodes to the key.                            
 ///                                                                  
 pub trait RecordStore<'a> {                                          
-    type RecordsIter: Iterator<Item = Cow<'a, Record>>;              
-    type ProvidedIter: Iterator<Item = Cow<'a, ProviderRecord>>;     
+    type RecordsIter: IntoIterator<Item = Cow<'a, Record>>;          
+    type ProvidedIter: IntoIterator<Item = Cow<'a, ProviderRecord>>; 
```

This allows a RecordStore to return a lot more types, such as a `Vec` or slices, or anything listed under blanket implementation (https://doc.rust-lang.org/std/iter/trait.IntoIterator.html).

This is backwards compatible for implementers of the trait (because `impl IntoIterator for I where I: Iterator`) and gives the implementer a bit more freedom, but is a breaking change for callers that want to directly chain iterator calls (example in the `jobs.rs` patch); they have to add `into_iter()`. Notably, it is not a breaking change when used directly in a `for` loop.