### PR TITLE
src/bandwidth: Drop `atomic` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ serde = ["libp2p-core/serde", "libp2p-kad/serde", "libp2p-gossipsub/serde"]
 all-features = true
 
 [dependencies]
-atomic = "0.5.0"
 bytes = "1"
 futures = "0.3.1"
 futures-timer = "3.0.2" # Explicit dependency to be used in `wasm-bindgen` feature

--- a/src/bandwidth.rs
+++ b/src/bandwidth.rs
@@ -26,7 +26,6 @@ use crate::{
     Multiaddr,
 };
 
-use atomic::Atomic;
 use futures::{
     io::{IoSlice, IoSliceMut},
     prelude::*,
@@ -36,7 +35,10 @@ use std::{
     convert::TryFrom as _,
     io,
     pin::Pin,
-    sync::{atomic::Ordering, Arc},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
     task::{Context, Poll},
 };
 
@@ -52,8 +54,8 @@ impl<TInner> BandwidthLogging<TInner> {
     /// Creates a new [`BandwidthLogging`] around the transport.
     pub fn new(inner: TInner) -> (Self, Arc<BandwidthSinks>) {
         let sink = Arc::new(BandwidthSinks {
-            inbound: Atomic::new(0),
-            outbound: Atomic::new(0),
+            inbound: AtomicU64::new(0),
+            outbound: AtomicU64::new(0),
         });
 
         let trans = BandwidthLogging {
@@ -165,8 +167,8 @@ impl<TInner: TryFuture> Future for BandwidthFuture<TInner> {
 
 /// Allows obtaining the average bandwidth of the connections created from a [`BandwidthLogging`].
 pub struct BandwidthSinks {
-    inbound: Atomic<u64>,
-    outbound: Atomic<u64>,
+    inbound: AtomicU64,
+    outbound: AtomicU64,
 }
 
 impl BandwidthSinks {


### PR DESCRIPTION
Replace `atomic::Atomic<u64>` by `std::sync::atomic:AtomicU64`.

The original motivation of using `atomic::Atomic<u64>` instead of
`std`'s version in https://github.com/libp2p/rust-libp2p/pull/1670 was the following:

> I used the atomic crate and an Atomic<u64> because the AtomicU64 type
> isn't available on all architectures. The atomic crate automatically
> falls back to using a Mutex on platforms that don't support AtomicU64.

This argumentation is moot because the crate directly depends on
`libp2p-core` which also uses `AtomicU64`.