### PR TITLE
swarm/src/protocols_handler: Document alternative to Event::Close

### DIFF
--- a/swarm/src/protocols_handler.rs
+++ b/swarm/src/protocols_handler.rs
@@ -321,8 +321,8 @@ pub enum ProtocolsHandlerEvent<TConnectionUpgrade, TOutboundOpenInfo, TCustom, T
     ///
     /// Note this will affect all [`ProtocolsHandlerEvent`] handling this
     /// connection, in other words it will close the connection for all
-    /// [`ProtocolHandler`]s. To signal that one has no more need for the
-    /// connection, while allowing other [`ProtocolHandler`]s to continue using
+    /// [`ProtocolsHandler`]s. To signal that one has no more need for the
+    /// connection, while allowing other [`ProtocolsHandler`]s to continue using
     /// the connection, return [`KeepAlive::No`] in
     /// [`ProtocolsHandler::connection_keep_alive`].
     Close(TErr),

--- a/swarm/src/protocols_handler.rs
+++ b/swarm/src/protocols_handler.rs
@@ -319,7 +319,7 @@ pub enum ProtocolsHandlerEvent<TConnectionUpgrade, TOutboundOpenInfo, TCustom, T
 
     /// Close the connection for the given reason.
     ///
-    /// Note this will affect all [`ProtocolsHandlerEvent`] handling this
+    /// Note this will affect all [`ProtocolsHandler`]s handling this
     /// connection, in other words it will close the connection for all
     /// [`ProtocolsHandler`]s. To signal that one has no more need for the
     /// connection, while allowing other [`ProtocolsHandler`]s to continue using

--- a/swarm/src/protocols_handler.rs
+++ b/swarm/src/protocols_handler.rs
@@ -318,6 +318,13 @@ pub enum ProtocolsHandlerEvent<TConnectionUpgrade, TOutboundOpenInfo, TCustom, T
     },
 
     /// Close the connection for the given reason.
+    ///
+    /// Note this will affect all [`ProtocolsHandlerEvent`] handling this
+    /// connection, in other words it will close the connection for all
+    /// [`ProtocolHandler`]s. To signal that one has no more need for the
+    /// connection, while allowing other [`ProtocolHandler`]s to continue using
+    /// the connection, return [`KeepAlive::No`] in
+    /// [`ProtocolsHandler::connection_keep_alive`].
     Close(TErr),
 
     /// Other event.


### PR DESCRIPTION
There are 3 ways to close a connection:

1. `ProtocolsHandlerEvent::Close`
2. `KeepAlive::No` via `ProtocolsHandler::connection_keep_alive`
3. `NetworkBehaviourAction::CloseConnection`

This commit references (2) as an alternative to (1) in the documentation
of (1).

Do you think this is helpful @MarcoPolo?