### PR TITLE
transports/noise: fix compilation

### DIFF
--- a/transports/noise/src/protocol/x25519.rs
+++ b/transports/noise/src/protocol/x25519.rs
@@ -219,7 +219,7 @@ impl SecretKey<X25519> {
         // let ed25519_sk = ed25519::SecretKey::from(ed);
         let mut curve25519_sk: [u8; 32] = [0; 32];
         let hash = Sha512::digest(ed25519_sk.as_ref());
-        curve25519_sk.copy_from_slice(&hash.as_ref()[..32]);
+        curve25519_sk.copy_from_slice(&hash[..32]);
         let sk = SecretKey(X25519(curve25519_sk)); // Copy
         curve25519_sk.zeroize();
         sk


### PR DESCRIPTION
For crate that depends on `generic-array = { version = "0.14.3", features = ["serde", "more_lengths"] }` It's seems that `as_ref()` is ambiguous.

`more-lengths` features seem to create this problem.

```
error[E0282]: type annotations needed
   --> /home/azureagent/.cargo/git/checkouts/rust-libp2p-98135dbcf5b63918/20183c1/transports/noise/src/protocol/x25519.rs:221:45
    |
221 |         curve25519_sk.copy_from_slice(&hash.as_ref()[..32]);
    |                                        -----^^^^^^--
    |                                        |    |
    |                                        |    cannot infer type for type parameter `T` declared on the trait `AsRef`
    |                                        this method call resolves to `&T`
    |
    = note: type must be known at this point
```