### PR TITLE
core/src/transport/memory: Test parse_memory_addr with PeerId

### DIFF
--- a/core/src/transport/memory.rs
+++ b/core/src/transport/memory.rs
@@ -388,6 +388,22 @@ mod tests {
             parse_memory_addr(&"/memory/1234567890".parse().unwrap()),
             Ok(1_234_567_890)
         );
+        assert_eq!(
+            parse_memory_addr(
+                &"/memory/5/p2p/12D3KooWETLZBFBfkzvH3BQEtA1TJZPmjb4a18ss5TpwNU7DHDX6"
+                    .parse()
+                    .unwrap()
+            ),
+            Ok(5)
+        );
+        assert_eq!(
+            parse_memory_addr(
+                &"/memory/5/p2p/12D3KooWETLZBFBfkzvH3BQEtA1TJZPmjb4a18ss5TpwNU7DHDX6/p2p-circuit/p2p/12D3KooWLiQ7i8sY6LkPvHmEymncicEgzrdpXegbxEr3xgN8oxMU"
+                    .parse()
+                    .unwrap()
+            ),
+            Ok(5)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add some test cases for memory transport with p2p. Mostly adding this so that it is obvious from the tests that these are valid addresses for MemoryTransport.