### PR TITLE
yamux 0.10.1, set_split_send_size

### DIFF
--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Update to `libp2p-core` `v0.33.0`.
 
+- Update `yamux` to `v0.10.1`.
+
+- Add `set_split_send_size` to `YamuxConfig`
+
 # 0.36.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.

--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -15,4 +15,4 @@ futures = "0.3.1"
 libp2p-core = { version = "0.33.0", path = "../../core", default-features = false }
 parking_lot = "0.12"
 thiserror = "1.0"
-yamux = "0.10.0"
+yamux = "0.10.1"

--- a/muxers/yamux/src/lib.rs
+++ b/muxers/yamux/src/lib.rs
@@ -290,6 +290,13 @@ impl YamuxConfig {
         self
     }
 
+    /// Set the max. payload size used when sending data frames. Payloads larger
+    /// than the configured max. will be split.
+    pub fn set_split_send_size(&mut self, n: usize) -> &mut Self {
+        self.inner.set_split_send_size(n);
+        self
+    }
+
     /// Converts the config into a [`YamuxLocalConfig`] for use with upgrades
     /// of I/O streams that are ![`Send`].
     pub fn into_local(self) -> YamuxLocalConfig {


### PR DESCRIPTION
- Update yamux to 0.10.1
- Add `set_split_send_size` to `YamuxConfig`

As I understand, it affects #2461.

P.S. I'm kinda surprised you don't commit Cargo.lock, is there a reason for that? From my PoV, it makes CI builds unpredictable and generates hard-to-investigate dependency bugs.