### PR TITLE
KademliaRecordFiltering and filter events

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 - Update dependencies.
 
+- Introduce `KademliaStoreInserts` option, which allows to record filtering (see
+  [PR 2163]).
+
+[PR 2163]: https://github.com/libp2p/rust-libp2p/pull/2163
+
 # 0.31.0 [2021-07-12]
 
 - Update dependencies.

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Update dependencies.
 
-- Introduce `KademliaStoreInserts` option, which allows to record filtering (see
+- Introduce `KademliaStoreInserts` option, which allows to filter records (see
   [PR 2163]).
 
 [PR 2163]: https://github.com/libp2p/rust-libp2p/pull/2163

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -2384,7 +2384,7 @@ pub enum KademliaEvent {
 
     /// A peer sent a [`KademliaHandlerIn::PutRecord`] request and filtering is enabled.
     ///
-    /// Cfr. [`KademliaRecordFiltering`] and [`KademliaConfig::set_record_filtering`].
+    /// See [`KademliaRecordFiltering`] and [`KademliaConfig::set_record_filtering`].
     InboundPutRecordRequest {
         source: PeerId,
         connection: ConnectionId,

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -156,9 +156,7 @@ pub enum KademliaRecordFiltering {
     /// Provider records generate a [`KademliaEvent::InboundAddProviderRequest`],
     /// normal records generate a [`KademliaEvent::InboundPutRecordRequest`].
     ///
-    /// The event loop should then asynchronously validate this record,
-    /// and if deemed correct, should call [`RecordStore::put`] or
-    /// [`RecordStore::add_provider`], whichever is applicable.
+    /// When deemed valid, a (provider) record needs to be explicitly stored in the [`RecordStore`] via [`RecordStore::put`] or [`RecordStore::add_provider`], whichever is applicable. A mutable reference to the [`RecordStore`] can be retrieved via [`Kademlia::store_mut`].
     FilterBoth,
 }
 

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -69,6 +69,9 @@ pub struct Kademlia<TStore> {
     /// Configuration of the wire protocol.
     protocol_config: KademliaProtocolConfig,
 
+    /// Configuration of [`RecordStore`] filtering.
+    record_filtering: KademliaRecordFiltering,
+
     /// The currently active (i.e. in-progress) queries.
     queries: QueryPool<QueryInner>,
 
@@ -430,6 +433,7 @@ where
             kbuckets: KBucketsTable::new(local_key, config.kbucket_pending_timeout),
             kbucket_inserts: config.kbucket_inserts,
             protocol_config: config.protocol_config,
+            record_filtering: config.record_filtering,
             queued_events: VecDeque::with_capacity(config.query_config.replication_factor.get()),
             queries: QueryPool::new(config.query_config),
             connected_peers: Default::default(),

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -2313,6 +2313,20 @@ pub struct PeerRecord {
 /// See [`NetworkBehaviour::poll`].
 #[derive(Debug)]
 pub enum KademliaEvent {
+    /// A peer sent a [`KademliaHandlerIn::PutRecord`] request and filtering is enabled.
+    ///
+    /// See [`KademliaRecordFiltering`] and [`KademliaConfig::set_record_filtering`].
+    InboundPutRecordRequest {
+        source: PeerId,
+        connection: ConnectionId,
+        record: Record,
+    },
+
+    /// A peer sent a [`KademliaHandlerIn::AddProvider`] request and filtering [`KademliaRecordFiltering::FilterBoth`] is enabled.
+    ///
+    /// See [`KademliaRecordFiltering`] and [`KademliaConfig::set_record_filtering`] for details..
+    InboundAddProviderRequest { record: ProviderRecord },
+
     /// An inbound request has been received and handled.
     //
     // Note on the difference between 'request' and 'query': A request is a
@@ -2379,20 +2393,6 @@ pub enum KademliaEvent {
     /// See [`Kademlia::kbucket`] for insight into the contents of
     /// the k-bucket of `peer`.
     PendingRoutablePeer { peer: PeerId, address: Multiaddr },
-
-    /// A peer sent a [`KademliaHandlerIn::PutRecord`] request and filtering is enabled.
-    ///
-    /// See [`KademliaRecordFiltering`] and [`KademliaConfig::set_record_filtering`].
-    InboundPutRecordRequest {
-        source: PeerId,
-        connection: ConnectionId,
-        record: Record,
-    },
-
-    /// A peer sent a [`KademliaHandlerIn::AddProvider`] request and filtering [`KademliaRecordFiltering::FilterBoth`] is enabled.
-    ///
-    /// See [`KademliaRecordFiltering`] and [`KademliaConfig::set_record_filtering`] for details..
-    InboundAddProviderRequest { record: ProviderRecord },
 }
 
 /// Information about a received and handled inbound request.

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -150,7 +150,10 @@ pub enum KademliaStoreInserts {
     /// Provider records generate a [`KademliaEvent::InboundAddProviderRequest`],
     /// normal records generate a [`KademliaEvent::InboundPutRecordRequest`].
     ///
-    /// When deemed valid, a (provider) record needs to be explicitly stored in the [`RecordStore`] via [`RecordStore::put`] or [`RecordStore::add_provider`], whichever is applicable. A mutable reference to the [`RecordStore`] can be retrieved via [`Kademlia::store_mut`].
+    /// When deemed valid, a (provider) record needs to be explicitly stored in
+    /// the [`RecordStore`] via [`RecordStore::put`] or [`RecordStore::add_provider`],
+    /// whichever is applicable. A mutable reference to the [`RecordStore`] can
+    /// be retrieved via [`Kademlia::store_mut`].
     FilterBoth,
 }
 

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -146,12 +146,6 @@ pub enum KademliaStoreInserts {
     /// Whenever a (provider) record is received,
     /// the record is forwarded immediately to the [`RecordStore`].
     Unfiltered,
-    /// Whenever a record is received, an event of type [`KademliaEvent::InboundPutRecordRequest`] is emitted.
-    /// The event loop should then asynchronously validate this record,
-    /// and if deemed correct, should call [`RecordStore::put`].
-    ///
-    /// Provider records are forwarded directly to the [`RecordStore`].
-    FilterRecords,
     /// Whenever a (provider) record is received, an event is emitted.
     /// Provider records generate a [`KademliaEvent::InboundAddProviderRequest`],
     /// normal records generate a [`KademliaEvent::InboundPutRecordRequest`].

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -2364,6 +2364,20 @@ pub enum KademliaEvent {
     /// See [`Kademlia::kbucket`] for insight into the contents of
     /// the k-bucket of `peer`.
     PendingRoutablePeer { peer: PeerId, address: Multiaddr },
+
+    /// A peer sent a [`PutRecord`] request and filtering is enabled.
+    ///
+    /// Cfr. [`KademliaRecordFiltering`] and [`KademliaConfig::set_record_filtering`].
+    InboundPutRecordRequest {
+        source: PeerId,
+        connection: ConnectionId,
+        record: Record,
+    },
+
+    /// A peer sent a [`AddProvider`] request and filtering [`KademliaRecordFiltering::FilterBoth`] is enabled.
+    ///
+    /// Cfr. [`KademliaRecordFiltering`] and [`KademliaConfig::set_record_filtering`].
+    InboundAddProviderRequest { record: ProviderRecord },
 }
 
 /// Information about a received and handled inbound request.

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -1613,22 +1613,32 @@ where
             // The record is cloned because of the weird libp2p protocol
             // requirement to send back the value in the response, although this
             // is a waste of resources.
-            match self.store.put(record.clone()) {
-                Ok(()) => debug!(
-                    "Record stored: {:?}; {} bytes",
-                    record.key,
-                    record.value.len()
-                ),
-                Err(e) => {
-                    info!("Record not stored: {:?}", e);
-                    self.queued_events
-                        .push_back(NetworkBehaviourAction::NotifyHandler {
-                            peer_id: source,
-                            handler: NotifyHandler::One(connection),
-                            event: KademliaHandlerIn::Reset(request_id),
-                        });
-
-                    return;
+            if self.record_filtering != KademliaRecordFiltering::Unfiltered {
+                self.queued_events
+                    .push_back(NetworkBehaviourAction::GenerateEvent(
+                        KademliaEvent::InboundPutRecordRequest {
+                            source,
+                            connection,
+                            record: record.clone(),
+                        },
+                    ));
+            } else {
+                match self.store.put(record.clone()) {
+                    Ok(()) => debug!(
+                        "Record stored: {:?}; {} bytes",
+                        record.key,
+                        record.value.len()
+                    ),
+                    Err(e) => {
+                        info!("Record not stored: {:?}", e);
+                        self.queued_events
+                            .push_back(NetworkBehaviourAction::NotifyHandler {
+                                peer_id: source,
+                                handler: NotifyHandler::One(connection),
+                                event: KademliaHandlerIn::Reset(request_id),
+                            });
+                        return;
+                    }
                 }
             }
         }
@@ -1661,7 +1671,12 @@ where
                 expires: self.provider_record_ttl.map(|ttl| Instant::now() + ttl),
                 addresses: provider.multiaddrs,
             };
-            if let Err(e) = self.store.add_provider(record) {
+            if self.record_filtering != KademliaRecordFiltering::Unfiltered {
+                self.queued_events
+                    .push_back(NetworkBehaviourAction::GenerateEvent(
+                        KademliaEvent::InboundAddProviderRequest { record },
+                    ));
+            } else if let Err(e) = self.store.add_provider(record) {
                 info!("Provider record not stored: {:?}", e);
             }
         }

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -139,6 +139,8 @@ pub enum KademliaBucketInserts {
 ///
 /// This can be used for e.g. signature verification or validating
 /// the accompanying [`Key`].
+///
+/// [`Key`]: crate::record::Key
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum KademliaRecordFiltering {
     /// Whenever a (provider) record is received,
@@ -146,7 +148,7 @@ pub enum KademliaRecordFiltering {
     Unfiltered,
     /// Whenever a record is received, an event of type [`KademliaEvent::InboundPutRecordRequest`] is emitted.
     /// The event loop should then asynchronously validate this record,
-    /// and if deemed correct, should call [`Kademlia::put_record`].
+    /// and if deemed correct, should call [`RecordStore::put`].
     ///
     /// Provider records are forwarded directly to the [`RecordStore`].
     FilterRecords,
@@ -155,8 +157,8 @@ pub enum KademliaRecordFiltering {
     /// normal records generate a [`KademliaEvent::InboundPutRecordRequest`].
     ///
     /// The event loop should then asynchronously validate this record,
-    /// and if deemed correct, should call [`Kademlia::put_record`] or
-    /// [`Kademlia::add_provider`], whichever is applicable.
+    /// and if deemed correct, should call [`RecordStore::put`] or
+    /// [`RecordStore::add_provider`], whichever is applicable.
     FilterBoth,
 }
 
@@ -2380,7 +2382,7 @@ pub enum KademliaEvent {
     /// the k-bucket of `peer`.
     PendingRoutablePeer { peer: PeerId, address: Multiaddr },
 
-    /// A peer sent a [`PutRecord`] request and filtering is enabled.
+    /// A peer sent a [`KademliaHandlerIn::PutRecord`] request and filtering is enabled.
     ///
     /// Cfr. [`KademliaRecordFiltering`] and [`KademliaConfig::set_record_filtering`].
     InboundPutRecordRequest {
@@ -2389,7 +2391,7 @@ pub enum KademliaEvent {
         record: Record,
     },
 
-    /// A peer sent a [`AddProvider`] request and filtering [`KademliaRecordFiltering::FilterBoth`] is enabled.
+    /// A peer sent a [`KademliaHandlerIn::AddProvider`] request and filtering [`KademliaRecordFiltering::FilterBoth`] is enabled.
     ///
     /// Cfr. [`KademliaRecordFiltering`] and [`KademliaConfig::set_record_filtering`].
     InboundAddProviderRequest { record: ProviderRecord },

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -2393,7 +2393,7 @@ pub enum KademliaEvent {
 
     /// A peer sent a [`KademliaHandlerIn::AddProvider`] request and filtering [`KademliaRecordFiltering::FilterBoth`] is enabled.
     ///
-    /// Cfr. [`KademliaRecordFiltering`] and [`KademliaConfig::set_record_filtering`].
+    /// See [`KademliaRecordFiltering`] and [`KademliaConfig::set_record_filtering`] for details..
     InboundAddProviderRequest { record: ProviderRecord },
 }
 

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -1669,13 +1669,18 @@ where
                 expires: self.provider_record_ttl.map(|ttl| Instant::now() + ttl),
                 addresses: provider.multiaddrs,
             };
-            if self.record_filtering != KademliaStoreInserts::Unfiltered {
-                self.queued_events
-                    .push_back(NetworkBehaviourAction::GenerateEvent(
-                        KademliaEvent::InboundAddProviderRequest { record },
-                    ));
-            } else if let Err(e) = self.store.add_provider(record) {
-                info!("Provider record not stored: {:?}", e);
+            match self.record_filtering {
+                KademliaStoreInserts::Unfiltered => {
+                    if let Err(e) = self.store.add_provider(record) {
+                        info!("Provider record not stored: {:?}", e);
+                    }
+                }
+                KademliaStoreInserts::FilterBoth => {
+                    self.queued_events
+                        .push_back(NetworkBehaviourAction::GenerateEvent(
+                            KademliaEvent::InboundAddProviderRequest { record },
+                        ));
+                }
             }
         }
     }

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -695,6 +695,407 @@ fn put_record() {
     QuickCheck::new().tests(3).quickcheck(prop as fn(_, _) -> _)
 }
 
+/// A node joining a fully connected network cannot store a record if the nodes ignore it through
+/// [KademliaStoreInserts::FilterBoth].
+#[test]
+fn put_record_filtered_accept() {
+    fn prop(records: Vec<Record>, seed: Seed) {
+        let mut rng = StdRng::from_seed(seed.0);
+        let replication_factor =
+            NonZeroUsize::new(rng.gen_range(1, (K_VALUE.get() / 2) + 1)).unwrap();
+        // At least 4 nodes, 1 under test + 3 bootnodes.
+        let num_total = usize::max(4, replication_factor.get() * 2);
+
+        let mut config = KademliaConfig::default();
+        config.set_replication_factor(replication_factor);
+        config.set_record_filtering(KademliaStoreInserts::FilterBoth);
+        if rng.gen() {
+            config.disjoint_query_paths(true);
+        }
+
+        let mut swarms = {
+            let mut fully_connected_swarms =
+                build_fully_connected_nodes_with_config(num_total - 1, config.clone());
+
+            let mut single_swarm = build_node_with_config(config);
+            // Connect `single_swarm` to three bootnodes.
+            for i in 0..3 {
+                single_swarm.1.behaviour_mut().add_address(
+                    fully_connected_swarms[i].1.local_peer_id(),
+                    fully_connected_swarms[i].0.clone(),
+                );
+            }
+
+            let mut swarms = vec![single_swarm];
+            swarms.append(&mut fully_connected_swarms);
+
+            // Drop the swarm addresses.
+            swarms
+                .into_iter()
+                .map(|(_addr, swarm)| swarm)
+                .collect::<Vec<_>>()
+        };
+
+        let records = records
+            .into_iter()
+            .take(num_total)
+            .map(|mut r| {
+                // We don't want records to expire prematurely, as they would
+                // be removed from storage and no longer replicated, but we still
+                // want to check that an explicitly set expiration is preserved.
+                r.expires = r.expires.map(|t| t + Duration::from_secs(60));
+                (r.key.clone(), r)
+            })
+            .collect::<HashMap<_, _>>();
+
+        // Initiate put_record queries.
+        let mut qids = HashSet::new();
+        for r in records.values() {
+            let qid = swarms[0]
+                .behaviour_mut()
+                .put_record(r.clone(), Quorum::All)
+                .unwrap();
+            match swarms[0].behaviour_mut().query(&qid) {
+                Some(q) => match q.info() {
+                    QueryInfo::PutRecord { phase, record, .. } => {
+                        assert_eq!(phase, &PutRecordPhase::GetClosestPeers);
+                        assert_eq!(record.key, r.key);
+                        assert_eq!(record.value, r.value);
+                        assert!(record.expires.is_some());
+                        qids.insert(qid);
+                    }
+                    i => panic!("Unexpected query info: {:?}", i),
+                },
+                None => panic!("Query not found: {:?}", qid),
+            }
+        }
+
+        // Each test run republishes all records once.
+        let mut republished = false;
+        // The accumulated results for one round of publishing.
+        let mut results = Vec::new();
+
+        block_on(poll_fn(move |ctx| loop {
+            // Poll all swarms until they are "Pending".
+            for swarm in &mut swarms {
+                loop {
+                    match swarm.poll_next_unpin(ctx) {
+                        Poll::Ready(Some(SwarmEvent::Behaviour(
+                            KademliaEvent::OutboundQueryCompleted {
+                                id,
+                                result: QueryResult::PutRecord(res),
+                                stats,
+                            },
+                        )))
+                        | Poll::Ready(Some(SwarmEvent::Behaviour(
+                            KademliaEvent::OutboundQueryCompleted {
+                                id,
+                                result: QueryResult::RepublishRecord(res),
+                                stats,
+                            },
+                        ))) => {
+                            assert!(qids.is_empty() || qids.remove(&id));
+                            assert!(stats.duration().is_some());
+                            assert!(stats.num_successes() >= replication_factor.get() as u32);
+                            assert!(stats.num_requests() >= stats.num_successes());
+                            assert_eq!(stats.num_failures(), 0);
+                            match res {
+                                Err(e) => panic!("{:?}", e),
+                                Ok(ok) => {
+                                    assert!(records.contains_key(&ok.key));
+                                    let record = swarm.behaviour_mut().store.get(&ok.key).unwrap();
+                                    results.push(record.into_owned());
+                                }
+                            }
+                        }
+                        Poll::Ready(Some(SwarmEvent::Behaviour(
+                            KademliaEvent::InboundPutRecordRequest { record, .. },
+                        ))) => {
+                            // Accept the record
+                            swarm
+                                .behaviour_mut()
+                                .store_mut()
+                                .put(record)
+                                .expect("record is stored");
+                        }
+                        // Ignore any other event.
+                        Poll::Ready(Some(_)) => (),
+                        e @ Poll::Ready(_) => panic!("Unexpected return value: {:?}", e),
+                        Poll::Pending => break,
+                    }
+                }
+            }
+
+            // All swarms are Pending and not enough results have been collected
+            // so far, thus wait to be polled again for further progress.
+            if results.len() != records.len() {
+                return Poll::Pending;
+            }
+
+            // Consume the results, checking that each record was replicated
+            // correctly to the closest peers to the key.
+            while let Some(r) = results.pop() {
+                let expected = records.get(&r.key).unwrap();
+
+                assert_eq!(r.key, expected.key);
+                assert_eq!(r.value, expected.value);
+                assert_eq!(r.expires, expected.expires);
+                assert_eq!(r.publisher, Some(*swarms[0].local_peer_id()));
+
+                let key = kbucket::Key::new(r.key.clone());
+                let mut expected = swarms
+                    .iter()
+                    .skip(1)
+                    .map(Swarm::local_peer_id)
+                    .cloned()
+                    .collect::<Vec<_>>();
+                expected.sort_by(|id1, id2| {
+                    kbucket::Key::from(*id1)
+                        .distance(&key)
+                        .cmp(&kbucket::Key::from(*id2).distance(&key))
+                });
+
+                let expected = expected
+                    .into_iter()
+                    .take(replication_factor.get())
+                    .collect::<HashSet<_>>();
+
+                let actual = swarms
+                    .iter()
+                    .skip(1)
+                    .filter_map(|swarm| {
+                        if swarm.behaviour().store.get(key.preimage()).is_some() {
+                            Some(*swarm.local_peer_id())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<HashSet<_>>();
+
+                assert_eq!(actual.len(), replication_factor.get());
+
+                let actual_not_expected = actual.difference(&expected).collect::<Vec<&PeerId>>();
+                assert!(
+                    actual_not_expected.is_empty(),
+                    "Did not expect records to be stored on nodes {:?}.",
+                    actual_not_expected,
+                );
+
+                let expected_not_actual = expected.difference(&actual).collect::<Vec<&PeerId>>();
+                assert!(
+                    expected_not_actual.is_empty(),
+                    "Expected record to be stored on nodes {:?}.",
+                    expected_not_actual,
+                );
+            }
+
+            if republished {
+                assert_eq!(
+                    swarms[0].behaviour_mut().store.records().count(),
+                    records.len()
+                );
+                assert_eq!(swarms[0].behaviour_mut().queries.size(), 0);
+                for k in records.keys() {
+                    swarms[0].behaviour_mut().store.remove(&k);
+                }
+                assert_eq!(swarms[0].behaviour_mut().store.records().count(), 0);
+                // All records have been republished, thus the test is complete.
+                return Poll::Ready(());
+            }
+
+            // Tell the replication job to republish asap.
+            swarms[0]
+                .behaviour_mut()
+                .put_record_job
+                .as_mut()
+                .unwrap()
+                .asap(true);
+            republished = true;
+        }))
+    }
+
+    QuickCheck::new().tests(3).quickcheck(prop as fn(_, _) -> _)
+}
+
+/// A node joining a fully connected network cannot store a record if the nodes ignore it through
+/// [KademliaStoreInserts::FilterBoth].
+#[test]
+fn put_record_filtered_out() {
+    fn prop(records: Vec<Record>, seed: Seed) {
+        let mut rng = StdRng::from_seed(seed.0);
+        let replication_factor =
+            NonZeroUsize::new(rng.gen_range(1, (K_VALUE.get() / 2) + 1)).unwrap();
+        // At least 4 nodes, 1 under test + 3 bootnodes.
+        let num_total = usize::max(4, replication_factor.get() * 2);
+
+        let mut config = KademliaConfig::default();
+        config.set_replication_factor(replication_factor);
+        config.set_record_filtering(KademliaStoreInserts::FilterBoth);
+        if rng.gen() {
+            config.disjoint_query_paths(true);
+        }
+
+        let mut swarms = {
+            let mut fully_connected_swarms =
+                build_fully_connected_nodes_with_config(num_total - 1, config.clone());
+
+            let mut single_swarm = build_node_with_config(config);
+            // Connect `single_swarm` to three bootnodes.
+            for i in 0..3 {
+                single_swarm.1.behaviour_mut().add_address(
+                    fully_connected_swarms[i].1.local_peer_id(),
+                    fully_connected_swarms[i].0.clone(),
+                );
+            }
+
+            let mut swarms = vec![single_swarm];
+            swarms.append(&mut fully_connected_swarms);
+
+            // Drop the swarm addresses.
+            swarms
+                .into_iter()
+                .map(|(_addr, swarm)| swarm)
+                .collect::<Vec<_>>()
+        };
+
+        let records = records
+            .into_iter()
+            .take(num_total)
+            .map(|mut r| {
+                // We don't want records to expire prematurely, as they would
+                // be removed from storage and no longer replicated, but we still
+                // want to check that an explicitly set expiration is preserved.
+                r.expires = r.expires.map(|t| t + Duration::from_secs(60));
+                (r.key.clone(), r)
+            })
+            .collect::<HashMap<_, _>>();
+
+        // Initiate put_record queries.
+        let mut qids = HashSet::new();
+        for r in records.values() {
+            let qid = swarms[0]
+                .behaviour_mut()
+                .put_record(r.clone(), Quorum::All)
+                .unwrap();
+            match swarms[0].behaviour_mut().query(&qid) {
+                Some(q) => match q.info() {
+                    QueryInfo::PutRecord { phase, record, .. } => {
+                        assert_eq!(phase, &PutRecordPhase::GetClosestPeers);
+                        assert_eq!(record.key, r.key);
+                        assert_eq!(record.value, r.value);
+                        assert!(record.expires.is_some());
+                        qids.insert(qid);
+                    }
+                    i => panic!("Unexpected query info: {:?}", i),
+                },
+                None => panic!("Query not found: {:?}", qid),
+            }
+        }
+
+        // The accumulated results for one round of publishing.
+        let mut results = Vec::new();
+
+        block_on(poll_fn(move |ctx| {
+            // Poll all swarms until they are "Pending".
+            for swarm in &mut swarms {
+                loop {
+                    match swarm.poll_next_unpin(ctx) {
+                        Poll::Ready(Some(SwarmEvent::Behaviour(
+                            KademliaEvent::OutboundQueryCompleted {
+                                id,
+                                result: QueryResult::PutRecord(res),
+                                stats,
+                            },
+                        )))
+                        | Poll::Ready(Some(SwarmEvent::Behaviour(
+                            KademliaEvent::OutboundQueryCompleted {
+                                id,
+                                result: QueryResult::RepublishRecord(res),
+                                stats,
+                            },
+                        ))) => {
+                            assert!(qids.is_empty() || qids.remove(&id));
+                            assert!(stats.duration().is_some());
+                            assert!(stats.num_successes() >= replication_factor.get() as u32);
+                            assert!(stats.num_requests() >= stats.num_successes());
+                            assert_eq!(stats.num_failures(), 0);
+                            match res {
+                                Err(e) => panic!("{:?}", e),
+                                Ok(ok) => {
+                                    assert!(records.contains_key(&ok.key));
+                                    let record = swarm.behaviour_mut().store.get(&ok.key).unwrap();
+                                    results.push(record.into_owned());
+                                }
+                            }
+                        }
+                        Poll::Ready(Some(SwarmEvent::Behaviour(
+                            KademliaEvent::InboundPutRecordRequest { record: _, .. },
+                        ))) => {
+                            // Ignore the record
+                        }
+                        // Ignore any other event.
+                        Poll::Ready(Some(_)) => (),
+                        e @ Poll::Ready(_) => panic!("Unexpected return value: {:?}", e),
+                        Poll::Pending => break,
+                    }
+                }
+            }
+
+            // All swarms are Pending and not enough results have been collected
+            // so far, thus wait to be polled again for further progress.
+            if results.len() != records.len() {
+                return Poll::Pending;
+            }
+
+            // Consume the results, checking that each record was replicated
+            // correctly to the closest peers to the key.
+            while let Some(r) = results.pop() {
+                let expected = records.get(&r.key).unwrap();
+
+                assert_eq!(r.key, expected.key);
+                assert_eq!(r.value, expected.value);
+                assert_eq!(r.expires, expected.expires);
+                assert_eq!(r.publisher, Some(*swarms[0].local_peer_id()));
+
+                let key = kbucket::Key::new(r.key.clone());
+                let mut expected = swarms
+                    .iter()
+                    .skip(1)
+                    .map(Swarm::local_peer_id)
+                    .cloned()
+                    .collect::<Vec<_>>();
+                expected.sort_by(|id1, id2| {
+                    kbucket::Key::from(*id1)
+                        .distance(&key)
+                        .cmp(&kbucket::Key::from(*id2).distance(&key))
+                });
+
+                let expected = expected
+                    .into_iter()
+                    .take(replication_factor.get())
+                    .collect::<HashSet<_>>();
+
+                let actual = swarms
+                    .iter()
+                    .skip(1)
+                    .filter_map(|swarm| {
+                        if swarm.behaviour().store.get(key.preimage()).is_some() {
+                            Some(*swarm.local_peer_id())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<HashSet<_>>();
+
+                assert_eq!(actual.len(), 0);
+            }
+            return Poll::Ready(());
+        }))
+    }
+
+    QuickCheck::new().tests(3).quickcheck(prop as fn(_, _) -> _)
+}
+
 #[test]
 fn get_record() {
     let mut swarms = build_nodes(3);

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -48,7 +48,8 @@ pub use behaviour::{
     QueryStats,
 };
 pub use behaviour::{
-    Kademlia, KademliaBucketInserts, KademliaCaching, KademliaConfig, KademliaEvent, Quorum,
+    Kademlia, KademliaBucketInserts, KademliaCaching, KademliaConfig, KademliaEvent,
+    KademliaRecordFiltering, Quorum,
 };
 pub use protocol::KadConnectionType;
 pub use query::QueryId;

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -48,8 +48,7 @@ pub use behaviour::{
     QueryStats,
 };
 pub use behaviour::{
-    Kademlia, KademliaBucketInserts, KademliaCaching, KademliaConfig, KademliaEvent,
-    KademliaRecordFiltering, Quorum,
+    Kademlia, KademliaCaching, KademliaConfig, KademliaEvent, KademliaStoreInserts, Quorum,
 };
 pub use protocol::KadConnectionType;
 pub use query::QueryId;


### PR DESCRIPTION
This is a first version of a record filtering system, which filters both PutRecord and AddProvider, on top of the existing ttl and key filters.  First comments would be nice. Currently untested (waiting for my previous PR to be merged, then I can rebase and test :wink: )

- [ ] What about reporting storage failures? Document that the caller should issue `Reset` on the connection?

Fixes #2140