### PR TITLE
core/: Remove DisconnectedPeer::set_connected and Pool::add

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -20,10 +20,14 @@
 - Require `ConnectionHandler::{InEvent,OutEvent,Error}` to implement `Debug`
   (see [PR 2183]).
 
+- Remove `DisconnectedPeer::set_connected` and `Pool::add` (see [PR 2195]).
+
+
 [PR 2145]: https://github.com/libp2p/rust-libp2p/pull/2145
 [PR 2142]: https://github.com/libp2p/rust-libp2p/pull/2142
 [PR 2137]: https://github.com/libp2p/rust-libp2p/pull/2137
 [PR 2183]: https://github.com/libp2p/rust-libp2p/pull/2183
+[PR 2195]: https://github.com/libp2p/rust-libp2p/pull/2195
 
 # 0.29.0 [2021-07-12]
 

--- a/core/src/connection/manager/task.rs
+++ b/core/src/connection/manager/task.rs
@@ -130,24 +130,6 @@ where
             },
         }
     }
-
-    /// Create a task for an existing node we are already connected to.
-    pub fn established(
-        id: TaskId,
-        events: mpsc::Sender<Event<H, E>>,
-        commands: mpsc::Receiver<Command<THandlerInEvent<H>>>,
-        connection: Connection<M, H::Handler>,
-    ) -> Self {
-        Task {
-            id,
-            events,
-            commands: commands.fuse(),
-            state: State::Established {
-                connection,
-                event: None,
-            },
-        }
-    }
 }
 
 /// The state associated with the `Task` of a connection.

--- a/core/src/connection/pool.rs
+++ b/core/src/connection/pool.rs
@@ -20,11 +20,10 @@
 
 use crate::{
     connection::{
-        self,
         handler::{THandlerError, THandlerInEvent, THandlerOutEvent},
         manager::{self, Manager, ManagerConfig},
-        Connected, Connection, ConnectionError, ConnectionHandler, ConnectionId, ConnectionLimit,
-        IncomingInfo, IntoConnectionHandler, OutgoingInfo, PendingConnectionError, Substream,
+        Connected, ConnectionError, ConnectionHandler, ConnectionId, ConnectionLimit, IncomingInfo,
+        IntoConnectionHandler, OutgoingInfo, PendingConnectionError, Substream,
     },
     muxing::StreamMuxer,
     ConnectedPoint, PeerId,

--- a/core/src/network/peer.rs
+++ b/core/src/network/peer.rs
@@ -21,7 +21,7 @@
 use super::{DialError, DialingOpts, Network};
 use crate::{
     connection::{
-        handler::THandlerInEvent, pool::Pool, Connected, ConnectedPoint, Connection,
+        handler::THandlerInEvent, pool::Pool, ConnectedPoint,
         ConnectionHandler, ConnectionId, ConnectionLimit, EstablishedConnection,
         EstablishedConnectionIter, IntoConnectionHandler, PendingConnection, Substream,
     },

--- a/core/src/network/peer.rs
+++ b/core/src/network/peer.rs
@@ -472,44 +472,6 @@ where
     pub fn into_peer(self) -> Peer<'a, TTrans, THandler> {
         Peer::Disconnected(self)
     }
-
-    /// Moves the peer into a connected state by supplying an existing
-    /// established connection.
-    ///
-    /// No event is generated for this action.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `connected.peer_id` does not identify the current peer.
-    pub fn set_connected<TMuxer>(
-        self,
-        connected: Connected,
-        connection: Connection<TMuxer, THandler::Handler>,
-    ) -> Result<ConnectedPeer<'a, TTrans, THandler>, ConnectionLimit>
-    where
-        THandler: Send + 'static,
-        TTrans::Error: Send + 'static,
-        THandler::Handler: ConnectionHandler<Substream = Substream<TMuxer>> + Send,
-        <THandler::Handler as ConnectionHandler>::OutboundOpenInfo: Send,
-        <THandler::Handler as ConnectionHandler>::Error: error::Error + Send + 'static,
-        TMuxer: StreamMuxer + Send + Sync + 'static,
-        TMuxer::OutboundSubstream: Send,
-    {
-        if connected.peer_id != self.peer_id {
-            panic!(
-                "Invalid peer ID given: {:?}. Expected: {:?}",
-                connected.peer_id, self.peer_id
-            )
-        }
-
-        self.network
-            .pool
-            .add(connection, connected)
-            .map(move |_id| ConnectedPeer {
-                network: self.network,
-                peer_id: self.peer_id,
-            })
-    }
 }
 
 /// The (internal) state of a `DialingAttempt`, tracking the

--- a/core/src/network/peer.rs
+++ b/core/src/network/peer.rs
@@ -21,9 +21,9 @@
 use super::{DialError, DialingOpts, Network};
 use crate::{
     connection::{
-        handler::THandlerInEvent, pool::Pool, ConnectedPoint,
-        ConnectionHandler, ConnectionId, ConnectionLimit, EstablishedConnection,
-        EstablishedConnectionIter, IntoConnectionHandler, PendingConnection, Substream,
+        handler::THandlerInEvent, pool::Pool, ConnectedPoint, ConnectionHandler, ConnectionId,
+        ConnectionLimit, EstablishedConnection, EstablishedConnectionIter, IntoConnectionHandler,
+        PendingConnection, Substream,
     },
     Multiaddr, PeerId, StreamMuxer, Transport,
 };


### PR DESCRIPTION
This logic seems to be a leftover of
https://github.com/libp2p/rust-libp2p/pull/889 and unused today.