### PR TITLE
Create ListenersEvent::Closed on Swarm::remove_listener

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -36,6 +36,9 @@
 - Add `SignedEnvelope` and `PeerRecord` according to [RFC0002] and [RFC0003]
   (see [PR 2107]).
 
+- Report `ListenersEvent::Closed` when dropping a listener in `ListenersStream::remove_listener`,
+  return `bool` instead of `Result<(), ()>` (see [PR 2261]).
+
 [PR 2145]: https://github.com/libp2p/rust-libp2p/pull/2145
 [PR 2213]: https://github.com/libp2p/rust-libp2p/pull/2213
 [PR 2142]: https://github.com/libp2p/rust-libp2p/pull/2142
@@ -44,6 +47,7 @@
 [PR 2191]: https://github.com/libp2p/rust-libp2p/pull/2191
 [PR 2195]: https://github.com/libp2p/rust-libp2p/pull/2195
 [PR 2107]: https://github.com/libp2p/rust-libp2p/pull/2107
+[PR 2261]: https://github.com/libp2p/rust-libp2p/pull/2261
 [RFC0002]: https://github.com/libp2p/specs/blob/master/RFC/0002-signed-envelopes.md
 [RFC0003]: https://github.com/libp2p/specs/blob/master/RFC/0003-routing-records.md
 

--- a/core/src/connection/listeners.rs
+++ b/core/src/connection/listeners.rs
@@ -90,7 +90,7 @@ where
     listeners: VecDeque<Pin<Box<Listener<TTrans>>>>,
     /// The next listener ID to assign.
     next_id: ListenerId,
-    /// Pending listeners events to return from `poll`.
+    /// Pending listeners events to return from [`ListenersStream::poll`].
     pending_events: VecDeque<ListenersEvent<TTrans>>,
 }
 

--- a/core/src/network.rs
+++ b/core/src/network.rs
@@ -147,8 +147,9 @@ where
 
     /// Remove a previously added listener.
     ///
-    /// Returns `Ok(())` if a listener with this ID was in the list.
-    pub fn remove_listener(&mut self, id: ListenerId) -> Result<(), ()> {
+    /// Returns `true` if there was a listener with this ID, `false`
+    /// otherwise.
+    pub fn remove_listener(&mut self, id: ListenerId) -> bool {
         self.listeners.remove_listener(id)
     }
 

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -42,11 +42,15 @@
   parameters to `NetworkBehaviourAction<Self::OutEvent,
   Self::ProtocolsHandler>`. See [PR 2191].
 
+- Return `bool` instead of `Result<(), ()>` for `Swarm::remove_listener`(see
+  [PR 2261]).
+
 [PR 2150]: https://github.com/libp2p/rust-libp2p/pull/2150
 [PR 2182]: https://github.com/libp2p/rust-libp2p/pull/2182
 [PR 2183]: https://github.com/libp2p/rust-libp2p/pull/2183
 [PR 2192]: https://github.com/libp2p/rust-libp2p/pull/2192
 [PR 2191]: https://github.com/libp2p/rust-libp2p/pull/2191
+[PR 2261]: https://github.com/libp2p/rust-libp2p/pull/2261
 
 # 0.30.0 [2021-07-12]
 

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -324,8 +324,9 @@ where
 
     /// Remove some listener.
     ///
-    /// Returns `Ok(())` if there was a listener with this ID.
-    pub fn remove_listener(&mut self, id: ListenerId) -> Result<(), ()> {
+    /// Returns `true` if there was a listener with this ID, `false`
+    /// otherwise.
+    pub fn remove_listener(&mut self, id: ListenerId) -> bool {
         self.network.remove_listener(id)
     }
 


### PR DESCRIPTION
Discussion #2113.
Create a `ListenersEvent::Closed` when a listener is removed via `Swarm::remove_listener`.
This makes it more consistent with `Swarm::listen_on`, and also informs the Swarm about the associated expired addresses.

I initially tried to realize it via a `Stream` implementation on the `connection::Listener`, so that it would just return `Poll::Ready(None)` if the listener was removed (see [this commit](https://github.com/elenaf9/rust-libp2p/commit/6acc63831ee996c466e2fd9e54fb21a254edf397)). But due to Listener being wrapped in a `Pin` it is a bit more complicated, whereas this Draft now is only a very minimal change.

_Note: https://github.com/libp2p/rust-libp2p/pull/2261/commits/0efe82c3c5081a9761268b95fa1ca822b7b7b1ad  introduces a minor API change so that `remove_listener` returns a boolean instead of `Result<(), ()>`. This 1. more consistent with other methods like `remove_external_address`, and 2. follows the clippy lint of [result_unit_err](https://rust-lang.github.io/rust-clippy/master/index.html#result_unit_err)._