### PR TITLE
Peer discovery docs

### DIFF
--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -58,8 +58,8 @@
 //! against the failure or replacement of the
 //! [boot nodes](https://docs.libp2p.io/reference/glossary/#boot-node) of the network.
 //!
-//! If your application needs to be resistant against the failure of your boot nodes, peer
-//! discovery can be implemented with the help of the [Kademlia](libp2p_kad::Kademlia) protocol
+//! Peer
+//! discovery can e.g. be implemented with the help of the [Kademlia](libp2p_kad::Kademlia) protocol
 //! in combination with the [Identify](libp2p_identify::Identify) protocol. See the
 //! [Kademlia](libp2p_kad::Kademlia) documentation for more information.
 //!

--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -55,13 +55,13 @@
 //!
 //! Gossipsub does not provide peer discovery by itself. Peer discovery is the process by which
 //! peers in a p2p network exchange information about eachother in order to become resistant
-//! against the failure or replacement of "boot nodes". Boot nodes are the nodes through which an
-//! initial connection to a p2p network is made.
+//! against the failure or replacement of your
+//! [boot nodes](https://docs.libp2p.io/reference/glossary/#boot-node).
 //!
-//! If your application needs to be resistant against the failure of these boot nodes, peer
+//! If your application needs to be resistant against the failure of your boot nodes, peer
 //! discovery can be implemented with the help of the [Kademlia](libp2p_kad::Kademlia) protocol
-//! in combination with the [Identify](libp2p_identify::Identify) protocol. See the [Kademlia]
-//! documentation for more information.
+//! in combination with the [Identify](libp2p_identify::Identify) protocol. See the
+//! [Kademlia](libp2p_kad::Kademlia) documentation for more information.
 //!
 //! # Using Gossipsub
 //!

--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -51,6 +51,18 @@
 //! integers. They are chosen at random in this implementation of gossipsub, but are sequential in
 //! the current go implementation.
 //!
+//! # Peer Discovery
+//!
+//! Gossipsub does not provide peer discovery by itself. Peer discovery is the process by which
+//! peers in a p2p network exchange information about eachother in order to become resistant
+//! against the failure or replacement of "boot nodes". Boot nodes are the nodes through which an
+//! initial connection to a p2p network is made.
+//!
+//! If your application needs to be resistant against the failure of these boot nodes, peer
+//! discovery can be implemented with the help of the [Kademlia](libp2p_kad::Kademlia) protocol
+//! in combination with the [Identify](libp2p_identify::Identify) protocol. See the [Kademlia]
+//! documentation for more information.
+//!
 //! # Using Gossipsub
 //!
 //! ## GossipsubConfig

--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -54,9 +54,9 @@
 //! # Peer Discovery
 //!
 //! Gossipsub does not provide peer discovery by itself. Peer discovery is the process by which
-//! peers in a p2p network exchange information about eachother in order to become resistant
-//! against the failure or replacement of your
-//! [boot nodes](https://docs.libp2p.io/reference/glossary/#boot-node).
+//! peers in a p2p network exchange information about each other among other reasons to become resistant
+//! against the failure or replacement of the
+//! [boot nodes](https://docs.libp2p.io/reference/glossary/#boot-node) of the network.
 //!
 //! If your application needs to be resistant against the failure of your boot nodes, peer
 //! discovery can be implemented with the help of the [Kademlia](libp2p_kad::Kademlia) protocol

--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -59,9 +59,9 @@
 //! [boot nodes](https://docs.libp2p.io/reference/glossary/#boot-node) of the network.
 //!
 //! Peer
-//! discovery can e.g. be implemented with the help of the [Kademlia](libp2p_kad::Kademlia) protocol
-//! in combination with the [Identify](libp2p_identify::Identify) protocol. See the
-//! [Kademlia](libp2p_kad::Kademlia) documentation for more information.
+//! discovery can e.g. be implemented with the help of the [Kademlia](https://github.com/libp2p/specs/blob/master/kad-dht/README.md) protocol
+//! in combination with the [Identify](https://github.com/libp2p/specs/tree/master/identify) protocol. See the
+//! Kademlia implementation documentation for more information.
 //!
 //! # Using Gossipsub
 //!

--- a/protocols/identify/src/lib.rs
+++ b/protocols/identify/src/lib.rs
@@ -26,6 +26,13 @@
 //! At least one identification request is sent on a newly established
 //! connection, beyond which the behaviour does not keep connections alive.
 //!
+//! # Important Discrepancies
+//!
+//! - **Using Identify with other protocols** Unlike some other libp2p implementations,
+//! rust-libp2p does not treat Identify as a core protocol. This means that other protocols cannot
+//! rely upon the existence of Identify, and need to be manually hooked up to Identify in order to
+//! make use of its capabilities.
+//!
 //! # Usage
 //!
 //! The [`Identify`] struct implements a `NetworkBehaviour` that negotiates

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -20,9 +20,7 @@
 
 //! Implementation of the libp2p-specific Kademlia protocol.
 //!
-//! # Overview
-//! Kademlia provides a distributed hash table in which data can be stored. Kademlia can also be
-//! used to store information about peers in a p2p network.
+//! See [specification](https://github.com/libp2p/specs/blob/master/kad-dht/README.md) for details.
 //!
 //! # Important Discrepancies
 //!

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -25,7 +25,7 @@
 //! # Important Discrepancies
 //!
 //! - **Peer Discovery with Identify** In other libp2p implementations, the
-//! [Identify](libp2p_identify::Identify) protocol might be seen as a core protocol. Rust-libp2p
+//! [Identify](https://github.com/libp2p/specs/tree/master/identify) protocol might be seen as a core protocol. Rust-libp2p
 //! tries to stay as generic as possible, and does not make this assumption.
 //! This means that the Identify protocol must be manually hooked up to Kademlia through calls
 //! to [`Kademlia::add_address`].

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -29,11 +29,11 @@
 //! tries to stay as generic as possible, and does not make this assumption.
 //! This means that the Identify protocol must be manually hooked up to Kademlia through calls
 //! to [`Kademlia::add_address`].
-//! If you choose not to implement the Identify protocol, and do not provide an alternative peer
-//! discovery mechanism, your kademlia network will not be resistant against the failure of your
+//! If you choose not to use the Identify protocol, and do not provide an alternative peer
+//! discovery mechanism, a Kademlia node will not discover nodes beyond the network's
 //! [boot nodes](https://docs.libp2p.io/reference/glossary/#boot-node). Without the Identify protocol,
-//! existing nodes in the kademlia network cannot obtain the [Multiaddr](multiaddr::Multiaddr)
-//! of nodes querying them, and thus will not be able to reach out to newer nodes.
+//! existing nodes in the kademlia network cannot obtain the listen addresses
+//! of nodes querying them, and thus will not be able to add them to their routing table.
 
 // TODO: we allow dead_code for now because this library contains a lot of unused code that will
 //       be useful later for record store

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -19,6 +19,23 @@
 // DEALINGS IN THE SOFTWARE.
 
 //! Implementation of the libp2p-specific Kademlia protocol.
+//!
+//! # Overview
+//! Kademlia provides a distributed hash table in which data can be stored. Kademlia can also be
+//! used to store information about peers in a p2p network.
+//!
+//! # Important Discrepancies
+//!
+//! - **Peer Discovery with Identify** In other libp2p implementations, the
+//! [Identify](libp2p_identify::Identify) protocol might be seen as a core protocol. Rust-libp2p
+//! tries to stay as generic as possible, and does not make this assumption.
+//! This means that the Identify protocol must be manually hooked up to Kademlia through calls
+//! to [`Kademlia::add_address`].
+//! If you choose not to implement the Identify protocol, and do not provide an alternative peer
+//! discovery mechanism, your kademlia network will not be resistant against the failure of your
+//! boot nodes. Without the Identify protocol, existing nodes in the kademlia network cannot
+//! obtain the [Multiaddr](multiaddr::Multiaddr) of nodes querying them, and thus will not be
+//! able to reach out to newer nodes.
 
 // TODO: we allow dead_code for now because this library contains a lot of unused code that will
 //       be useful later for record store

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -33,9 +33,9 @@
 //! to [`Kademlia::add_address`].
 //! If you choose not to implement the Identify protocol, and do not provide an alternative peer
 //! discovery mechanism, your kademlia network will not be resistant against the failure of your
-//! boot nodes. Without the Identify protocol, existing nodes in the kademlia network cannot
-//! obtain the [Multiaddr](multiaddr::Multiaddr) of nodes querying them, and thus will not be
-//! able to reach out to newer nodes.
+//! [boot nodes](https://docs.libp2p.io/reference/glossary/#boot-node). Without the Identify protocol,
+//! existing nodes in the kademlia network cannot obtain the [Multiaddr](multiaddr::Multiaddr)
+//! of nodes querying them, and thus will not be able to reach out to newer nodes.
 
 // TODO: we allow dead_code for now because this library contains a lot of unused code that will
 //       be useful later for record store


### PR DESCRIPTION
Draft, waiting on https://github.com/libp2p/docs/pull/128 so I can refer there for an explanation about boot nodes instead of explaining what boot nodes are in multiple places.