### PR TITLE
protocols/dcutr/examples: Wait to tell relay its public addr

### DIFF
--- a/protocols/dcutr/examples/client.rs
+++ b/protocols/dcutr/examples/client.rs
@@ -186,22 +186,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     });
 
-    match opts.mode {
-        Mode::Dial => {
-            swarm.dial(opts.relay_address.clone()).unwrap();
-        }
-        Mode::Listen => {
-            swarm
-                .listen_on(opts.relay_address.clone().with(Protocol::P2pCircuit))
-                .unwrap();
-        }
-    }
-
-    // Wait till connected to relay to learn external address. In case we are in listening mode,
-    // wait for the relay to accept our reservation request.
+    // Connect to the relay server. Not for the reservation or relayed connection, but to (a) learn
+    // our local public address and (b) enable a freshly started relay to learn its public address.
+    swarm.dial(opts.relay_address.clone()).unwrap();
     block_on(async {
         let mut learned_observed_addr = false;
-        let mut relay_accepted_reservation = false;
+        let mut told_relay_observed_addr = false;
 
         loop {
             match swarm.next().await.unwrap() {
@@ -209,46 +199,62 @@ fn main() -> Result<(), Box<dyn Error>> {
                 SwarmEvent::Dialing { .. } => {}
                 SwarmEvent::ConnectionEstablished { .. } => {}
                 SwarmEvent::Behaviour(Event::Ping(_)) => {}
-                SwarmEvent::Behaviour(Event::Relay(client::Event::ReservationReqAccepted {
-                    ..
-                })) => {
-                    info!("Relay accepted our reservation request.");
-                    relay_accepted_reservation = true
+                SwarmEvent::Behaviour(Event::Identify(IdentifyEvent::Sent { .. })) => {
+                    info!("Told relay its public address.");
+                    told_relay_observed_addr = true;
                 }
-                SwarmEvent::Behaviour(Event::Identify(IdentifyEvent::Sent { .. })) => {}
                 SwarmEvent::Behaviour(Event::Identify(IdentifyEvent::Received {
                     info: IdentifyInfo { observed_addr, .. },
                     ..
                 })) => {
-                    info!("Relay observes us under the address: {:?}", observed_addr);
+                    info!("Relay told us our public address: {:?}", observed_addr);
                     learned_observed_addr = true;
                 }
                 event => panic!("{:?}", event),
             }
 
-            // Check whether we are done.
-
-            if !learned_observed_addr {
-                continue;
+            if learned_observed_addr && told_relay_observed_addr {
+                break;
             }
-
-            if opts.mode == Mode::Listen && !relay_accepted_reservation {
-                continue;
-            }
-
-            break;
         }
     });
 
-    if opts.mode == Mode::Dial {
-        swarm
-            .dial(
-                opts.relay_address
-                    .clone()
-                    .with(Protocol::P2pCircuit)
-                    .with(Protocol::P2p(opts.remote_peer_id.unwrap().into())),
-            )
-            .unwrap();
+    match opts.mode {
+        Mode::Dial => {
+            swarm
+                .dial(
+                    opts.relay_address
+                        .clone()
+                        .with(Protocol::P2pCircuit)
+                        .with(Protocol::P2p(opts.remote_peer_id.unwrap().into())),
+                )
+                .unwrap();
+        }
+        Mode::Listen => {
+            swarm
+                .listen_on(opts.relay_address.clone().with(Protocol::P2pCircuit))
+                .unwrap();
+
+            // Wait for relay to accept reservation request.
+            block_on(async {
+                loop {
+                    match swarm.next().await.unwrap() {
+                        SwarmEvent::NewListenAddr { .. } => {}
+                        SwarmEvent::Dialing { .. } => {}
+                        SwarmEvent::ConnectionEstablished { .. } => {}
+                        SwarmEvent::Behaviour(Event::Ping(_)) => {}
+                        SwarmEvent::Behaviour(Event::Relay(
+                            client::Event::ReservationReqAccepted { .. },
+                        )) => {
+                            info!("Relay accepted our reservation request.");
+                            break;
+                        }
+                        SwarmEvent::Behaviour(Event::Identify(_)) => {}
+                        event => panic!("{:?}", event),
+                    }
+                }
+            });
+        }
     }
 
     block_on(async {

--- a/protocols/dcutr/examples/client.rs
+++ b/protocols/dcutr/examples/client.rs
@@ -232,7 +232,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
         Mode::Listen => {
             swarm
-                .listen_on(opts.relay_address.clone().with(Protocol::P2pCircuit))
+                .listen_on(opts.relay_address.with(Protocol::P2pCircuit))
                 .unwrap();
 
             // Wait for relay to accept reservation request.

--- a/protocols/dcutr/examples/client.rs
+++ b/protocols/dcutr/examples/client.rs
@@ -224,7 +224,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             swarm
                 .dial(
                     opts.relay_address
-                        .clone()
                         .with(Protocol::P2pCircuit)
                         .with(Protocol::P2p(opts.remote_peer_id.unwrap().into())),
                 )

--- a/src/tutorials/hole_punching.rs
+++ b/src/tutorials/hole_punching.rs
@@ -136,8 +136,10 @@
 //! [2022-05-11T10:38:52Z INFO  client] Local peer id: PeerId("XXX")
 //! [2022-05-11T10:38:52Z INFO  client] Listening on "/ip4/127.0.0.1/tcp/44703"
 //! [2022-05-11T10:38:52Z INFO  client] Listening on "/ip4/XXX/tcp/44703"
+//! [2022-05-11T10:38:54Z INFO  client] Relay told us our public address: "/ip4/XXX/tcp/53160"
+//! [2022-05-11T10:38:54Z INFO  client] Told relay its public address.
 //! [2022-05-11T10:38:54Z INFO  client] Relay accepted our reservation request.
-//! [2022-05-11T10:38:54Z INFO  client] Relay observes us under the address: "/ip4/XXX/tcp/53160"
+//! [2022-05-11T10:38:54Z INFO  client] Listening on "/ip4/$RELAY_SERVER_IP/tcp/4001/p2p/12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN/p2p-circuit/p2p/XXX"
 //! ```
 //!
 //! Now let's make sure that the listening client is not public, in other words let's make sure one


### PR DESCRIPTION
# Description

As a listening client, when requesting a reservation with a relay, the relay
responds with its public addresses. The listening client can then use the public
addresses of the relay to advertise itself as reachable under a relayed
address (`/<public-relay-addr>/p2p-circuit/p2p/<listening-client-peer-id>`).

The above operates under the assumption that the relay knows its public address.
A relay learns its public address from remote peers, via the identify protocol.
In the case where the relay just started up, the listening client might be the
very first node to connect to it.

Such scenario allows for a race condition. The listening client requests a
reservation from the relay, while the relay requests its public address from the
listening client. The former needs to contain the response from the latter.

This commit serializes the two requests, making sure, in the case of a freshly
started relay, that the listening client tells the relay its public address
before requesting a reservation from the relay.

<!-- Please write a summary of your changes and why you made them.-->

## Links to any relevant issues

Follow up to https://github.com/libp2p/rust-libp2p/pull/2642. Suggested in https://github.com/libp2p/rust-libp2p/issues/2621#issuecomment-1127963348.

Note that hole punching is still broken due to https://github.com/libp2p/rust-libp2p/issues/2651.

<!-- Reference any related issues.-->


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
