### PR TITLE
protocols/autonat: Add changelog and start version at v0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ getrandom = "0.2.3" # Explicit dependency to be used in `wasm-bindgen` feature
 instant = "0.1.11" # Explicit dependency to be used in `wasm-bindgen` feature
 lazy_static = "1.2"
 
-libp2p-autonat = { version = "0.20.0", path = "protocols/autonat", optional = true }
+libp2p-autonat = { version = "0.1.0", path = "protocols/autonat", optional = true }
 libp2p-core = { version = "0.31.0", path = "core",  default-features = false }
 libp2p-floodsub = { version = "0.33.0", path = "protocols/floodsub", optional = true }
 libp2p-gossipsub = { version = "0.35.0", path = "./protocols/gossipsub", optional = true }

--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0 [unreleased]
+
+- Initial release.

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-autonat"
 edition = "2021"
 rust-version = "1.56.1"
-version = "0.20.0"
+version = "0.1.0"
 authors = ["David Craven <david@craven.ch>", "Elena Frank <elena.frank@protonmail.com>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
The `libp2p-autonat` crate has never been released, thus it should start at
`v0.1.0`.



@elenaf9 @dvc94ch am I missing something? Not sure why https://github.com/libp2p/rust-libp2p/pull/1672 started with `v0.20.0`.