### PR TITLE
swarm/behaviour: make `either` mod private

### DIFF
--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 - Update to `libp2p-core` `v0.33.0`.
 
+- Make `behaviour::either` module private. See [PR 2610]
+
 [PR 2529]: https://github.com/libp2p/rust-libp2p/pull/2529
+[PR 2610]: https://github.com/libp2p/rust-libp2p/pull/2610/
 
 # 0.35.0
 

--- a/swarm/src/behaviour.rs
+++ b/swarm/src/behaviour.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-pub mod either;
+mod either;
 pub mod toggle;
 
 use crate::dial_opts::DialOpts;


### PR DESCRIPTION
Change the `swarm::behaviour::either` module to be private, since it has no public items: https://docs.rs/libp2p/latest/libp2p/swarm/behaviour/either/index.html.