### PR TITLE
core/src/connection: Add ConnectedPoint::is_relayed

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -9,9 +9,12 @@
 
 - Add support for ECDSA identities (see [PR 2352]).
 
+- Add `ConnectedPoint::is_relayed` (see [PR 2392]).
+
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 [PR 2350]: https://github.com/libp2p/rust-libp2p/pull/2350
 [PR 2352]: https://github.com/libp2p/rust-libp2p/pull/2352
+[PR 2392]: https://github.com/libp2p/rust-libp2p/pull/2392
 
 # 0.30.1 [2021-11-16]
 

--- a/core/src/connection.rs
+++ b/core/src/connection.rs
@@ -35,8 +35,9 @@ pub use pool::{ConnectionCounters, ConnectionLimits};
 pub use pool::{EstablishedConnection, EstablishedConnectionIter, PendingConnection};
 pub use substream::{Close, Substream, SubstreamEndpoint};
 
+use crate::multiaddr::{Multiaddr, Protocol};
 use crate::muxing::StreamMuxer;
-use crate::{Multiaddr, PeerId};
+use crate::PeerId;
 use std::hash::Hash;
 use std::{error::Error, fmt, pin::Pin, task::Context, task::Poll};
 use substream::{Muxing, SubstreamEvent};
@@ -173,6 +174,16 @@ impl ConnectedPoint {
             ConnectedPoint::Dialer { .. } => false,
             ConnectedPoint::Listener { .. } => true,
         }
+    }
+
+    /// Returns true if the connection is relayed.
+    pub fn is_relayed(&self) -> bool {
+        match self {
+            ConnectedPoint::Dialer { address } => address,
+            ConnectedPoint::Listener { local_addr, .. } => local_addr,
+        }
+        .iter()
+        .any(|p| p == Protocol::P2pCircuit)
     }
 
     /// Returns the address of the remote stored in this struct.


### PR DESCRIPTION
Add convenience function `is_relayed` to `ConnectedPoint`, determining
whether a connection is relayed based on whether it contains a
`Protocol::P2pCircuit`.

//CC @elenaf9 would make suggestion for https://github.com/libp2p/rust-libp2p/pull/2059#discussion_r770542701 a bit cleaner.