### PR TITLE
Expose Error Types of Relay and DCUtR

### DIFF
--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -1,4 +1,8 @@
 # 0.2.0 [unreleased]
+- Made DCUtR Error Types visibility to public
+  > protocol::inbound::UpgradeError  as InboundUpgradeError
+  
+  > protocol::outbound::UpgradeError as OutboundUpgradeError
 
 - Update to `libp2p-swarm` `v0.35.0`.
 

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.2.0 [unreleased]
-- Made DCUtR Error Types visibility to public
+- Made DCUtR Error Types visibility to public (See PR https://github.com/libp2p/rust-libp2p/pull/2586)
   > protocol::inbound::UpgradeError  as InboundUpgradeError
-  
+  >
   > protocol::outbound::UpgradeError as OutboundUpgradeError
 
 - Update to `libp2p-swarm` `v0.35.0`.

--- a/protocols/dcutr/src/lib.rs
+++ b/protocols/dcutr/src/lib.rs
@@ -25,6 +25,10 @@ pub mod behaviour;
 mod handler;
 mod protocol;
 
+pub use protocol::{
+    inbound::UpgradeError as InboundUpgradeError, outbound::UpgradeError as OutboundUpgradeError,
+};
+
 mod message_proto {
     include!(concat!(env!("OUT_DIR"), "/holepunch.pb.rs"));
 }

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.8.0 [unreleased]
-- Made Relay Error Types visibility to public
+- Made Relay Error Types visibility to public (see PR https://github.com/libp2p/rust-libp2p/pull/2586)
    > inbound_hop::FatalUpgradeError   as InboundHopFatalUpgradeError,
    > 
    > inbound_stop::FatalUpgradeError  as InboundStopFatalUpgradeError,

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,4 +1,12 @@
 # 0.8.0 [unreleased]
+- Made Relay Error Types visibility to public
+   > inbound_hop::FatalUpgradeError   as InboundHopFatalUpgradeError,
+   > 
+   > inbound_stop::FatalUpgradeError  as InboundStopFatalUpgradeError,
+   > 
+   > outbound_hop::FatalUpgradeError  as OutboundHopFatalUpgradeError,
+   > 
+   > outbound_stop::FatalUpgradeError as OutboundStopFatalUpgradeError,
 
 - Update to `libp2p-swarm` `v0.35.0`.
 

--- a/protocols/relay/src/v2.rs
+++ b/protocols/relay/src/v2.rs
@@ -30,6 +30,13 @@ mod copy_future;
 mod protocol;
 pub mod relay;
 
+pub use protocol::{
+    inbound_hop::FatalUpgradeError as InHopUpgradeError,
+    inbound_stop::FatalUpgradeError as InStopUpgradeError,
+    outbound_hop::FatalUpgradeError as OutHopUpgradeError,
+    outbound_stop::FatalUpgradeError as OutStopUpgradeError,
+};
+
 /// The ID of an outgoing / incoming, relay / destination request.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct RequestId(u64);

--- a/protocols/relay/src/v2.rs
+++ b/protocols/relay/src/v2.rs
@@ -31,10 +31,10 @@ mod protocol;
 pub mod relay;
 
 pub use protocol::{
-    inbound_hop::FatalUpgradeError as InHopUpgradeError,
-    inbound_stop::FatalUpgradeError as InStopUpgradeError,
-    outbound_hop::FatalUpgradeError as OutHopUpgradeError,
-    outbound_stop::FatalUpgradeError as OutStopUpgradeError,
+    inbound_hop::FatalUpgradeError as InboundHopFatalUpgradeError,
+    inbound_stop::FatalUpgradeError as InboundStopFatalUpgradeError,
+    outbound_hop::FatalUpgradeError as OutboundHopFatalUpgradeError,
+    outbound_stop::FatalUpgradeError as OutboundStopFatalUpgradeError,
 };
 
 /// The ID of an outgoing / incoming, relay / destination request.


### PR DESCRIPTION
This Exposure is required for passing swarm event to handler methods, instead dealing them at one place.
```
event = swarm1.select_next_some() => {
      match event {
                 event =>  DecentNetworkBehaviour::handle_swarm_event(&mut swarm1, event, &client_config1)
     }
}
```