### PR TITLE
muxers/yamux: Update to yamux v0.10.1-rc.1

### DIFF
--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -15,4 +15,4 @@ futures = "0.3.1"
 libp2p-core = { version = "0.32.0", path = "../../core", default-features = false }
 parking_lot = "0.12"
 thiserror = "1.0"
-yamux = "0.10.0"
+yamux = "0.10.1-rc.1"


### PR DESCRIPTION
The change in the `yamux` `v0.10.1-rc.1` is tricky (see https://github.com/libp2p/rust-yamux/pull/130). I would like it to be tested on a larger deployment before releasing it to the wild.

Anyone has some time to deploy it on their infrastructure? @divagant-martian or @thomaseizinger?

Also @appaquet can you confirm once more that this is fixing all issues on your end?