### PR TITLE
protocols/identify Check multiaddr has valid peer id component prior to caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 ## Version 0.41.0 [unreleased]
 
 - Update individual crates.
+    - `libp2p-identify`
     - `libp2p-kad`
     - `libp2p-websocket`
 - Forward `wasm-bindgen` feature to `futures-timer`, `instant`, `parking_lot`, `getrandom/js` and `rand/wasm-bindgen`.

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,10 +1,12 @@
 # 0.32.0 [unreleased]
 
 - Use `futures-timer` instead of `wasm-timer` (see [PR 2245]).
+- Filter invalid peers from cache used in `addresses_of_peer` – [PR 2338].
 
 - Update dependencies.
 
 [PR 2245]: https://github.com/libp2p/rust-libp2p/pull/2245
+[PR 2338]: https://github.com/libp2p/rust-libp2p/pull/2338
 
 # 0.31.0 [2021-11-01]
 


### PR DESCRIPTION
## Context
Resolves https://github.com/libp2p/rust-libp2p/issues/2302. 

https://github.com/libp2p/rust-libp2p/pull/2232 introduced a change to the [Identify protocol](https://github.com/libp2p/specs/blob/master/identify/README.md) implementation that caches the discovered `listenAddrs` from the [Identify message](https://github.com/libp2p/specs/blob/master/identify/README.md#the-identify-message). The cache is then used in the [addresses_of_peer](https://docs.rs/libp2p/0.40.0/libp2p/swarm/trait.NetworkBehaviour.html#method.addresses_of_peer) method that is called by swarm code to find possible addresses to dial for a given peer.

This lets the Identify assist in peer discovery of a given [network behavior](https://docs.rs/libp2p/0.40.0/libp2p/swarm/trait.NetworkBehaviour.html) automatically. See https://github.com/libp2p/rust-libp2p/issues/2216 for more information.

This cache was disabled in https://github.com/libp2p/rust-libp2p/pull/2312 because we weren't doing any validation. This PR adds the peer id validation.

## Proposed Solution
This adds a simple validation before we cache the multiaddr. We don't cache a multiaddr with a wrong final peer-id component. e.g. something that ends with `.../p2p/Qmsome-other-peer`. While this should fail to dial because we [check this before dialing](https://github.com/libp2p/rust-libp2p/blob/master/core/src/connection/pool/concurrent_dial.rs#L144), it's probably better to not cache this in the first place.

If the multiaddr doesn't have a final `.../p2p/Qmfoo` component, we consider it valid. 

Testing this locally, it seems like all `listenAddrs` in Identify messages generally don't include the `.../p2p/` component (except for [dnsaddr](https://github.com/multiformats/multiaddr/blob/master/protocols/DNSADDR.md), but do these even show up in identify messages?)

## Rollback strategy
This is safe to revert. Without this, multiaddrs with a wrong peerid will [fail to dial](https://github.com/libp2p/rust-libp2p/blob/master/core/src/connection/pool/concurrent_dial.rs#L152).

## Next steps

This doesn't enable the caching, I can do that in this PR or another one if we want to keep things smaller.