### PR TITLE
*: Prepare v0.42.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,13 @@
 
 # `libp2p` facade crate
 
-## Version 0.42.1 [unreleased]
+## Version 0.42.1 [2022-02-02]
 
 - Update individual crates.
   - `libp2p-relay`
+      - [v0.6.1](protocols/relay/CHANGELOG.md#061-2022-02-02)
   - `libp2p-tcp`
+      - [v0.31.1](transports/tcp/CHANGELOG.md#0311-2022-02-02)
 
 ## Version 0.42.0 [2022-01-27]
 

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.6.1 [unreleased]
+# 0.6.1 [2022-02-02]
 
 - Remove empty peer entries in `reservations` `HashMap`. See [PR 2464].
 

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.31.1 [unreleased]
+# 0.31.1 [2022-02-02]
 
 - Call `TcpSocket::take_error` to report connection establishment errors early.
 


### PR DESCRIPTION
With https://github.com/libp2p/rust-libp2p/pull/2458 and https://github.com/libp2p/rust-libp2p/pull/2464 merged, I would like to cut a patch release.

Anything else you would like to see included?