### PR TITLE
core: Add Serialize and Deserialize to PeerId and MessageId

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ wasm-ext-websocket = ["wasm-ext", "libp2p-wasm-ext/websocket"]
 websocket = ["libp2p-websocket"]
 yamux = ["libp2p-yamux"]
 secp256k1 = ["libp2p-core/secp256k1"]
+serde = ["libp2p-core/serde"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -72,7 +73,7 @@ futures-timer = "3.0.2" # Explicit dependency to be used in `wasm-bindgen` featu
 getrandom = "0.2.3" # Explicit dependency to be used in `wasm-bindgen` feature
 instant = "0.1.11" # Explicit dependency to be used in `wasm-bindgen` feature
 lazy_static = "1.2"
-libp2p-core = { version = "0.31.0", path = "core",  default-features = false }
+libp2p-core = { version = "0.31.0", path = "core", default-features = false }
 libp2p-floodsub = { version = "0.33.0", path = "protocols/floodsub", optional = true }
 libp2p-gossipsub = { version = "0.35.0", path = "./protocols/gossipsub", optional = true }
 libp2p-identify = { version = "0.33.0", path = "protocols/identify", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ wasm-ext-websocket = ["wasm-ext", "libp2p-wasm-ext/websocket"]
 websocket = ["libp2p-websocket"]
 yamux = ["libp2p-yamux"]
 secp256k1 = ["libp2p-core/secp256k1"]
-serde = ["libp2p-core/serde"]
+serde = ["libp2p-core/use-serde"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,9 +23,16 @@ lazy_static = "1.2"
 libsecp256k1 = { version = "0.7.0", optional = true }
 log = "0.4"
 multiaddr = { version = "0.13.0" }
-multihash = { version = "0.14", default-features = false, features = ["std", "multihash-impl", "identity", "sha2"] }
+multihash = { version = "0.14", default-features = false, features = [
+  "std",
+  "multihash-impl",
+  "identity",
+  "sha2",
+] }
 multistream-select = { version = "0.11", path = "../misc/multistream-select" }
-p256 = { version = "0.10.0", default-features = false, features = ["ecdsa"], optional = true }
+p256 = { version = "0.10.0", default-features = false, features = [
+  "ecdsa",
+], optional = true }
 parking_lot = "0.11.0"
 pin-project = "1.0.0"
 prost = "0.9"
@@ -37,9 +44,13 @@ thiserror = "1.0"
 unsigned-varint = "0.7"
 void = "1"
 zeroize = "1"
+serde = { version = "1", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ring = { version = "0.16.9", features = ["alloc", "std"], default-features = false }
+ring = { version = "0.16.9", features = [
+  "alloc",
+  "std",
+], default-features = false }
 
 [dev-dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }
@@ -56,9 +67,9 @@ rand07 = { package = "rand", version = "0.7" }
 prost-build = "0.9"
 
 [features]
-default = [ "secp256k1", "ecdsa" ]
-secp256k1 = [ "libsecp256k1" ]
-ecdsa = [ "p256" ]
+default = ["secp256k1", "ecdsa"]
+secp256k1 = ["libsecp256k1"]
+ecdsa = ["p256"]
 
 [[bench]]
 name = "peer_id"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -70,6 +70,7 @@ prost-build = "0.9"
 default = ["secp256k1", "ecdsa"]
 secp256k1 = ["libsecp256k1"]
 ecdsa = ["p256"]
+use-serde = ["multihash/serde-codec", "serde"]
 
 [[bench]]
 name = "peer_id"

--- a/core/src/peer_id.rs
+++ b/core/src/peer_id.rs
@@ -24,6 +24,9 @@ use rand::Rng;
 use std::{convert::TryFrom, fmt, str::FromStr};
 use thiserror::Error;
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 /// Public keys with byte-lengths smaller than `MAX_INLINE_KEY_LENGTH` will be
 /// automatically used as the peer id using an identity multihash.
 const MAX_INLINE_KEY_LENGTH: usize = 42;

--- a/core/src/peer_id.rs
+++ b/core/src/peer_id.rs
@@ -31,6 +31,7 @@ const MAX_INLINE_KEY_LENGTH: usize = 42;
 /// Identifier of a peer of the network.
 ///
 /// The data is a multihash of the public key of the peer.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct PeerId {
     multihash: Multihash,

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -32,6 +32,7 @@ pin-project = "1.0.8"
 instant = "0.1.11"
 # Metrics dependencies
 open-metrics-client = "0.13.0"
+serde = { version = "1", optional = true }
 
 [dev-dependencies]
 async-std = "1.6.3"

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -750,7 +750,7 @@ impl GossipsubConfigBuilder {
     }
 
     /// Constructs a [`GossipsubConfig`] from the given configuration and validates the settings.
-    pub fn build(&self) -> Result<GossipsubConfig, &str> {
+    pub fn build(&self) -> Result<GossipsubConfig, &'static str> {
         // check all constraints on config
 
         if self.config.max_transmit_size < 100 {

--- a/protocols/gossipsub/src/types.rs
+++ b/protocols/gossipsub/src/types.rs
@@ -27,6 +27,9 @@ use prost::Message;
 use std::fmt;
 use std::fmt::Debug;
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
 #[derive(Debug)]
 /// Validation kinds from the application for received messages.
 pub enum MessageAcceptance {

--- a/protocols/gossipsub/src/types.rs
+++ b/protocols/gossipsub/src/types.rs
@@ -42,6 +42,7 @@ pub enum MessageAcceptance {
 /// Macro for declaring message id types
 macro_rules! declare_message_id_type {
     ($name: ident, $name_string: expr) => {
+        #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
         #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
         pub struct $name(pub Vec<u8>);
 


### PR DESCRIPTION
- added a new feature `serde` to the `libp2p` crate
- when this feature is enabled, `Serialize` and `Deserialize` are implemented for `PeerId` and `gossipsub::MessageId`
- fixes an issue with `GossipsubConfigBuilder::build()` where it requires `&self` to be borrowed for `'static` lifetime due to lifetime elision