### PR TITLE
*: Apply clippy suggestions

### DIFF
--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -473,14 +473,9 @@ where
 
     /// Lists all mesh peers for a certain topic hash.
     pub fn mesh_peers(&self, topic_hash: &TopicHash) -> impl Iterator<Item = &PeerId> {
-        self.mesh
-            .get(topic_hash)
-            .into_iter()
-            .map(|x| x.iter())
-            .flatten()
+        self.mesh.get(topic_hash).into_iter().flat_map(|x| x.iter())
     }
 
-    /// Lists all mesh peers for all topics.
     pub fn all_mesh_peers(&self) -> impl Iterator<Item = &PeerId> {
         let mut res = BTreeSet::new();
         for peers in self.mesh.values() {

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -240,8 +240,7 @@ impl NetworkBehaviour for Identify {
         if let Some(entry) = self.discovered_peers.get_mut(peer_id) {
             for addr in failed_addresses
                 .into_iter()
-                .map(|addresses| addresses.into_iter())
-                .flatten()
+                .flat_map(|addresses| addresses.into_iter())
             {
                 entry.remove(addr);
             }

--- a/protocols/relay/src/v1/behaviour.rs
+++ b/protocols/relay/src/v1/behaviour.rs
@@ -189,12 +189,11 @@ impl NetworkBehaviour for Relay {
                     .get(remote_peer_id)
                     .into_iter()
                     .flatten()
-                    .map(
+                    .flat_map(
                         |IncomingRelayReq::DialingDst {
                              incoming_relay_req, ..
                          }| incoming_relay_req.dst_peer().addrs.clone(),
-                    )
-                    .flatten(),
+                    ),
             )
             .collect()
     }

--- a/protocols/relay/src/v1/protocol/outgoing_dst_req.rs
+++ b/protocols/relay/src/v1/protocol/outgoing_dst_req.rs
@@ -110,8 +110,7 @@ impl upgrade::OutboundUpgrade<NegotiatedSubstream> for OutgoingDstReq {
             } = CircuitRelay::decode(msg)?;
 
             match r#type
-                .map(circuit_relay::Type::from_i32)
-                .flatten()
+                .and_then(circuit_relay::Type::from_i32)
                 .ok_or(OutgoingDstReqError::ParseTypeField)?
             {
                 circuit_relay::Type::Status => {}
@@ -126,8 +125,7 @@ impl upgrade::OutboundUpgrade<NegotiatedSubstream> for OutgoingDstReq {
             }
 
             match code
-                .map(circuit_relay::Status::from_i32)
-                .flatten()
+                .and_then(circuit_relay::Status::from_i32)
                 .ok_or(OutgoingDstReqError::ParseStatusField)?
             {
                 circuit_relay::Status::Success => {}

--- a/protocols/relay/src/v1/protocol/outgoing_relay_req.rs
+++ b/protocols/relay/src/v1/protocol/outgoing_relay_req.rs
@@ -120,8 +120,7 @@ impl upgrade::OutboundUpgrade<NegotiatedSubstream> for OutgoingRelayReq {
             } = CircuitRelay::decode(msg)?;
 
             match r#type
-                .map(circuit_relay::Type::from_i32)
-                .flatten()
+                .and_then(circuit_relay::Type::from_i32)
                 .ok_or(OutgoingRelayReqError::ParseTypeField)?
             {
                 circuit_relay::Type::Status => {}
@@ -129,8 +128,7 @@ impl upgrade::OutboundUpgrade<NegotiatedSubstream> for OutgoingRelayReq {
             }
 
             match code
-                .map(circuit_relay::Status::from_i32)
-                .flatten()
+                .and_then(circuit_relay::Status::from_i32)
                 .ok_or(OutgoingRelayReqError::ParseStatusField)?
             {
                 circuit_relay::Status::Success => {}

--- a/protocols/relay/src/v2/relay.rs
+++ b/protocols/relay/src/v2/relay.rs
@@ -437,8 +437,7 @@ impl NetworkBehaviour for Relay {
                 } else if let Some(dst_conn) = self
                     .reservations
                     .get(&inbound_circuit_req.dst())
-                    .map(|cs| cs.iter().next())
-                    .flatten()
+                    .and_then(|cs| cs.iter().next())
                 {
                     // Accept circuit request if reservation present.
                     let circuit_id = self.circuits.insert(Circuit {

--- a/swarm/src/handler/multi.rs
+++ b/swarm/src/handler/multi.rs
@@ -452,8 +452,7 @@ where
         self.upgrades
             .iter()
             .enumerate()
-            .map(|(i, (_, h))| iter::repeat(i).zip(h.protocol_info()))
-            .flatten()
+            .flat_map(|(i, (_, h))| iter::repeat(i).zip(h.protocol_info()))
             .map(|(i, h)| IndexedProtoName(i, h))
             .collect::<Vec<_>>()
             .into_iter()

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1192,16 +1192,16 @@ pub struct SwarmPollParameters<'a> {
 }
 
 impl<'a> PollParameters for SwarmPollParameters<'a> {
-    type SupportedProtocolsIter = std::vec::IntoIter<Vec<u8>>;
-    type ListenedAddressesIter = std::vec::IntoIter<Multiaddr>;
+    type SupportedProtocolsIter = std::iter::Cloned<std::slice::Iter<'a, std::vec::Vec<u8>>>;
+    type ListenedAddressesIter = std::iter::Cloned<std::slice::Iter<'a, Multiaddr>>;
     type ExternalAddressesIter = AddressIntoIter;
 
     fn supported_protocols(&self) -> Self::SupportedProtocolsIter {
-        self.supported_protocols.to_vec().into_iter()
+        self.supported_protocols.iter().cloned()
     }
 
     fn listened_addresses(&self) -> Self::ListenedAddressesIter {
-        self.listened_addrs.to_vec().into_iter()
+        self.listened_addrs.iter().cloned()
     }
 
     fn external_addresses(&self) -> Self::ExternalAddressesIter {


### PR DESCRIPTION
Current `master` fails on clippy stage, see https://github.com/libp2p/rust-libp2p/runs/5338775279?check_suite_focus=true

Apart from the change in `libp2p-swarm` I don't think any of these contain a breaking change. Changelog entries for the breaking change in `libp2p-swarm` are added through https://github.com/libp2p/rust-libp2p/pull/2535.