### PR TITLE
core/src/: Validate PeerRecord signature matching peer ID

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 - Implement `Display` on `DialError`. See [PR 2456].
 
+- Validate PeerRecord signature matching peer ID. See [RUSTSEC-2022-0009].
+
 [PR 2456]: https://github.com/libp2p/rust-libp2p/pull/2456
+[RUSTSEC-2022-0009]: https://rustsec.org/advisories/RUSTSEC-2022-0009.html
 
 # 0.31.0 [2022-01-27]
 

--- a/core/src/peer_record.rs
+++ b/core/src/peer_record.rs
@@ -36,6 +36,11 @@ impl PeerRecord {
         let record = peer_record_proto::PeerRecord::decode(payload)?;
 
         let peer_id = PeerId::from_bytes(&record.peer_id)?;
+
+        if peer_id != envelope.key.to_peer_id() {
+            return Err(FromEnvelopeError::MismatchedSignature);
+        }
+
         let seq = record.seq;
         let addresses = record
             .addresses
@@ -126,6 +131,8 @@ pub enum FromEnvelopeError {
     InvalidPeerRecord(prost::DecodeError),
     /// Failed to decode the peer ID.
     InvalidPeerId(multihash::Error),
+    /// The signer of the envelope is different than the peer id in the record.
+    MismatchedSignature,
     /// Failed to decode a multi-address.
     InvalidMultiaddr(multiaddr::Error),
 }
@@ -162,6 +169,10 @@ impl fmt::Display for FromEnvelopeError {
                 write!(f, "Failed to decode bytes as PeerRecord")
             }
             Self::InvalidPeerId(_) => write!(f, "Failed to decode bytes as PeerId"),
+            Self::MismatchedSignature => write!(
+                f,
+                "The signer of the envelope is different than the peer id in the record"
+            ),
             Self::InvalidMultiaddr(_) => {
                 write!(f, "Failed to decode bytes as MultiAddress")
             }
@@ -174,6 +185,7 @@ impl std::error::Error for FromEnvelopeError {
         match self {
             Self::InvalidPeerRecord(inner) => Some(inner),
             Self::InvalidPeerId(inner) => Some(inner),
+            Self::MismatchedSignature => None,
             Self::InvalidMultiaddr(inner) => Some(inner),
             Self::BadPayload(inner) => Some(inner),
         }
@@ -195,5 +207,46 @@ mod tests {
         let reconstructed = PeerRecord::from_signed_envelope(envelope).unwrap();
 
         assert_eq!(reconstructed, record)
+    }
+
+    #[test]
+    fn mismatched_signature() {
+        use prost::Message;
+
+        let addr: Multiaddr = HOME.parse().unwrap();
+
+        let envelope = {
+            let identity_a = Keypair::generate_ed25519();
+            let identity_b = Keypair::generate_ed25519();
+
+            let payload = {
+                let record = peer_record_proto::PeerRecord {
+                    peer_id: identity_a.public().to_peer_id().to_bytes(),
+                    seq: 0,
+                    addresses: vec![peer_record_proto::peer_record::AddressInfo {
+                        multiaddr: addr.to_vec(),
+                    }],
+                };
+
+                let mut buf = Vec::with_capacity(record.encoded_len());
+                record
+                    .encode(&mut buf)
+                    .expect("Vec<u8> provides capacity as needed");
+                buf
+            };
+
+            SignedEnvelope::new(
+                identity_b,
+                String::from(DOMAIN_SEP),
+                PAYLOAD_TYPE.as_bytes().to_vec(),
+                payload,
+            )
+            .unwrap()
+        };
+
+        assert!(matches!(
+            PeerRecord::from_signed_envelope(envelope),
+            Err(FromEnvelopeError::MismatchedSignature)
+        ));
     }
 }


### PR DESCRIPTION
This pull request brings the patches of `v0.42.2` and `v0.41.2` back into `master`.

Credit goes to @MarcoPolo for finding the vulnerability.

(Potential) follow up steps:
- Use `thiserror`.
- Revert `pub(crate)` key in `SignedEnvelope`.
- Don't take ownership of `key` in `SignedEnvelope::new`.
- Stress the fact that as a user of `SignedEnvelope` one has to validate that the contained public key is correct. This can e.g. be done by returning both the payload and the public key, or requiring a closure to be passed which does the validation.



