### PR TITLE
*: Fix clippy errors from upgrade to Rust 1.57

### DIFF
--- a/core/src/transport/and_then.rs
+++ b/core/src/transport/and_then.rs
@@ -77,7 +77,7 @@ where
         let future = AndThenFuture {
             inner: Either::Left(Box::pin(dialed_fut)),
             args: Some((self.fun, ConnectedPoint::Dialer { address: addr })),
-            marker: PhantomPinned,
+            _marker: PhantomPinned,
         };
         Ok(future)
     }
@@ -132,7 +132,7 @@ where
                             upgrade: AndThenFuture {
                                 inner: Either::Left(Box::pin(upgrade)),
                                 args: Some((this.fun.clone(), point)),
-                                marker: PhantomPinned,
+                                _marker: PhantomPinned,
                             },
                             local_addr,
                             remote_addr,
@@ -159,7 +159,7 @@ where
 pub struct AndThenFuture<TFut, TMap, TMapOut> {
     inner: Either<Pin<Box<TFut>>, Pin<Box<TMapOut>>>,
     args: Option<(TMap, ConnectedPoint)>,
-    marker: PhantomPinned,
+    _marker: PhantomPinned,
 }
 
 impl<TFut, TMap, TMapOut> Future for AndThenFuture<TFut, TMap, TMapOut>

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -147,6 +147,7 @@ pub enum GossipsubEvent {
 
 /// A data structure for storing configuration for publishing messages. See [`MessageAuthenticity`]
 /// for further details.
+#[allow(clippy::large_enum_variant)]
 enum PublishConfig {
     Signing {
         keypair: Keypair,

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -459,6 +459,7 @@ impl NetworkBehaviour for Identify {
 }
 
 /// Event emitted  by the `Identify` behaviour.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum IdentifyEvent {
     /// Identification information has been received from a peer.

--- a/protocols/rendezvous/src/codec.rs
+++ b/protocols/rendezvous/src/codec.rs
@@ -28,6 +28,7 @@ use unsigned_varint::codec::UviBytes;
 
 pub type Ttl = u64;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum Message {
     Register(NewRegistration),

--- a/protocols/rendezvous/src/handler.rs
+++ b/protocols/rendezvous/src/handler.rs
@@ -28,6 +28,7 @@ pub mod inbound;
 pub mod outbound;
 
 /// Errors that can occur while interacting with a substream.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Reading message {0:?} at this stage is a protocol violation")]

--- a/protocols/rendezvous/src/handler/inbound.rs
+++ b/protocols/rendezvous/src/handler/inbound.rs
@@ -54,6 +54,7 @@ impl fmt::Debug for Stream {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum OutEvent {
     RegistrationRequested(NewRegistration),

--- a/protocols/rendezvous/src/handler/outbound.rs
+++ b/protocols/rendezvous/src/handler/outbound.rs
@@ -120,6 +120,7 @@ pub enum OutEvent {
     },
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum OpenInfo {
     RegisterRequest(NewRegistration),

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -231,8 +231,6 @@ impl std::error::Error for InboundFailure {}
 /// See [`RequestResponse::send_response`].
 #[derive(Debug)]
 pub struct ResponseChannel<TResponse> {
-    request_id: RequestId,
-    peer: PeerId,
     sender: oneshot::Sender<TResponse>,
 }
 
@@ -750,11 +748,7 @@ where
                 request,
                 sender,
             } => {
-                let channel = ResponseChannel {
-                    request_id,
-                    peer,
-                    sender,
-                };
+                let channel = ResponseChannel { sender };
                 let message = RequestResponseMessage::Request {
                     request_id,
                     request,

--- a/transports/noise/src/lib.rs
+++ b/transports/noise/src/lib.rs
@@ -420,7 +420,7 @@ where
 }
 
 /// Legacy configuration options.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct LegacyConfig {
     /// Whether to continue sending legacy handshake payloads,
     /// i.e. length-prefixed protobuf payloads inside a length-prefixed
@@ -432,13 +432,4 @@ pub struct LegacyConfig {
     /// noise frame. These payloads are not interoperable with other
     /// libp2p implementations.
     pub recv_legacy_handshake: bool,
-}
-
-impl Default for LegacyConfig {
-    fn default() -> Self {
-        Self {
-            send_legacy_handshake: false,
-            recv_legacy_handshake: false,
-        }
-    }
 }


### PR DESCRIPTION
The newly released version of clippy is flagging several things.

This PR is an attempt to tackle these quickly to unblock CI for other PRs.
