### PR TITLE
Optionally use only global IPs for AutoNAT

### DIFF
--- a/protocols/autonat/src/behaviour/as_client.rs
+++ b/protocols/autonat/src/behaviour/as_client.rs
@@ -21,8 +21,8 @@
 use crate::ResponseError;
 
 use super::{
-    Action, AutoNatCodec, Config, DialRequest, DialResponse, Event, HandleInnerEvent, NatStatus,
-    ProbeId,
+    Action, AutoNatCodec, Config, DialRequest, DialResponse, Event, GlobalAddress,
+    HandleInnerEvent, NatStatus, ProbeId,
 };
 use futures::FutureExt;
 use futures_timer::Delay;
@@ -201,6 +201,12 @@ impl<'a> AsClient<'a> {
 
                 let mut addresses: Vec<_> = params.external_addresses().map(|r| r.addr).collect();
                 addresses.extend(params.listened_addresses());
+                if self.config.use_only_global_ips {
+                    addresses = addresses
+                        .into_iter()
+                        .filter(|a| a.contains_global_address())
+                        .collect::<Vec<_>>();
+                };
 
                 let probe_id = self.probe_id.next();
                 let event = match self.do_probe(probe_id, addresses) {

--- a/protocols/autonat/src/lib.rs
+++ b/protocols/autonat/src/lib.rs
@@ -19,6 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 //! Implementation of the AutoNAT protocol.
+#![feature(ip)]
 mod behaviour;
 mod protocol;
 


### PR DESCRIPTION
Fixes #2514.

Beware, this is my first attempt at a pull request. And my first attempt to contribute Rust code to a public project...

This change introduces a config option for AutoNAT that forces it to only consider globally routable IP addresses for NAT probing. The default behavior is unchanged (all addresses are considered), and the restriction to globally routable addresses can be switched on using `use_only_global_ips` option.

This branch is based on v0.42 as that is the libp2p version currently in crates.io. It requires a crate level attribute `#![feature(ip)]` to use the `is_global()` methods of Ipv4Addr and Ipv6Addr.