### PR TITLE
protocols/gossipsub: Implement std::error::Error for error types

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Allow `message_id_fn`s to accept closures that capture variables.
   [PR 2103](https://github.com/libp2p/rust-libp2p/pull/2103)
 
+- Added std::error::Error impls for error types
+
 # 0.32.0 [2021-07-12]
 
 - Update dependencies.

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Allow `message_id_fn`s to accept closures that capture variables.
   [PR 2103](https://github.com/libp2p/rust-libp2p/pull/2103)
 
-- Added std::error::Error impls for error types
+- Implement std::error::Error for error types.
   [PR 2254](https://github.com/libp2p/rust-libp2p/pull/2254)
 
 # 0.32.0 [2021-07-12]

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -15,6 +15,7 @@
   [PR 2103](https://github.com/libp2p/rust-libp2p/pull/2103)
 
 - Added std::error::Error impls for error types
+  [PR 2254](https://github.com/libp2p/rust-libp2p/pull/2254)
 
 # 0.32.0 [2021-07-12]
 

--- a/protocols/gossipsub/src/error.rs
+++ b/protocols/gossipsub/src/error.rs
@@ -40,6 +40,14 @@ pub enum PublishError {
     TransformFailed(std::io::Error),
 }
 
+impl std::fmt::Display for PublishError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for PublishError {}
+
 /// Error associated with subscribing to a topic.
 #[derive(Debug)]
 pub enum SubscriptionError {
@@ -48,6 +56,14 @@ pub enum SubscriptionError {
     /// We are not allowed to subscribe to this topic by the subscription filter
     NotAllowed,
 }
+
+impl std::fmt::Display for SubscriptionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for SubscriptionError {}
 
 impl From<SigningError> for PublishError {
     fn from(error: SigningError) -> Self {
@@ -94,6 +110,15 @@ pub enum ValidationError {
     /// The data transformation failed.
     TransformFailed,
 }
+
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for ValidationError {}
 
 impl From<std::io::Error> for GossipsubHandlerError {
     fn from(error: std::io::Error) -> GossipsubHandlerError {

--- a/protocols/gossipsub/src/error.rs
+++ b/protocols/gossipsub/src/error.rs
@@ -46,7 +46,15 @@ impl std::fmt::Display for PublishError {
     }
 }
 
-impl std::error::Error for PublishError {}
+impl std::error::Error for PublishError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::SigningError(err) => Some(err),
+            Self::TransformFailed(err) => Some(err),
+            _ => None,
+        }
+    }
+}
 
 /// Error associated with subscribing to a topic.
 #[derive(Debug)]
@@ -63,7 +71,14 @@ impl std::fmt::Display for SubscriptionError {
     }
 }
 
-impl std::error::Error for SubscriptionError {}
+impl std::error::Error for SubscriptionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::PublishError(err) => Some(err),
+            _ => None,
+        }
+    }
+}
 
 impl From<SigningError> for PublishError {
     fn from(error: SigningError) -> Self {
@@ -110,7 +125,6 @@ pub enum ValidationError {
     /// The data transformation failed.
     TransformFailed,
 }
-
 
 impl std::fmt::Display for ValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {


### PR DESCRIPTION
It's annoying to work with these error types, because they can't be used with the `?` operator. This fixes that