### PR TITLE
*: Update tokio, lru and prost

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ async-std = { version = "1.6.2", features = ["attributes"] }
 async-trait = "0.1"
 env_logger = "0.9.0"
 structopt = "0.3.21"
-tokio = { version = "1.0.1", features = ["io-util", "io-std", "macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1.15", features = ["io-util", "io-std", "macros", "rt", "rt-multi-thread"] }
 
 [workspace]
 members = [

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-autonat"
 edition = "2021"
 rust-version = "1.56.1"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["David Craven <david@craven.ch>", "Elena Frank <elena.frank@protonmail.com>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -10,7 +10,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [build-dependencies]
-prost-build = "0.6"
+prost-build = "0.9"
 
 [dependencies]
 async-trait = "0.1"
@@ -22,7 +22,7 @@ libp2p-swarm = { version = "0.33.0", path = "../../swarm" }
 libp2p-request-response = { version = "0.15.0", path = "../request-response" }
 log = "0.4"
 rand = "0.8"
-prost = "0.8"
+prost = "0.9"
 
 [dev-dependencies]
 async-std = { version = "1.10", features = ["attributes"] }

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-autonat"
 edition = "2021"
 rust-version = "1.56.1"
-version = "0.20.1"
+version = "0.20.0"
 authors = ["David Craven <david@craven.ch>", "Elena Frank <elena.frank@protonmail.com>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -16,7 +16,7 @@ futures-timer = "3.0.2"
 libp2p-core = { version = "0.31.0", path = "../../core", default-features = false }
 libp2p-swarm = { version = "0.33.0", path = "../../swarm" }
 log = "0.4.1"
-lru = "0.7"
+lru = "0.7.2"
 prost = "0.9"
 smallvec = "1.6.1"
 

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -29,4 +29,4 @@ void = "1.0.2"
 async-std = { version = "1.9.0", features = ["attributes"] }
 env_logger = "0.9.0"
 libp2p = { path = "../.." }
-tokio = { version = "1.2.0", default-features = false, features = ["macros", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1.15", default-features = false, features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/protocols/rendezvous/Cargo.toml
+++ b/protocols/rendezvous/Cargo.toml
@@ -31,7 +31,7 @@ async-trait = "0.1"
 env_logger = "0.8"
 libp2p = { path = "../.." }
 rand = "0.8"
-tokio = { version = "1", features = [ "rt-multi-thread", "time", "macros", "sync", "process", "fs", "net" ] }
+tokio = { version = "1.15", features = [ "rt-multi-thread", "time", "macros", "sync", "process", "fs", "net" ] }
 
 [build-dependencies]
 prost-build = "0.9"

--- a/transports/uds/Cargo.toml
+++ b/transports/uds/Cargo.toml
@@ -15,7 +15,7 @@ async-std = { version = "1.6.2", optional = true }
 libp2p-core = { version = "0.31.0", path = "../../core", default-features = false  }
 log = "0.4.1"
 futures = "0.3.1"
-tokio = { version = "1.0.1", default-features = false, features = ["net"], optional = true }
+tokio = { version = "1.15", default-features = false, features = ["net"], optional = true }
 
 [target.'cfg(all(unix, not(target_os = "emscripten")))'.dev-dependencies]
 tempfile = "3.0"


### PR DESCRIPTION
Fix errors from `cargo deny check advisories`

- prost-build
```
error[A001]: Conversion from `prost_types::Timestamp` to `SystemTime` can cause an overflow and panic
    │
285 │ prost-types 0.6.1 registry+https://github.com/rust-lang/crates.io-index
    │ ----------------------------------------------------------------------- security vulnerability detected
    │
    = ID: RUSTSEC-2021-0073
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2021-0073
    = Affected versions of this crate contained a bug in which untrusted input could cause an overflow and panic when converting a `Timestamp` to `SystemTime`.

      It is recommended to upgrade to `prost-types` v0.8 and switch the usage of `From<Timestamp> for SystemTime` to `TryFrom<Timestamp> for SystemTime`.

      See [#438] for more information.

      [#438]: https://github.com/tokio-rs/prost/issues/438
    = Announcement: https://github.com/tokio-rs/prost/issues/438
    = Solution: Upgrade to >=0.8.0
```

- [lru](https://deps.rs/repo/github/libp2p/rust-libp2p)
![image](https://user-images.githubusercontent.com/6546635/150066415-1bdd2390-7528-47af-9fe0-26343f829bdf.png)

- [tokio](https://deps.rs/repo/github/libp2p/rust-libp2p)
![image](https://user-images.githubusercontent.com/6546635/150066475-a09d7abc-ff76-4038-911d-d03accdcd697.png)
