### PR TITLE
protocols/gossipsub: Emit gossip of all non empty topics

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 - Move from `open-metrics-client` to `prometheus-client` (see [PR 2442]).
 
+- Emit gossip of all non empty topics (see [PR 2481]).
+
 [PR 2442]: https://github.com/libp2p/rust-libp2p/pull/2442
+[PR 2481]: https://github.com/libp2p/rust-libp2p/pull/2481
 
 # 0.35.0 [2022-01-27]
 

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -2508,7 +2508,7 @@ where
         for (topic_hash, peers) in self.mesh.iter().chain(self.fanout.iter()) {
             let mut message_ids = self.mcache.get_gossip_message_ids(topic_hash);
             if message_ids.is_empty() {
-                return;
+                continue;
             }
 
             // if we are emitting more than GossipSubMaxIHaveLength message_ids, truncate the list


### PR DESCRIPTION
tiny censoring bug in gossipsub. When a topic had no messages to gossip about, `emit_gossip` was returning early