### PR TITLE
Fix clippy warnings turned into compiler warnings (1.58)

### DIFF
--- a/core/src/transport/and_then.rs
+++ b/core/src/transport/and_then.rs
@@ -77,7 +77,7 @@ where
         let future = AndThenFuture {
             inner: Either::Left(Box::pin(dialed_fut)),
             args: Some((self.fun, ConnectedPoint::Dialer { address: addr })),
-            marker: PhantomPinned,
+            _marker: PhantomPinned,
         };
         Ok(future)
     }
@@ -132,7 +132,7 @@ where
                             upgrade: AndThenFuture {
                                 inner: Either::Left(Box::pin(upgrade)),
                                 args: Some((this.fun.clone(), point)),
-                                marker: PhantomPinned,
+                                _marker: PhantomPinned,
                             },
                             local_addr,
                             remote_addr,
@@ -159,7 +159,7 @@ where
 pub struct AndThenFuture<TFut, TMap, TMapOut> {
     inner: Either<Pin<Box<TFut>>, Pin<Box<TMapOut>>>,
     args: Option<(TMap, ConnectedPoint)>,
-    marker: PhantomPinned,
+    _marker: PhantomPinned,
 }
 
 impl<TFut, TMap, TMapOut> Future for AndThenFuture<TFut, TMap, TMapOut>

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -230,8 +230,7 @@ impl std::error::Error for InboundFailure {}
 /// See [`RequestResponse::send_response`].
 #[derive(Debug)]
 pub struct ResponseChannel<TResponse> {
-    request_id: RequestId,
-    peer: PeerId,
+    _debug_id: (RequestId, PeerId),
     sender: oneshot::Sender<TResponse>,
 }
 
@@ -727,8 +726,7 @@ where
                 sender,
             } => {
                 let channel = ResponseChannel {
-                    request_id,
-                    peer,
+                    _debug_id: (request_id, peer),
                     sender,
                 };
                 let message = RequestResponseMessage::Request {

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -230,7 +230,6 @@ impl std::error::Error for InboundFailure {}
 /// See [`RequestResponse::send_response`].
 #[derive(Debug)]
 pub struct ResponseChannel<TResponse> {
-    _debug_id: (RequestId, PeerId),
     sender: oneshot::Sender<TResponse>,
 }
 
@@ -725,10 +724,7 @@ where
                 request,
                 sender,
             } => {
-                let channel = ResponseChannel {
-                    _debug_id: (request_id, peer),
-                    sender,
-                };
+                let channel = ResponseChannel { sender };
                 let message = RequestResponseMessage::Request {
                     request_id,
                     request,

--- a/transports/uds/src/lib.rs
+++ b/transports/uds/src/lib.rs
@@ -48,7 +48,7 @@ use log::debug;
 use std::{io, path::PathBuf};
 
 macro_rules! codegen {
-    ($feature_name:expr, $uds_config:ident, $build_listener:expr, $unix_stream:ty, $($mut_or_not:tt)*) => {
+    ($feature_name:expr, $uds_config:ident, $build_listener:expr, $unix_stream:ty, ) => {
 
 /// Represents the configuration for a Unix domain sockets transport capability for libp2p.
 #[cfg_attr(docsrs, doc(cfg(feature = $feature_name)))]
@@ -80,7 +80,7 @@ impl Transport for $uds_config {
                             debug!("Now listening on {}", addr);
                             Ok(ListenerEvent::NewAddress(addr))
                         }
-                    }).chain(stream::unfold(listener, move |$($mut_or_not)* listener| {
+                    }).chain(stream::unfold(listener, move |listener| {
                         let addr = addr.clone();
                         async move {
                             let (stream, _) = match listener.accept().await {
@@ -134,7 +134,6 @@ codegen!(
     TokioUdsConfig,
     |addr| async move { tokio::net::UnixListener::bind(addr) },
     tokio::net::UnixStream,
-    mut
 );
 
 /// Turns a `Multiaddr` containing a single `Unix` component into a path.


### PR DESCRIPTION
I am on a 1.58.0-nightly and I got several warnings:

```
warning: field is never read: `marker`
   --> core/src/transport/and_then.rs:162:5
    |
162 |     marker: PhantomPinned,
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: `libp2p-core` (lib) generated 1 warning

warning: field is never read: `request_id`
   --> protocols/request-response/src/lib.rs:233:5
    |
233 |     request_id: RequestId,
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: field is never read: `peer`
   --> protocols/request-response/src/lib.rs:234:5
    |
234 |     peer: PeerId,
    |     ^^^^^^^^^^^^

warning: `libp2p-request-response` (lib) generated 2 warnings



warning: variable does not need to be mutable
   --> transports/uds/src/lib.rs:83:77
    |
83  |                       }).chain(stream::unfold(listener, move |$($mut_or_not)* listener| {
    |                                                                               ^^^^^^^^ help: remove this `mut`
...
132 | / codegen!(
133 | |     "tokio",
134 | |     TokioUdsConfig,
135 | |     |addr| async move { tokio::net::UnixListener::bind(addr) },
136 | |     tokio::net::UnixStream,
137 | |     mut
138 | | );
    | |_- in this macro invocation
    |
    = note: `#[warn(unused_mut)]` on by default
    = note: this warning originates in the macro `codegen` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: `libp2p-uds` (lib) generated 1 warning