### PR TITLE
protocols/kad: Refactor KademliaEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 ## Version 0.41.0 [unreleased]
 
 - Update individual crates.
+    - `libp2p-kad`
     - `libp2p-websocket`
 - Forward `wasm-bindgen` feature to `futures-timer`, `instant`, `parking_lot`, `getrandom/js` and `rand/wasm-bindgen`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ libp2p-core = { version = "0.30.0-rc.2", path = "core",  default-features = fals
 libp2p-floodsub = { version = "0.31.0-rc.1", path = "protocols/floodsub", optional = true }
 libp2p-gossipsub = { version = "0.33.0-rc.1", path = "./protocols/gossipsub", optional = true }
 libp2p-identify = { version = "0.31.0-rc.2", path = "protocols/identify", optional = true }
-libp2p-kad = { version = "0.32.0-rc.2", path = "protocols/kad", optional = true }
+libp2p-kad = { version = "0.33.0", path = "protocols/kad", optional = true }
 libp2p-metrics = { version = "0.1.0-rc.1", path = "misc/metrics", optional = true }
 libp2p-mplex = { version = "0.30.0-rc.1", path = "muxers/mplex", optional = true }
 libp2p-noise = { version = "0.33.0-rc.1", path = "transports/noise", optional = true }

--- a/misc/metrics/Cargo.toml
+++ b/misc/metrics/Cargo.toml
@@ -17,7 +17,7 @@ ping = ["libp2p-ping"]
 [dependencies]
 libp2p-core=  { version = "0.30.0-rc.1", path = "../../core" }
 libp2p-identify =  { version = "0.31.0-rc.1", path = "../../protocols/identify", optional = true }
-libp2p-kad =  { version = "0.32.0-rc.1", path = "../../protocols/kad", optional = true }
+libp2p-kad =  { version = "0.33.0", path = "../../protocols/kad", optional = true }
 libp2p-ping =  { version = "0.31.0-rc.1", path = "../../protocols/ping", optional = true }
 libp2p-swarm =  { version = "0.31.0-rc.1", path = "../../swarm" }
 open-metrics-client = "0.12.0"

--- a/misc/metrics/src/kad.rs
+++ b/misc/metrics/src/kad.rs
@@ -258,7 +258,7 @@ impl super::Recorder<libp2p_kad::KademliaEvent> for super::Metrics {
                 }
             }
 
-            libp2p_kad::KademliaEvent::InboundRequestServed { request } => {
+            libp2p_kad::KademliaEvent::InboundRequest { request } => {
                 self.kad
                     .inbound_requests
                     .get_or_create(&request.into())

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 - Rename `KademliaEvent::InboundRequestServed` to `KademliaEvent::InboundRequest` and move
   `InboundPutRecordRequest` into `InboundRequest::PutRecord` and `InboundAddProviderRequest` into
-  `InboundRequest::AddProvider`
+  `InboundRequest::AddProvider` (see [PR 2297]).
 
 [PR 2245]: https://github.com/libp2p/rust-libp2p/pull/2245
+[PR 2297]: https://github.com/libp2p/rust-libp2p/pull/2297
 
 # 0.32.0-rc.2 [2021-10-15]
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,6 +1,10 @@
-# 0.32.1 [unreleased]
+# 0.33.0 [unreleased]
 
 - Use `instant` and `futures-timer` instead of `wasm-timer` (see [PR 2245]).
+
+- Rename `KademliaEvent::InboundRequestServed` to `KademliaEvent::InboundRequest` and move
+  `InboundPutRecordRequest` into `InboundRequest::PutRecord` and `InboundAddProviderRequest` into
+  `InboundRequest::AddProvider`
 
 [PR 2245]: https://github.com/libp2p/rust-libp2p/pull/2245
 

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-kad"
 edition = "2018"
 description = "Kademlia protocol for libp2p"
-version = "0.32.1"
+version = "0.33.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -1699,7 +1699,7 @@ where
             };
             match self.record_filtering {
                 KademliaStoreInserts::Unfiltered => {
-                    if let Err(e) = self.store.add_provider(record.clone()) {
+                    if let Err(e) = self.store.add_provider(record) {
                         info!("Provider record not stored: {:?}", e);
                         return;
                     }

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -147,10 +147,6 @@ pub enum KademliaStoreInserts {
     /// Whenever a (provider) record is received,
     /// the record is forwarded immediately to the [`RecordStore`].
     Unfiltered,
-    /// Whenever a (provider) record is received, an event is emitted.
-    /// Provider records generate a [`KademliaEvent::InboundAddProviderRequest`],
-    /// normal records generate a [`KademliaEvent::InboundPutRecordRequest`].
-    ///
     /// When deemed valid, a (provider) record needs to be explicitly stored in
     /// the [`RecordStore`] via [`RecordStore::put`] or [`RecordStore::add_provider`],
     /// whichever is applicable. A mutable reference to the [`RecordStore`] can

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -607,12 +607,23 @@ fn put_record() {
                             },
                         ))) => {
                             if !drop_records {
-                                // Accept the record
-                                swarm
-                                    .behaviour_mut()
-                                    .store_mut()
-                                    .put(record)
-                                    .expect("record is stored");
+                                if let Some(record) = record {
+                                    assert_eq!(
+                                        swarm.behaviour().record_filtering,
+                                        KademliaStoreInserts::FilterBoth
+                                    );
+                                    // Accept the record
+                                    swarm
+                                        .behaviour_mut()
+                                        .store_mut()
+                                        .put(record)
+                                        .expect("record is stored");
+                                } else {
+                                    assert_eq!(
+                                        swarm.behaviour().record_filtering,
+                                        KademliaStoreInserts::Unfiltered
+                                    );
+                                }
                             }
                         }
                         // Ignore any other event.

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -602,12 +602,10 @@ fn put_record() {
                             }
                         }
                         Poll::Ready(Some(SwarmEvent::Behaviour(
-                            KademliaEvent::InboundPutRecordRequest { record, .. },
+                            KademliaEvent::InboundRequest {
+                                request: InboundRequest::PutRecord { record, .. },
+                            },
                         ))) => {
-                            assert_ne!(
-                                swarm.behaviour().record_filtering,
-                                KademliaStoreInserts::Unfiltered
-                            );
                             if !drop_records {
                                 // Accept the record
                                 swarm


### PR DESCRIPTION
Rename `KademliaEvent::InboundRequestServed` to `KademliaEvent::InboundRequest` and move
`InboundPutRecordRequest` into `InboundRequest::PutRecord` and `InboundAddProviderRequest` into
`InboundRequest::AddProvider`.

Replaces https://github.com/libp2p/rust-libp2p/pull/2297.
