### PR TITLE
core: help the compiler disambiguate

### DIFF
--- a/core/src/connection/pool/concurrent_dial.rs
+++ b/core/src/connection/pool/concurrent_dial.rs
@@ -81,7 +81,7 @@ where
         let dials = FuturesUnordered::new();
         while let Some(dial) = pending_dials.next() {
             dials.push(dial);
-            if dials.len() == concurrency_factor.get().into() {
+            if dials.len() == concurrency_factor.get() as usize {
                 break;
             }
         }


### PR DESCRIPTION
when pulling in libp2p as a dependency and compiling for `wasm32-unknown-unknown`, I hit this error:
```
    Checking libp2p-core v0.30.0-rc.1 (https://github.com/wngr/rust-libp2p?branch=wasm-support#19e47553)
error[E0283]: type annotations needed
  --> /home/ow/.cargo/git/checkouts/rust-libp2p-8eaa3598de58093a/19e4755/core/src/connection/pool/concurrent_dial.rs:84:28
   |
84 |             if dials.len() == concurrency_factor.get().into() {
   |                            ^^ ------------------------------- this method call resolves to `T`
   |                            |
   |                            cannot infer type
   |
   = note: cannot satisfy `usize: PartialEq<_>`
```

Not sure why this target dependant, and doesn't happen when running cargo check inside `rust-libp2p` though :confused: