### PR TITLE
*: Fix clippy warnings

### DIFF
--- a/core/src/identity/rsa.rs
+++ b/core/src/identity/rsa.rs
@@ -263,7 +263,7 @@ impl DerDecodable<'_> for Asn1SubjectPublicKey {
             )));
         }
 
-        let pk_der: Vec<u8> = object.value().into_iter().skip(1).cloned().collect();
+        let pk_der: Vec<u8> = object.value().iter().skip(1).cloned().collect();
         // We don't parse pk_der further as an ASN.1 RsaPublicKey, since
         // we only need the DER encoding for `verify`.
         Ok(Self(PublicKey(pk_der)))

--- a/core/src/peer_id.rs
+++ b/core/src/peer_id.rs
@@ -94,7 +94,7 @@ impl PeerId {
     /// In case the given [`Multiaddr`] ends with `/p2p/<peer-id>`, this function
     /// will return the encapsulated [`PeerId`], otherwise it will return `None`.
     pub fn try_from_multiaddr(address: &Multiaddr) -> Option<PeerId> {
-        address.iter().last().map_or(None, |p| match p {
+        address.iter().last().and_then(|p| match p {
             Protocol::P2p(hash) => PeerId::from_multihash(hash).ok(),
             _ => None,
         })

--- a/core/src/peer_record.rs
+++ b/core/src/peer_record.rs
@@ -89,7 +89,7 @@ impl PeerRecord {
         };
 
         let envelope = SignedEnvelope::new(
-            &key,
+            key,
             String::from(DOMAIN_SEP),
             PAYLOAD_TYPE.as_bytes().to_vec(),
             payload,

--- a/core/src/transport/memory.rs
+++ b/core/src/transport/memory.rs
@@ -358,9 +358,9 @@ impl<T> Sink<T> for Chan<T> {
     }
 }
 
-impl<T: AsRef<[u8]>> Into<RwStreamSink<Chan<T>>> for Chan<T> {
-    fn into(self) -> RwStreamSink<Chan<T>> {
-        RwStreamSink::new(self)
+impl<T: AsRef<[u8]>> From<Chan<T>> for RwStreamSink<Chan<T>> {
+    fn from(channel: Chan<T>) -> RwStreamSink<Chan<T>> {
+        RwStreamSink::new(channel)
     }
 }
 

--- a/muxers/mplex/src/config.rs
+++ b/muxers/mplex/src/config.rs
@@ -21,7 +21,7 @@
 use crate::codec::MAX_FRAME_SIZE;
 use std::cmp;
 
-pub(crate) const DEFAULT_MPLEX_PROTOCOL_NAME: &'static [u8] = b"/mplex/6.7.0";
+pub(crate) const DEFAULT_MPLEX_PROTOCOL_NAME: &[u8] = b"/mplex/6.7.0";
 
 /// Configuration for the multiplexer.
 #[derive(Debug, Clone)]

--- a/muxers/mplex/src/io.rs
+++ b/muxers/mplex/src/io.rs
@@ -810,10 +810,10 @@ where
 
     /// Checks whether a substream is open for reading.
     fn can_read(&self, id: &LocalStreamId) -> bool {
-        match self.substreams.get(id) {
-            Some(SubstreamState::Open { .. }) | Some(SubstreamState::SendClosed { .. }) => true,
-            _ => false,
-        }
+        matches!(
+            self.substreams.get(id),
+            Some(SubstreamState::Open { .. }) | Some(SubstreamState::SendClosed { .. })
+        )
     }
 
     /// Sends pending frames, without flushing.

--- a/muxers/yamux/src/lib.rs
+++ b/muxers/yamux/src/lib.rs
@@ -252,17 +252,19 @@ impl YamuxConfig {
     /// Creates a new `YamuxConfig` in client mode, regardless of whether
     /// it will be used for an inbound or outbound upgrade.
     pub fn client() -> Self {
-        let mut cfg = Self::default();
-        cfg.mode = Some(yamux::Mode::Client);
-        cfg
+        Self {
+            mode: Some(yamux::Mode::Client),
+            ..Default::default()
+        }
     }
 
     /// Creates a new `YamuxConfig` in server mode, regardless of whether
     /// it will be used for an inbound or outbound upgrade.
     pub fn server() -> Self {
-        let mut cfg = Self::default();
-        cfg.mode = Some(yamux::Mode::Server);
-        cfg
+        Self {
+            mode: Some(yamux::Mode::Server),
+            ..Default::default()
+        }
     }
 
     /// Sets the size (in bytes) of the receive window per substream.

--- a/swarm/src/behaviour/either.rs
+++ b/swarm/src/behaviour/either.rs
@@ -227,11 +227,11 @@ where
     ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
         let event = match self {
             Either::Left(behaviour) => futures::ready!(behaviour.poll(cx, params))
-                .map_out(|e| Either::Left(e))
-                .map_handler_and_in(|h| IntoEitherHandler::Left(h), |e| Either::Left(e)),
+                .map_out(Either::Left)
+                .map_handler_and_in(IntoEitherHandler::Left, Either::Left),
             Either::Right(behaviour) => futures::ready!(behaviour.poll(cx, params))
-                .map_out(|e| Either::Right(e))
-                .map_handler_and_in(|h| IntoEitherHandler::Right(h), |e| Either::Right(e)),
+                .map_out(Either::Right)
+                .map_handler_and_in(IntoEitherHandler::Right, Either::Right),
         };
 
         Poll::Ready(event)

--- a/swarm/src/connection/pool/concurrent_dial.rs
+++ b/swarm/src/connection/pool/concurrent_dial.rs
@@ -60,7 +60,7 @@ where
         let mut pending_dials = pending_dials.into_iter();
 
         let dials = FuturesUnordered::new();
-        while let Some(dial) = pending_dials.next() {
+        for dial in pending_dials.by_ref() {
             dials.push(dial);
             if dials.len() == concurrency_factor.get() as usize {
                 break;
@@ -95,7 +95,7 @@ where
         loop {
             match ready!(self.dials.poll_next_unpin(cx)) {
                 Some((addr, Ok(output))) => {
-                    let errors = std::mem::replace(&mut self.errors, vec![]);
+                    let errors = std::mem::take(&mut self.errors);
                     return Poll::Ready(Ok((addr, output, errors)));
                 }
                 Some((addr, Err(e))) => {
@@ -105,7 +105,7 @@ where
                     }
                 }
                 None => {
-                    return Poll::Ready(Err(std::mem::replace(&mut self.errors, vec![])));
+                    return Poll::Ready(Err(std::mem::take(&mut self.errors)));
                 }
             }
         }

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -514,7 +514,7 @@ where
                     };
                     match dial {
                         Ok(fut) => fut
-                            .map(|r| (address, r.map_err(|e| TransportError::Other(e))))
+                            .map(|r| (address, r.map_err(TransportError::Other)))
                             .boxed(),
                         Err(err) => futures::future::ready((address, Err(err))).boxed(),
                     }
@@ -538,7 +538,7 @@ where
             Err((connection_limit, handler)) => {
                 let error = DialError::ConnectionLimit(connection_limit);
                 self.behaviour.inject_dial_failure(None, handler, &error);
-                return Err(error);
+                Err(error)
             }
         }
     }
@@ -800,7 +800,7 @@ where
                         .expect("n + 1 is always non-zero; qed");
                         let non_banned_established = other_established_connection_ids
                             .into_iter()
-                            .filter(|conn_id| !this.banned_peer_connections.contains(&conn_id))
+                            .filter(|conn_id| !this.banned_peer_connections.contains(conn_id))
                             .count();
 
                         log::debug!(
@@ -896,7 +896,7 @@ where
                     if conn_was_reported {
                         let remaining_non_banned = remaining_established_connection_ids
                             .into_iter()
-                            .filter(|conn_id| !this.banned_peer_connections.contains(&conn_id))
+                            .filter(|conn_id| !this.banned_peer_connections.contains(conn_id))
                             .count();
                         this.behaviour.inject_connection_closed(
                             &peer_id,

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -264,12 +264,14 @@ where
             // dialing attempts as soon as there is another fully resolved
             // address.
             while let Some(addr) = unresolved.pop() {
-                if let Some((i, name)) = addr.iter().enumerate().find(|(_, p)| match p {
-                    Protocol::Dns(_)
-                    | Protocol::Dns4(_)
-                    | Protocol::Dns6(_)
-                    | Protocol::Dnsaddr(_) => true,
-                    _ => false,
+                if let Some((i, name)) = addr.iter().enumerate().find(|(_, p)| {
+                    matches!(
+                        p,
+                        Protocol::Dns(_)
+                            | Protocol::Dns4(_)
+                            | Protocol::Dns6(_)
+                            | Protocol::Dnsaddr(_)
+                    )
                 }) {
                     if dns_lookups == MAX_DNS_LOOKUPS {
                         log::debug!("Too many DNS lookups. Dropping unresolved {}.", addr);

--- a/transports/noise/src/protocol/x25519.rs
+++ b/transports/noise/src/protocol/x25519.rs
@@ -180,6 +180,12 @@ impl Keypair<X25519> {
     }
 }
 
+impl Default for Keypair<X25519> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Promote a X25519 secret key into a keypair.
 impl From<SecretKey<X25519>> for Keypair<X25519> {
     fn from(secret: SecretKey<X25519>) -> Keypair<X25519> {

--- a/transports/noise/src/protocol/x25519_spec.rs
+++ b/transports/noise/src/protocol/x25519_spec.rs
@@ -61,6 +61,12 @@ impl Keypair<X25519Spec> {
     }
 }
 
+impl Default for Keypair<X25519Spec> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Promote a X25519 secret key into a keypair.
 impl From<SecretKey<X25519Spec>> for Keypair<X25519Spec> {
     fn from(secret: SecretKey<X25519Spec>) -> Keypair<X25519Spec> {

--- a/transports/tcp/src/lib.rs
+++ b/transports/tcp/src/lib.rs
@@ -328,6 +328,12 @@ where
     }
 }
 
+impl<T: Provider + Send> Default for GenTcpConfig<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> Transport for GenTcpConfig<T>
 where
     T: Provider + Send + 'static,

--- a/transports/uds/src/lib.rs
+++ b/transports/uds/src/lib.rs
@@ -63,6 +63,12 @@ impl $uds_config {
     }
 }
 
+impl Default for $uds_config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Transport for $uds_config {
     type Output = $unix_stream;
     type Error = io::Error;

--- a/transports/wasm-ext/src/lib.rs
+++ b/transports/wasm-ext/src/lib.rs
@@ -318,15 +318,15 @@ impl Stream for Listen {
             };
 
             if let Some(addrs) = event.new_addrs() {
-                for addr in addrs.into_iter() {
-                    let addr = js_value_to_addr(&addr)?;
+                for addr in addrs.iter() {
+                    let addr = js_value_to_addr(addr)?;
                     self.pending_events
                         .push_back(ListenerEvent::NewAddress(addr));
                 }
             }
 
             if let Some(upgrades) = event.new_connections() {
-                for upgrade in upgrades.into_iter().cloned() {
+                for upgrade in upgrades.iter().cloned() {
                     let upgrade: ffi::ConnectionEvent = upgrade.into();
                     self.pending_events.push_back(ListenerEvent::Upgrade {
                         local_addr: upgrade.local_addr().parse()?,
@@ -337,8 +337,8 @@ impl Stream for Listen {
             }
 
             if let Some(addrs) = event.expired_addrs() {
-                for addr in addrs.into_iter() {
-                    match js_value_to_addr(&addr) {
+                for addr in addrs.iter() {
+                    match js_value_to_addr(addr) {
                         Ok(addr) => self
                             .pending_events
                             .push_back(ListenerEvent::NewAddress(addr)),


### PR DESCRIPTION
Hello! After some time tidying up (tried to do something different but I always start with a linter :D ) I noticed you use a custom clippy command. Figured I'll propose some of the changes I made anyway.

Is there a specific reason why many of the lints are disabled? Or do you think it'd be useful to fix the offending pedantic and style issues and disable the suppressions? (complex type may be overkill though)