### PR TITLE
to/into consistency for PublicKey and PeerId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,30 @@
 
 # `libp2p` facade crate
 
+## Version 0.40.0 [unreleased]
+
+- Update individual crates.
+    - `libp2p-core`
+    - `libp2p-deflate`
+    - `libp2p-dns`
+    - `libp2p-floodsub`
+    - `libp2p-gossipsub`
+    - `libp2p-identify`
+    - `libp2p-kad`
+    - `libp2p-mdns`
+    - `libp2p-mplex`
+    - `libp2p-noise`
+    - `libp2p-ping`
+    - `libp2p-plaintext`
+    - `libp2p-relay`
+    - `libp2p-request-response`
+    - `libp2p-swarm`
+    - `libp2p-tcp`
+    - `libp2p-uds`
+    - `libp2p-wasm-ext`
+    - `libp2p-websocket`
+    - `libp2p-yamux`
+
 ## Version 0.39.1 [2021-07-12]
 
 - Update individual crates.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p"
 edition = "2018"
 description = "Peer-to-peer networking library"
-version = "0.39.1"
+version = "0.40.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -64,23 +64,23 @@ atomic = "0.5.0"
 bytes = "1"
 futures = "0.3.1"
 lazy_static = "1.2"
-libp2p-core = { version = "0.29.0", path = "core",  default-features = false }
-libp2p-floodsub = { version = "0.30.0", path = "protocols/floodsub", optional = true }
-libp2p-gossipsub = { version = "0.32.0", path = "./protocols/gossipsub", optional = true }
-libp2p-identify = { version = "0.30.0", path = "protocols/identify", optional = true }
-libp2p-kad = { version = "0.31.0", path = "protocols/kad", optional = true }
-libp2p-mplex = { version = "0.29.0", path = "muxers/mplex", optional = true }
-libp2p-noise = { version = "0.32.0", path = "transports/noise", optional = true }
-libp2p-ping = { version = "0.30.0", path = "protocols/ping", optional = true }
-libp2p-plaintext = { version = "0.29.0", path = "transports/plaintext", optional = true }
+libp2p-core = { version = "0.30.0", path = "core",  default-features = false }
+libp2p-floodsub = { version = "0.31.0", path = "protocols/floodsub", optional = true }
+libp2p-gossipsub = { version = "0.33.0", path = "./protocols/gossipsub", optional = true }
+libp2p-identify = { version = "0.31.0", path = "protocols/identify", optional = true }
+libp2p-kad = { version = "0.32.0", path = "protocols/kad", optional = true }
+libp2p-mplex = { version = "0.30.0", path = "muxers/mplex", optional = true }
+libp2p-noise = { version = "0.33.0", path = "transports/noise", optional = true }
+libp2p-ping = { version = "0.31.0", path = "protocols/ping", optional = true }
+libp2p-plaintext = { version = "0.30.0", path = "transports/plaintext", optional = true }
 libp2p-pnet = { version = "0.21.0", path = "transports/pnet", optional = true }
-libp2p-relay = { version = "0.3.0", path = "protocols/relay", optional = true }
-libp2p-request-response = { version = "0.12.0", path = "protocols/request-response", optional = true }
-libp2p-swarm = { version = "0.30.0", path = "swarm" }
+libp2p-relay = { version = "0.4.0", path = "protocols/relay", optional = true }
+libp2p-request-response = { version = "0.13.0", path = "protocols/request-response", optional = true }
+libp2p-swarm = { version = "0.31.0", path = "swarm" }
 libp2p-swarm-derive = { version = "0.24.0", path = "swarm-derive" }
-libp2p-uds = { version = "0.29.0", path = "transports/uds", optional = true }
-libp2p-wasm-ext = { version = "0.29.0", path = "transports/wasm-ext", default-features = false, optional = true }
-libp2p-yamux = { version = "0.33.0", path = "muxers/yamux", optional = true }
+libp2p-uds = { version = "0.30.0", path = "transports/uds", optional = true }
+libp2p-wasm-ext = { version = "0.30.0", path = "transports/wasm-ext", default-features = false, optional = true }
+libp2p-yamux = { version = "0.34.0", path = "muxers/yamux", optional = true }
 multiaddr = { version = "0.13.0" }
 parking_lot = "0.11.0"
 pin-project = "1.0.0"
@@ -88,11 +88,11 @@ smallvec = "1.6.1"
 wasm-timer = "0.2.4"
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")))'.dependencies]
-libp2p-deflate = { version = "0.29.0", path = "transports/deflate", optional = true }
-libp2p-dns = { version = "0.29.0", path = "transports/dns", optional = true, default-features = false }
-libp2p-mdns = { version = "0.31.0", path = "protocols/mdns", optional = true }
-libp2p-tcp = { version = "0.29.0", path = "transports/tcp", default-features = false, optional = true }
-libp2p-websocket = { version = "0.30.0", path = "transports/websocket", optional = true }
+libp2p-deflate = { version = "0.30.0", path = "transports/deflate", optional = true }
+libp2p-dns = { version = "0.30.0", path = "transports/dns", optional = true, default-features = false }
+libp2p-mdns = { version = "0.32.0", path = "protocols/mdns", optional = true }
+libp2p-tcp = { version = "0.30.0", path = "transports/tcp", default-features = false, optional = true }
+libp2p-websocket = { version = "0.31.0", path = "transports/websocket", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,8 @@
-- Change `PublicKey::into_protobuf_encoding` to `PublicKey::to_protobuf_encoding` (see [PR 2145])
+- Change `PublicKey::into_protobuf_encoding` to `PublicKey::to_protobuf_encoding`.
+  Change `PublicKey::into_peer_id` to `PublicKey::to_peer_id`.
+  Change `PeerId::from_public_key(PublicKey)` to `PeerId::from_public_key(&PublicKey)`.
+  Add `From<&PublicKey> for PeerId`.
+  See [PR 2145]
 
 [PR 2145]: https://github.com/libp2p/rust-libp2p/pull/2145
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,3 +1,7 @@
+- Change `PublicKey::into_protobuf_encoding` to `PublicKey::to_protobuf_encoding` (see [PR 2145])
+
+[PR 2145]: https://github.com/libp2p/rust-libp2p/pull/2145
+
 # 0.29.0 [2021-07-12]
 
 - Switch from `parity-multiaddr` to upstream `multiaddr`.

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,8 +1,12 @@
-- Change `PublicKey::into_protobuf_encoding` to `PublicKey::to_protobuf_encoding`.
-  Change `PublicKey::into_peer_id` to `PublicKey::to_peer_id`.
-  Change `PeerId::from_public_key(PublicKey)` to `PeerId::from_public_key(&PublicKey)`.
-  Add `From<&PublicKey> for PeerId`.
-  See [PR 2145]
+# 0.30.0 [unreleased]
+
+- Change `PublicKey::into_protobuf_encoding` to `PublicKey::to_protobuf_encoding` (see [PR 2145]).
+
+- Change `PublicKey::into_peer_id` to `PublicKey::to_peer_id` (see [PR 2145]).
+
+- Change `PeerId::from_public_key(PublicKey)` to `PeerId::from_public_key(&PublicKey)` (see [PR 2145]).
+
+- Add `From<&PublicKey> for PeerId` (see [PR 2145]).
 
 [PR 2145]: https://github.com/libp2p/rust-libp2p/pull/2145
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-core"
 edition = "2018"
 description = "Core traits and structs of libp2p"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/core/benches/peer_id.rs
+++ b/core/benches/peer_id.rs
@@ -24,7 +24,7 @@ use libp2p_core::{identity, PeerId};
 fn from_bytes(c: &mut Criterion) {
     let peer_id_bytes = identity::Keypair::generate_ed25519()
         .public()
-        .into_peer_id()
+        .to_peer_id()
         .to_bytes();
 
     c.bench_function("from_bytes", |b| {
@@ -37,7 +37,7 @@ fn from_bytes(c: &mut Criterion) {
 fn clone(c: &mut Criterion) {
     let peer_id = identity::Keypair::generate_ed25519()
         .public()
-        .into_peer_id();
+        .to_peer_id();
 
     c.bench_function("clone", |b| {
         b.iter(|| {
@@ -51,7 +51,7 @@ fn sort_vec(c: &mut Criterion) {
         .map(|_| {
             identity::Keypair::generate_ed25519()
                 .public()
-                .into_peer_id()
+                .to_peer_id()
         })
         .collect();
 

--- a/core/src/identity.rs
+++ b/core/src/identity.rs
@@ -245,7 +245,7 @@ impl PublicKey {
     }
 
     /// Convert the `PublicKey` into the corresponding `PeerId`.
-    pub fn into_peer_id(self) -> PeerId {
+    pub fn to_peer_id(&self) -> PeerId {
         self.into()
     }
 }
@@ -264,7 +264,7 @@ mod tests {
         let encoded = base64::decode(base_64_encoded).unwrap();
 
         let keypair = Keypair::from_protobuf_encoding(&encoded).unwrap();
-        let peer_id = keypair.public().into_peer_id();
+        let peer_id = keypair.public().to_peer_id();
 
         assert_eq!(expected_peer_id, peer_id);
     }

--- a/core/src/identity.rs
+++ b/core/src/identity.rs
@@ -179,7 +179,7 @@ impl PublicKey {
 
     /// Encode the public key into a protobuf structure for storage or
     /// exchange with other nodes.
-    pub fn into_protobuf_encoding(self) -> Vec<u8> {
+    pub fn to_protobuf_encoding(&self) -> Vec<u8> {
         use prost::Message;
 
         let public_key = match self {

--- a/core/src/peer_id.rs
+++ b/core/src/peer_id.rs
@@ -114,7 +114,7 @@ impl PeerId {
     pub fn is_public_key(&self, public_key: &PublicKey) -> Option<bool> {
         let alg = Code::try_from(self.multihash.code())
             .expect("Internal multihash is always a valid `Code`");
-        let enc = public_key.clone().to_protobuf_encoding();
+        let enc = public_key.to_protobuf_encoding();
         Some(alg.digest(&enc) == self.multihash)
     }
 }

--- a/core/src/peer_id.rs
+++ b/core/src/peer_id.rs
@@ -53,7 +53,7 @@ impl fmt::Display for PeerId {
 impl PeerId {
     /// Builds a `PeerId` from a public key.
     pub fn from_public_key(key: PublicKey) -> PeerId {
-        let key_enc = key.into_protobuf_encoding();
+        let key_enc = key.to_protobuf_encoding();
 
         let hash_algorithm = if key_enc.len() <= MAX_INLINE_KEY_LENGTH {
             Code::Identity
@@ -114,7 +114,7 @@ impl PeerId {
     pub fn is_public_key(&self, public_key: &PublicKey) -> Option<bool> {
         let alg = Code::try_from(self.multihash.code())
             .expect("Internal multihash is always a valid `Code`");
-        let enc = public_key.clone().into_protobuf_encoding();
+        let enc = public_key.clone().to_protobuf_encoding();
         Some(alg.digest(&enc) == self.multihash)
     }
 }

--- a/core/src/peer_id.rs
+++ b/core/src/peer_id.rs
@@ -52,7 +52,7 @@ impl fmt::Display for PeerId {
 
 impl PeerId {
     /// Builds a `PeerId` from a public key.
-    pub fn from_public_key(key: PublicKey) -> PeerId {
+    pub fn from_public_key(key: &PublicKey) -> PeerId {
         let key_enc = key.to_protobuf_encoding();
 
         let hash_algorithm = if key_enc.len() <= MAX_INLINE_KEY_LENGTH {
@@ -121,6 +121,12 @@ impl PeerId {
 
 impl From<PublicKey> for PeerId {
     fn from(key: PublicKey) -> PeerId {
+        PeerId::from_public_key(&key)
+    }
+}
+
+impl From<&PublicKey> for PeerId {
+    fn from(key: &PublicKey) -> PeerId {
         PeerId::from_public_key(key)
     }
 }
@@ -184,20 +190,20 @@ mod tests {
     #[test]
     fn peer_id_is_public_key() {
         let key = identity::Keypair::generate_ed25519().public();
-        let peer_id = key.clone().into_peer_id();
+        let peer_id = key.to_peer_id();
         assert_eq!(peer_id.is_public_key(&key), Some(true));
     }
 
     #[test]
     fn peer_id_into_bytes_then_from_bytes() {
-        let peer_id = identity::Keypair::generate_ed25519().public().into_peer_id();
+        let peer_id = identity::Keypair::generate_ed25519().public().to_peer_id();
         let second = PeerId::from_bytes(&peer_id.to_bytes()).unwrap();
         assert_eq!(peer_id, second);
     }
 
     #[test]
     fn peer_id_to_base58_then_back() {
-        let peer_id = identity::Keypair::generate_ed25519().public().into_peer_id();
+        let peer_id = identity::Keypair::generate_ed25519().public().to_peer_id();
         let second: PeerId = peer_id.to_base58().parse().unwrap();
         assert_eq!(peer_id, second);
     }

--- a/core/tests/transport_upgrade.rs
+++ b/core/tests/transport_upgrade.rs
@@ -80,7 +80,7 @@ where
 #[test]
 fn upgrade_pipeline() {
     let listener_keys = identity::Keypair::generate_ed25519();
-    let listener_id = listener_keys.public().into_peer_id();
+    let listener_id = listener_keys.public().to_peer_id();
     let listener_noise_keys = noise::Keypair::<noise::X25519Spec>::new().into_authentic(&listener_keys).unwrap();
     let listener_transport = MemoryTransport::default()
         .upgrade(upgrade::Version::V1)
@@ -96,7 +96,7 @@ fn upgrade_pipeline() {
         });
 
     let dialer_keys = identity::Keypair::generate_ed25519();
-    let dialer_id = dialer_keys.public().into_peer_id();
+    let dialer_id = dialer_keys.public().to_peer_id();
     let dialer_noise_keys = noise::Keypair::<noise::X25519Spec>::new().into_authentic(&dialer_keys).unwrap();
     let dialer_transport = MemoryTransport::default()
         .upgrade(upgrade::Version::V1)

--- a/misc/multistream-select/tests/transport.rs
+++ b/misc/multistream-select/tests/transport.rs
@@ -42,7 +42,7 @@ type TestNetwork = Network<TestTransport, (), (), TestHandler>;
 
 fn mk_transport(up: upgrade::Version) -> (PeerId, TestTransport) {
     let keys = identity::Keypair::generate_ed25519();
-    let id = keys.public().into_peer_id();
+    let id = keys.public().to_peer_id();
     (id, MemoryTransport::default()
         .upgrade(up)
         .authenticate(PlainText2Config { local_public_key: keys.public() })

--- a/misc/peer-id-generator/src/main.rs
+++ b/misc/peer-id-generator/src/main.rs
@@ -68,7 +68,7 @@ fn main() {
         thread::spawn(move || loop {
             let keypair = identity::ed25519::Keypair::generate();
             let secret = keypair.secret();
-            let peer_id = identity::PublicKey::Ed25519(keypair.public()).into_peer_id();
+            let peer_id = identity::PublicKey::Ed25519(keypair.public()).to_peer_id();
             let base58 = peer_id.to_base58();
             if base58[2..].starts_with(&prefix) {
                 println!("Found {:?}", peer_id);

--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.30.0 [unreleased]
+
+- Update dependencies.
+
 # 0.29.0 [2021-07-12]
 
 - Update dependencies.

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-mplex"
 edition = "2018"
 description = "Mplex multiplexing protocol for libp2p"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 bytes = "1"
 futures = "0.3.1"
 asynchronous-codec = "0.6"
-libp2p-core = { version = "0.29.0", path = "../../core" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
 log = "0.4"
 nohash-hasher = "0.2"
 parking_lot = "0.11"

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.34.0 [unreleased]
+
+- Update dependencies.
+
 # 0.33.0 [2021-07-12]
 
 - Update dependencies.

--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-yamux"
 edition = "2018"
 description = "Yamux multiplexing protocol for libp2p"
-version = "0.33.0"
+version = "0.34.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.29.0", path = "../../core" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
 parking_lot = "0.11"
 thiserror = "1.0"
 yamux = "0.9.0"

--- a/protocols/floodsub/CHANGELOG.md
+++ b/protocols/floodsub/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.31.0 [unreleased]
+
+- Update dependencies.
+
 # 0.30.0 [2021-07-12]
 
 - Update dependencies.

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-floodsub"
 edition = "2018"
 description = "Floodsub protocol for libp2p"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -13,8 +13,8 @@ categories = ["network-programming", "asynchronous"]
 cuckoofilter = "0.5.0"
 fnv = "1.0"
 futures = "0.3.1"
-libp2p-core = { version = "0.29.0", path = "../../core" }
-libp2p-swarm = { version = "0.30.0", path = "../../swarm" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
+libp2p-swarm = { version = "0.31.0", path = "../../swarm" }
 log = "0.4"
 prost = "0.8"
 rand = "0.7"

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.33.0 [unreleased]
+
+- Update dependencies.
+
 # 0.32.0 [2021-07-12]
 
 - Update dependencies.

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-gossipsub"
 edition = "2018"
 description = "Gossipsub protocol for libp2p"
-version = "0.32.0"
+version = "0.33.0"
 authors = ["Age Manning <Age@AgeManning.com>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -10,8 +10,8 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-libp2p-swarm = { version = "0.30.0", path = "../../swarm" }
-libp2p-core = { version = "0.29.0", path = "../../core" }
+libp2p-swarm = { version = "0.31.0", path = "../../swarm" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
 bytes = "1.0"
 byteorder = "1.3.4"
 fnv = "1.0.7"

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -169,7 +169,7 @@ impl From<MessageAuthenticity> for PublishConfig {
         match authenticity {
             MessageAuthenticity::Signed(keypair) => {
                 let public_key = keypair.public();
-                let key_enc = public_key.clone().into_protobuf_encoding();
+                let key_enc = public_key.clone().to_protobuf_encoding();
                 let key = if key_enc.len() <= 42 {
                     // The public key can be inlined in [`rpc_proto::Message::from`], so we don't include it
                     // specifically in the [`rpc_proto::Message::key`] field.

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -181,7 +181,7 @@ impl From<MessageAuthenticity> for PublishConfig {
 
                 PublishConfig::Signing {
                     keypair,
-                    author: public_key.into_peer_id(),
+                    author: public_key.to_peer_id(),
                     inline_key: key,
                 }
             }

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -169,7 +169,7 @@ impl From<MessageAuthenticity> for PublishConfig {
         match authenticity {
             MessageAuthenticity::Signed(keypair) => {
                 let public_key = keypair.public();
-                let key_enc = public_key.clone().to_protobuf_encoding();
+                let key_enc = public_key.to_protobuf_encoding();
                 let key = if key_enc.len() <= 42 {
                     // The public key can be inlined in [`rpc_proto::Message::from`], so we don't include it
                     // specifically in the [`rpc_proto::Message::key`] field.

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -228,7 +228,7 @@ impl GossipsubCodec {
         };
 
         // The key must match the peer_id
-        if source != public_key.clone().to_peer_id() {
+        if source != public_key.to_peer_id() {
             warn!("Signature verification failed: Public key doesn't match source peer id");
             return false;
         }

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -228,7 +228,7 @@ impl GossipsubCodec {
         };
 
         // The key must match the peer_id
-        if source != public_key.clone().into_peer_id() {
+        if source != public_key.clone().to_peer_id() {
             warn!("Signature verification failed: Public key doesn't match source peer id");
             return false;
         }

--- a/protocols/gossipsub/tests/smoke.rs
+++ b/protocols/gossipsub/tests/smoke.rs
@@ -153,7 +153,7 @@ fn build_node() -> (Multiaddr, Swarm<Gossipsub>) {
         .multiplex(yamux::YamuxConfig::default())
         .boxed();
 
-    let peer_id = public_key.clone().into_peer_id();
+    let peer_id = public_key.clone().to_peer_id();
 
     // NOTE: The graph of created nodes can be disconnected from the mesh point of view as nodes
     // can reach their d_lo value and not add other nodes to their mesh. To speed up this test, we
@@ -176,7 +176,7 @@ fn build_node() -> (Multiaddr, Swarm<Gossipsub>) {
     swarm.listen_on(addr.clone()).unwrap();
 
     addr = addr.with(libp2p_core::multiaddr::Protocol::P2p(
-        public_key.into_peer_id().into(),
+        public_key.to_peer_id().into(),
     ));
 
     (addr, swarm)

--- a/protocols/gossipsub/tests/smoke.rs
+++ b/protocols/gossipsub/tests/smoke.rs
@@ -153,7 +153,7 @@ fn build_node() -> (Multiaddr, Swarm<Gossipsub>) {
         .multiplex(yamux::YamuxConfig::default())
         .boxed();
 
-    let peer_id = public_key.clone().to_peer_id();
+    let peer_id = public_key.to_peer_id();
 
     // NOTE: The graph of created nodes can be disconnected from the mesh point of view as nodes
     // can reach their d_lo value and not add other nodes to their mesh. To speed up this test, we

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.31.0 [unreleased]
+
+- Update dependencies.
+
 # 0.30.0 [2021-07-12]
 
 - Update dependencies.

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-identify"
 edition = "2018"
 description = "Nodes identifcation protocol for libp2p"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,8 +11,8 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.29.0", path = "../../core" }
-libp2p-swarm = { version = "0.30.0", path = "../../swarm" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
+libp2p-swarm = { version = "0.31.0", path = "../../swarm" }
 log = "0.4.1"
 prost = "0.8"
 smallvec = "1.6.1"

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -478,7 +478,7 @@ mod tests {
             let protocol = Identify::new(
                 IdentifyConfig::new("a".to_string(), pubkey.clone())
                     .with_agent_version("b".to_string()));
-            let swarm = Swarm::new(transport, protocol, pubkey.clone().into_peer_id());
+            let swarm = Swarm::new(transport, protocol, pubkey.clone().to_peer_id());
             (swarm, pubkey)
         };
 
@@ -487,7 +487,7 @@ mod tests {
             let protocol = Identify::new(
                 IdentifyConfig::new("c".to_string(), pubkey.clone())
                     .with_agent_version("d".to_string()));
-            let swarm = Swarm::new(transport, protocol, pubkey.clone().into_peer_id());
+            let swarm = Swarm::new(transport, protocol, pubkey.clone().to_peer_id());
             (swarm, pubkey)
         };
 
@@ -555,7 +555,7 @@ mod tests {
                 IdentifyConfig::new("a".to_string(), pubkey.clone())
                     // Delay identification requests so we can test the push protocol.
                     .with_initial_delay(Duration::from_secs(u32::MAX as u64)));
-            let swarm = Swarm::new(transport, protocol, pubkey.clone().into_peer_id());
+            let swarm = Swarm::new(transport, protocol, pubkey.clone().to_peer_id());
             (swarm, pubkey)
         };
 
@@ -566,7 +566,7 @@ mod tests {
                     .with_agent_version("b".to_string())
                     // Delay identification requests so we can test the push protocol.
                     .with_initial_delay(Duration::from_secs(u32::MAX as u64)));
-            let swarm = Swarm::new(transport, protocol, pubkey.clone().into_peer_id());
+            let swarm = Swarm::new(transport, protocol, pubkey.clone().to_peer_id());
             (swarm, pubkey)
         };
 
@@ -612,7 +612,7 @@ mod tests {
                     }
                 }
 
-                swarm2.behaviour_mut().push(std::iter::once(pubkey1.clone().into_peer_id()));
+                swarm2.behaviour_mut().push(std::iter::once(pubkey1.clone().to_peer_id()));
             }
         })
     }

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -478,7 +478,7 @@ mod tests {
             let protocol = Identify::new(
                 IdentifyConfig::new("a".to_string(), pubkey.clone())
                     .with_agent_version("b".to_string()));
-            let swarm = Swarm::new(transport, protocol, pubkey.clone().to_peer_id());
+            let swarm = Swarm::new(transport, protocol, pubkey.to_peer_id());
             (swarm, pubkey)
         };
 
@@ -487,7 +487,7 @@ mod tests {
             let protocol = Identify::new(
                 IdentifyConfig::new("c".to_string(), pubkey.clone())
                     .with_agent_version("d".to_string()));
-            let swarm = Swarm::new(transport, protocol, pubkey.clone().to_peer_id());
+            let swarm = Swarm::new(transport, protocol, pubkey.to_peer_id());
             (swarm, pubkey)
         };
 
@@ -555,7 +555,7 @@ mod tests {
                 IdentifyConfig::new("a".to_string(), pubkey.clone())
                     // Delay identification requests so we can test the push protocol.
                     .with_initial_delay(Duration::from_secs(u32::MAX as u64)));
-            let swarm = Swarm::new(transport, protocol, pubkey.clone().to_peer_id());
+            let swarm = Swarm::new(transport, protocol, pubkey.to_peer_id());
             (swarm, pubkey)
         };
 
@@ -566,7 +566,7 @@ mod tests {
                     .with_agent_version("b".to_string())
                     // Delay identification requests so we can test the push protocol.
                     .with_initial_delay(Duration::from_secs(u32::MAX as u64)));
-            let swarm = Swarm::new(transport, protocol, pubkey.clone().to_peer_id());
+            let swarm = Swarm::new(transport, protocol, pubkey.to_peer_id());
             (swarm, pubkey)
         };
 
@@ -612,7 +612,7 @@ mod tests {
                     }
                 }
 
-                swarm2.behaviour_mut().push(std::iter::once(pubkey1.clone().to_peer_id()));
+                swarm2.behaviour_mut().push(std::iter::once(pubkey1.to_peer_id()));
             }
         })
     }

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -173,7 +173,7 @@ where
         .map(|addr| addr.to_vec())
         .collect();
 
-    let pubkey_bytes = info.public_key.into_protobuf_encoding();
+    let pubkey_bytes = info.public_key.to_protobuf_encoding();
 
     let message = structs_proto::Identify {
         agent_version: Some(info.agent_version),

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.32.0 [unreleased]
+
+- Update dependencies.
+
 # 0.31.0 [2021-07-12]
 
 - Update dependencies.

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-kad"
 edition = "2018"
 description = "Kademlia protocol for libp2p"
-version = "0.31.0"
+version = "0.32.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -17,8 +17,8 @@ fnv = "1.0"
 asynchronous-codec = "0.6"
 futures = "0.3.1"
 log = "0.4"
-libp2p-core = { version = "0.29.0", path = "../../core" }
-libp2p-swarm = { version = "0.30.0", path = "../../swarm" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
+libp2p-swarm = { version = "0.31.0", path = "../../swarm" }
 prost = "0.8"
 rand = "0.7.2"
 sha2 = "0.9.1"

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -64,7 +64,7 @@ fn build_node_with_config(cfg: KademliaConfig) -> (Multiaddr, TestSwarm) {
         .multiplex(yamux::YamuxConfig::default())
         .boxed();
 
-    let local_id = local_public_key.clone().to_peer_id();
+    let local_id = local_public_key.to_peer_id();
     let store = MemoryStore::new(local_id.clone());
     let behaviour = Kademlia::with_config(local_id.clone(), store, cfg.clone());
 

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -64,7 +64,7 @@ fn build_node_with_config(cfg: KademliaConfig) -> (Multiaddr, TestSwarm) {
         .multiplex(yamux::YamuxConfig::default())
         .boxed();
 
-    let local_id = local_public_key.clone().into_peer_id();
+    let local_id = local_public_key.clone().to_peer_id();
     let store = MemoryStore::new(local_id.clone());
     let behaviour = Kademlia::with_config(local_id.clone(), store, cfg.clone());
 

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.32.0 [unreleased]
+
+- Update dependencies.
+
 # 0.31.0 [2021-07-12]
 
 - Update dependencies.

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-mdns"
 edition = "2018"
-version = "0.31.0"
+version = "0.32.0"
 description = "Implementation of the libp2p mDNS discovery method"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
@@ -16,8 +16,8 @@ dns-parser = "0.8.0"
 futures = "0.3.13"
 if-watch = "0.2.0"
 lazy_static = "1.4.0"
-libp2p-core = { version = "0.29.0", path = "../../core" }
-libp2p-swarm = { version = "0.30.0", path = "../../swarm" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
+libp2p-swarm = { version = "0.31.0", path = "../../swarm" }
 log = "0.4.14"
 rand = "0.8.3"
 smallvec = "1.6.1"

--- a/protocols/mdns/src/dns.rs
+++ b/protocols/mdns/src/dns.rs
@@ -419,7 +419,7 @@ mod tests {
     fn build_query_response_correct() {
         let my_peer_id = identity::Keypair::generate_ed25519()
             .public()
-            .into_peer_id();
+            .to_peer_id();
         let addr1 = "/ip4/1.2.3.4/tcp/5000".parse().unwrap();
         let addr2 = "/ip6/::1/udp/10000".parse().unwrap();
         let packets = build_query_response(

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.31.0 [unreleased]
+
+- Update dependencies.
+
 # 0.30.0 [2021-07-12]
 
 - Update dependencies.

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-ping"
 edition = "2018"
 description = "Ping protocol for libp2p"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,8 +11,8 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.29.0", path = "../../core" }
-libp2p-swarm = { version = "0.30.0", path = "../../swarm" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
+libp2p-swarm = { version = "0.31.0", path = "../../swarm" }
 log = "0.4.1"
 rand = "0.7.2"
 void = "1.0"

--- a/protocols/ping/tests/ping.rs
+++ b/protocols/ping/tests/ping.rs
@@ -195,7 +195,7 @@ fn mk_transport(muxer: MuxerChoice) -> (
     transport::Boxed<(PeerId, StreamMuxerBox)>
 ) {
     let id_keys = identity::Keypair::generate_ed25519();
-    let peer_id = id_keys.public().into_peer_id();
+    let peer_id = id_keys.public().to_peer_id();
     let noise_keys = noise::Keypair::<noise::X25519Spec>::new().into_authentic(&id_keys).unwrap();
     (peer_id, TcpConfig::new()
         .nodelay(true)

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.0 [unreleased]
+
+- Update dependencies.
+
 # 0.3.0 [2021-07-12]
 
 - Update dependencies.

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-relay"
 edition = "2018"
 description = "Communications relaying for libp2p"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -14,8 +14,8 @@ asynchronous-codec = "0.6"
 bytes = "1"
 futures = "0.3.1"
 futures-timer = "3"
-libp2p-core = { version = "0.29", path = "../../core" }
-libp2p-swarm = { version = "0.30", path = "../../swarm" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
+libp2p-swarm = { version = "0.31.0", path = "../../swarm" }
 log = "0.4"
 pin-project = "1"
 prost = "0.8"

--- a/protocols/relay/src/lib.rs
+++ b/protocols/relay/src/lib.rs
@@ -35,7 +35,7 @@
 //! #
 //! # let local_key = identity::Keypair::generate_ed25519();
 //! # let local_public_key = local_key.public();
-//! # let local_peer_id = local_public_key.clone().into_peer_id();
+//! # let local_peer_id = local_public_key.to_peer_id();
 //! # let plaintext = PlainText2Config {
 //! #     local_public_key: local_public_key.clone(),
 //! # };

--- a/protocols/relay/tests/lib.rs
+++ b/protocols/relay/tests/lib.rs
@@ -1249,7 +1249,7 @@ fn build_swarm(reachability: Reachability, relay_mode: RelayMode) -> Swarm<Combi
     let plaintext = PlainText2Config {
         local_public_key: local_public_key.clone(),
     };
-    let local_peer_id = local_public_key.clone().to_peer_id();
+    let local_peer_id = local_public_key.to_peer_id();
 
     let transport = MemoryTransport::default();
 
@@ -1295,7 +1295,7 @@ fn build_keep_alive_swarm() -> Swarm<CombinedKeepAliveBehaviour> {
     let plaintext = PlainText2Config {
         local_public_key: local_public_key.clone(),
     };
-    let local_peer_id = local_public_key.clone().to_peer_id();
+    let local_peer_id = local_public_key.to_peer_id();
 
     let transport = MemoryTransport::default();
 
@@ -1322,7 +1322,7 @@ fn build_keep_alive_only_swarm() -> Swarm<KeepAliveBehaviour> {
     let plaintext = PlainText2Config {
         local_public_key: local_public_key.clone(),
     };
-    let local_peer_id = local_public_key.clone().to_peer_id();
+    let local_peer_id = local_public_key.to_peer_id();
 
     let transport = MemoryTransport::default();
 

--- a/protocols/relay/tests/lib.rs
+++ b/protocols/relay/tests/lib.rs
@@ -1249,7 +1249,7 @@ fn build_swarm(reachability: Reachability, relay_mode: RelayMode) -> Swarm<Combi
     let plaintext = PlainText2Config {
         local_public_key: local_public_key.clone(),
     };
-    let local_peer_id = local_public_key.clone().into_peer_id();
+    let local_peer_id = local_public_key.clone().to_peer_id();
 
     let transport = MemoryTransport::default();
 
@@ -1295,7 +1295,7 @@ fn build_keep_alive_swarm() -> Swarm<CombinedKeepAliveBehaviour> {
     let plaintext = PlainText2Config {
         local_public_key: local_public_key.clone(),
     };
-    let local_peer_id = local_public_key.clone().into_peer_id();
+    let local_peer_id = local_public_key.clone().to_peer_id();
 
     let transport = MemoryTransport::default();
 
@@ -1322,7 +1322,7 @@ fn build_keep_alive_only_swarm() -> Swarm<KeepAliveBehaviour> {
     let plaintext = PlainText2Config {
         local_public_key: local_public_key.clone(),
     };
-    let local_peer_id = local_public_key.clone().into_peer_id();
+    let local_peer_id = local_public_key.clone().to_peer_id();
 
     let transport = MemoryTransport::default();
 

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.13.0 [unreleased]
+
+- Update dependencies.
+
 # 0.12.0 [2021-07-12]
 
 - Update dependencies.

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-request-response"
 edition = "2018"
 description = "Generic Request/Response Protocols"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -13,8 +13,8 @@ categories = ["network-programming", "asynchronous"]
 async-trait = "0.1"
 bytes = "1"
 futures = "0.3.1"
-libp2p-core = { version = "0.29.0", path = "../../core" }
-libp2p-swarm = { version = "0.30.0", path = "../../swarm" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
+libp2p-swarm = { version = "0.31.0", path = "../../swarm" }
 log = "0.4.11"
 lru = "0.6"
 minicbor = { version = "0.8", features = ["std", "derive"] }

--- a/protocols/request-response/tests/ping.rs
+++ b/protocols/request-response/tests/ping.rs
@@ -383,7 +383,7 @@ fn ping_protocol_throttled() {
 
 fn mk_transport() -> (PeerId, transport::Boxed<(PeerId, StreamMuxerBox)>) {
     let id_keys = identity::Keypair::generate_ed25519();
-    let peer_id = id_keys.public().into_peer_id();
+    let peer_id = id_keys.public().to_peer_id();
     let noise_keys = Keypair::<X25519Spec>::new().into_authentic(&id_keys).unwrap();
     (peer_id, TcpConfig::new()
         .nodelay(true)

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.31.0 [unreleased]
+
+- Update dependencies.
+
 # 0.30.0 [2021-07-12]
 
 - Update dependencies.

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-swarm"
 edition = "2018"
 description = "The libp2p swarm"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 either = "1.6.0"
 futures = "0.3.1"
-libp2p-core = { version = "0.29.0", path = "../core" }
+libp2p-core = { version = "0.30.0", path = "../core" }
 log = "0.4"
 rand = "0.7"
 smallvec = "1.6.1"

--- a/transports/deflate/CHANGELOG.md
+++ b/transports/deflate/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.30.0 [unreleased]
+
+- Update dependencies.
+
 # 0.29.0 [2021-07-12]
 
 - Update dependencies.

--- a/transports/deflate/Cargo.toml
+++ b/transports/deflate/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-deflate"
 edition = "2018"
 description = "Deflate encryption protocol for libp2p"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-libp2p-core = { version = "0.29.0", path = "../../core" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
 flate2 = "1.0"
 
 [dev-dependencies]

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.30.0 [unreleased]
+
+- Update dependencies.
+
 # 0.29.0 [2021-07-12]
 
 - Update dependencies.

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-dns"
 edition = "2018"
 description = "DNS transport implementation for libp2p"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -10,7 +10,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-libp2p-core = { version = "0.29.0", path = "../../core" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
 log = "0.4.1"
 futures = "0.3.1"
 trust-dns-resolver = { version = "0.20", default-features = false, features = ["system-config"] }

--- a/transports/noise/CHANGELOG.md
+++ b/transports/noise/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.33.0 [unreleased]
+
+- Update dependencies.
+
 # 0.32.0 [2021-07-12]
 
 - Update dependencies.

--- a/transports/noise/Cargo.toml
+++ b/transports/noise/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-noise"
 description = "Cryptographic handshake protocol using the noise framework."
-version = "0.32.0"
+version = "0.33.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -12,7 +12,7 @@ bytes = "1"
 curve25519-dalek = "3.0.0"
 futures = "0.3.1"
 lazy_static = "1.2"
-libp2p-core = { version = "0.29.0", path = "../../core" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
 log = "0.4"
 prost = "0.8"
 rand = "0.8.3"

--- a/transports/noise/src/io/handshake.rs
+++ b/transports/noise/src/io/handshake.rs
@@ -432,7 +432,7 @@ where
     let mut pb = payload_proto::NoiseHandshakePayload::default();
 
     if state.send_identity {
-        pb.identity_key = state.identity.public.clone().to_protobuf_encoding()
+        pb.identity_key = state.identity.public.to_protobuf_encoding()
     }
 
     if let Some(ref sig) = state.identity.signature {

--- a/transports/noise/src/io/handshake.rs
+++ b/transports/noise/src/io/handshake.rs
@@ -432,7 +432,7 @@ where
     let mut pb = payload_proto::NoiseHandshakePayload::default();
 
     if state.send_identity {
-        pb.identity_key = state.identity.public.clone().into_protobuf_encoding()
+        pb.identity_key = state.identity.public.clone().to_protobuf_encoding()
     }
 
     if let Some(ref sig) = state.identity.signature {

--- a/transports/noise/src/lib.rs
+++ b/transports/noise/src/lib.rs
@@ -354,7 +354,7 @@ where
     fn upgrade_inbound(self, socket: T, info: Self::Info) -> Self::Future {
         Box::pin(self.config.upgrade_inbound(socket, info)
             .and_then(|(remote, io)| match remote {
-                RemoteIdentity::IdentityKey(pk) => future::ok((pk.into_peer_id(), io)),
+                RemoteIdentity::IdentityKey(pk) => future::ok((pk.to_peer_id(), io)),
                 _ => future::err(NoiseError::AuthenticationFailed)
             }))
     }
@@ -377,7 +377,7 @@ where
     fn upgrade_outbound(self, socket: T, info: Self::Info) -> Self::Future {
         Box::pin(self.config.upgrade_outbound(socket, info)
             .and_then(|(remote, io)| match remote {
-                RemoteIdentity::IdentityKey(pk) => future::ok((pk.into_peer_id(), io)),
+                RemoteIdentity::IdentityKey(pk) => future::ok((pk.to_peer_id(), io)),
                 _ => future::err(NoiseError::AuthenticationFailed)
             }))
     }

--- a/transports/plaintext/CHANGELOG.md
+++ b/transports/plaintext/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.30.0 [unreleased]
+
+- Update dependencies.
+
 # 0.29.0 [2021-07-12]
 
 - Update dependencies.

--- a/transports/plaintext/Cargo.toml
+++ b/transports/plaintext/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-plaintext"
 edition = "2018"
 description = "Plaintext encryption dummy protocol for libp2p"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 bytes = "1"
 futures = "0.3.1"
 asynchronous-codec = "0.6"
-libp2p-core = { version = "0.29.0", path = "../../core" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
 log = "0.4.8"
 prost = "0.8"
 unsigned-varint = { version = "0.7", features = ["asynchronous_codec"] }

--- a/transports/plaintext/src/handshake.rs
+++ b/transports/plaintext/src/handshake.rs
@@ -53,7 +53,7 @@ pub struct Remote {
 impl HandshakeContext<Local> {
     fn new(config: PlainText2Config) -> Self {
         let exchange = Exchange {
-            id: Some(config.local_public_key.clone().into_peer_id().to_bytes()),
+            id: Some(config.local_public_key.to_peer_id().to_bytes()),
             pubkey: Some(config.local_public_key.to_protobuf_encoding())
         };
         let mut buf = Vec::with_capacity(exchange.encoded_len());
@@ -95,7 +95,7 @@ impl HandshakeContext<Local> {
         };
 
         // Check the validity of the remote's `Exchange`.
-        if peer_id != public_key.clone().into_peer_id() {
+        if peer_id != public_key.clone().to_peer_id() {
             debug!("the remote's `PeerId` isn't consistent with the remote's public key");
             return Err(PlainTextError::InvalidPeerId)
         }

--- a/transports/plaintext/src/handshake.rs
+++ b/transports/plaintext/src/handshake.rs
@@ -54,7 +54,7 @@ impl HandshakeContext<Local> {
     fn new(config: PlainText2Config) -> Self {
         let exchange = Exchange {
             id: Some(config.local_public_key.clone().into_peer_id().to_bytes()),
-            pubkey: Some(config.local_public_key.clone().into_protobuf_encoding())
+            pubkey: Some(config.local_public_key.to_protobuf_encoding())
         };
         let mut buf = Vec::with_capacity(exchange.encoded_len());
         exchange.encode(&mut buf).expect("Vec<u8> provides capacity as needed");

--- a/transports/plaintext/src/handshake.rs
+++ b/transports/plaintext/src/handshake.rs
@@ -95,7 +95,7 @@ impl HandshakeContext<Local> {
         };
 
         // Check the validity of the remote's `Exchange`.
-        if peer_id != public_key.clone().to_peer_id() {
+        if peer_id != public_key.to_peer_id() {
             debug!("the remote's `PeerId` isn't consistent with the remote's public key");
             return Err(PlainTextError::InvalidPeerId)
         }

--- a/transports/plaintext/tests/smoke.rs
+++ b/transports/plaintext/tests/smoke.rs
@@ -86,7 +86,7 @@ fn variable_msg_length() {
             let client_fut = async {
                 debug!("dialing {:?}", server_address);
                 let (received_server_id, mut client_channel) = client_transport.dial(server_address).unwrap().await.unwrap();
-                assert_eq!(received_server_id, server_id.public().into_peer_id());
+                assert_eq!(received_server_id, server_id.public().to_peer_id());
 
                 debug!("Client: writing message.");
                 client_channel.write_all(&mut msg_to_send).await.expect("no error");

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.30.0 [unreleased]
+
+- Update dependencies.
+
 # 0.29.0 [2021-07-12]
 
 - Update dependencies.

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-tcp"
 edition = "2018"
 description = "TCP/IP transport protocol for libp2p"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -17,7 +17,7 @@ if-watch = { version = "0.2.0", optional = true }
 if-addrs = { version = "0.6.4", optional = true }
 ipnet = "2.0.0"
 libc = "0.2.80"
-libp2p-core = { version = "0.29.0", path = "../../core" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
 log = "0.4.11"
 socket2 = { version = "0.4.0", features = ["all"] }
 tokio-crate = { package = "tokio", version = "1.0.1", default-features = false, features = ["net"], optional = true }

--- a/transports/uds/CHANGELOG.md
+++ b/transports/uds/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.30.0 [unreleased]
+
+- Update dependencies.
+
 # 0.29.0 [2021-07-12]
 
 - Update dependencies.

--- a/transports/uds/Cargo.toml
+++ b/transports/uds/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-uds"
 edition = "2018"
 description = "Unix domain sockets transport for libp2p"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [target.'cfg(all(unix, not(target_os = "emscripten")))'.dependencies]
 async-std = { version = "1.6.2", optional = true }
-libp2p-core = { version = "0.29.0", path = "../../core" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
 log = "0.4.1"
 futures = "0.3.1"
 tokio = { version = "1.0.1", default-features = false, features = ["net"], optional = true }

--- a/transports/wasm-ext/CHANGELOG.md
+++ b/transports/wasm-ext/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.30.0 [unreleased]
+
+- Update dependencies.
+
 # 0.29.0 [2021-07-12]
 
 - Update dependencies.

--- a/transports/wasm-ext/Cargo.toml
+++ b/transports/wasm-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-wasm-ext"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 edition = "2018"
 description = "Allows passing in an external transport in a WASM environment"
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 futures = "0.3.1"
 js-sys = "0.3.50"
-libp2p-core = { version = "0.29.0", path = "../../core" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
 parity-send-wrapper = "0.1.0"
 wasm-bindgen = "0.2.42"
 wasm-bindgen-futures = "0.4.4"

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.31.0 [unreleased]
+
+- Update dependencies.
+
 # 0.30.0 [2021-07-12]
 
 - Update dependencies.

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-websocket"
 edition = "2018"
 description = "WebSocket transport for libp2p"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 futures-rustls = "0.21"
 either = "1.5.3"
 futures = "0.3.1"
-libp2p-core = { version = "0.29.0", path = "../../core" }
+libp2p-core = { version = "0.30.0", path = "../../core" }
 log = "0.4.8"
 quicksink = "0.1"
 rw-stream-sink = "0.2.0"


### PR DESCRIPTION
As per discussion in #2142:

- [x] Change `PublicKey::into_protobuf_encoding(self)` to `PublicKey::to_protobuf_encoding(&self)`
- [x] Change `PublicKey::into_peer_id(self)` to `PublicKey::to_peer_id(&self)`
  - [x] Yeet out a whole bunch of `clone()`'s.

The latter goes via a `From` implementation.