### PR TITLE
protocols/ping: Log remote PeerId instead of payload

### DIFF
--- a/protocols/ping/src/lib.rs
+++ b/protocols/ping/src/lib.rs
@@ -120,6 +120,14 @@ impl NetworkBehaviour for Behaviour {
         _: &mut impl PollParameters,
     ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
         if let Some(e) = self.events.pop_back() {
+            let Event { result, peer } = &e;
+
+            match result {
+                Ok(Success::Ping { .. }) => log::debug!("Ping sent to {:?}", peer),
+                Ok(Success::Pong) => log::debug!("Ping received from {:?}", peer),
+                _ => {}
+            }
+
             Poll::Ready(NetworkBehaviourAction::GenerateEvent(e))
         } else {
             Poll::Pending

--- a/protocols/ping/src/protocol.rs
+++ b/protocols/ping/src/protocol.rs
@@ -85,12 +85,10 @@ where
     S: AsyncRead + AsyncWrite + Unpin,
 {
     let payload: [u8; PING_SIZE] = thread_rng().sample(distributions::Standard);
-    log::debug!("Preparing ping payload {:?}", payload);
     stream.write_all(&payload).await?;
     stream.flush().await?;
     let started = Instant::now();
     let mut recv_payload = [0u8; PING_SIZE];
-    log::debug!("Awaiting pong for {:?}", payload);
     stream.read_exact(&mut recv_payload).await?;
     if recv_payload == payload {
         Ok((stream, started.elapsed()))
@@ -108,9 +106,7 @@ where
     S: AsyncRead + AsyncWrite + Unpin,
 {
     let mut payload = [0u8; PING_SIZE];
-    log::debug!("Waiting for ping ...");
     stream.read_exact(&mut payload).await?;
-    log::debug!("Sending pong for {:?}", payload);
     stream.write_all(&payload).await?;
     stream.flush().await?;
     Ok(stream)


### PR DESCRIPTION
In this PR we move Ping logging out of the protocol to the behaviour.

And we also reduce noise by only logging to whom (PeerId) we sent the Ping payload - and from whom we received it,
instead of the payload itself.

it closes #2583 