### PR TITLE
misc/metrics: Set default-features = false on libp2p-core

### DIFF
--- a/misc/metrics/Cargo.toml
+++ b/misc/metrics/Cargo.toml
@@ -17,7 +17,7 @@ kad = ["libp2p-kad"]
 ping = ["libp2p-ping"]
 
 [dependencies]
-libp2p-core = { version = "0.31.0", path = "../../core" }
+libp2p-core = { version = "0.31.0", path = "../../core", default-features = false }
 libp2p-gossipsub =  { version = "0.35.0", path = "../../protocols/gossipsub", optional = true }
 libp2p-identify = { version = "0.33.0", path = "../../protocols/identify", optional = true }
 libp2p-kad = { version = "0.34.0", path = "../../protocols/kad", optional = true }


### PR DESCRIPTION
Right now, `libp2p-metrics` uses all default features from `libp2p-core`. As a result, it is very hard (may be impossible) to disable e.g. `ecdsa` in `libp2p-core` in a project that depends on `libp2p`.

After this change, the problem is completely fixed.