### PR TITLE
Deal with some clippy warnings

### DIFF
--- a/core/src/peer_id.rs
+++ b/core/src/peer_id.rs
@@ -68,8 +68,8 @@ impl PeerId {
 
     /// Parses a `PeerId` from bytes.
     pub fn from_bytes(data: &[u8]) -> Result<PeerId, Error> {
-        Ok(PeerId::from_multihash(Multihash::from_bytes(&data)?)
-            .map_err(|mh| Error::UnsupportedCode(mh.code()))?)
+        PeerId::from_multihash(Multihash::from_bytes(&data)?)
+            .map_err(|mh| Error::UnsupportedCode(mh.code()))
     }
 
     /// Tries to turn a `Multihash` into a `PeerId`.

--- a/muxers/mplex/src/codec.rs
+++ b/muxers/mplex/src/codec.rs
@@ -244,25 +244,25 @@ impl Encoder for Codec {
     fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
         let (header, data) = match item {
             Frame::Open { stream_id } => {
-                (u64::from(stream_id.num) << 3, Bytes::new())
+                (stream_id.num << 3, Bytes::new())
             },
             Frame::Data { stream_id: LocalStreamId { num, role: Endpoint::Listener }, data } => {
-                (u64::from(num) << 3 | 1, data)
+                (num << 3 | 1, data)
             },
             Frame::Data { stream_id: LocalStreamId { num, role: Endpoint::Dialer }, data } => {
-                (u64::from(num) << 3 | 2, data)
+                (num << 3 | 2, data)
             },
             Frame::Close { stream_id: LocalStreamId { num, role: Endpoint::Listener } } => {
-                (u64::from(num) << 3 | 3, Bytes::new())
+                (num << 3 | 3, Bytes::new())
             },
             Frame::Close { stream_id: LocalStreamId { num, role: Endpoint::Dialer } } => {
-                (u64::from(num) << 3 | 4, Bytes::new())
+                (num << 3 | 4, Bytes::new())
             },
             Frame::Reset { stream_id: LocalStreamId { num, role: Endpoint::Listener } } => {
-                (u64::from(num) << 3 | 5, Bytes::new())
+                (num << 3 | 5, Bytes::new())
             },
             Frame::Reset { stream_id: LocalStreamId { num, role: Endpoint::Dialer } } => {
-                (u64::from(num) << 3 | 6, Bytes::new())
+                (num << 3 | 6, Bytes::new())
             },
         };
 

--- a/protocols/identify/src/handler.rs
+++ b/protocols/identify/src/handler.rs
@@ -211,7 +211,7 @@ impl ProtocolsHandler for IdentifyHandler {
                 };
                 Poll::Ready(ev)
             }
-            Poll::Ready(Err(err)) => Poll::Ready(ProtocolsHandlerEvent::Close(err.into()))
+            Poll::Ready(Err(err)) => Poll::Ready(ProtocolsHandlerEvent::Close(err))
         }
     }
 }

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -207,7 +207,7 @@ where
         Ok(v) => v,
         Err(err) => {
             debug!("Invalid message: {:?}", err);
-            return Err(err.into())
+            return Err(err)
         }
     };
 

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -186,7 +186,7 @@ where
     ///
     /// The buckets are ordered by proximity to the `local_key`, i.e. the first
     /// bucket is the closest bucket (containing at most one key).
-    pub fn iter<'a>(&'a mut self) -> impl Iterator<Item = KBucketRef<'a, TKey, TVal>> + 'a {
+    pub fn iter(&mut self) -> impl Iterator<Item = KBucketRef<'_, TKey, TVal>> + '_ {
         let applied_pending = &mut self.applied_pending;
         self.buckets.iter_mut().enumerate().map(move |(i, b)| {
             if let Some(applied) = b.apply_pending() {

--- a/protocols/mdns/src/dns.rs
+++ b/protocols/mdns/src/dns.rs
@@ -371,8 +371,7 @@ fn append_txt_record(
     if value.len() > MAX_TXT_VALUE_LENGTH {
         return Err(MdnsResponseError::TxtRecordTooLong);
     }
-    let mut buffer = Vec::new();
-    buffer.push(value.len() as u8);
+    let mut buffer = vec![value.len() as u8];
     append_character_string(&mut buffer, value)?;
 
     append_u16(out, buffer.len() as u16);

--- a/transports/noise/src/protocol/x25519.rs
+++ b/transports/noise/src/protocol/x25519.rs
@@ -235,7 +235,7 @@ impl snow::types::Dh for Keypair<X25519> {
 
     fn set(&mut self, sk: &[u8]) {
         let mut secret = [0u8; 32];
-        secret.copy_from_slice(&sk[..]);
+        secret.copy_from_slice(&sk);
         self.secret = SecretKey(X25519(secret)); // Copy
         self.public = PublicKey(X25519(x25519(secret, X25519_BASEPOINT_BYTES)));
         secret.zeroize();

--- a/transports/noise/src/protocol/x25519_spec.rs
+++ b/transports/noise/src/protocol/x25519_spec.rs
@@ -146,7 +146,7 @@ impl snow::types::Dh for Keypair<X25519Spec> {
 
     fn set(&mut self, sk: &[u8]) {
         let mut secret = [0u8; 32];
-        secret.copy_from_slice(&sk[..]);
+        secret.copy_from_slice(&sk);
         self.secret = SecretKey(X25519Spec(secret)); // Copy
         self.public = PublicKey(X25519Spec(x25519(secret, X25519_BASEPOINT_BYTES)));
         secret.zeroize();


### PR DESCRIPTION
Can drop individual commits if some of the changes are not wanted.

I purposely left everything in `relay` untouched to not interfere with https://github.com/libp2p/rust-libp2p/pull/2059 too much.