### PR TITLE
Request-Response: Add method connected_peers

### DIFF
--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -450,6 +450,11 @@ where
         }
     }
 
+    /// List of currently connected peers.
+    pub fn connected_peers(&self) -> Vec<&PeerId> {
+        self.connected.keys().collect()
+    }
+
     /// Checks whether an outbound request to the peer with the provided
     /// [`PeerId`] initiated by [`RequestResponse::send_request`] is still
     /// pending, i.e. waiting for a response.
@@ -686,7 +691,7 @@ where
                     self.pending_events
                         .push_back(NetworkBehaviourAction::GenerateEvent(
                             RequestResponseEvent::OutboundFailure {
-                                peer: peer,
+                                peer,
                                 request_id: request.request_id,
                                 error: OutboundFailure::DialFailure,
                             },

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -598,6 +598,29 @@ where
         addresses
     }
 
+    fn inject_address_change(
+        &mut self,
+        peer: &PeerId,
+        conn: &ConnectionId,
+        _old: &ConnectedPoint,
+        new: &ConnectedPoint,
+    ) {
+        let new_address = match new {
+            ConnectedPoint::Dialer { address } => Some(address.clone()),
+            ConnectedPoint::Listener { .. } => None,
+        };
+        let connections = self
+            .connected
+            .get_mut(peer)
+            .expect("Address change can only happen on an established connection.");
+
+        let connection = connections
+            .iter_mut()
+            .find(|c| &c.id == conn)
+            .expect("Address change can only happen on an established connection.");
+        connection.address = new_address;
+    }
+
     fn inject_connected(&mut self, peer: &PeerId) {
         if let Some(pending) = self.pending_outbound_requests.remove(peer) {
             for request in pending {

--- a/protocols/request-response/tests/ping.rs
+++ b/protocols/request-response/tests/ping.rs
@@ -122,6 +122,11 @@ fn ping_protocol() {
                     assert_eq!(&peer, &peer2_id);
                 }
                 SwarmEvent::Behaviour(e) => panic!("Peer1: Unexpected event: {:?}", e),
+                SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                    assert_eq!(peer_id, peer2_id);
+                    assert!(swarm1.behaviour().is_connected(&peer_id));
+                    assert_eq!(swarm1.behaviour().connected_peers(), vec![&peer_id]);
+                }
                 _ => {}
             }
         }
@@ -157,6 +162,11 @@ fn ping_protocol() {
                     }
                 }
                 SwarmEvent::Behaviour(e) => panic!("Peer2: Unexpected event: {:?}", e),
+                SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                    assert_eq!(peer_id, peer1_id);
+                    assert!(swarm2.behaviour().is_connected(&peer_id));
+                    assert_eq!(swarm2.behaviour().connected_peers(), vec![&peer_id]);
+                }
                 _ => {}
             }
         }


### PR DESCRIPTION
The request-response protocol manages a list of connected peers. This list is currently not exposed to the user, only the method `RequestResponse::is_connected` allows to the check the connection for a specific peers.
However, in case that the user needs to know the whole list of connected peers, it forces them to also track connected peers themself, which is redundant as the information is already there, e.g. as it currently has to be done in the AutoNAT draft #2262.
56f1ede190834e3876649d40a44f4e83b807fa8c adds a method `RequestResponse::connected_peers` to share the list of connected peers.

Apart from that, I noticed that at the moment `inject_address_change` is not handled, which means that the associated `Connection` still has the address of the old `ConnectedPoint.` bd6622a1dd3e59bad212f10fc0619198c32084b1 changes this, unless there was a specific reason to do so?  
Note that with this change, if the ConnectedPoint changed from `Dialer` to `Listener`, the address will change from `Some(old_addr)` to `None`. Are there cases in which we still want to keep the old address? If I am not mistaken, the address is only used to return it in `addresses_of_peer`, therefore I would say it's valid to remove an outdated address?

