### PR TITLE
protocols/gossipsub/Cargo.toml: Update to `regex` v1.5.5

### DIFF
--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -26,7 +26,7 @@ base64 = "0.13.0"
 smallvec = "1.6.1"
 prost = "0.9"
 hex_fmt = "0.3.0"
-regex = "1.4.0"
+regex = "1.5.5"
 serde = { version = "1", optional = true, features = ["derive"] }
 wasm-timer = "0.2.5"
 instant = "0.1.11"


### PR DESCRIPTION
See https://rustsec.org/advisories/RUSTSEC-2022-0013