### PR TITLE
protocols/identify: Disable address cache by default

### DIFF
--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -5,9 +5,9 @@
 
 - Update dependencies.
 
-- Assist in peer discovery by returning reported listen addresses
-  of other peers from `addresses_of_peer`.
-  [PR 2232](https://github.com/libp2p/rust-libp2p/pull/2232)
+- Assist in peer discovery by optionally returning reported listen addresses
+  of other peers from `addresses_of_peer` (see [PR
+  2232](https://github.com/libp2p/rust-libp2p/pull/2232)), disabled by default.
 
 # 0.30.0 [2021-07-12]
 

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -116,6 +116,8 @@ pub struct IdentifyConfig {
 
     /// How many entries of discovered peers to keep before we discard
     /// the least-recently used one.
+    ///
+    /// Disabled by default.
     pub cache_size: usize,
 }
 
@@ -130,7 +132,7 @@ impl IdentifyConfig {
             initial_delay: Duration::from_millis(500),
             interval: Duration::from_secs(5 * 60),
             push_listen_addr_updates: false,
-            cache_size: 100,
+            cache_size: 0,
         }
     }
 

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -697,6 +697,7 @@ mod tests {
             let (pubkey, transport) = transport();
             let protocol = Identify::new(
                 IdentifyConfig::new("a".to_string(), pubkey.clone())
+                    .with_cache_size(100)
                     .with_agent_version("b".to_string()),
             );
 


### PR DESCRIPTION
See https://github.com/libp2p/rust-libp2p/issues/2302 for details, more particularly https://github.com/libp2p/rust-libp2p/issues/2302#issuecomment-949685352.