### PR TITLE
Send/forward messages only to target peers.

### DIFF
--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -253,6 +253,12 @@ impl Floodsub {
 
         // Send to peers we know are subscribed to the topic.
         for (peer_id, sub_topic) in self.connected_peers.iter() {
+            // Peer must be in a communication list.
+            if !self.target_peers.contains(peer_id) {
+                continue;
+            }
+
+            // Peer must be subscribed for the topic.
             if !sub_topic
                 .iter()
                 .any(|t| message.topics.iter().any(|u| t == u))
@@ -402,6 +408,12 @@ impl NetworkBehaviour for Floodsub {
                     continue;
                 }
 
+                // Peer must be in a communication list.
+                if !self.target_peers.contains(peer_id) {
+                    continue;
+                }
+
+                // Peer must be subscribed for the topic.
                 if !subscr_topics
                     .iter()
                     .any(|t| message.topics.iter().any(|u| t == u))


### PR DESCRIPTION
Problem:
Observe the definition of `Floodsub`:
```rust
pub struct Floodsub {
   ...
    /// List of peers to send messages to.
    target_peers: FnvHashSet<PeerId>,

    /// List of peers the network is connected to, and the topics that they're subscribed to.
    connected_peers: HashMap<PeerId, SmallVec<[Topic; 8]>>,
    ...
}
```

Say, you have added a peer to your communication list as such

```rust
floodsub.add_node_to_partial_view(peer_id)
```

and then publish a message as such

```rust
floodsub.publish(topic, bytes)
```

You will find that the message will be propagated across all _connected_ peers, rather than _target_ peers.
Problem is that `target_peers` seems to not be used as intended, and thus the call `add_node_to_partial_view` has no influence on whether messages are going to be sent to that `peer_id`.

This behaviour is easy to abuse by establishing an unauthorized connection to a network and sniffing on the internal communication, even if the unauthorized node did was not added to the partial view.

PS: Corrected loops are very much imperative and can be written in a more functional style. I did not want to introduce larger changes before you either confirm or deny my claim on the anticipated behaviour.

