### PR TITLE
Add get_address_proto to handle trailing "tls/ws" in multiaddr

### DIFF
--- a/transports/websocket/src/framed.rs
+++ b/transports/websocket/src/framed.rs
@@ -197,7 +197,6 @@ where
                 ListenerEvent::NewAddress(mut a) => {
                     a = a.with(proto.clone());
                     debug!("Listening on {}", a);
-                    println!("Listening on {}", a);
                     ListenerEvent::NewAddress(a)
                 }
                 ListenerEvent::AddressExpired(mut a) => {

--- a/transports/websocket/src/framed.rs
+++ b/transports/websocket/src/framed.rs
@@ -121,11 +121,13 @@ pub(crate) fn get_address_proto(
     use Protocol::{Tls, Ws, Wss};
 
     let (last, next_last) = (addr.pop(), addr.into_iter().last());
+    let err = Err(format!("{} is not a websocket multiaddr", addr));
     match (last, next_last) {
         (Some(p1 @ Wss(_)), Some(p2)) if p2 != Tls => Ok((true, p1, addr)),
-        (Some(Ws(ref s)), Some(Tls)) => Ok((true, Protocol::Wss(s.clone()), addr)),
+        (Some(Ws(ref s)), Some(Tls)) => Ok((true, Wss(s.clone()), addr)),
         (Some(ref p @ Ws(_)), Some(_)) => Ok((false, p.clone(), addr)),
-        (Some(Wss(_)), Some(Tls)) | _ => Err(format!("{} is not a websocket multiaddr", addr)),
+        (Some(Wss(_)), Some(Tls)) => err,
+        _ => err,
     }
 }
 

--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -244,24 +244,24 @@ mod tests {
     }
     #[test]
     fn get_wss_proto_from_wss_addr() {
-        let mut a = "/ip4/127.0.0.1/tcp/0/wss".parse().unwrap();
+        let a = "/ip4/127.0.0.1/tcp/0/wss".parse().unwrap();
         let expect = (true, Protocol::Wss(Cow::Borrowed("/")));
-        let result = framed::WsConfig::<()>::get_address_proto(&mut a).unwrap();
-        assert_eq!(expect, result);
+        let (use_tls, proto, _) = framed::get_address_proto(a).unwrap();
+        assert_eq!(expect, (use_tls, proto));
     }
 
     #[test]
     fn get_wss_proto_from_tls_addr() {
-        let mut a = "/ip4/127.0.0.1/tcp/0/tls/ws".parse().unwrap();
+        let a = "/ip4/127.0.0.1/tcp/0/tls/ws".parse().unwrap();
         let expect = (true, Protocol::Wss(Cow::Borrowed("/")));
-        let result = framed::WsConfig::<()>::get_address_proto(&mut a).unwrap();
-        assert_eq!(expect, result);
+        let (use_tls, proto, _) = framed::get_address_proto(a).unwrap();
+        assert_eq!(expect, (use_tls, proto));
     }
 
     #[test]
     fn err_from_bad_tls_addr() {
-        let mut a = "/ip4/127.0.0.1/tcp/0/tls/wss".parse().unwrap();
-        let result = framed::WsConfig::<()>::get_address_proto(&mut a);
+        let a = "/ip4/127.0.0.1/tcp/0/tls/wss".parse().unwrap();
+        let result = framed::get_address_proto(a);
         assert!(result.is_err());
     }
 

--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -252,10 +252,17 @@ mod tests {
 
     #[test]
     fn get_wss_proto_from_tls_addr() {
-        let mut a = "/ip4/127.0.0.1/tcp/0/tls/wss".parse().unwrap();
+        let mut a = "/ip4/127.0.0.1/tcp/0/tls/ws".parse().unwrap();
         let expect = (true, Protocol::Wss(Cow::Borrowed("/")));
         let result = framed::WsConfig::<()>::get_address_proto(&mut a).unwrap();
         assert_eq!(expect, result);
+    }
+
+    #[test]
+    fn err_from_bad_tls_addr() {
+        let mut a = "/ip4/127.0.0.1/tcp/0/tls/wss".parse().unwrap();
+        let result = framed::WsConfig::<()>::get_address_proto(&mut a);
+        assert!(result.is_err());
     }
 
     async fn connect(listen_addr: Multiaddr) {

--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -219,10 +219,13 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::framed;
     use super::WsConfig;
     use futures::prelude::*;
+
     use libp2p::core::{multiaddr::Protocol, Multiaddr, PeerId, Transport};
     use libp2p::tcp;
+    use std::borrow::Cow;
 
     #[test]
     fn dialer_connects_to_listener_ipv4() {
@@ -239,6 +242,24 @@ mod tests {
     fn new_ws_config() -> WsConfig<tcp::async_io::Transport> {
         WsConfig::new(tcp::async_io::Transport::new(tcp::Config::default()))
     }
+    #[test]
+    fn get_wss_proto_from_wss_addr() {
+        let mut a = "/ip4/127.0.0.1/tcp/0/wss".parse().unwrap();
+        let expect = (true, Protocol::Wss(Cow::Borrowed("/")));
+        let result = framed::WsConfig::<()>::get_address_proto(&mut a).unwrap();
+        assert_eq!(expect, result);
+    }
+
+    #[test]
+    fn get_wss_proto_from_tls_addr() {
+        let mut a = "/ip4/127.0.0.1/tcp/0/tls/wss".parse().unwrap();
+        let expect = (true, Protocol::Wss(Cow::Borrowed("/")));
+        let result = framed::WsConfig::<()>::get_address_proto(&mut a).unwrap();
+        assert_eq!(expect, result);
+    }
+
+    async fn connect(listen_addr: Multiaddr) {
+        let ws_config = WsConfig::new(tcp::TcpConfig::new());
 
     async fn connect(listen_addr: Multiaddr) {
         let mut ws_config = new_ws_config().boxed();


### PR DESCRIPTION
Before returning `Ws` protocol when hitting the last trailing `/ws` in a multiaddr,
check to see if the next path segment is `/tls`. If it is, then return `Wss` instead.
This addresses #2449 the deprecated `/wss` specifier for the new `/tls/ws` in the spec.