### PR TITLE
protocols/: Fix clippy and fmt warnings

### DIFF
--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -211,9 +211,11 @@ impl ProtocolsHandler for GossipsubHandler {
 
     fn inject_fully_negotiated_inbound(
         &mut self,
-        (substream, peer_kind): <Self::InboundProtocol as InboundUpgrade<NegotiatedSubstream>>::Output,
+        protocol: <Self::InboundProtocol as InboundUpgrade<NegotiatedSubstream>>::Output,
         _info: Self::InboundOpenInfo,
     ) {
+        let (substream, peer_kind) = protocol;
+
         // If the peer doesn't support the protocol, reject all substreams
         if self.protocol_unsupported {
             return;
@@ -233,9 +235,11 @@ impl ProtocolsHandler for GossipsubHandler {
 
     fn inject_fully_negotiated_outbound(
         &mut self,
-        (substream, peer_kind): <Self::OutboundProtocol as OutboundUpgrade<NegotiatedSubstream>>::Output,
+        protocol: <Self::OutboundProtocol as OutboundUpgrade<NegotiatedSubstream>>::Output,
         message: Self::OutboundOpenInfo,
     ) {
+        let (substream, peer_kind) = protocol;
+
         // If the peer doesn't support the protocol, reject all substreams
         if self.protocol_unsupported {
             return;

--- a/protocols/mdns/src/behaviour/iface/dns.rs
+++ b/protocols/mdns/src/behaviour/iface/dns.rs
@@ -127,7 +127,7 @@ pub fn build_query_response(
     // Encode the addresses as TXT records, and multiple TXT records into a
     // response packet.
     for addr in addresses {
-        let txt_to_send = format!("dnsaddr={}/p2p/{}", addr.to_string(), peer_id.to_base58());
+        let txt_to_send = format!("dnsaddr={}/p2p/{}", addr, peer_id.to_base58());
         let mut txt_record = Vec::with_capacity(txt_to_send.len());
         match append_txt_record(&mut txt_record, &peer_name_bytes, ttl, &txt_to_send) {
             Ok(()) => {


### PR DESCRIPTION
Github actions are failing in #2262 due to new rustfmt and clippy versions. This PR fixes clippy and rustfmt. 
Note: in 4fbaa2d9673eb8970d1d95f57261b03a4a5d6dd9 I had to remove the tuple from the function signature and instead add it in the function body, because it caused some internal error on rustfmt.