### PR TITLE
core/: Merge pending and established connection limits

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,6 +1,13 @@
 # 0.30.0 [unreleased]
 
-- Add `ConnectionLimit::with_max_established` (see [PR 2137]).
+- Add `ConnectionLimits::with_max_established` (see [PR 2137]).
+
+- Merge pending and established limits for both incoming and outgoing connections. More specifically
+  merge `ConnectionLimits::with_max_pending_incoming` with
+  `ConnectionLimits::with_max_established_incoming` and
+  `ConnectionLimits::with_max_pending_outgoing` with
+  `ConnectionLimits::with_max_established_outgoing`. Connection limits are checked on
+  `Network::dial` for outgoing and on `Network::accept` for incoming connections.
 
 - Add `Keypair::to_protobuf_encoding` (see [PR 2142]).
 
@@ -21,11 +28,6 @@
   (see [PR 2183]).
 
 - Remove `DisconnectedPeer::set_connected` and `Pool::add` (see [PR 2195]).
-
-- Report `ConnectionLimit` error through `ConnectionError` and thus through
-  `NetworkEvent::ConnectionClosed` instead of previously through
-  `PendingConnectionError` and thus `NetworkEvent::{IncomingConnectionError,
-  DialError}` (see [PR 2191]).
 
 - Report abortion of pending connection through `DialError`,
   `UnknownPeerDialError` or `IncomingConnectionError` (see [PR 2191]).

--- a/core/src/connection/error.rs
+++ b/core/src/connection/error.rs
@@ -18,7 +18,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::connection::ConnectionLimit;
 use crate::transport::TransportError;
 use std::{fmt, io};
 
@@ -28,10 +27,6 @@ pub enum ConnectionError<THandlerErr> {
     /// An I/O error occurred on the connection.
     // TODO: Eventually this should also be a custom error?
     IO(io::Error),
-
-    /// The connection was dropped because the connection limit
-    /// for a peer has been reached.
-    ConnectionLimit(ConnectionLimit),
 
     /// The connection handler produced an error.
     Handler(THandlerErr),
@@ -45,9 +40,6 @@ where
         match self {
             ConnectionError::IO(err) => write!(f, "Connection error: I/O error: {}", err),
             ConnectionError::Handler(err) => write!(f, "Connection error: Handler error: {}", err),
-            ConnectionError::ConnectionLimit(l) => {
-                write!(f, "Connection error: Connection limit: {}.", l)
-            }
         }
     }
 }
@@ -60,7 +52,6 @@ where
         match self {
             ConnectionError::IO(err) => Some(err),
             ConnectionError::Handler(err) => Some(err),
-            ConnectionError::ConnectionLimit(..) => None,
         }
     }
 }

--- a/core/src/connection/manager.rs
+++ b/core/src/connection/manager.rs
@@ -20,8 +20,8 @@
 
 use super::{
     handler::{THandlerError, THandlerInEvent, THandlerOutEvent},
-    Connected, ConnectedPoint, ConnectionError, ConnectionHandler, ConnectionLimit,
-    IntoConnectionHandler, PendingConnectionError, Substream,
+    Connected, ConnectedPoint, ConnectionError, ConnectionHandler, IntoConnectionHandler,
+    PendingConnectionError, Substream,
 };
 use crate::{muxing::StreamMuxer, Executor};
 use fnv::FnvHashMap;
@@ -439,7 +439,7 @@ impl<'a, I> EstablishedEntry<'a, I> {
     ///
     /// When the connection is ultimately closed, [`Event::ConnectionClosed`]
     /// is emitted by [`Manager::poll`].
-    pub fn start_close(mut self, error: Option<ConnectionLimit>) {
+    pub fn start_close(mut self) {
         // Clone the sender so that we are guaranteed to have
         // capacity for the close command (every sender gets a slot).
         match self
@@ -447,7 +447,7 @@ impl<'a, I> EstablishedEntry<'a, I> {
             .get_mut()
             .sender
             .clone()
-            .try_send(task::Command::Close(error))
+            .try_send(task::Command::Close)
         {
             Ok(()) => {}
             Err(e) => assert!(e.is_disconnected(), "No capacity for close command."),

--- a/core/src/network.rs
+++ b/core/src/network.rs
@@ -614,6 +614,7 @@ where
         (
             opts,
             NetworkEvent::DialError {
+                id,
                 attempts_remaining,
                 peer_id,
                 multiaddr: failed_addr,
@@ -626,6 +627,7 @@ where
             ConnectedPoint::Dialer { address } => (
                 None,
                 NetworkEvent::UnknownPeerDialError {
+                    id,
                     multiaddr: address,
                     error,
                     handler,

--- a/core/src/network/event.rs
+++ b/core/src/network/event.rs
@@ -130,6 +130,8 @@ where
 
     /// A dialing attempt to an address of a peer failed.
     DialError {
+        /// The ID of the connection that encountered an error.
+        id: ConnectionId,
         /// The number of remaining dialing attempts.
         attempts_remaining: DialAttemptsRemaining<THandler>,
 
@@ -145,6 +147,8 @@ where
 
     /// Failed to reach a peer that we were trying to dial.
     UnknownPeerDialError {
+        /// The ID of the connection that encountered an error.
+        id: ConnectionId,
         /// The multiaddr we failed to reach.
         multiaddr: Multiaddr,
 
@@ -262,21 +266,27 @@ where
                 .field("error", error)
                 .finish(),
             NetworkEvent::DialError {
+                id,
                 attempts_remaining,
                 peer_id,
                 multiaddr,
                 error,
             } => f
                 .debug_struct("DialError")
+                .field("id", id)
                 .field("attempts_remaining", &attempts_remaining.get_attempts())
                 .field("peer_id", peer_id)
                 .field("multiaddr", multiaddr)
                 .field("error", error)
                 .finish(),
             NetworkEvent::UnknownPeerDialError {
-                multiaddr, error, ..
+                id,
+                multiaddr,
+                error,
+                ..
             } => f
                 .debug_struct("UnknownPeerDialError")
+                .field("id", id)
                 .field("multiaddr", multiaddr)
                 .field("error", error)
                 .finish(),

--- a/core/tests/network_dial_error.rs
+++ b/core/tests/network_dial_error.rs
@@ -51,7 +51,7 @@ fn deny_incoming_connec() {
         _ => panic!("Was expecting the listen address to be reported"),
     }));
 
-    swarm2
+    let (connection_id, _) = swarm2
         .peer(swarm1.local_peer_id().clone())
         .dial(address.clone(), Vec::new(), TestHandler())
         .unwrap();
@@ -65,11 +65,13 @@ fn deny_incoming_connec() {
 
         match swarm2.poll(cx) {
             Poll::Ready(NetworkEvent::DialError {
+                id,
                 attempts_remaining,
                 peer_id,
                 multiaddr,
                 error: PendingConnectionError::Transport(_),
             }) => {
+                assert_eq!(id, connection_id);
                 assert_eq!(0u32, attempts_remaining.get_attempts());
                 assert_eq!(&peer_id, swarm1.local_peer_id());
                 assert_eq!(
@@ -191,6 +193,7 @@ fn multiple_addresses_err() {
         loop {
             match swarm.poll(cx) {
                 Poll::Ready(NetworkEvent::DialError {
+                    id: _,
                     attempts_remaining,
                     peer_id,
                     multiaddr,

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -624,6 +624,7 @@ where
                         );
                     let local_addr = connection.local_addr.clone();
                     let send_back_addr = connection.send_back_addr.clone();
+                    // TODO: Handler is lost here.
                     if let Err(e) = this.network.accept(connection, handler) {
                         log::warn!("Incoming connection rejected: {:?}", e);
                     }
@@ -709,6 +710,7 @@ where
                     });
                 }
                 Poll::Ready(NetworkEvent::DialError {
+                    id: _,
                     peer_id,
                     multiaddr,
                     error,
@@ -745,7 +747,10 @@ where
                     });
                 }
                 Poll::Ready(NetworkEvent::UnknownPeerDialError {
-                    multiaddr, error, ..
+                    id: _,
+                    multiaddr,
+                    error,
+                    ..
                 }) => {
                     log::debug!(
                         "Connection attempt to address {:?} of unknown peer failed with {:?}",


### PR DESCRIPTION
Merge pending and established limits for both incoming and outgoing
connections. More specifically merge
`ConnectionLimits::with_max_pending_incoming` with
`ConnectionLimits::with_max_established_incoming` and
`ConnectionLimits::with_max_pending_outgoing` with
`ConnectionLimits::with_max_established_outgoing`. Connection limits are
checked on `Network::dial` for outgoing and on `Network::accept` for
incoming connections.

This (a) simplifies connection limits from an implementations and user
perspective and (b) simplifies returning a connection handler on limit
error as limits can only be exceeded at the start of dialing and
accepting. See [1].

[1]: https://github.com/libp2p/rust-libp2p/issues/2242#issuecomment-928229155