### PR TITLE
.github/workflows/ci: Improve cache effectiveness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
 
     - uses: actions/checkout@v2.3.4
 
+    - uses: Swatinem/rust-cache@v1.3.0
+
     - name: Check rustdoc links
       run: RUSTDOCFLAGS="--deny broken_intra_doc_links" cargo doc --verbose --workspace --no-deps --document-private-items
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
     - uses: actions/checkout@v2.3.4
 
     - uses: Swatinem/rust-cache@v1.3.0
+      with:
+        key: ${{ matrix.args }}
 
     - run: cargo test --workspace ${{ matrix.args }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,13 @@ jobs:
   test-desktop:
     name: Build and test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        args: [
+          "--no-default-features",
+          "--all-features",
+          "--benches --all-features",
+        ]
     steps:
 
     - name: Cancel Previous Runs
@@ -21,18 +28,17 @@ jobs:
 
     - uses: Swatinem/rust-cache@v1.3.0
 
-    - name: Run tests, with no feature
-      run: cargo test --workspace --no-default-features
-
-    - name: Run tests, with all features
-      run: cargo test --workspace --all-features
-
-    - name: Run benches, with all features
-      run: cargo test --workspace --benches --all-features
+    - run: cargo test --workspace ${{ matrix.args }}
 
   test-wasm:
     name: Build on WASM
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain: [
+          wasm32-unknown-emscripten,
+          wasm32-wasi
+        ]
     container:
       image: rust
       env:
@@ -46,18 +52,11 @@ jobs:
 
     - uses: actions/checkout@v2.3.4
 
-    - name: Install Rust wasm32-unknown-emscripten
+    - name: Install Rust ${{ matrix.toolchain }}
       uses: actions-rs/toolchain@v1.0.7
       with:
         toolchain: stable
-        target: wasm32-unknown-emscripten
-        override: true
-
-    - name: Install Rust wasm32-wasi
-      uses: actions-rs/toolchain@v1.0.7
-      with:
-        toolchain: stable
-        target: wasm32-wasi
+        target: ${{ matrix.toolchain }}
         override: true
 
     - name: Install a recent version of clang
@@ -70,15 +69,10 @@ jobs:
 
     - uses: Swatinem/rust-cache@v1.3.0
 
-    - name: Build on wasm32-unknown-emscripten
+    - name: Build on ${{ matrix.toolchain }}
       # TODO: also run `cargo test`
       # TODO: ideally we would build `--workspace`, but not all crates compile for WASM
-      run: cargo build --target=wasm32-unknown-emscripten
-
-    - name: Build on wasm32-wasi
-      # TODO: also run `cargo test`
-      # TODO: ideally we would build `--workspace`, but not all crates compile for WASM
-      run: cargo build --target=wasm32-wasi
+      run: cargo build --target=${{ matrix.toolchain }}
 
   check-rustdoc-links:
     name: Check rustdoc intra-doc links

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
       run: apt-get install -y cmake
 
     - uses: Swatinem/rust-cache@v1.3.0
+      with:
+        key: ${{ matrix.toolchain }}
 
     - name: Build on ${{ matrix.toolchain }}
       # TODO: also run `cargo test`


### PR DESCRIPTION
To have caches operate at its maximum usefulness, we need to have a
1-to-1 mapping between build-comamnd and cache key. Otherwise rustc
has to rebuild certain artefacts because they were not in the cache.

By using matrices, we make github parallelise some of our jobs. This
has a double positive impact on CI runtime. Not only are our caches
more effective now, several jobs are now run in parallel.
