### PR TITLE
protocols/autonat/tests: ignore irrelevant events

### DIFF
--- a/protocols/autonat/tests/test_client.rs
+++ b/protocols/autonat/tests/test_client.rs
@@ -176,7 +176,7 @@ async fn test_auto_probe() {
             .unwrap();
         loop {
             match client.select_next_some().await {
-                SwarmEvent::NewListenAddr { .. } | SwarmEvent::ExpiredListenAddr { .. } => break,
+                SwarmEvent::NewListenAddr { .. } => break,
                 _ => {}
             }
         }
@@ -258,9 +258,7 @@ async fn test_confidence() {
                 .unwrap();
             loop {
                 match client.select_next_some().await {
-                    SwarmEvent::NewListenAddr { .. } | SwarmEvent::ExpiredListenAddr { .. } => {
-                        break
-                    }
+                    SwarmEvent::NewListenAddr { .. } => break,
                     _ => {}
                 }
             }
@@ -349,7 +347,7 @@ async fn test_throttle_server_period() {
             .unwrap();
         loop {
             match client.select_next_some().await {
-                SwarmEvent::NewListenAddr { .. } | SwarmEvent::ExpiredListenAddr { .. } => break,
+                SwarmEvent::NewListenAddr { .. } => break,
                 _ => {}
             }
         }
@@ -471,7 +469,7 @@ async fn test_outbound_failure() {
 
         loop {
             match client.select_next_some().await {
-                SwarmEvent::NewListenAddr { .. } | SwarmEvent::ExpiredListenAddr { .. } => break,
+                SwarmEvent::NewListenAddr { .. } => break,
                 _ => {}
             }
         }

--- a/protocols/autonat/tests/test_client.rs
+++ b/protocols/autonat/tests/test_client.rs
@@ -194,12 +194,16 @@ async fn test_auto_probe() {
             match client.select_next_some().await {
                 SwarmEvent::ConnectionEstablished {
                     endpoint, peer_id, ..
-                } if endpoint.is_listener() => {
+                } => {
+                    assert!(endpoint.is_listener());
                     assert_eq!(peer_id, server_id);
                     break;
                 }
-                SwarmEvent::IncomingConnection { .. } | SwarmEvent::NewListenAddr { .. } => {}
-                _ => panic!("Unexpected Swarm Event"),
+                SwarmEvent::IncomingConnectionError { .. } => {
+                    panic!("Unexpected error on inbound connection.")
+                }
+                SwarmEvent::Behaviour(event) => panic!("Unexpected behaviour event {:?}.", event),
+                _ => {}
             }
         }
 

--- a/protocols/autonat/tests/test_client.rs
+++ b/protocols/autonat/tests/test_client.rs
@@ -121,7 +121,7 @@ async fn test_auto_probe() {
                 assert!(peer.is_none());
                 assert_eq!(error, OutboundProbeError::NoAddresses);
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         }
 
         assert_eq!(client.behaviour().nat_status(), NatStatus::Unknown);
@@ -139,7 +139,7 @@ async fn test_auto_probe() {
                 assert_eq!(peer, server_id);
                 probe_id
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         };
 
         match next_event(&mut client).await {
@@ -155,7 +155,7 @@ async fn test_auto_probe() {
                     OutboundProbeError::Response(ResponseError::DialError)
                 );
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         }
 
         match next_event(&mut client).await {
@@ -163,7 +163,7 @@ async fn test_auto_probe() {
                 assert_eq!(old, NatStatus::Unknown);
                 assert_eq!(new, NatStatus::Private);
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         }
 
         assert_eq!(client.behaviour().confidence(), 0);
@@ -176,7 +176,7 @@ async fn test_auto_probe() {
             .unwrap();
         loop {
             match client.select_next_some().await {
-                SwarmEvent::NewListenAddr { .. } => break,
+                SwarmEvent::NewListenAddr { .. } | SwarmEvent::ExpiredListenAddr { .. } => break,
                 _ => {}
             }
         }
@@ -186,7 +186,7 @@ async fn test_auto_probe() {
                 assert_eq!(peer, server_id);
                 probe_id
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         };
 
         // Expect inbound dial from server.
@@ -198,8 +198,10 @@ async fn test_auto_probe() {
                     assert_eq!(peer_id, server_id);
                     break;
                 }
-                SwarmEvent::IncomingConnection { .. } | SwarmEvent::NewListenAddr { .. } => {}
-                _ => panic!("Unexpected Swarm Event"),
+                SwarmEvent::IncomingConnection { .. }
+                | SwarmEvent::NewListenAddr { .. }
+                | SwarmEvent::ExpiredListenAddr { .. } => {}
+                other => panic!("Unexpected swarm event: {:?}.", other),
             }
         }
 
@@ -208,7 +210,7 @@ async fn test_auto_probe() {
                 assert_eq!(peer, server_id);
                 assert_eq!(probe_id, id);
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         }
 
         // Expect to flip status to public
@@ -218,7 +220,7 @@ async fn test_auto_probe() {
                 assert!(matches!(new, NatStatus::Public(_)));
                 assert!(new.is_public());
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         }
 
         assert_eq!(client.behaviour().confidence(), 0);
@@ -256,7 +258,9 @@ async fn test_confidence() {
                 .unwrap();
             loop {
                 match client.select_next_some().await {
-                    SwarmEvent::NewListenAddr { .. } => break,
+                    SwarmEvent::NewListenAddr { .. } | SwarmEvent::ExpiredListenAddr { .. } => {
+                        break
+                    }
                     _ => {}
                 }
             }
@@ -271,7 +275,7 @@ async fn test_confidence() {
                     assert_eq!(peer, server_id);
                     probe_id
                 }
-                other => panic!("Unexpected Event: {:?}", other),
+                other => panic!("Unexpected behaviour event: {:?}.", other),
             };
 
             match next_event(&mut client).await {
@@ -296,7 +300,7 @@ async fn test_confidence() {
                     assert_eq!(peer, server_id);
                     assert_eq!(probe_id, id);
                 }
-                other => panic!("Unexpected Event: {:?}", other),
+                other => panic!("Unexpected behaviour event: {:?}.", other),
             }
 
             // Confidence should increase each iteration up to MAX_CONFIDENCE
@@ -315,7 +319,7 @@ async fn test_confidence() {
                         assert_eq!(old, NatStatus::Unknown);
                         assert_eq!(new.is_public(), test_public);
                     }
-                    other => panic!("Unexpected Event: {:?}", other),
+                    other => panic!("Unexpected behaviour event: {:?}.", other),
                 }
             }
         }
@@ -345,7 +349,7 @@ async fn test_throttle_server_period() {
             .unwrap();
         loop {
             match client.select_next_some().await {
-                SwarmEvent::NewListenAddr { .. } => break,
+                SwarmEvent::NewListenAddr { .. } | SwarmEvent::ExpiredListenAddr { .. } => break,
                 _ => {}
             }
         }
@@ -364,7 +368,7 @@ async fn test_throttle_server_period() {
                 }
                 Event::OutboundProbe(OutboundProbeEvent::Request { .. }) => {}
                 Event::OutboundProbe(OutboundProbeEvent::Response { .. }) => {}
-                other => panic!("Unexpected Event: {:?}", other),
+                other => panic!("Unexpected behaviour event: {:?}.", other),
             }
         }
 
@@ -377,7 +381,7 @@ async fn test_throttle_server_period() {
                 assert!(peer.is_none());
                 assert_eq!(error, OutboundProbeError::NoServer);
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         }
         assert_eq!(client.behaviour().confidence(), 0);
 
@@ -423,14 +427,14 @@ async fn test_use_connected_as_server() {
             Event::OutboundProbe(OutboundProbeEvent::Request { peer, .. }) => {
                 assert_eq!(peer, server_id);
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         }
 
         match next_event(&mut client).await {
             Event::OutboundProbe(OutboundProbeEvent::Response { peer, .. }) => {
                 assert_eq!(peer, server_id);
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         }
 
         drop(_handle);
@@ -467,7 +471,7 @@ async fn test_outbound_failure() {
 
         loop {
             match client.select_next_some().await {
-                SwarmEvent::NewListenAddr { .. } => break,
+                SwarmEvent::NewListenAddr { .. } | SwarmEvent::ExpiredListenAddr { .. } => break,
                 _ => {}
             }
         }
@@ -481,7 +485,7 @@ async fn test_outbound_failure() {
                 }
                 Event::OutboundProbe(OutboundProbeEvent::Request { .. }) => {}
                 Event::OutboundProbe(OutboundProbeEvent::Response { .. }) => {}
-                other => panic!("Unexpected Event: {:?}", other),
+                other => panic!("Unexpected behaviour event: {:?}.", other),
             }
         }
 
@@ -504,7 +508,7 @@ async fn test_outbound_failure() {
                 }) => {
                     assert!(inactive_ids.contains(&peer));
                 }
-                other => panic!("Unexpected Event: {:?}", other),
+                other => panic!("Unexpected behaviour event: {:?}.", other),
             }
         }
     };

--- a/protocols/autonat/tests/test_client.rs
+++ b/protocols/autonat/tests/test_client.rs
@@ -194,16 +194,12 @@ async fn test_auto_probe() {
             match client.select_next_some().await {
                 SwarmEvent::ConnectionEstablished {
                     endpoint, peer_id, ..
-                } => {
-                    assert!(endpoint.is_listener());
+                } if endpoint.is_listener() => {
                     assert_eq!(peer_id, server_id);
                     break;
                 }
-                SwarmEvent::IncomingConnectionError { .. } => {
-                    panic!("Unexpected error on inbound connection.")
-                }
-                SwarmEvent::Behaviour(event) => panic!("Unexpected behaviour event {:?}.", event),
-                _ => {}
+                SwarmEvent::IncomingConnection { .. } | SwarmEvent::NewListenAddr { .. } => {}
+                _ => panic!("Unexpected Swarm Event"),
             }
         }
 

--- a/protocols/autonat/tests/test_server.rs
+++ b/protocols/autonat/tests/test_server.rs
@@ -165,8 +165,10 @@ async fn test_dial_back() {
                     };
                     break observed_client_ip;
                 }
-                SwarmEvent::IncomingConnection { .. } | SwarmEvent::NewListenAddr { .. } => {}
-                _ => panic!("Unexpected Swarm Event"),
+                SwarmEvent::IncomingConnection { .. }
+                | SwarmEvent::NewListenAddr { .. }
+                | SwarmEvent::ExpiredListenAddr { .. } => {}
+                other => panic!("Unexpected swarm event: {:?}.", other),
             }
         };
         let expect_addr = Multiaddr::empty()
@@ -184,7 +186,7 @@ async fn test_dial_back() {
                 assert_eq!(addresses[0], expect_addr);
                 probe_id
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         };
 
         loop {
@@ -206,8 +208,8 @@ async fn test_dial_back() {
                     break;
                 }
                 SwarmEvent::Dialing(peer) => assert_eq!(peer, client_id),
-                SwarmEvent::NewListenAddr { .. } => {}
-                _ => panic!("Unexpected Swarm Event"),
+                SwarmEvent::NewListenAddr { .. } | SwarmEvent::ExpiredListenAddr { .. } => {}
+                other => panic!("Unexpected swarm event: {:?}.", other),
             }
         }
 
@@ -221,7 +223,7 @@ async fn test_dial_back() {
                 assert_eq!(peer, client_id);
                 assert_eq!(address, expect_addr);
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         }
 
         drop(_handle);
@@ -241,7 +243,7 @@ async fn test_dial_error() {
                 assert_eq!(peer, client_id);
                 probe_id
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         };
 
         loop {
@@ -252,8 +254,8 @@ async fn test_dial_error() {
                     break;
                 }
                 SwarmEvent::Dialing(peer) => assert_eq!(peer, client_id),
-                SwarmEvent::NewListenAddr { .. } => {}
-                _ => panic!("Unexpected Swarm Event"),
+                SwarmEvent::NewListenAddr { .. } | SwarmEvent::ExpiredListenAddr { .. } => {}
+                other => panic!("Unexpected swarm event: {:?}.", other),
             }
         }
 
@@ -267,7 +269,7 @@ async fn test_dial_error() {
                 assert_eq!(peer, client_id);
                 assert_eq!(error, InboundProbeError::Response(ResponseError::DialError));
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         }
 
         drop(_handle);
@@ -296,7 +298,7 @@ async fn test_throttle_global_max() {
             Event::InboundProbe(InboundProbeEvent::Request { peer, probe_id, .. }) => {
                 (probe_id, peer)
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         };
 
         loop {
@@ -314,7 +316,7 @@ async fn test_throttle_global_max() {
                     assert_eq!(first_peer_id, peer);
                     assert_eq!(first_probe_id, probe_id);
                 }
-                other => panic!("Unexpected Event: {:?}", other),
+                other => panic!("Unexpected behaviour event: {:?}.", other),
             };
         }
 
@@ -342,7 +344,7 @@ async fn test_throttle_peer_max() {
                 assert_eq!(client_id, peer);
                 probe_id
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         };
 
         match next_event(&mut server).await {
@@ -350,7 +352,7 @@ async fn test_throttle_peer_max() {
                 assert_eq!(peer, client_id);
                 assert_eq!(probe_id, first_probe_id);
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         }
 
         match next_event(&mut server).await {
@@ -366,7 +368,7 @@ async fn test_throttle_peer_max() {
                     InboundProbeError::Response(ResponseError::DialRefused)
                 )
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         };
 
         drop(_handle);
@@ -396,7 +398,7 @@ async fn test_dial_multiple_addr() {
                 assert_eq!(client_id, peer);
                 addresses
             }
-            other => panic!("Unexpected Event: {:?}", other),
+            other => panic!("Unexpected behaviour event: {:?}.", other),
         };
 
         loop {
@@ -419,8 +421,8 @@ async fn test_dial_multiple_addr() {
                     break;
                 }
                 SwarmEvent::Dialing(peer) => assert_eq!(peer, client_id),
-                SwarmEvent::NewListenAddr { .. } => {}
-                _ => panic!("Unexpected Swarm Event"),
+                SwarmEvent::NewListenAddr { .. } | SwarmEvent::ExpiredListenAddr { .. } => {}
+                other => panic!("Unexpected swarm event: {:?}.", other),
             }
         }
     };

--- a/protocols/autonat/tests/test_server.rs
+++ b/protocols/autonat/tests/test_server.rs
@@ -165,11 +165,8 @@ async fn test_dial_back() {
                     };
                     break observed_client_ip;
                 }
-                SwarmEvent::IncomingConnectionError { .. } => {
-                    panic!("Unexpected error on inbound connection.")
-                }
-                SwarmEvent::Behaviour(event) => panic!("Unexpected behaviour event {:?}.", event),
-                _ => {}
+                SwarmEvent::IncomingConnection { .. } | SwarmEvent::NewListenAddr { .. } => {}
+                _ => panic!("Unexpected Swarm Event"),
             }
         };
         let expect_addr = Multiaddr::empty()
@@ -209,11 +206,8 @@ async fn test_dial_back() {
                     break;
                 }
                 SwarmEvent::Dialing(peer) => assert_eq!(peer, client_id),
-                SwarmEvent::OutgoingConnectionError { .. } => {
-                    panic!("Unexpected error on outbound connection.")
-                }
-                SwarmEvent::Behaviour(event) => panic!("Unexpected behaviour event {:?}.", event),
-                _ => {}
+                SwarmEvent::NewListenAddr { .. } => {}
+                _ => panic!("Unexpected Swarm Event"),
             }
         }
 
@@ -258,11 +252,8 @@ async fn test_dial_error() {
                     break;
                 }
                 SwarmEvent::Dialing(peer) => assert_eq!(peer, client_id),
-                SwarmEvent::ConnectionEstablished { .. } => {
-                    panic!("Unexpected connection established.")
-                }
-                SwarmEvent::Behaviour(event) => panic!("Unexpected behaviour event {:?}.", event),
-                _ => {}
+                SwarmEvent::NewListenAddr { .. } => {}
+                _ => panic!("Unexpected Swarm Event"),
             }
         }
 
@@ -428,11 +419,8 @@ async fn test_dial_multiple_addr() {
                     break;
                 }
                 SwarmEvent::Dialing(peer) => assert_eq!(peer, client_id),
-                SwarmEvent::OutgoingConnectionError { .. } => {
-                    panic!("Unexpected error on outbound connection.")
-                }
-                SwarmEvent::Behaviour(event) => panic!("Unexpected behaviour event {:?}.", event),
-                _ => {}
+                SwarmEvent::NewListenAddr { .. } => {}
+                _ => panic!("Unexpected Swarm Event"),
             }
         }
     };

--- a/protocols/autonat/tests/test_server.rs
+++ b/protocols/autonat/tests/test_server.rs
@@ -165,8 +165,11 @@ async fn test_dial_back() {
                     };
                     break observed_client_ip;
                 }
-                SwarmEvent::IncomingConnection { .. } | SwarmEvent::NewListenAddr { .. } => {}
-                _ => panic!("Unexpected Swarm Event"),
+                SwarmEvent::IncomingConnectionError { .. } => {
+                    panic!("Unexpected error on inbound connection.")
+                }
+                SwarmEvent::Behaviour(event) => panic!("Unexpected behaviour event {:?}.", event),
+                _ => {}
             }
         };
         let expect_addr = Multiaddr::empty()
@@ -206,8 +209,11 @@ async fn test_dial_back() {
                     break;
                 }
                 SwarmEvent::Dialing(peer) => assert_eq!(peer, client_id),
-                SwarmEvent::NewListenAddr { .. } => {}
-                _ => panic!("Unexpected Swarm Event"),
+                SwarmEvent::OutgoingConnectionError { .. } => {
+                    panic!("Unexpected error on outbound connection.")
+                }
+                SwarmEvent::Behaviour(event) => panic!("Unexpected behaviour event {:?}.", event),
+                _ => {}
             }
         }
 
@@ -252,8 +258,11 @@ async fn test_dial_error() {
                     break;
                 }
                 SwarmEvent::Dialing(peer) => assert_eq!(peer, client_id),
-                SwarmEvent::NewListenAddr { .. } => {}
-                _ => panic!("Unexpected Swarm Event"),
+                SwarmEvent::ConnectionEstablished { .. } => {
+                    panic!("Unexpected connection established.")
+                }
+                SwarmEvent::Behaviour(event) => panic!("Unexpected behaviour event {:?}.", event),
+                _ => {}
             }
         }
 
@@ -419,8 +428,11 @@ async fn test_dial_multiple_addr() {
                     break;
                 }
                 SwarmEvent::Dialing(peer) => assert_eq!(peer, client_id),
-                SwarmEvent::NewListenAddr { .. } => {}
-                _ => panic!("Unexpected Swarm Event"),
+                SwarmEvent::OutgoingConnectionError { .. } => {
+                    panic!("Unexpected error on outbound connection.")
+                }
+                SwarmEvent::Behaviour(event) => panic!("Unexpected behaviour event {:?}.", event),
+                _ => {}
             }
         }
     };


### PR DESCRIPTION
CI failed in #2440  due to a flaky test in libp2p_autonat with "Unexpected Swarm Event". Wild guess is that a listener event happened. This PR changes it so that the autonat tests only panic on swarm-events that indicate an error in the autonat behaviour protocol, and ignore irrelevant events.