### PR TITLE
swarm/src/behaviour: Update DialAddress doc comment

### DIFF
--- a/swarm/src/behaviour.rs
+++ b/swarm/src/behaviour.rs
@@ -233,8 +233,7 @@ pub enum NetworkBehaviourAction<TInEvent, TOutEvent> {
     /// Instructs the `Swarm` to return an event when it is being polled.
     GenerateEvent(TOutEvent),
 
-    /// Instructs the swarm to dial the given multiaddress, with no knowledge of the `PeerId` that
-    /// may be reached.
+    /// Instructs the swarm to dial the given multiaddress optionally including a [`PeerId`].
     DialAddress {
         /// The address to dial.
         address: Multiaddr,
@@ -242,7 +241,8 @@ pub enum NetworkBehaviourAction<TInEvent, TOutEvent> {
 
     /// Instructs the swarm to dial a known `PeerId`.
     ///
-    /// The `addresses_of_peer` method is called to determine which addresses to attempt to reach.
+    /// The [`NetworkBehaviour::addresses_of_peer`] method is called to determine which addresses to
+    /// attempt to reach.
     ///
     /// If we were already trying to dial this node, the addresses that are not yet in the queue of
     /// addresses to try are added back to this queue.


### PR DESCRIPTION
With 45f07bf8639fd9056e4ffe52298ca113a0308951 `Network::dial` accepts a
`Multiaddr` with a `PeerId`. With that in mind the doc comment on
`NetworkBehaviourAction::DialAddress` is outdated.