### PR TITLE
transports/noise: Update to snow 0.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     container:
       image: rust
       env:
-        CC: clang-10
+        CC: clang-11
     steps:
 
     - name: Cancel Previous Runs
@@ -75,7 +75,7 @@ jobs:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
         echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" >> /etc/apt/sources.list
         apt-get update
-        apt-get install -y clang-10
+        apt-get install -y clang-11
 
     - name: Install CMake
       run: apt-get install -y cmake

--- a/transports/noise/CHANGELOG.md
+++ b/transports/noise/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.30.1 [2021-10-06]
+
+- Update dependencies (see [PR 2272]).
+
+[PR 2272]: https://github.com/libp2p/rust-libp2p/pull/2272
+
 # 0.30.0 [2021-03-17]
 
 - Update `libp2p-core`.

--- a/transports/noise/Cargo.toml
+++ b/transports/noise/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-noise"
 description = "Cryptographic handshake protocol using the noise framework."
-version = "0.30.0"
+version = "0.30.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/transports/noise/Cargo.toml
+++ b/transports/noise/Cargo.toml
@@ -15,17 +15,17 @@ lazy_static = "1.2"
 libp2p-core = { version = "0.28.0", path = "../../core" }
 log = "0.4"
 prost = "0.7"
-rand = "0.7.2"
+rand = "0.8.3"
 sha2 = "0.9.1"
 static_assertions = "1"
 x25519-dalek = "1.1.0"
 zeroize = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-snow = { version = "0.7.1", features = ["ring-resolver"], default-features = false }
+snow = { version = "0.8.0", features = ["ring-resolver"], default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-snow = { version = "0.7.1", features = ["default-resolver"], default-features = false }
+snow = { version = "0.8.0", features = ["default-resolver"], default-features = false }
 
 [dev-dependencies]
 async-io = "1.2.0"

--- a/transports/noise/src/protocol/x25519.rs
+++ b/transports/noise/src/protocol/x25519.rs
@@ -218,7 +218,7 @@ impl SecretKey<X25519> {
         // let ed25519_sk = ed25519::SecretKey::from(ed);
         let mut curve25519_sk: [u8; 32] = [0; 32];
         let hash = Sha512::digest(ed25519_sk.as_ref());
-        curve25519_sk.copy_from_slice(&hash.as_ref()[..32]);
+        curve25519_sk.copy_from_slice(&hash[..32]);
         let sk = SecretKey(X25519(curve25519_sk)); // Copy
         curve25519_sk.zeroize();
         sk


### PR DESCRIPTION
Note that this pull request is merging to `libp2p-noise-0.30` and not `master`.

Replaces https://github.com/libp2p/rust-libp2p/pull/2269.

Note that this includes https://github.com/libp2p/rust-libp2p/pull/2264.