### PR TITLE
protocols/mdns: Use a random alphanumeric string for peer name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 - Update individual crates.
     - `libp2p-swarm-derive`
+    - `libp2p-mdns` (breaking compatibility with previous versions)
 
 ## Version 0.41.0 [2021-11-16]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ smallvec = "1.6.1"
 [target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")))'.dependencies]
 libp2p-deflate = { version = "0.30.0", path = "transports/deflate", optional = true }
 libp2p-dns = { version = "0.30.0", path = "transports/dns", optional = true, default-features = false }
-libp2p-mdns = { version = "0.33.0", path = "protocols/mdns", optional = true }
+libp2p-mdns = { version = "0.34.0", path = "protocols/mdns", optional = true }
 libp2p-tcp = { version = "0.30.0", path = "transports/tcp", default-features = false, optional = true }
 libp2p-websocket = { version = "0.32.0", path = "transports/websocket", optional = true }
 

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,6 +1,11 @@
 # 0.33.1 [unreleased]
 
-- Use a random alphanumeric string for mDNS peer name (see [PR 2311]).
+- Use a random alphanumeric string instead of the local peer ID for mDNS peer
+  name (see [PR 2311]).
+
+  Note that previous versions of `libp2p-mdns` expect the peer name to be a
+  valid peer ID. Thus they will be unable to discover nodes running this new
+  version of `libp2p-mdns`.
 
 [PR 2311]: https://github.com/libp2p/rust-libp2p/pull/2311/
 

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.33.1 [unreleased]
+# 0.34.0 [unreleased]
 
 - Use a random alphanumeric string instead of the local peer ID for mDNS peer
   name (see [PR 2311]).

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.33.1 [unreleased]
+
+- Use a random alphanumeric string for mDNS peer name (see [PR 2311]).
+
+[PR 2311]: https://github.com/libp2p/rust-libp2p/pull/2311/
+
 # 0.33.0 [2021-11-16]
 
 - Update dependencies.

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-mdns"
 edition = "2018"
-version = "0.33.0"
+version = "0.33.1"
 description = "Implementation of the libp2p mDNS discovery method"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-mdns"
 edition = "2018"
-version = "0.33.1"
+version = "0.34.0"
 description = "Implementation of the libp2p mDNS discovery method"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"

--- a/protocols/mdns/src/dns.rs
+++ b/protocols/mdns/src/dns.rs
@@ -271,7 +271,7 @@ fn random_string(length: usize) -> String {
 /// Generates a peer ID bytes for a DNS query.
 fn generate_peer_id() -> Vec<u8> {
     // Use a variable-length random string for mDNS peer name.
-    // See discussion: https://github.com/libp2p/go-libp2p/pull/1222
+    // See https://github.com/libp2p/rust-libp2p/pull/2311/
     let peer_name = random_string(32 + thread_rng().gen_range(0..32));
 
     // allocate with a little extra padding for QNAME encoding

--- a/protocols/mdns/src/dns.rs
+++ b/protocols/mdns/src/dns.rs
@@ -22,9 +22,9 @@
 
 use crate::{META_QUERY_SERVICE, SERVICE_NAME};
 use libp2p_core::{Multiaddr, PeerId};
-use std::{borrow::Cow, cmp, error, fmt, str, time::Duration};
-use rand::{thread_rng, Rng};
 use rand::distributions::Alphanumeric;
+use rand::{thread_rng, Rng};
+use std::{borrow::Cow, cmp, error, fmt, str, time::Duration};
 
 /// DNS TXT records can have up to 255 characters as a single string value.
 ///
@@ -153,7 +153,12 @@ pub fn build_query_response(
     // If no packets have been built at all, because `addresses` is empty,
     // construct an empty response packet.
     if packets.is_empty() {
-        packets.push(query_response_packet(id, &peer_name_bytes, &Vec::new(), ttl));
+        packets.push(query_response_packet(
+            id,
+            &peer_name_bytes,
+            &Vec::new(),
+            ttl,
+        ));
     }
 
     packets

--- a/protocols/mdns/src/query.rs
+++ b/protocols/mdns/src/query.rs
@@ -253,14 +253,11 @@ impl MdnsPeer {
             })
             .collect();
 
-        match my_peer_id {
-            Some(peer_id) => Some(MdnsPeer {
-                addrs,
-                peer_id,
-                ttl,
-            }),
-            None => None,
-        }
+        my_peer_id.map(|peer_id| MdnsPeer {
+            addrs,
+            peer_id,
+            ttl,
+        })
     }
 
     /// Returns the id of the peer.
@@ -302,8 +299,8 @@ mod tests {
         let ttl = 300;
         let peer_id = PeerId::random();
 
-        let mut addr1: Multiaddr = "/ip4/1.2.3.4/tcp/5000".parse().unwrap();
-        let mut addr2: Multiaddr = "/ip6/::1/udp/10000".parse().unwrap();
+        let mut addr1: Multiaddr = "/ip4/1.2.3.4/tcp/5000".parse().expect("bad multiaddress");
+        let mut addr2: Multiaddr = "/ip6/::1/udp/10000".parse().expect("bad multiaddress");
         addr1.push(Protocol::P2p(peer_id.clone().into()));
         addr2.push(Protocol::P2p(peer_id.clone().into()));
 
@@ -315,7 +312,7 @@ mod tests {
         );
 
         for bytes in packets {
-            let packet = Packet::parse(&bytes).unwrap();
+            let packet = Packet::parse(&bytes).expect("unable to parse packet");
             let record_value = packet
                 .answers
                 .iter()
@@ -330,9 +327,9 @@ mod tests {
                     return Some(record_value);
                 })
                 .next()
-                .unwrap();
+                .expect("empty record value");
 
-            let peer = MdnsPeer::new(&packet, record_value, ttl).unwrap();
+            let peer = MdnsPeer::new(&packet, record_value, ttl).expect("fail to create peer");
             assert_eq!(peer.peer_id, peer_id);
         }
     }

--- a/protocols/mdns/src/query.rs
+++ b/protocols/mdns/src/query.rs
@@ -159,13 +159,7 @@ impl MdnsResponse {
                     _ => return None,
                 };
 
-                match MdnsPeer::new(&packet, record_value, record.ttl) {
-                    Ok(peer) => Some(peer),
-                    Err(err) => {
-                        log::debug!("Creating mdns peer failed: {:?}", err);
-                        None
-                    }
-                }
+                MdnsPeer::new(&packet, record_value, record.ttl)
             })
             .collect();
 
@@ -209,7 +203,7 @@ impl MdnsPeer {
         packet: &Packet<'_>,
         record_value: String,
         ttl: u32,
-    ) -> Result<MdnsPeer, String> {
+    ) -> Option<MdnsPeer> {
         let mut my_peer_id: Option<PeerId> = None;
         let addrs = packet
             .additional
@@ -265,12 +259,12 @@ impl MdnsPeer {
 
         match my_peer_id {
             Some(peer_id) =>
-                Ok(MdnsPeer {
+                Some(MdnsPeer {
                     addrs,
                     peer_id,
                     ttl,
                 }),
-            None => Err("Missing Peer ID".to_string())
+            None => None,
         }
     }
 
@@ -309,7 +303,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_create_mdns_peer() -> Result<(), String> {
+    fn test_create_mdns_peer() {
         let ttl = 300;
         let peer_id = PeerId::random();
 
@@ -341,11 +335,9 @@ mod tests {
                     return Some(record_value);
                 }).next().unwrap();
 
-            let peer = MdnsPeer::new(&packet, record_value, ttl)?;
+            let peer = MdnsPeer::new(&packet, record_value, ttl).unwrap();
             assert_eq!(peer.peer_id, peer_id);
         }
-
-        Ok(())
     }
 }
 

--- a/protocols/mdns/src/query.rs
+++ b/protocols/mdns/src/query.rs
@@ -199,11 +199,7 @@ pub struct MdnsPeer {
 
 impl MdnsPeer {
     /// Creates a new `MdnsPeer` based on the provided `Packet`.
-    pub fn new(
-        packet: &Packet<'_>,
-        record_value: String,
-        ttl: u32,
-    ) -> Option<MdnsPeer> {
+    pub fn new(packet: &Packet<'_>, record_value: String, ttl: u32) -> Option<MdnsPeer> {
         let mut my_peer_id: Option<PeerId> = None;
         let addrs = packet
             .additional
@@ -258,12 +254,11 @@ impl MdnsPeer {
             .collect();
 
         match my_peer_id {
-            Some(peer_id) =>
-                Some(MdnsPeer {
-                    addrs,
-                    peer_id,
-                    ttl,
-                }),
+            Some(peer_id) => Some(MdnsPeer {
+                addrs,
+                peer_id,
+                ttl,
+            }),
             None => None,
         }
     }
@@ -299,8 +294,8 @@ impl fmt::Debug for MdnsPeer {
 #[cfg(test)]
 mod tests {
 
-    use crate::dns::build_query_response;
     use super::*;
+    use crate::dns::build_query_response;
 
     #[test]
     fn test_create_mdns_peer() {
@@ -333,12 +328,12 @@ mod tests {
                         _ => return None,
                     };
                     return Some(record_value);
-                }).next().unwrap();
+                })
+                .next()
+                .unwrap();
 
             let peer = MdnsPeer::new(&packet, record_value, ttl).unwrap();
             assert_eq!(peer.peer_id, peer_id);
         }
     }
 }
-
-


### PR DESCRIPTION
Fixes #2285.