### PR TITLE
Don't take ownership of key in SignedEnvelope::new (#2510)

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -12,9 +12,12 @@
 
 - Validate PeerRecord signature matching peer ID. See [RUSTSEC-2022-0009].
 
+- Don't take ownership of key in `PeerRecord::new` and `SignedEnvelope::new`. See [PR 2516].
+
 [PR 2456]: https://github.com/libp2p/rust-libp2p/pull/2456
 [RUSTSEC-2022-0009]: https://rustsec.org/advisories/RUSTSEC-2022-0009.html
 [PR 2492]: https://github.com/libp2p/rust-libp2p/pull/2492
+[PR 2516]: https://github.com/libp2p/rust-libp2p/pull/2516
 
 # 0.31.0 [2022-01-27]
 

--- a/core/src/peer_record.rs
+++ b/core/src/peer_record.rs
@@ -59,7 +59,7 @@ impl PeerRecord {
     /// Construct a new [`PeerRecord`] by authenticating the provided addresses with the given key.
     ///
     /// This is the same key that is used for authenticating every libp2p connection of your application, i.e. what you use when setting up your [`crate::transport::Transport`].
-    pub fn new(key: Keypair, addresses: Vec<Multiaddr>) -> Result<Self, SigningError> {
+    pub fn new(key: &Keypair, addresses: Vec<Multiaddr>) -> Result<Self, SigningError> {
         use prost::Message;
 
         let seq = SystemTime::now()
@@ -88,7 +88,7 @@ impl PeerRecord {
         };
 
         let envelope = SignedEnvelope::new(
-            key,
+            &key,
             String::from(DOMAIN_SEP),
             PAYLOAD_TYPE.as_bytes().to_vec(),
             payload,
@@ -200,8 +200,9 @@ mod tests {
 
     #[test]
     fn roundtrip_envelope() {
-        let record =
-            PeerRecord::new(Keypair::generate_ed25519(), vec![HOME.parse().unwrap()]).unwrap();
+        let key = Keypair::generate_ed25519();
+
+        let record = PeerRecord::new(&key, vec![HOME.parse().unwrap()]).unwrap();
 
         let envelope = record.to_signed_envelope();
         let reconstructed = PeerRecord::from_signed_envelope(envelope).unwrap();
@@ -236,7 +237,7 @@ mod tests {
             };
 
             SignedEnvelope::new(
-                identity_b,
+                &identity_b,
                 String::from(DOMAIN_SEP),
                 PAYLOAD_TYPE.as_bytes().to_vec(),
                 payload,

--- a/core/src/signed_envelope.rs
+++ b/core/src/signed_envelope.rs
@@ -19,7 +19,7 @@ pub struct SignedEnvelope {
 impl SignedEnvelope {
     /// Constructs a new [`SignedEnvelope`].
     pub fn new(
-        key: Keypair,
+        key: &Keypair,
         domain_separation: String,
         payload_type: Vec<u8>,
         payload: Vec<u8>,
@@ -214,7 +214,7 @@ mod tests {
         let payload_type: Vec<u8> = "payload type".into();
 
         let env = SignedEnvelope::new(
-            kp.clone(),
+            &kp,
             domain_separation.clone(),
             payload_type.clone(),
             payload.into(),

--- a/protocols/rendezvous/src/client.rs
+++ b/protocols/rendezvous/src/client.rs
@@ -234,7 +234,7 @@ impl NetworkBehaviour for Behaviour {
                 ));
             }
 
-            let action = match PeerRecord::new(self.keypair.clone(), external_addresses) {
+            let action = match PeerRecord::new(&self.keypair, external_addresses) {
                 Ok(peer_record) => NetworkBehaviourAction::NotifyHandler {
                     peer_id: rendezvous_node,
                     event: handler::OutboundInEvent::NewSubstream {

--- a/protocols/rendezvous/src/server.rs
+++ b/protocols/rendezvous/src/server.rs
@@ -730,7 +730,7 @@ mod tests {
     ) -> NewRegistration {
         NewRegistration::new(
             Namespace::from_static(namespace),
-            PeerRecord::new(identity, vec!["/ip4/127.0.0.1/tcp/1234".parse().unwrap()]).unwrap(),
+            PeerRecord::new(&identity, vec!["/ip4/127.0.0.1/tcp/1234".parse().unwrap()]).unwrap(),
             ttl,
         )
     }


### PR DESCRIPTION
Fixes issues #2510 

- [x] don't take ownership of key in SignedEnvelope::new
- [x] clarify if we want / should use a ref through all the code instead of making a clone
- [x] don't take ownership of key in PeerContrustor::new