### PR TITLE
protocols/{dcutr,relay}: Expose error types

### DIFF
--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -1,10 +1,10 @@
 # 0.2.0 [unreleased]
-- Made DCUtR Error Types visibility to public (See PR https://github.com/libp2p/rust-libp2p/pull/2586)
-  > protocol::inbound::UpgradeError  as InboundUpgradeError
-  >
-  > protocol::outbound::UpgradeError as OutboundUpgradeError
+
+- Expose `InboundUpgradeError` and `OutboundUpgradeError`. See [PR, 2586].
 
 - Update to `libp2p-swarm` `v0.35.0`.
+
+[PR 2586]: https://github.com/libp2p/rust-libp2p/pull/2586
 
 # 0.1.0 [2022-02-22]
 

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -1,4 +1,8 @@
 # 0.2.0 [unreleased]
+- Made DCUtR Error Types visibility to public
+  > protocol::inbound::UpgradeError  as InboundUpgradeError
+  
+  > protocol::outbound::UpgradeError as OutboundUpgradeError
 
 - Update to `libp2p-swarm` `v0.35.0`.
 

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.2.0 [unreleased]
-- Made DCUtR Error Types visibility to public
+- Made DCUtR Error Types visibility to public (See PR https://github.com/libp2p/rust-libp2p/pull/2586)
   > protocol::inbound::UpgradeError  as InboundUpgradeError
-  
+  >
   > protocol::outbound::UpgradeError as OutboundUpgradeError
 
 - Update to `libp2p-swarm` `v0.35.0`.

--- a/protocols/dcutr/src/lib.rs
+++ b/protocols/dcutr/src/lib.rs
@@ -25,6 +25,10 @@ pub mod behaviour;
 mod handler;
 mod protocol;
 
+pub use protocol::{
+    inbound::UpgradeError as InboundUpgradeError, outbound::UpgradeError as OutboundUpgradeError,
+};
+
 mod message_proto {
     include!(concat!(env!("OUT_DIR"), "/holepunch.pb.rs"));
 }

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,16 +1,13 @@
 # 0.8.0 [unreleased]
-- Made Relay Error Types visibility to public (see PR https://github.com/libp2p/rust-libp2p/pull/2586)
-   > inbound_hop::FatalUpgradeError   as InboundHopFatalUpgradeError,
-   > 
-   > inbound_stop::FatalUpgradeError  as InboundStopFatalUpgradeError,
-   > 
-   > outbound_hop::FatalUpgradeError  as OutboundHopFatalUpgradeError,
-   > 
-   > outbound_stop::FatalUpgradeError as OutboundStopFatalUpgradeError,
+
+- Expose `{Inbound,Outbound}{Hop,Stop}UpgradeError`. See [PR 2586].
 
 - Update to `libp2p-swarm` `v0.35.0`.
 
-- Remove support for Circuit Relay v1 protocol.
+- Remove support for Circuit Relay v1 protocol. See [PR 2549].
+
+[PR 2549]: https://github.com/libp2p/rust-libp2p/pull/2549
+[PR 2586]: https://github.com/libp2p/rust-libp2p/pull/2586
 
 # 0.7.0 [2022-02-22]
 
@@ -18,7 +15,7 @@
 
 - Update to `libp2p-swarm` `v0.34.0`.
 
-- Merge NetworkBehaviour's inject_\* paired methods (see PR 2445).
+- Merge NetworkBehaviour's inject_\* paired methods (see [PR 2445]).
 
 [PR 2445]: https://github.com/libp2p/rust-libp2p/pull/2445
 

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.8.0 [unreleased]
-- Made Relay Error Types visibility to public
+- Made Relay Error Types visibility to public (see PR https://github.com/libp2p/rust-libp2p/pull/2586)
    > inbound_hop::FatalUpgradeError   as InboundHopFatalUpgradeError,
    > 
    > inbound_stop::FatalUpgradeError  as InboundStopFatalUpgradeError,

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,4 +1,12 @@
 # 0.8.0 [unreleased]
+- Made Relay Error Types visibility to public
+   > inbound_hop::FatalUpgradeError   as InboundHopFatalUpgradeError,
+   > 
+   > inbound_stop::FatalUpgradeError  as InboundStopFatalUpgradeError,
+   > 
+   > outbound_hop::FatalUpgradeError  as OutboundHopFatalUpgradeError,
+   > 
+   > outbound_stop::FatalUpgradeError as OutboundStopFatalUpgradeError,
 
 - Update to `libp2p-swarm` `v0.35.0`.
 

--- a/protocols/relay/src/v2.rs
+++ b/protocols/relay/src/v2.rs
@@ -30,6 +30,13 @@ mod copy_future;
 mod protocol;
 pub mod relay;
 
+pub use protocol::{
+    inbound_hop::FatalUpgradeError as InHopUpgradeError,
+    inbound_stop::FatalUpgradeError as InStopUpgradeError,
+    outbound_hop::FatalUpgradeError as OutHopUpgradeError,
+    outbound_stop::FatalUpgradeError as OutStopUpgradeError,
+};
+
 /// The ID of an outgoing / incoming, relay / destination request.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct RequestId(u64);

--- a/protocols/relay/src/v2.rs
+++ b/protocols/relay/src/v2.rs
@@ -31,10 +31,10 @@ mod protocol;
 pub mod relay;
 
 pub use protocol::{
-    inbound_hop::FatalUpgradeError as InHopUpgradeError,
-    inbound_stop::FatalUpgradeError as InStopUpgradeError,
-    outbound_hop::FatalUpgradeError as OutHopUpgradeError,
-    outbound_stop::FatalUpgradeError as OutStopUpgradeError,
+    inbound_hop::FatalUpgradeError as InboundHopFatalUpgradeError,
+    inbound_stop::FatalUpgradeError as InboundStopFatalUpgradeError,
+    outbound_hop::FatalUpgradeError as OutboundHopFatalUpgradeError,
+    outbound_stop::FatalUpgradeError as OutboundStopFatalUpgradeError,
 };
 
 /// The ID of an outgoing / incoming, relay / destination request.


### PR DESCRIPTION
Replaces https://github.com/libp2p/rust-libp2p/pull/2586.