### PR TITLE
protocols/mdns/: Generate peer expiry and fix IPv6 support

### DIFF
--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,9 +1,3 @@
-# 0.35.0 [unreleased]
-
-- Fix generation of the peer expiration event, see [PR 2359]
-
-[PR 2359]: https://github.com/libp2p/rust-libp2p/pull/2359
-
 # 0.34.0 [unreleased]
 
 - Update dependencies.
@@ -17,9 +11,13 @@
 
 - Migrate to Rust edition 2021 (see [PR 2339]).
 
+- Fix generation of peer expiration event and listen on specified IP version (see [PR 2359]).
+
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 
 [PR 2311]: https://github.com/libp2p/rust-libp2p/pull/2311/
+
+[PR 2359]: https://github.com/libp2p/rust-libp2p/pull/2359
 
 # 0.33.0 [2021-11-16]
 

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.35.0 [unreleased]
+
+- Fix generation of the peer expiration event, see [PR 2359]
+
+[PR 2359]: https://github.com/libp2p/rust-libp2p/pull/2359
+
 # 0.34.0 [unreleased]
 
 - Update dependencies.

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -28,4 +28,4 @@ void = "1.0.2"
 [dev-dependencies]
 async-std = { version = "1.9.0", features = ["attributes"] }
 libp2p = { path = "../.." }
-tokio = { version = "1.2.0", default-features = false, features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1.2.0", default-features = false, features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/protocols/mdns/src/behaviour.rs
+++ b/protocols/mdns/src/behaviour.rs
@@ -144,12 +144,12 @@ impl Mdns {
             }
         };
         let send_socket = {
-            let addrs = [
-                SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
-                SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
-            ];
+            let addr = match config.multicast_addr {
+                IpAddr::V4(_) => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+                IpAddr::V6(_) => SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
+            };
 
-            let socket = std::net::UdpSocket::bind(&addrs[..])?;
+            let socket = std::net::UdpSocket::bind(addr)?;
             Async::new(socket)?
         };
         let if_watch = if_watch::IfWatcher::new().await?;
@@ -406,7 +406,7 @@ impl NetworkBehaviour for Mdns {
                 while let Some(pos) = self
                     .discovered_nodes
                     .iter()
-                    .position(|(_, _, exp)| *exp < now)
+                    .position(|(_, _, exp)| *exp <= now)
                 {
                     let (peer_id, addr, _) = self.discovered_nodes.remove(pos);
                     expired.push((peer_id, addr));

--- a/protocols/mdns/src/behaviour.rs
+++ b/protocols/mdns/src/behaviour.rs
@@ -54,7 +54,11 @@ pub struct MdnsConfig {
     /// peer joins the network. Receiving an mdns packet resets the timer
     /// preventing unnecessary traffic.
     pub query_interval: Duration,
-    /// IP address for multicast.
+    /// Internet protocol version (v4 or v6) to use.
+    ///
+    /// Note that the provided IP address itself is ignored and instead the
+    /// unspecified address (`0.0.0.0` or `::`) of the corresponding version is
+    /// used.
     pub multicast_addr: IpAddr,
 }
 

--- a/protocols/mdns/src/behaviour.rs
+++ b/protocols/mdns/src/behaviour.rs
@@ -54,11 +54,7 @@ pub struct MdnsConfig {
     /// peer joins the network. Receiving an mdns packet resets the timer
     /// preventing unnecessary traffic.
     pub query_interval: Duration,
-    /// Internet protocol version (v4 or v6) to use.
-    ///
-    /// Note that the provided IP address itself is ignored and instead the
-    /// unspecified address (`0.0.0.0` or `::`) of the corresponding version is
-    /// used.
+    /// IP address for multicast.
     pub multicast_addr: IpAddr,
 }
 

--- a/protocols/mdns/tests/smoke.rs
+++ b/protocols/mdns/tests/smoke.rs
@@ -85,7 +85,7 @@ async fn test_discovery_async_std_ipv4() -> Result<(), Box<dyn Error>> {
 async fn test_discovery_async_std_ipv6() -> Result<(), Box<dyn Error>> {
     let mut config = MdnsConfig::default();
     config.multicast_addr = *IPV6_MDNS_MULTICAST_ADDRESS;
-    run_test(MdnsConfig::default()).await
+    run_test(config).await
 }
 
 #[tokio::test]
@@ -97,5 +97,5 @@ async fn test_discovery_tokio_ipv4() -> Result<(), Box<dyn Error>> {
 async fn test_discovery_tokio_ipv6() -> Result<(), Box<dyn Error>> {
     let mut config = MdnsConfig::default();
     config.multicast_addr = *IPV6_MDNS_MULTICAST_ADDRESS;
-    run_test(MdnsConfig::default()).await
+    run_test(config).await
 }

--- a/protocols/mdns/tests/smoke.rs
+++ b/protocols/mdns/tests/smoke.rs
@@ -26,6 +26,8 @@ use libp2p::{
     PeerId,
 };
 use std::error::Error;
+use std::future::Future;
+use std::time::Duration;
 
 async fn create_swarm(config: MdnsConfig) -> Result<Swarm<Mdns>, Box<dyn Error>> {
     let id_keys = identity::Keypair::generate_ed25519();
@@ -37,7 +39,7 @@ async fn create_swarm(config: MdnsConfig) -> Result<Swarm<Mdns>, Box<dyn Error>>
     Ok(swarm)
 }
 
-async fn run_test(config: MdnsConfig) -> Result<(), Box<dyn Error>> {
+async fn run_discovery_test(config: MdnsConfig) -> Result<(), Box<dyn Error>> {
     let mut a = create_swarm(config.clone()).await?;
     let mut b = create_swarm(config).await?;
     let mut discovered_a = false;
@@ -78,24 +80,121 @@ async fn run_test(config: MdnsConfig) -> Result<(), Box<dyn Error>> {
 
 #[async_std::test]
 async fn test_discovery_async_std_ipv4() -> Result<(), Box<dyn Error>> {
-    run_test(MdnsConfig::default()).await
+    run_discovery_test(MdnsConfig::default()).await
 }
 
 #[async_std::test]
 async fn test_discovery_async_std_ipv6() -> Result<(), Box<dyn Error>> {
     let mut config = MdnsConfig::default();
     config.multicast_addr = *IPV6_MDNS_MULTICAST_ADDRESS;
-    run_test(config).await
+    run_discovery_test(config).await
 }
 
 #[tokio::test]
 async fn test_discovery_tokio_ipv4() -> Result<(), Box<dyn Error>> {
-    run_test(MdnsConfig::default()).await
+    run_discovery_test(MdnsConfig::default()).await
 }
 
 #[tokio::test]
 async fn test_discovery_tokio_ipv6() -> Result<(), Box<dyn Error>> {
     let mut config = MdnsConfig::default();
     config.multicast_addr = *IPV6_MDNS_MULTICAST_ADDRESS;
-    run_test(config).await
+    run_discovery_test(config).await
+}
+
+async fn run_peer_expiration_test(config: MdnsConfig) -> Result<(), Box<dyn Error>> {
+    let mut a = create_swarm(config.clone()).await?;
+    let mut b = create_swarm(config).await?;
+
+    loop {
+        futures::select! {
+            ev = a.select_next_some() => match ev {
+                SwarmEvent::Behaviour(MdnsEvent::Expired(peers)) => {
+                    for (peer, _addr) in peers {
+                        if peer == *b.local_peer_id() {
+                            return Ok(());
+                        }
+                    }
+                }
+                _ => {}
+            },
+            ev = b.select_next_some() => match ev {
+                SwarmEvent::Behaviour(MdnsEvent::Expired(peers)) => {
+                    for (peer, _addr) in peers {
+                        if peer == *a.local_peer_id() {
+                            return Ok(());
+                        }
+                    }
+                }
+                _ => {}
+            }
+
+        }
+    }
+}
+
+#[async_std::test]
+async fn test_expired_async_std_ipv4() -> Result<(), Box<dyn Error>> {
+    let config = MdnsConfig {
+        ttl: Duration::from_millis(500),
+        query_interval: Duration::from_secs(1),
+        ..Default::default()
+    };
+
+    run_timebound_test(
+        run_peer_expiration_test(config),
+        Duration::from_secs(6)
+    ).await
+}
+
+#[async_std::test]
+async fn test_expired_async_std_ipv6() -> Result<(), Box<dyn Error>> {
+    let config = MdnsConfig {
+        ttl: Duration::from_millis(500),
+        query_interval: Duration::from_secs(1),
+        multicast_addr: *IPV6_MDNS_MULTICAST_ADDRESS,
+    };
+
+    run_timebound_test(
+        run_peer_expiration_test(config),
+        Duration::from_secs(6)
+    ).await
+}
+
+#[tokio::test]
+async fn test_expired_tokio_ipv4() -> Result<(), Box<dyn Error>> {
+    let config = MdnsConfig {
+        ttl: Duration::from_millis(500),
+        query_interval: Duration::from_secs(1),
+        ..Default::default()
+    };
+
+    run_timebound_test(
+        run_peer_expiration_test(config),
+        Duration::from_secs(6)
+    ).await
+}
+
+#[tokio::test]
+async fn test_expired_tokio_ipv6() -> Result<(), Box<dyn Error>> {
+    let config = MdnsConfig {
+        ttl: Duration::from_millis(500),
+        query_interval: Duration::from_secs(1),
+        multicast_addr: *IPV6_MDNS_MULTICAST_ADDRESS,
+    };
+
+    run_timebound_test(
+        run_peer_expiration_test(config),
+        Duration::from_secs(6)
+    ).await
+}
+
+async fn run_timebound_test(fut: impl Future<Output=Result<(), Box<dyn Error>>>, bound: Duration) -> Result<(), Box<dyn Error>> {
+    let result = async_std::future::timeout(bound, fut)
+        .await;
+
+    match result {
+        Ok(res) => res,
+        Err(err) => Err::<(), Box<dyn Error>>(Box::new(err))
+    }
 }


### PR DESCRIPTION
Fix peer discovery testing to use IPv6 where appropriate.
Generate peer expiry event and test. Please see discussion here #2308 