### PR TITLE
Enforce no clippy warnings through CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+lint = "clippy -- -A clippy::type_complexity -A clippy::pedantic -A clippy::style"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [alias]
-lint = "clippy -- -A clippy::type_complexity -A clippy::pedantic -A clippy::style"
+lint = "clippy -- -A clippy::type_complexity -A clippy::pedantic -A clippy::style -D warnings"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [alias]
 # Temporary solution to have clippy config in a single place until https://github.com/rust-lang/rust-clippy/blob/master/doc/roadmap-2021.md#lintstoml-configuration is shipped.
-lint = "clippy -- -A clippy::type_complexity -A clippy::pedantic -A clippy::style -D warnings"
+custom-clippy = "clippy -- -A clippy::type_complexity -A clippy::pedantic -A clippy::style -D warnings"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [alias]
+# Temporary solution to have clippy config in a single place until https://github.com/rust-lang/rust-clippy/blob/master/doc/roadmap-2021.md#lintstoml-configuration is shipped.
 lint = "clippy -- -A clippy::type_complexity -A clippy::pedantic -A clippy::style -D warnings"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,8 +152,7 @@ jobs:
     - name: Run cargo clippy
       uses: actions-rs/cargo@v1.0.3
       with:
-        command: clippy
-        args: -- -A clippy::type_complexity -A clippy::pedantic -A clippy::style
+        command: lint # cargo alias to allow reuse of config locally
 
   integration-test:
     name: Integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
     - name: Run cargo clippy
       uses: actions-rs/cargo@v1.0.3
       with:
-        command: lint # cargo alias to allow reuse of config locally
+        command: custom-clippy # cargo alias to allow reuse of config locally
 
   integration-test:
     name: Integration tests

--- a/protocols/relay/src/behaviour.rs
+++ b/protocols/relay/src/behaviour.rs
@@ -756,6 +756,7 @@ impl NetworkBehaviour for Relay {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum BehaviourToListenerMsg {
     ConnectionToRelayEstablished,
     IncomingRelayedConnection {

--- a/protocols/relay/src/handler.rs
+++ b/protocols/relay/src/handler.rs
@@ -733,6 +733,7 @@ impl ProtocolsHandler for RelayHandler {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum RelayOutboundOpenInfo {
     Relay {
         dst_peer_id: PeerId,

--- a/protocols/relay/src/protocol/listen.rs
+++ b/protocols/relay/src/protocol/listen.rs
@@ -76,7 +76,7 @@ impl upgrade::InboundUpgrade<NegotiatedSubstream> for RelayListen {
             let msg: bytes::BytesMut = substream
                 .next()
                 .await
-                .ok_or(std::io::Error::new(std::io::ErrorKind::UnexpectedEof, ""))??;
+                .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::UnexpectedEof, ""))??;
             let CircuitRelay {
                 r#type,
                 src_peer,

--- a/protocols/relay/src/protocol/outgoing_dst_req.rs
+++ b/protocols/relay/src/protocol/outgoing_dst_req.rs
@@ -100,7 +100,7 @@ impl upgrade::OutboundUpgrade<NegotiatedSubstream> for OutgoingDstReq {
                 substream
                     .next()
                     .await
-                    .ok_or(OutgoingDstReqError::Io(std::io::Error::new(
+                    .ok_or_else(|| OutgoingDstReqError::Io(std::io::Error::new(
                         std::io::ErrorKind::UnexpectedEof,
                         "",
                     )))??;

--- a/protocols/relay/src/protocol/outgoing_relay_req.rs
+++ b/protocols/relay/src/protocol/outgoing_relay_req.rs
@@ -87,7 +87,7 @@ impl upgrade::OutboundUpgrade<NegotiatedSubstream> for OutgoingRelayReq {
             }),
             dst_peer: Some(circuit_relay::Peer {
                 id: dst_id.to_bytes(),
-                addrs: vec![dst_address.unwrap_or(Multiaddr::empty()).to_vec()],
+                addrs: vec![dst_address.unwrap_or_else(Multiaddr::empty).to_vec()],
             }),
             code: None,
         };
@@ -107,7 +107,7 @@ impl upgrade::OutboundUpgrade<NegotiatedSubstream> for OutgoingRelayReq {
                 substream
                     .next()
                     .await
-                    .ok_or(OutgoingRelayReqError::Io(std::io::Error::new(
+                    .ok_or_else(|| OutgoingRelayReqError::Io(std::io::Error::new(
                         std::io::ErrorKind::UnexpectedEof,
                         "",
                     )))??;

--- a/protocols/relay/src/transport.rs
+++ b/protocols/relay/src/transport.rs
@@ -198,7 +198,7 @@ impl<T: Transport + Clone> Transport for RelayTransport<T> {
                 };
 
                 let (to_listener, from_behaviour) = mpsc::channel(0);
-                let mut to_behaviour = self.to_behaviour.clone();
+                let mut to_behaviour = self.to_behaviour;
                 let msg_to_behaviour = Some(
                     async move {
                         to_behaviour
@@ -242,7 +242,7 @@ impl<T: Transport + Clone> Transport for RelayTransport<T> {
                 let relay_addr = relay_addr.ok_or(RelayError::MissingRelayAddr)?;
                 let dst_peer_id = dst_peer_id.ok_or(RelayError::MissingDstPeerId)?;
 
-                let mut to_behaviour = self.to_behaviour.clone();
+                let mut to_behaviour = self.to_behaviour;
                 Ok(EitherFuture::Second(
                     async move {
                         let (tx, rx) = oneshot::channel();

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -330,6 +330,7 @@ where
 
 /// The possible errors of a [`GenDnsConfig`] wrapped transport.
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum DnsErr<TErr> {
     /// The underlying transport encountered an error.
     Transport(TErr),


### PR DESCRIPTION
Opened as a result of https://github.com/libp2p/rust-libp2p/pull/2139.

Might also want to change the GitHub configuration to pervent merge if clippy fails.