### PR TITLE
protocols/request-response: handle address change on connection

### DIFF
--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -593,6 +593,29 @@ where
         addresses
     }
 
+    fn inject_address_change(
+        &mut self,
+        peer: &PeerId,
+        conn: &ConnectionId,
+        _old: &ConnectedPoint,
+        new: &ConnectedPoint,
+    ) {
+        let new_address = match new {
+            ConnectedPoint::Dialer { address } => Some(address.clone()),
+            ConnectedPoint::Listener { .. } => None,
+        };
+        let connections = self
+            .connected
+            .get_mut(peer)
+            .expect("Address change can only happen on an established connection.");
+
+        let connection = connections
+            .iter_mut()
+            .find(|c| &c.id == conn)
+            .expect("Address change can only happen on an established connection.");
+        connection.address = new_address;
+    }
+
     fn inject_connected(&mut self, peer: &PeerId) {
         if let Some(pending) = self.pending_outbound_requests.remove(peer) {
             for request in pending {

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -6,8 +6,11 @@
 
 - Migrate to Rust edition 2021 (see [PR 2339]).
 
+- Update `Connection::address` on `inject_address_change` (see [PR 2362]).
+
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 [PR 2350]: https://github.com/libp2p/rust-libp2p/pull/2350
+[PR 2362]: https://github.com/libp2p/rust-libp2p/pull/2362
 
 # 0.32.0 [2021-11-16]
 


### PR DESCRIPTION
Handle address change on a tracked connection in the `Request-Response` protocol.
See #2354.