### PR TITLE
src/tutorials/ping: Fix typo in multiaddress

### DIFF
--- a/src/tutorials/ping.rs
+++ b/src/tutorials/ping.rs
@@ -224,7 +224,7 @@
 //! over time as interfaces become available or unavailable.
 //! For example, in case of our TCP transport it may (among others) listen on the
 //! loopback interface (localhost) `/ip4/127.0.0.1/tcp/24915` as well as the local
-//! network `/ip4/192.168.178.25tcp/24915`.
+//! network `/ip4/192.168.178.25/tcp/24915`.
 //!
 //! In addition, if provided on the CLI, let's instruct our local node to dial a
 //! remote peer.


### PR DESCRIPTION
# Description

Fix a multiaddr typo in tutorial. (I believe it's a typo)

## Links to any relevant issues

<!-- Reference any related issues.-->


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
