### PR TITLE
Maintenance: update to clap 3.1 from structopt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ libp2p-gossipsub = { version = "0.37.0", path = "protocols/gossipsub", optional 
 async-std = { version = "1.6.2", features = ["attributes"] }
 async-trait = "0.1"
 env_logger = "0.9.0"
-structopt = "0.3.21"
+clap = {version = "3.1.6", features = ["derive"]}
 tokio = { version = "1.15", features = ["io-util", "io-std", "macros", "rt", "rt-multi-thread"] }
 
 [workspace]

--- a/examples/file-sharing.rs
+++ b/examples/file-sharing.rs
@@ -79,18 +79,18 @@
 
 use async_std::io;
 use async_std::task::spawn;
+use clap::Parser;
 use futures::prelude::*;
 use libp2p::core::{Multiaddr, PeerId};
 use libp2p::multiaddr::Protocol;
 use std::error::Error;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
 #[async_std::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     let (mut network_client, mut network_events, network_event_loop) =
         network::new(opt.secret_key_seed).await?;
@@ -170,33 +170,33 @@ async fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "libp2p file sharing example")]
+#[derive(Parser, Debug)]
+#[clap(name = "libp2p file sharing example")]
 struct Opt {
     /// Fixed value to generate deterministic peer ID.
-    #[structopt(long)]
+    #[clap(long)]
     secret_key_seed: Option<u8>,
 
-    #[structopt(long)]
+    #[clap(long)]
     peer: Option<Multiaddr>,
 
-    #[structopt(long)]
+    #[clap(long)]
     listen_address: Option<Multiaddr>,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     argument: CliArgument,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 enum CliArgument {
     Provide {
-        #[structopt(long)]
+        #[clap(long)]
         path: PathBuf,
-        #[structopt(long)]
+        #[clap(long)]
         name: String,
     },
     Get {
-        #[structopt(long)]
+        #[clap(long)]
         name: String,
     },
 }

--- a/misc/keygen/Cargo.toml
+++ b/misc/keygen/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-structopt = "0.3.26"
+clap = {version = "3.1.6", features = ["derive"]}
 zeroize = "1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"

--- a/misc/keygen/src/main.rs
+++ b/misc/keygen/src/main.rs
@@ -6,34 +6,34 @@ use std::thread;
 
 mod config;
 
+use clap::Parser;
 use libp2p_core::identity::{self, ed25519};
 use libp2p_core::PeerId;
-use structopt::StructOpt;
 use zeroize::Zeroizing;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "libp2p key material generator")]
+#[derive(Debug, Parser)]
+#[clap(name = "libp2p key material generator")]
 struct Args {
     /// JSON formatted output
-    #[structopt(long, global = true)]
+    #[clap(long, global = true)]
     json: bool,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     cmd: Command,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 enum Command {
     /// Read from config file
     From {
         /// Provide a IPFS config file
-        #[structopt(parse(from_os_str))]
+        #[clap(parse(from_os_str))]
         config: PathBuf,
     },
     /// Generate random
     Rand {
         /// The keypair prefix
-        #[structopt(long)]
+        #[clap(long)]
         prefix: Option<String>,
     },
 }
@@ -46,7 +46,7 @@ const ALLOWED_FIRST_BYTE: &[u8] = b"NPQRSTUVWXYZ";
 const ALPHABET: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let args = Args::from_args();
+    let args = Args::parse();
 
     let (local_peer_id, local_keypair) = match args.cmd {
         // Generate keypair from some sort of key material. Currently supporting `IPFS` config file

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -28,7 +28,7 @@ prost = "0.9"
 [dev-dependencies]
 async-std = { version = "1.10", features = ["attributes"] }
 env_logger = "0.9"
-structopt = "0.3"
+clap = {version = "3.1.6", features = ["derive"]}
 
 
 [dev-dependencies.libp2p]

--- a/protocols/autonat/examples/client.rs
+++ b/protocols/autonat/examples/client.rs
@@ -29,6 +29,7 @@
 //! ```
 //! The `listen-port` parameter is optional and allows to set a fixed port at which the local client should listen.
 
+use clap::Parser;
 use futures::prelude::*;
 use libp2p::autonat;
 use libp2p::identify::{Identify, IdentifyConfig, IdentifyEvent};
@@ -38,18 +39,17 @@ use libp2p::{identity, Multiaddr, NetworkBehaviour, PeerId};
 use std::error::Error;
 use std::net::Ipv4Addr;
 use std::time::Duration;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "libp2p autonat")]
+#[derive(Debug, Parser)]
+#[clap(name = "libp2p autonat")]
 struct Opt {
-    #[structopt(long)]
+    #[clap(long)]
     listen_port: Option<u16>,
 
-    #[structopt(long)]
+    #[clap(long)]
     server_address: Multiaddr,
 
-    #[structopt(long)]
+    #[clap(long)]
     server_peer_id: PeerId,
 }
 
@@ -57,7 +57,7 @@ struct Opt {
 async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     let local_key = identity::Keypair::generate_ed25519();
     let local_peer_id = PeerId::from(local_key.public());

--- a/protocols/autonat/examples/server.rs
+++ b/protocols/autonat/examples/server.rs
@@ -26,6 +26,7 @@
 //! ```
 //! The `listen-port` parameter is optional and allows to set a fixed port at which the local peer should listen.
 
+use clap::Parser;
 use futures::prelude::*;
 use libp2p::autonat;
 use libp2p::identify::{Identify, IdentifyConfig, IdentifyEvent};
@@ -34,12 +35,11 @@ use libp2p::swarm::{Swarm, SwarmEvent};
 use libp2p::{identity, Multiaddr, NetworkBehaviour, PeerId};
 use std::error::Error;
 use std::net::Ipv4Addr;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "libp2p autonat")]
+#[derive(Debug, Parser)]
+#[clap(name = "libp2p autonat")]
 struct Opt {
-    #[structopt(long)]
+    #[clap(long)]
     listen_port: Option<u16>,
 }
 
@@ -47,7 +47,7 @@ struct Opt {
 async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     let local_key = identity::Keypair::generate_ed25519();
     let local_peer_id = PeerId::from(local_key.public());

--- a/protocols/dcutr/Cargo.toml
+++ b/protocols/dcutr/Cargo.toml
@@ -36,4 +36,4 @@ libp2p-plaintext = { path = "../../transports/plaintext" }
 libp2p-relay = { path = "../relay" }
 libp2p-yamux = { path = "../../muxers/yamux" }
 rand = "0.7"
-structopt = "0.3.21"
+clap = {version = "3.1.6", features = ["derive"]}

--- a/protocols/dcutr/examples/client.rs
+++ b/protocols/dcutr/examples/client.rs
@@ -18,6 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use clap::Parser;
 use futures::executor::block_on;
 use futures::future::FutureExt;
 use futures::stream::StreamExt;
@@ -39,29 +40,28 @@ use std::convert::TryInto;
 use std::error::Error;
 use std::net::Ipv4Addr;
 use std::str::FromStr;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "libp2p DCUtR client")]
+#[derive(Debug, Parser)]
+#[clap(name = "libp2p DCUtR client")]
 struct Opts {
     /// The mode (client-listen, client-dial).
-    #[structopt(long)]
+    #[clap(long)]
     mode: Mode,
 
     /// Fixed value to generate deterministic peer id.
-    #[structopt(long)]
+    #[clap(long)]
     secret_key_seed: u8,
 
     /// The listening address
-    #[structopt(long)]
+    #[clap(long)]
     relay_address: Multiaddr,
 
     /// Peer ID of the remote peer to hole punch to.
-    #[structopt(long)]
+    #[clap(long)]
     remote_peer_id: Option<PeerId>,
 }
 
-#[derive(Debug, StructOpt, PartialEq)]
+#[derive(Debug, Parser, PartialEq)]
 enum Mode {
     Dial,
     Listen,
@@ -81,7 +81,7 @@ impl FromStr for Mode {
 fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
-    let opts = Opts::from_args();
+    let opts = Opts::parse();
 
     let local_key = generate_ed25519(opts.secret_key_seed);
     let local_peer_id = PeerId::from(local_key.public());

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -41,4 +41,4 @@ libp2p-ping = { path = "../ping" }
 libp2p-plaintext = { path = "../../transports/plaintext" }
 libp2p-yamux = { path = "../../muxers/yamux" }
 quickcheck = "1"
-structopt = "0.3.21"
+clap = {version = "3.1.6", features = ["derive"]}

--- a/protocols/relay/examples/relay_v2.rs
+++ b/protocols/relay/examples/relay_v2.rs
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use clap::Parser;
 use futures::executor::block_on;
 use futures::stream::StreamExt;
 use libp2p::core::upgrade;
@@ -33,12 +34,11 @@ use libp2p::{identity, NetworkBehaviour, PeerId};
 use libp2p::{noise, Multiaddr};
 use std::error::Error;
 use std::net::{Ipv4Addr, Ipv6Addr};
-use structopt::StructOpt;
 
 fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
     println!("opt: {:?}", opt);
 
     // Create a static known PeerId based on given secret
@@ -135,18 +135,18 @@ fn generate_ed25519(secret_key_seed: u8) -> identity::Keypair {
     identity::Keypair::Ed25519(secret_key.into())
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "libp2p relay")]
+#[derive(Debug, Parser)]
+#[clap(name = "libp2p relay")]
 struct Opt {
     /// Determine if the relay listen on ipv6 or ipv4 loopback address. the default is ipv4
-    #[structopt(long)]
+    #[clap(long)]
     use_ipv6: Option<bool>,
 
     /// Fixed value to generate deterministic peer id
-    #[structopt(long)]
+    #[clap(long)]
     secret_key_seed: u8,
 
     /// The port used to listen on all interfaces
-    #[structopt(long)]
+    #[clap(long)]
     port: u16,
 }


### PR DESCRIPTION
structopt is no longer actively maintained, and all features are in clap v3 that is also released. This basically just shortens the dependency tree a bit, since structopt anyway was depending on clap.