### PR TITLE
.github/workflows/: Fix test-wasm and pin third-party action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,11 @@ jobs:
         include:
           - toolchain: wasm32-unknown-unknown
             args: "--features wasm-bindgen"
-    container:
-      image: rust
-      env:
-        CC: clang-11
+    env:
+      CC: clang-11
+    defaults:
+      run:
+        shell: bash
     steps:
 
     - name: Cancel Previous Runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,11 @@ jobs:
 
     - name: Install a recent version of clang
       run: |
-        apt-get update
-        apt-get install -y clang-11
+        sudo apt-get update
+        sudo apt-get install -y clang-11
 
     - name: Install CMake
-      run: apt-get install -y cmake
+      run: sudo apt-get install -y cmake
 
     - uses: Swatinem/rust-cache@v1.3.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
 
     - name: Install a recent version of clang
       run: |
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main"
         sudo apt-get update
         sudo apt-get install -y clang-11
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
     steps:
 
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@a40b8845c0683271d9f53dfcb887a7e181d3918b # 0.9.1
       with:
         access_token: ${{ github.token }}
 
     - uses: actions/checkout@v2.4.0
 
-    - uses: Swatinem/rust-cache@v1.3.0
+    - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641 # v1.3.0
       with:
         key: ${{ matrix.args }}
 
@@ -52,14 +52,14 @@ jobs:
     steps:
 
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@a40b8845c0683271d9f53dfcb887a7e181d3918b # 0.9.1
       with:
         access_token: ${{ github.token }}
 
     - uses: actions/checkout@v2.4.0
 
     - name: Install Rust ${{ matrix.toolchain }}
-      uses: actions-rs/toolchain@v1.0.7
+      uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
         toolchain: stable
         target: ${{ matrix.toolchain }}
@@ -75,7 +75,7 @@ jobs:
     - name: Install CMake
       run: sudo apt-get install -y cmake
 
-    - uses: Swatinem/rust-cache@v1.3.0
+    - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641 # v1.3.0
       with:
         key: ${{ matrix.toolchain }}
 
@@ -92,13 +92,13 @@ jobs:
     steps:
 
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@a40b8845c0683271d9f53dfcb887a7e181d3918b # 0.9.1
       with:
         access_token: ${{ github.token }}
 
     - uses: actions/checkout@v2.4.0
 
-    - uses: Swatinem/rust-cache@v1.3.0
+    - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641 # v1.3.0
 
     - name: Check rustdoc links
       run: RUSTDOCFLAGS="--deny broken_intra_doc_links" cargo doc --verbose --workspace --no-deps --document-private-items
@@ -108,23 +108,23 @@ jobs:
     steps:
 
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@a40b8845c0683271d9f53dfcb887a7e181d3918b # 0.9.1
       with:
         access_token: ${{ github.token }}
 
     - uses: actions/checkout@v2.4.0
 
-    - uses: actions-rs/toolchain@v1.0.7
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
         profile: minimal
         toolchain: stable
         override: true
         components: clippy
 
-    - uses: Swatinem/rust-cache@v1.3.0
+    - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641 # v1.3.0
 
     - name: Run cargo clippy
-      uses: actions-rs/cargo@v1.0.3
+      uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
       with:
         command: custom-clippy # cargo alias to allow reuse of config locally
 
@@ -136,13 +136,13 @@ jobs:
     steps:
 
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@a40b8845c0683271d9f53dfcb887a7e181d3918b # 0.9.1
       with:
         access_token: ${{ github.token }}
 
     - uses: actions/checkout@v2.4.0
 
-    - uses: Swatinem/rust-cache@v1.3.0
+    - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641 # v1.3.0
 
     - name: Run ipfs-kad example
       run: RUST_LOG=libp2p_swarm=debug,libp2p_kad=trace,libp2p_tcp=debug cargo run --example ipfs-kad
@@ -152,13 +152,13 @@ jobs:
     steps:
 
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.0
+      uses: styfle/cancel-workflow-action@a40b8845c0683271d9f53dfcb887a7e181d3918b # 0.9.1
       with:
         access_token: ${{ github.token }}
 
     - uses: actions/checkout@v2.4.0
 
-    - uses: actions-rs/toolchain@v1.0.7
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
         profile: minimal
         toolchain: stable


### PR DESCRIPTION
# Description

## `test-wasm`

I remove the `container` configuration from `test-wasm` job so that the job starts using `rust` installed here https://github.com/libp2p/rust-libp2p/blob/eefed59877609148562286a7a1bd2a38e974f443/.github/workflows/ci.yml#L61

Previously, we would run last step(https://github.com/libp2p/rust-libp2p/blob/eefed59877609148562286a7a1bd2a38e974f443/.github/workflows/ci.yml#L82) inside the container with `rust` from the container.

## third-party action versions

I pinned the third-party action versions to the exact commit SHAs. We follow the same strategy in protocol go repositories to ensure the code we use doesn't change.

# Testing

- [x] CI workflow in forked repo
- [x] CI workflow in this repo