### PR TITLE
transports/dns: Remove `Clone` trait bound

### DIFF
--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -175,7 +175,7 @@ where
 
 impl<T, C, P> Transport for GenDnsConfig<T, C, P>
 where
-    T: Transport + Clone + Send + 'static,
+    T: Transport + Send + 'static,
     T::Error: Send,
     T::Dial: Send,
     C: DnsHandle<Error = ResolveError>,
@@ -235,7 +235,7 @@ where
 
 impl<T, C, P> GenDnsConfig<T, C, P>
 where
-    T: Transport + Clone + Send + 'static,
+    T: Transport + Send + 'static,
     T::Error: Send,
     T::Dial: Send,
     C: DnsHandle<Error = ResolveError>,


### PR DESCRIPTION
# Description

Follow on to https://github.com/libp2p/rust-libp2p/pull/2529, otherwise this error gets generated when trying to use it

```rust
let transport = libp2p::tcp::TokioTcpConfig::new().nodelay(true);
let transport = libp2p::websocket::WsConfig::new(transport.clone()).or_transport(transport);
let transport = libp2p::dns::TokioDnsConfig::system(transport).unwrap();

transport.upgrade(core::upgrade::Version::V1Lazy) // < this line fails

```

```
error[E0599]: the method `upgrade` exists for struct `GenDnsConfig<OrTransport<libp2p::libp2p_websocket::WsConfig<GenTcpConfig<libp2p::libp2p_tcp::tokio::Tcp>>, GenTcpConfig<libp2p::libp2p_tcp::tokio::Tcp>>, trust_dns_resolver::name_server::connection_provider::GenericConnection, trust_dns_resolver::name_server::connection_provider::GenericConnectionProvider<trust_dns_resolver::name_server::connection_provider::tokio_runtime::TokioRuntime>>`, but its trait bounds were not satisfied
   --> iroh-p2p/src/service.rs:349:10
    |
349 |           .upgrade(core::upgrade::Version::V1Lazy)
    |            ^^^^^^^ method cannot be called on `GenDnsConfig<OrTransport<libp2p::libp2p_websocket::WsConfig<GenTcpConfig<libp2p::libp2p_tcp::tokio::Tcp>>, GenTcpConfig<libp2p::libp2p_tcp::tokio::Tcp>>, trust_dns_resolver::name_server::connection_provider::GenericConnection, trust_dns_resolver::name_server::connection_provider::GenericConnectionProvider<trust_dns_resolver::name_server::connection_provider::tokio_runtime::TokioRuntime>>` due to unsatisfied trait bounds
    |
   ::: /Users/dignifiedquire/.cargo/git/checkouts/rust-libp2p-98135dbcf5b63918/999a212/core/src/transport/choice.rs:27:1
    |
27  |   pub struct OrTransport<A, B>(A, B);
    |   ----------------------------------- doesn't satisfy `_: Clone`
    |
   ::: /Users/dignifiedquire/.cargo/git/checkouts/rust-libp2p-98135dbcf5b63918/999a212/transports/dns/src/lib.rs:111:1
    |
111 | / pub struct GenDnsConfig<T, C, P>
112 | | where
113 | |     C: DnsHandle<Error = ResolveError>,
114 | |     P: ConnectionProvider<Conn = C>,
...   |
119 | |     resolver: AsyncResolver<C, P>,
120 | | }
    | |_- doesn't satisfy `_: libp2p::Transport`
    |
    = note: the following trait bounds were not satisfied:
            `OrTransport<libp2p::libp2p_websocket::WsConfig<GenTcpConfig<libp2p::libp2p_tcp::tokio::Tcp>>, GenTcpConfig<libp2p::libp2p_tcp::tokio::Tcp>>: Clone`
            which is required by `GenDnsConfig<OrTransport<libp2p::libp2p_websocket::WsConfig<GenTcpConfig<libp2p::libp2p_tcp::tokio::Tcp>>, GenTcpConfig<libp2p::libp2p_tcp::tokio::Tcp>>, trust_dns_resolver::name_server::connection_provider::GenericConnection, trust_dns_resolver::name_server::connection_provider::GenericConnectionProvider<trust_dns_resolver::name_server::connection_provider::tokio_runtime::TokioRuntime>>: libp2p::Transport`
```


## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
