### PR TITLE
Replace `Into` with `From`

### DIFF
--- a/misc/multistream-select/CHANGELOG.md
+++ b/misc/multistream-select/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Implement `From<io::Error> for ProtocolError` instead of `Into`.
+  [PR 2169](https://github.com/libp2p/rust-libp2p/pull/2169)
+
 # 0.10.3 [2021-03-17]
 
 - Update dependencies.

--- a/misc/multistream-select/CHANGELOG.md
+++ b/misc/multistream-select/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 0.10.4 [unreleased]
 
 - Implement `From<io::Error> for ProtocolError` instead of `Into`.
   [PR 2169](https://github.com/libp2p/rust-libp2p/pull/2169)

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "multistream-select"
 description = "Multistream-select negotiation protocol for libp2p"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/misc/multistream-select/src/protocol.rs
+++ b/misc/multistream-select/src/protocol.rs
@@ -391,9 +391,9 @@ impl From<io::Error> for ProtocolError {
     }
 }
 
-impl Into<io::Error> for ProtocolError {
-    fn into(self) -> io::Error {
-        if let ProtocolError::IoError(e) = self {
+impl From<ProtocolError> for io::Error {
+    fn from(err: ProtocolError) -> Self {
+        if let ProtocolError::IoError(e) = err {
             return e
         }
         io::ErrorKind::InvalidData.into()

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,11 +1,9 @@
-# Unreleased
-
-- Implement `From<io::Error> for YamuxError` instead of `Into`.
-  [PR 2169](https://github.com/libp2p/rust-libp2p/pull/2169)
-
 # 0.34.0 [unreleased]
 
 - Update dependencies.
+
+- Implement `From<io::Error> for YamuxError` instead of `Into`.
+  [PR 2169](https://github.com/libp2p/rust-libp2p/pull/2169)
 
 # 0.33.0 [2021-07-12]
 

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Implement `From<io::Error> for YamuxError` instead of `Into`.
+  [PR 2169](https://github.com/libp2p/rust-libp2p/pull/2169)
+
 # 0.34.0 [unreleased]
 
 - Update dependencies.

--- a/muxers/yamux/src/lib.rs
+++ b/muxers/yamux/src/lib.rs
@@ -360,9 +360,9 @@ where
 #[error("yamux error: {0}")]
 pub struct YamuxError(#[from] yamux::ConnectionError);
 
-impl Into<io::Error> for YamuxError {
-    fn into(self: YamuxError) -> io::Error {
-        match self.0 {
+impl From<YamuxError> for io::Error {
+    fn from(err: YamuxError) -> Self {
+        match err.0 {
             yamux::ConnectionError::Io(e) => e,
             e => io::Error::new(io::ErrorKind::Other, e)
         }

--- a/protocols/gossipsub/src/types.rs
+++ b/protocols/gossipsub/src/types.rs
@@ -233,13 +233,13 @@ impl GossipsubRpc {
     }
 }
 
-impl Into<rpc_proto::Rpc> for GossipsubRpc {
+impl From<GossipsubRpc> for rpc_proto::Rpc {
     /// Converts the RPC into protobuf format.
-    fn into(self) -> rpc_proto::Rpc {
+    fn from(rpc: GossipsubRpc) -> Self {
         // Messages
         let mut publish = Vec::new();
 
-        for message in self.messages.into_iter() {
+        for message in rpc.messages.into_iter() {
             let message = rpc_proto::Message {
                 from: message.source.map(|m| m.to_bytes()),
                 data: Some(message.data),
@@ -253,7 +253,7 @@ impl Into<rpc_proto::Rpc> for GossipsubRpc {
         }
 
         // subscriptions
-        let subscriptions = self
+        let subscriptions = rpc
             .subscriptions
             .into_iter()
             .map(|sub| rpc_proto::rpc::SubOpts {
@@ -270,9 +270,9 @@ impl Into<rpc_proto::Rpc> for GossipsubRpc {
             prune: Vec::new(),
         };
 
-        let empty_control_msg = self.control_msgs.is_empty();
+        let empty_control_msg = rpc.control_msgs.is_empty();
 
-        for action in self.control_msgs {
+        for action in rpc.control_msgs {
             match action {
                 // collect all ihave messages
                 GossipsubControlAction::IHave {

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -71,10 +71,10 @@ impl From<proto::message::ConnectionType> for KadConnectionType {
     }
 }
 
-impl Into<proto::message::ConnectionType> for KadConnectionType {
-    fn into(self) -> proto::message::ConnectionType {
+impl From<KadConnectionType> for proto::message::ConnectionType {
+    fn from(val: KadConnectionType) -> Self {
         use proto::message::ConnectionType::*;
-        match self {
+        match val {
             KadConnectionType::NotConnected => NotConnected,
             KadConnectionType::Connected => Connected,
             KadConnectionType::CanConnect => CanConnect,
@@ -123,13 +123,13 @@ impl TryFrom<proto::message::Peer> for KadPeer {
     }
 }
 
-impl Into<proto::message::Peer> for KadPeer {
-    fn into(self) -> proto::message::Peer {
+impl From<KadPeer> for proto::message::Peer {
+    fn from(peer: KadPeer) -> Self {
         proto::message::Peer {
-            id: self.node_id.to_bytes(),
-            addrs: self.multiaddrs.into_iter().map(|a| a.to_vec()).collect(),
+            id: peer.node_id.to_bytes(),
+            addrs: peer.multiaddrs.into_iter().map(|a| a.to_vec()).collect(),
             connection: {
-                let ct: proto::message::ConnectionType = self.connection_ty.into();
+                let ct: proto::message::ConnectionType = peer.connection_ty.into();
                 ct as i32
             }
         }


### PR DESCRIPTION
Unless restricted by orphan rules, implementing `From` is superior
because it implies `Into` but leaves the choice to the user, which
one to use. Especially for errors, `From` is convenient because that
is what `?` builds on.

Not sure if this needs a changelog entry?