### PR TITLE
protocols/gossipsub/src/config: Document peer exchange default is false

### DIFF
--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -248,7 +248,7 @@ impl GossipsubConfig {
     }
 
     /// Whether Peer eXchange is enabled; this should be enabled in bootstrappers and other well
-    /// connected/trusted nodes. The default is true.
+    /// connected/trusted nodes. The default is false.
     pub fn do_px(&self) -> bool {
         self.do_px
     }

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -249,6 +249,9 @@ impl GossipsubConfig {
 
     /// Whether Peer eXchange is enabled; this should be enabled in bootstrappers and other well
     /// connected/trusted nodes. The default is false.
+    ///
+    /// Note: Peer exchange is not implemented today, see
+    /// https://github.com/libp2p/rust-libp2p/issues/2398.
     pub fn do_px(&self) -> bool {
         self.do_px
     }
@@ -602,7 +605,10 @@ impl GossipsubConfigBuilder {
     }
 
     /// Enables Peer eXchange. This should be enabled in bootstrappers and other well
-    /// connected/trusted nodes. The default is true.
+    /// connected/trusted nodes. The default is false.
+    ///
+    /// Note: Peer exchange is not implemented today, see
+    /// https://github.com/libp2p/rust-libp2p/issues/2398.
     pub fn do_px(&mut self) -> &mut Self {
         self.config.do_px = true;
         self


### PR DESCRIPTION
```rust
impl Default for GossipsubConfigBuilder {
    fn default() -> Self {
        GossipsubConfigBuilder {
            config: GossipsubConfig {
                // ...
                do_px: false,
                // ...
            },
        }
    }
}
```

https://github.com/libp2p/rust-libp2p/blob/b6c82a499c185eae6af716a5ecae2a8c7a4b6476/protocols/gossipsub/src/config.rs#L418

Spotted through https://github.com/libp2p/rust-libp2p/issues/2391.