### PR TITLE
swarm/src/lib: Rework connection exports

### DIFF
--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -67,7 +67,10 @@ pub use behaviour::{
     CloseConnection, NetworkBehaviour, NetworkBehaviourAction, NetworkBehaviourEventProcess,
     NotifyHandler, PollParameters,
 };
-pub use connection::{PendingConnectionError, PendingInboundConnectionError};
+pub use connection::{
+    ConnectionCounters, ConnectionError, ConnectionLimit, ConnectionLimits, PendingConnectionError,
+    PendingInboundConnectionError, PendingOutboundConnectionError,
+};
 pub use protocols_handler::{
     IntoProtocolsHandler, IntoProtocolsHandlerSelect, KeepAlive, OneShotHandler,
     OneShotHandlerConfig, ProtocolsHandler, ProtocolsHandlerEvent, ProtocolsHandlerSelect,
@@ -75,13 +78,8 @@ pub use protocols_handler::{
 };
 pub use registry::{AddAddressResult, AddressRecord, AddressScore};
 
-use crate::connection::IncomingInfo;
-use crate::connection::{pool::PoolEvent, ListenersEvent, ListenersStream};
-use connection::pool::{ConnectionCounters, ConnectionLimits, Pool, PoolConfig};
-use connection::{
-    ConnectionError, ConnectionLimit, EstablishedConnection, PendingOutboundConnectionError,
-    Substream,
-};
+use connection::pool::{Pool, PoolConfig, PoolEvent};
+use connection::{EstablishedConnection, IncomingInfo, ListenersEvent, ListenersStream, Substream};
 use dial_opts::{DialOpts, PeerCondition};
 use either::Either;
 use futures::{executor::ThreadPoolBuilder, prelude::*, stream::FusedStream};


### PR DESCRIPTION
Mostly to unblock @dignifiedquire, i.e. to expose `ConnectionLimits`. My bad, bug introduced with https://github.com/libp2p/rust-libp2p/pull/2492.

I am surprised that the compiler didn't catch `ConnectionLimits` not being exposed, given that it is used in the public `SwarmBuilder` method `connection_limits`.

---

For a follow up pull request:

I am not happy with how we do exports in `libp2p-swarm` today, mostly as it does not seem to be consistent and thus not intuitive.

- I like the idea of exposing modules like `behaviour` and  `protocols_handler` as a exports grouping mechanism. Ideally with https://github.com/libp2p/rust-libp2p/discussions/2174, i.e. exposing `libp2p_swarm::behaviour::Action` and not `libp2p_swarm::behaviour::NetworkBehaviourAction`.
- I want to prevent both accidental exposure of private types (e.g. `Pool` should never be exposed) as well as preventing to forget exposing a publicly used type (e.g. `ConnectionLimits`).

Anyone has opinions / suggestions on the above?