### PR TITLE
Don't build secp256k1 by default.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
     - uses: actions/checkout@v2.3.4
 
     - name: Check rustdoc links
-      run: RUSTDOCFLAGS="--deny broken_intra_doc_links" cargo doc --verbose --workspace --no-deps --document-private-items
+      run: RUSTDOCFLAGS="--deny broken_intra_doc_links" cargo doc --verbose --workspace --no-deps --document-private-items --all-features
 
   check-clippy:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,28 +10,6 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [features]
-default = [
-    "deflate",
-    "dns-async-std",
-    "floodsub",
-    "identify",
-    "kad",
-    "gossipsub",
-    "mdns",
-    "mplex",
-    "noise",
-    "ping",
-    "plaintext",
-    "pnet",
-    "relay",
-    "request-response",
-    "secp256k1",
-    "tcp-async-io",
-    "uds",
-    "wasm-ext",
-    "websocket",
-    "yamux",
-]
 deflate = ["libp2p-deflate"]
 dns-async-std = ["libp2p-dns", "libp2p-dns/async-std"]
 dns-tokio = ["libp2p-dns", "libp2p-dns/tokio"]
@@ -98,6 +76,23 @@ libp2p-websocket = { version = "0.30.0", path = "transports/websocket", optional
 async-std = { version = "1.6.2", features = ["attributes"] }
 env_logger = "0.9.0"
 tokio = { version = "1.0.1", features = ["io-util", "io-std", "macros", "rt", "rt-multi-thread"] }
+
+[dev-dependencies.libp2p]
+path = "."
+features = [
+    "dns-async-std",
+    "floodsub",
+    "gossipsub",
+    "kad",
+    "mdns",
+    "mplex",
+    "noise",
+    "ping",
+    "pnet",
+    "tcp-async-io",
+    "websocket",
+    "yamux",
+]
 
 [workspace]
 resolver = "2"

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -31,7 +31,7 @@ prost-build = "0.8"
 [dev-dependencies]
 env_logger = "0.9.0"
 structopt = "0.3.21"
-libp2p = { path = "../.." }
+libp2p = { path = "../..", features = ["plaintext", "relay", "tcp-async-io"] }
 libp2p-kad = { path = "../kad" }
 libp2p-ping = { path = "../ping" }
 libp2p-identify = { path = "../identify" }

--- a/swarm-derive/Cargo.toml
+++ b/swarm-derive/Cargo.toml
@@ -17,5 +17,5 @@ syn = { version = "1.0.8", default-features = false, features = ["clone-impls", 
 quote = "1.0"
 
 [dev-dependencies]
-libp2p = { path = "../" }
+libp2p = { path = "../", features = ["identify", "kad", "ping"] }
 futures = "0.3.1"


### PR DESCRIPTION
any features required to make a network behaviour work will be specified manually. for testing it is common to just add libp2p to the dev-dependencies to get a development-transport. This PR disables all the features that aren't required for building a development transport.