### PR TITLE
Change representation of PeerId to CIDv1

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 asn1_der = "0.7.4"
 bs58 = "0.4.0"
+cid = "0.7.0"
 ed25519-dalek = "1.0.1"
 either = "1.5"
 fnv = "1.0"

--- a/core/src/peer_id.rs
+++ b/core/src/peer_id.rs
@@ -394,4 +394,26 @@ mod tests {
 
         assert_eq!(cid_bytes, peer_id.to_cidv1_bytes());
     }
+
+    #[test]
+    fn peer_ids_from_base58_and_from_base32_are_equal() {
+        use std::str::FromStr;
+
+        let peer_id_as_base58_str = "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N";
+        let peer_id_as_base32_str = "bafzbeie5745rpv2m6tjyuugywy4d5ewrqgqqhfnf445he3omzpjbx5xqxe";
+
+        let peer_id_from_base58_str = PeerId::from_str(peer_id_as_base58_str).unwrap();
+        let peer_id_from_base32_str = PeerId::from_str(peer_id_as_base32_str).unwrap();
+
+        assert_eq!(peer_id_from_base58_str, peer_id_from_base32_str);
+    }
+
+    #[test]
+    fn peer_id_from_base58_str_then_back() {
+        use std::str::FromStr;
+
+        let cidv1_peer_id = identity::Keypair::generate_ed25519().public().to_peer_id();
+
+        assert_eq!(cidv1_peer_id, PeerId::from_str(&cidv1_peer_id.to_base58()).unwrap());
+    }
 }

--- a/core/src/peer_id.rs
+++ b/core/src/peer_id.rs
@@ -168,7 +168,7 @@ impl PeerId {
         bs58::encode(self.to_bytes()).into_string()
     }
 
-    /// Returns a `base32` encoded string of this `PeerId`.
+    /// Returns a `base32` multibase encoded string of this `PeerId`.
     pub fn to_base32(&self) -> String {
         self.cid.to_string_of_base(Base::Base32Lower).unwrap()
     }

--- a/core/src/peer_id.rs
+++ b/core/src/peer_id.rs
@@ -114,18 +114,22 @@ impl PeerId {
 
     /// Tries to turn a `Cid` into a `PeerId`.
     ///
-    /// If the CID's multihash does not fit the specifications:
-    ///
-    /// * use a valid hashing algorithm for peer IDs, or
-    /// * the value does not satisfy the constraints for a hashed peerID,
-    ///
-    /// or, if the CID does not fit the specifications:
-    ///
-    /// * is a CIDv0 with a multihash that fits the specifications
-    /// for multihash, or
-    /// * is a CIDv1 with the proper codec (LIBP2P_KEY_CODEC),
-    ///
-    /// then the CID will be returned as an `Err`.
+    /// If the `Cid` is valid, then a `Some(PeerId)` will be
+    /// returned, otherwise, `Err(Cid)` is returned.
+    /// 
+    /// A `Cid` is considered valid if and only if:
+    /// * the `Cid` is a [`Cidv0`] with a valid `multihash`, or
+    /// * the `Cid` is a [`Cidv1`] with:
+    ///  1. a valid `multihash`, and
+    ///  2. the codec for [`libp2p-key`].
+    /// 
+    /// A `multihash` is considered valid if and only if:
+    /// 1. it uses a valid hashing algorithm for peer IDs, and
+    /// 2. it satisfies the constraints for a hashed peerID.
+    /// 
+    /// [`Cidv0`]: https://github.com/multiformats/cid#cidv0
+    /// [`Cidv1`]: https://github.com/multiformats/cid#cidv1
+    /// [`libp2p-key`]: https://github.com/multiformats/multicodec/blob/master/table.csv
     pub fn from_cid(cid: Cid) -> Result<PeerId, Cid> {
         let multihash = *cid.hash();
 

--- a/core/src/peer_id.rs
+++ b/core/src/peer_id.rs
@@ -164,6 +164,10 @@ impl PeerId {
     }
 
     /// Returns a base-58 raw encoded string of this `PeerId`.
+    ///
+    /// This corresponds to the old peer ID [representation].
+    ///
+    /// [representation]: https://github.com/libp2p/specs/blob/master/RFC/0001-text-peerid-cid.md
     pub fn to_base58(&self) -> String {
         bs58::encode(self.to_bytes()).into_string()
     }

--- a/core/src/peer_record.rs
+++ b/core/src/peer_record.rs
@@ -1,7 +1,7 @@
 use crate::identity::error::SigningError;
 use crate::identity::Keypair;
 use crate::signed_envelope::SignedEnvelope;
-use crate::{peer_record_proto, signed_envelope, Multiaddr, PeerId};
+use crate::{peer_id::PeerIdError, peer_record_proto, signed_envelope, Multiaddr, PeerId};
 use instant::SystemTime;
 use std::convert::TryInto;
 use std::fmt;
@@ -125,7 +125,7 @@ pub enum FromEnvelopeError {
     /// Failed to decode the provided bytes as a [`PeerRecord`].
     InvalidPeerRecord(prost::DecodeError),
     /// Failed to decode the peer ID.
-    InvalidPeerId(multihash::Error),
+    InvalidPeerId(PeerIdError),
     /// Failed to decode a multi-address.
     InvalidMultiaddr(multiaddr::Error),
 }
@@ -142,8 +142,8 @@ impl From<prost::DecodeError> for FromEnvelopeError {
     }
 }
 
-impl From<multihash::Error> for FromEnvelopeError {
-    fn from(e: multihash::Error) -> Self {
+impl From<PeerIdError> for FromEnvelopeError {
+    fn from(e: PeerIdError) -> Self {
         Self::InvalidPeerId(e)
     }
 }


### PR DESCRIPTION
Addresses #2259.

To encapsulate both errors from Multihash and CID, we change the interface of `from_bytes` to return a `PeerIdError` in the case of `Err`.