### PR TITLE
Proposal: Add templates for Issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,8 +5,6 @@ about: Create a bug report for rust-libp2p.
 
 <!-- Thank you for filing a bug report! -->
 
-<!-- For questions please use the rust-libp2p GitHub Discussions forum.-->
-
 <!-- For security related issues please reach out to security@ipfs.io. Please do not file a public issue on GitHub. -->
 
 ## Summary

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,54 @@
+---
+name: Bug Report
+about: Create a bug report for rust-libp2p.
+---
+
+<!-- Thank you for filing a bug report! -->
+
+<!-- For questions please use the rust-libp2p GitHub Discussions forum.-->
+
+<!-- For security related issues please reach out to security@ipfs.io. Please do not file a public issue on GitHub. -->
+
+## Summary
+
+<!--
+Please provide a short summary of the bug, along with any information you feel relevant to replicate the bug.
+-->
+
+## Expected behaviour
+
+<!-- Describe what you expect to happen.-->
+
+## Actual behaviour
+
+<!-- Describe what actually happens.-->
+
+<!--
+Include debug output in the code block by setting `RUST_LOG=debug` in your environment.
+-->
+<details><summary>Debug Output</summary>
+<p>
+
+```
+<output>
+```
+</p>
+</details>
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, or ideas how to implement the addition or change. -->
+
+## Version
+<!--
+Which version of libp2p are you using?
+-->
+
+- libp2p version (version number, commit, or branch):
+
+
+## Would you like to work on fixing this bug?
+
+<!--Any contribution towards fixing the bug is greatly appreciated.
+We are more than happy to provide help on the process.-->
+
+Yes / No / Maybe.

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Libp2p Discourse Forum
+    url:  https://discuss.libp2p.io
+    about: Discussions and questions related to multiple libp2p implementations 

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Question
+    url:  https://github.com/libp2p/rust-libp2p/discussions/new?category=q-a
+    about: Please ask questions in the rust-libp2p GitHub Discussions forum.
   - name: Libp2p Discourse Forum
     url:  https://discuss.libp2p.io
-    about: Discussions and questions related to multiple libp2p implementations 
+    about: Discussions and questions related to multiple libp2p implementations.

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,22 @@
+---
+name: Enhancement
+about: Suggest an improvement to an existing rust-libp2p feature.
+---
+
+## Description
+
+<!-- Describe the enhancement that you are proposing.-->
+
+## Motivation
+
+<!-- Explain why this enhancement is beneficial.-->
+
+## Current Implementation
+
+<!-- Describe the current implementation. -->
+
+## Are you planning to do it yourself in a pull request?
+
+<!--Any contribution is greatly appreciated. We are more than happy to provide help on the process.-->
+
+Yes / No / Maybe.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,34 @@
+---
+name: Feature request
+about: Suggest a new feature in rust-libp2p.
+---
+
+<!--
+Note: If you'd like to suggest an feature related to libp2p but not specifically related to the rust implementation, please file an issue at https://github.com/libp2p/libp2p instead. Even better, create a new topic on the forums (https://discuss.libp2p.io).
+-->
+
+## Description
+
+<!-- Briefly describe the feature that you are requesting.-->
+
+## Motivation
+
+<!-- Explain why this feature is needed.-->
+
+## Requirements
+
+<!-- Write a list of what you want this feature to do.-->
+
+1.
+2.
+3.
+
+## Open questions
+
+<!-- Optional: use this section to ask any questions that are related to the feature.-->
+
+## Are you planning to do it yourself in a pull request?
+
+<!--Any contribution is greatly appreciated. We are more than happy to provide help on the process.-->
+
+Yes / No / Maybe.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,7 @@ about: Suggest a new feature in rust-libp2p.
 ---
 
 <!--
-Note: If you'd like to suggest an feature related to libp2p but not specifically related to the rust implementation, please file an issue at https://github.com/libp2p/libp2p instead. Even better, create a new topic on the forums (https://discuss.libp2p.io).
+Note: If you'd like to suggest an feature related to libp2p but not specifically related to the rust implementation, please file an issue at https://github.com/libp2p/specs instead.
 -->
 
 ## Description

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+# Description
+
+<!-- Please write a summary of your changes and why you made them.-->
+
+## Links to any relevant issues
+
+<!-- Reference any related issues.-->
+
+## Type of change
+
+<!-- Choose a type of change, and delete any options that are not relevant.-->
+
+- [ ] Bug Fix
+- [ ] Enhancement
+- [ ] Feature
+- [ ] Refactor
+- [ ] Documentation Fix
+- [ ] Other:
+
+## Open Questions
+
+<!-- Unresolved questions, if any. -->
+
+## Change checklist
+
+<!-- Please add a Changelog entry in the appropriate packages. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->
+
+- [ ] I have performed a self-review of my own code
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] A changelog entry has been made in the appropriate packages

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,16 +6,6 @@
 
 <!-- Reference any related issues.-->
 
-## Type of change
-
-<!-- Choose a type of change, and delete any options that are not relevant.-->
-
-- [ ] Bug Fix
-- [ ] Enhancement
-- [ ] Feature
-- [ ] Refactor
-- [ ] Documentation Fix
-- [ ] Other:
 
 ## Open Questions
 
@@ -23,9 +13,9 @@
 
 ## Change checklist
 
-<!-- Please add a Changelog entry in the appropriate packages. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->
+<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->
 
 - [ ] I have performed a self-review of my own code
 - [ ] I have made corresponding changes to the documentation
 - [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] A changelog entry has been made in the appropriate packages
+- [ ] A changelog entry has been made in the appropriate crates


### PR DESCRIPTION
This PR drafts a couple of templates for issues and pull-requests. I think these templates would help debugging reported bugs, and ease the reviews (e.g. not having to ask for a Changelog entry every single time 😄).
The templates are mostly copied from what I saw in other projects. I tried to keep them rather short but include all relevant sections. Happy to add more cases or drop individual templates. Also grateful for any suggestions for improvement of the proposed templates.
In case that anybody is opposed to adding templates I am happy to discuss it. 