### PR TITLE
Exclude two swarm event from panic in file-sharing example

### DIFF
--- a/examples/file-sharing.rs
+++ b/examples/file-sharing.rs
@@ -499,7 +499,7 @@ mod network {
                         }
                     }
                 }
-                SwarmEvent::IncomingConnectionError { .. } => {},
+                SwarmEvent::IncomingConnectionError { .. } => {}
                 SwarmEvent::Dialing(peer_id) => println!("Dialing {}", peer_id),
                 e => panic!("{:?}", e),
             }

--- a/examples/file-sharing.rs
+++ b/examples/file-sharing.rs
@@ -138,7 +138,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             network_client.respond_file(file_content, channel).await;
                         }
                     }
-                    _ => todo!(),
+                    e => todo!("{:?}", e),
                 }
             }
         }
@@ -498,7 +498,10 @@ mod network {
                             let _ = sender.send(Err(Box::new(error)));
                         }
                     }
-                }
+                },
+                // Exclude these two events from panic to prevent unexpected panic. (Issue #2546) 
+                SwarmEvent::IncomingConnectionError { error, .. } => println!("{}", error),
+                SwarmEvent::Dialing(peer_id) => println!("{}", peer_id),
                 e => panic!("{:?}", e),
             }
         }
@@ -631,6 +634,7 @@ mod network {
         },
     }
 
+    #[derive(Debug)]
     pub enum Event {
         InboundRequest {
             request: String,

--- a/examples/file-sharing.rs
+++ b/examples/file-sharing.rs
@@ -499,9 +499,8 @@ mod network {
                         }
                     }
                 }
-                // Exclude these two events from panic to prevent unexpected panic. (Issue #2546)
-                SwarmEvent::IncomingConnectionError { error, .. } => println!("{}", error),
-                SwarmEvent::Dialing(peer_id) => println!("{}", peer_id),
+                SwarmEvent::IncomingConnectionError { .. } => {},
+                SwarmEvent::Dialing(peer_id) => println!("Dialing {}", peer_id),
                 e => panic!("{:?}", e),
             }
         }

--- a/examples/file-sharing.rs
+++ b/examples/file-sharing.rs
@@ -498,8 +498,8 @@ mod network {
                             let _ = sender.send(Err(Box::new(error)));
                         }
                     }
-                },
-                // Exclude these two events from panic to prevent unexpected panic. (Issue #2546) 
+                }
+                // Exclude these two events from panic to prevent unexpected panic. (Issue #2546)
                 SwarmEvent::IncomingConnectionError { error, .. } => println!("{}", error),
                 SwarmEvent::Dialing(peer_id) => println!("{}", peer_id),
                 e => panic!("{:?}", e),


### PR DESCRIPTION
Related to #2546 