### PR TITLE
protocols/kad: Implement `Error` and `Clone` for error types

### DIFF
--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -29,6 +29,7 @@ unsigned-varint = { version = "0.7", features = ["asynchronous_codec"] }
 void = "1.0"
 futures-timer = "3.0.2"
 instant = "0.1.11"
+thiserror = "1"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -55,6 +55,7 @@ use std::num::NonZeroUsize;
 use std::task::{Context, Poll};
 use std::vec;
 use std::{borrow::Cow, time::Duration};
+use thiserror::Error;
 
 pub use crate::query::QueryStats;
 
@@ -2583,14 +2584,16 @@ pub struct PutRecordOk {
 }
 
 /// The error result of [`Kademlia::put_record`].
-#[derive(Debug)]
+#[derive(Debug, Clone, Error)]
 pub enum PutRecordError {
+    #[error("the quorum failed; needed {quorum} peers")]
     QuorumFailed {
         key: record::Key,
         /// [`PeerId`]s of the peers the record was successfully stored on.
         success: Vec<PeerId>,
         quorum: NonZeroUsize,
     },
+    #[error("the request timed out")]
     Timeout {
         key: record::Key,
         /// [`PeerId`]s of the peers the record was successfully stored on.
@@ -2629,8 +2632,9 @@ pub struct BootstrapOk {
 }
 
 /// The error result of [`Kademlia::bootstrap`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Error)]
 pub enum BootstrapError {
+    #[error("the request timed out")]
     Timeout {
         peer: PeerId,
         num_remaining: Option<u32>,
@@ -2648,8 +2652,9 @@ pub struct GetClosestPeersOk {
 }
 
 /// The error result of [`Kademlia::get_closest_peers`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Error)]
 pub enum GetClosestPeersError {
+    #[error("the request timed out")]
     Timeout { key: Vec<u8>, peers: Vec<PeerId> },
 }
 
@@ -2682,8 +2687,9 @@ pub struct GetProvidersOk {
 }
 
 /// The error result of [`Kademlia::get_providers`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Error)]
 pub enum GetProvidersError {
+    #[error("the request timed out")]
     Timeout {
         key: record::Key,
         providers: HashSet<PeerId>,
@@ -2718,9 +2724,9 @@ pub struct AddProviderOk {
 }
 
 /// The possible errors when publishing a provider record.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum AddProviderError {
-    /// The query timed out.
+    #[error("the request timed out")]
     Timeout { key: record::Key },
 }
 

--- a/protocols/kad/src/record/store.rs
+++ b/protocols/kad/src/record/store.rs
@@ -30,7 +30,7 @@ use std::borrow::Cow;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// The possible errors of a `RecordStore` operation.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Error {
     /// The store is at capacity w.r.t. the total number of stored records.
     MaxRecords,

--- a/protocols/kad/src/record/store.rs
+++ b/protocols/kad/src/record/store.rs
@@ -41,9 +41,6 @@ pub enum Error {
 
     #[error("the value is too large to be stored")]
     ValueTooLarge,
-
-    #[error("the value is invalid")]
-    Invalid,
 }
 
 /// Trait for types implementing a record store.

--- a/protocols/kad/src/record/store.rs
+++ b/protocols/kad/src/record/store.rs
@@ -33,12 +33,15 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// The possible errors of a `RecordStore` operation.
 #[derive(Error, Debug, Clone)]
 pub enum Error {
+    /// The store is at capacity w.r.t. the total number of stored records.
     #[error("the store cannot contain any more records")]
     MaxRecords,
 
+    /// The store is at capacity w.r.t. the total number of stored provider records.
     #[error("the store cannot contain any more provider records")]
     MaxProvidedKeys,
 
+    /// The store cannot store this value because it is too large.
     #[error("the value is too large to be stored")]
     ValueTooLarge,
 }

--- a/protocols/kad/src/record/store.rs
+++ b/protocols/kad/src/record/store.rs
@@ -21,6 +21,7 @@
 mod memory;
 
 pub use memory::{MemoryStore, MemoryStoreConfig};
+use thiserror::Error;
 
 use super::*;
 use crate::K_VALUE;
@@ -30,15 +31,19 @@ use std::borrow::Cow;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// The possible errors of a `RecordStore` operation.
-#[derive(Debug, Clone)]
+#[derive(Error, Debug, Clone)]
 pub enum Error {
-    /// The store is at capacity w.r.t. the total number of stored records.
+    #[error("the store cannot contain any more records")]
     MaxRecords,
-    /// The store is at capacity w.r.t. the total number of stored keys for
-    /// provider records.
+
+    #[error("the store cannot contain any more provider records")]
     MaxProvidedKeys,
-    /// The value of a record to be stored is too large.
+
+    #[error("the value is too large to be stored")]
     ValueTooLarge,
+
+    #[error("the value is invalid")]
+    Invalid,
 }
 
 /// Trait for types implementing a record store.


### PR DESCRIPTION
- implement `Error` for `kad::record::store::Error`, `kad::AddProviderError`, `kad::GetProvidersError`, `kad::GetClosestPeersError`, `kad::BootstrapError` using `thiserror`
- implement `Clone` for `kad::record::store::Error`, `kad::AddProviderError`, `kad::GetProvidersError`, `kad::GetClosestPeersError`, `kad::BootstrapError`

