### PR TITLE
swarm-derive/lib: Don't clone error on inject_dial_failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@
 
 # `libp2p` facade crate
 
+## Version 0.41.1 [unreleased]
+
+- Update individual crates.
+    - `libp2p-swarm-derive`
+
 ## Version 0.41.0 [2021-11-16]
 
 - Update individual crates.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p"
 edition = "2018"
 description = "Peer-to-peer networking library"
-version = "0.41.0"
+version = "0.41.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -86,7 +86,7 @@ libp2p-relay = { version = "0.5.0", path = "protocols/relay", optional = true }
 libp2p-rendezvous = { version = "0.2.0", path = "protocols/rendezvous", optional = true }
 libp2p-request-response = { version = "0.14.0", path = "protocols/request-response", optional = true }
 libp2p-swarm = { version = "0.32.0", path = "swarm" }
-libp2p-swarm-derive = { version = "0.26.0", path = "swarm-derive" }
+libp2p-swarm-derive = { version = "0.26.1", path = "swarm-derive" }
 libp2p-uds = { version = "0.30.0", path = "transports/uds", optional = true }
 libp2p-wasm-ext = { version = "0.30.0", path = "transports/wasm-ext", default-features = false, optional = true }
 libp2p-yamux = { version = "0.34.0", path = "muxers/yamux", optional = true }

--- a/swarm-derive/CHANGELOG.md
+++ b/swarm-derive/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.26.1 [unreleased]
+
+- Remove unnecessary clone of error in `inject_dial_failure` (see [PR 2349]).
+
+[PR 2349]: https://github.com/libp2p/rust-libp2p/pull/2349
+
 # 0.26.0 [2021-11-16]
 
 - Adjust to advanced dialing requests API changes (see [PR 2317]).

--- a/swarm-derive/Cargo.toml
+++ b/swarm-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-swarm-derive"
 edition = "2018"
 description = "Procedural macros of libp2p-core"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/swarm-derive/src/lib.rs
+++ b/swarm-derive/src/lib.rs
@@ -276,10 +276,10 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
 
                 let inject = match field.ident {
                     Some(ref i) => {
-                        quote! { self.#i.inject_dial_failure(peer_id, handler, error.clone()) }
+                        quote! { self.#i.inject_dial_failure(peer_id, handler, error) }
                     }
                     None => {
-                        quote! { self.#enum_n.inject_dial_failure(peer_id, handler, error.clone()) }
+                        quote! { self.#enum_n.inject_dial_failure(peer_id, handler, error) }
                     }
                 };
 


### PR DESCRIPTION
`NetworkBehaviour::inject_dial_failure` expects a reference for the error, thus the error should not be cloned when passing it to the inner behaviours in the  `NetworkBehaviour` derivation.

Fixes Issue #2348.

@mxinden do I need to add a Changelog entry for this?