### PR TITLE
protocols/kad: Export KademliaBucketInserts 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@
 
 # `libp2p` facade crate
 
+
+## Version 0.40.0-rc.2 [2021-10-15]
+
+- Update individual crates.
+    - `libp2p-kad`
+
 ## Version 0.40.0-rc.1 [2021-10-15]
 
 - Update individual crates.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p"
 edition = "2018"
 description = "Peer-to-peer networking library"
-version = "0.40.0-rc.1"
+version = "0.40.0-rc.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -72,7 +72,7 @@ libp2p-core = { version = "0.30.0-rc.1", path = "core",  default-features = fals
 libp2p-floodsub = { version = "0.31.0-rc.1", path = "protocols/floodsub", optional = true }
 libp2p-gossipsub = { version = "0.33.0-rc.1", path = "./protocols/gossipsub", optional = true }
 libp2p-identify = { version = "0.31.0-rc.1", path = "protocols/identify", optional = true }
-libp2p-kad = { version = "0.32.0-rc.1", path = "protocols/kad", optional = true }
+libp2p-kad = { version = "0.32.0-rc.2", path = "protocols/kad", optional = true }
 libp2p-metrics = { version = "0.1.0-rc.1", path = "misc/metrics", optional = true }
 libp2p-mplex = { version = "0.30.0-rc.1", path = "muxers/mplex", optional = true }
 libp2p-noise = { version = "0.33.0-rc.1", path = "transports/noise", optional = true }

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.32.0-rc.2 [2021-10-15]
+
+- Export `KademliaBucketInserts`.
+
 # 0.32.0-rc.1 [2021-10-15]
 
 - Make default features of `libp2p-core` optional.

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 0.32.0-rc.2 [2021-10-15]
 
-- Export `KademliaBucketInserts`.
+- Export `KademliaBucketInserts` (see [PR 2294]).
+
+[PR 2294]: https://github.com/libp2p/rust-libp2p/pull/2294
 
 # 0.32.0-rc.1 [2021-10-15]
 

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-kad"
 edition = "2018"
 description = "Kademlia protocol for libp2p"
-version = "0.32.0-rc.1"
+version = "0.32.0-rc.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -48,7 +48,8 @@ pub use behaviour::{
     QueryStats,
 };
 pub use behaviour::{
-    Kademlia, KademliaCaching, KademliaConfig, KademliaEvent, KademliaStoreInserts, Quorum,
+    Kademlia, KademliaBucketInserts, KademliaCaching, KademliaConfig, KademliaEvent,
+    KademliaStoreInserts, Quorum,
 };
 pub use protocol::KadConnectionType;
 pub use query::QueryId;


### PR DESCRIPTION
Export for `KademliaBucketInserts` was accidentally removed in https://github.com/libp2p/rust-libp2p/pull/2163/files. This reverts the change, exporting the type again.

Raised in https://github.com/libp2p/rust-libp2p/pull/2290#issuecomment-944245195.

//CC @kpp 