### PR TITLE
.github/workflow: Use ubuntu-18.04 fixing missing protoc binary 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
 
     - name: Check protoc
       run: |
+        ls -la /lib64/ld-linux-x86-64.so.2
         echo $PROTOC
         echo $PROTOC_INCLUDE
         whereis protoc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
+    - name: Check protoc
+      run: |
+        whereis protoc
+        protoc --version
+
     - uses: actions/checkout@v2.4.0
 
     - uses: Swatinem/rust-cache@v1.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
 
     - name: Check protoc
       run: |
-        ls -la /lib64/ld-linux-x86-64.so.2
         echo $PROTOC
         echo $PROTOC_INCLUDE
         whereis protoc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,7 @@ jobs:
 
     - name: Check protoc
       run: |
-        echo $PROTOC
-        echo $PROTOC_INCLUDE
         whereis protoc
-
 
     - uses: actions/checkout@v2.4.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,11 @@ jobs:
 
     - name: Check protoc
       run: |
+        echo $PROTOC
+        echo $PROTOC_INCLUDE
         whereis protoc
         protoc --version
+
 
     - uses: actions/checkout@v2.4.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,6 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
-    - name: Check protoc
-      run: |
-        whereis protoc
-
     - uses: actions/checkout@v2.4.0
 
     - uses: Swatinem/rust-cache@v1.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test-desktop:
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         args: [
@@ -30,7 +30,6 @@ jobs:
         echo $PROTOC
         echo $PROTOC_INCLUDE
         whereis protoc
-        protoc --version
 
 
     - uses: actions/checkout@v2.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
   test-wasm:
     name: Build on WASM
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         toolchain: [
@@ -91,7 +91,7 @@ jobs:
 
   check-rustdoc-links:
     name: Check rustdoc intra-doc links
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     container:
       image: rust
     steps:
@@ -109,7 +109,7 @@ jobs:
       run: RUSTDOCFLAGS="--deny broken_intra_doc_links" cargo doc --verbose --workspace --no-deps --document-private-items
 
   check-clippy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
 
     - name: Cancel Previous Runs
@@ -135,7 +135,7 @@ jobs:
 
   integration-test:
     name: Integration tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     container:
       image: rust
     steps:
@@ -153,7 +153,7 @@ jobs:
       run: RUST_LOG=libp2p_swarm=debug,libp2p_kad=trace,libp2p_tcp=debug cargo run --example ipfs-kad
 
   rustfmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
 
     - name: Cancel Previous Runs


### PR DESCRIPTION
Debug CI failure on missing protoc binary.

Caused by:
  process didn't exit successfully:
`/home/runner/work/rust-libp2p/rust-libp2p/target/debug/build/libp2p-core-31f9552cf2db9053/build-script-build`
(exit status: 101)
  --- stderr
  thread 'main' panicked at 'called `Result::unwrap()` on an `Err`
value: Custom { kind: NotFound, error: "failed to invoke protoc (hint:
https://docs.rs/prost-build/#sourcing-protoc): No such file or directory
(os error 2)" }', core/build.rs:30:6