### PR TITLE
Keypair::to_protobuf_encoding

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Introduce `Keypair::to_protobuf_encoding`, see [PR 2142]
+- Introduce `Keypair::to_protobuf_encoding`, see [PR 2142].
 
 [PR 2142]: https://github.com/libp2p/rust-libp2p/pull/2142
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,3 +1,7 @@
+- Introduce `Keypair::to_protobuf_encoding`, see [PR 2142]
+
+[PR 2142]: https://github.com/libp2p/rust-libp2p/pull/2142
+
 # 0.29.0 [2021-07-12]
 
 - Switch from `parity-multiaddr` to upstream `multiaddr`.

--- a/core/src/identity.rs
+++ b/core/src/identity.rs
@@ -285,12 +285,12 @@ mod tests {
     #[test]
     fn keypair_protobuf_roundtrip() {
         let expected_keypair = Keypair::generate_ed25519();
-        let expected_peer_id = expected_keypair.public().into_peer_id();
+        let expected_peer_id = expected_keypair.public().to_peer_id();
 
         let encoded = expected_keypair.to_protobuf_encoding().unwrap();
 
         let keypair = Keypair::from_protobuf_encoding(&encoded).unwrap();
-        let peer_id = keypair.public().into_peer_id();
+        let peer_id = keypair.public().to_peer_id();
 
         assert_eq!(expected_peer_id, peer_id);
     }

--- a/core/src/identity.rs
+++ b/core/src/identity.rs
@@ -116,6 +116,33 @@ impl Keypair {
         }
     }
 
+    /// Encode a private key as protobuf structure.
+    pub fn to_protobuf_encoding(&self) -> Result<Vec<u8>, DecodingError> {
+        use prost::Message;
+
+        let pk = match self {
+            Self::Ed25519(data) => keys_proto::PrivateKey {
+                r#type: keys_proto::KeyType::Ed25519.into(),
+                data: data.encode().into(),
+            },
+            #[cfg(not(target_arch = "wasm32"))]
+            Self::Rsa(_) => {
+                return Err(DecodingError::new(
+                    "Encoding RSA key into Protobuf is unsupported",
+                ))
+            }
+            #[cfg(feature = "secp256k1")]
+            Self::Secp256k1(_) => {
+                return Err(DecodingError::new(
+                    "Encoding Secp256k1 key into Protobuf is unsupported",
+                ))
+            }
+        };
+
+        Ok(pk.encode_to_vec())
+    }
+
+
     /// Decode a private key from a protobuf structure and parse it as a [`Keypair`].
     pub fn from_protobuf_encoding(bytes: &[u8]) -> Result<Keypair, DecodingError> {
         use prost::Message;
@@ -254,6 +281,19 @@ impl PublicKey {
 mod tests {
     use super::*;
     use std::str::FromStr;
+
+    #[test]
+    fn keypair_protobuf_roundtrip() {
+        let expected_keypair = Keypair::generate_ed25519();
+        let expected_peer_id = expected_keypair.public().into_peer_id();
+
+        let encoded = expected_keypair.to_protobuf_encoding().unwrap();
+
+        let keypair = Keypair::from_protobuf_encoding(&encoded).unwrap();
+        let peer_id = keypair.public().into_peer_id();
+
+        assert_eq!(expected_peer_id, peer_id);
+    }
 
     #[test]
     fn keypair_from_protobuf_encoding() {


### PR DESCRIPTION
Keypair was able to decode protobuf-encoded keys, but not to encode them yet afaik. This adds a method to encode `identity::Keypair`s.