### PR TITLE
swarm/src/lib: Update outdated SwarmEvent::Dialing comment

### DIFF
--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -236,12 +236,13 @@ pub enum SwarmEvent<TBehaviourOutEvent, THandlerErr> {
         /// The listener error.
         error: io::Error,
     },
-    /// A new dialing attempt has been initiated.
+    /// A new dialing attempt has been initiated by the [`NetworkBehaviour`]
+    /// implementation.
     ///
     /// A [`ConnectionEstablished`](SwarmEvent::ConnectionEstablished) event is
     /// reported if the dialing attempt succeeds, otherwise a
     /// [`OutgoingConnectionError`](SwarmEvent::OutgoingConnectionError) event
-    /// is reported with `attempts_remaining` equal to 0.
+    /// is reported.
     Dialing(PeerId),
 }
 


### PR DESCRIPTION
Since https://github.com/libp2p/rust-libp2p/pull/2248 dial attempts are
no longer reported per address, but instead reported for all addresses
of a single dial at once.

This commit updates the comment accordingly.

//CC @rkuhn 