### PR TITLE
core/muxing: Fix `StreamMuxer::Error` to io::Error

### DIFF
--- a/core/src/muxing/singleton.rs
+++ b/core/src/muxing/singleton.rs
@@ -72,12 +72,11 @@ where
 {
     type Substream = Substream;
     type OutboundSubstream = OutboundSubstream;
-    type Error = io::Error;
 
     fn poll_event(
         &self,
         _: &mut Context<'_>,
-    ) -> Poll<Result<StreamMuxerEvent<Self::Substream>, io::Error>> {
+    ) -> Poll<io::Result<StreamMuxerEvent<Self::Substream>>> {
         match self.endpoint {
             Endpoint::Dialer => return Poll::Pending,
             Endpoint::Listener => {}
@@ -149,12 +148,12 @@ where
 
     fn destroy_substream(&self, _: Self::Substream) {}
 
-    fn close(&self, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+    fn close(&self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         // The `StreamMuxer` trait requires that `close()` implies `flush_all()`.
         self.flush_all(cx)
     }
 
-    fn flush_all(&self, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+    fn flush_all(&self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         AsyncWrite::poll_flush(Pin::new(&mut *self.inner.lock()), cx)
     }
 }

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -22,9 +22,10 @@
 
 pub use crate::upgrade::Version;
 
+use crate::muxing::StreamMuxerBox;
 use crate::{
     connection::ConnectedPoint,
-    muxing::{StreamMuxer, StreamMuxerBox},
+    muxing::StreamMuxer,
     transport::{
         and_then::AndThen, boxed::boxed, timeout::TransportTimeout, ListenerEvent, Transport,
         TransportError,

--- a/core/tests/util.rs
+++ b/core/tests/util.rs
@@ -24,9 +24,8 @@ pub enum CloseMuxerState<M> {
 impl<M> Future for CloseMuxer<M>
 where
     M: StreamMuxer,
-    M::Error: From<std::io::Error>,
 {
-    type Output = Result<M, M::Error>;
+    type Output = std::io::Result<M>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         loop {

--- a/muxers/mplex/src/lib.rs
+++ b/muxers/mplex/src/lib.rs
@@ -88,8 +88,6 @@ where
 {
     type Substream = Substream;
     type OutboundSubstream = OutboundSubstream;
-    type Error = io::Error;
-
     fn poll_event(
         &self,
         cx: &mut Context<'_>,

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 0.37.0 [unreleased]
 
 - Update to `libp2p-core` `v0.33.0`.
+- Remove `YamuxError` and `YamuxResult` from public API (see [PR 2664])
+
+[PR 2664]: https://github.com/libp2p/rust-libp2p/pull/2664/
 
 # 0.36.0 [2022-02-22]
 

--- a/muxers/yamux/src/lib.rs
+++ b/muxers/yamux/src/lib.rs
@@ -35,7 +35,6 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use thiserror::Error;
 
 /// A Yamux connection.
 pub struct Yamux<S>(Mutex<Inner<S>>);
@@ -95,26 +94,23 @@ where
     }
 }
 
-pub type YamuxResult<T> = Result<T, YamuxError>;
-
 /// > **Note**: This implementation never emits [`StreamMuxerEvent::AddressChange`] events.
 impl<S> StreamMuxer for Yamux<S>
 where
-    S: Stream<Item = Result<yamux::Stream, YamuxError>> + Unpin,
+    S: Stream<Item = Result<yamux::Stream, yamux::ConnectionError>> + Unpin,
 {
     type Substream = yamux::Stream;
     type OutboundSubstream = OpenSubstreamToken;
-    type Error = YamuxError;
 
     fn poll_event(
         &self,
         c: &mut Context<'_>,
-    ) -> Poll<YamuxResult<StreamMuxerEvent<Self::Substream>>> {
+    ) -> Poll<io::Result<StreamMuxerEvent<Self::Substream>>> {
         let mut inner = self.0.lock();
         match ready!(inner.incoming.poll_next_unpin(c)) {
             Some(Ok(s)) => Poll::Ready(Ok(StreamMuxerEvent::InboundSubstream(s))),
-            Some(Err(e)) => Poll::Ready(Err(e)),
-            None => Poll::Ready(Err(yamux::ConnectionError::Closed.into())),
+            Some(Err(e)) => Poll::Ready(Err(to_io_error(e))),
+            None => Poll::Ready(Err(to_io_error(yamux::ConnectionError::Closed))),
         }
     }
 
@@ -126,11 +122,11 @@ where
         &self,
         c: &mut Context<'_>,
         _: &mut OpenSubstreamToken,
-    ) -> Poll<YamuxResult<Self::Substream>> {
+    ) -> Poll<io::Result<Self::Substream>> {
         let mut inner = self.0.lock();
         Pin::new(&mut inner.control)
             .poll_open_stream(c)
-            .map_err(YamuxError)
+            .map_err(to_io_error)
     }
 
     fn destroy_outbound(&self, _: Self::OutboundSubstream) {
@@ -142,10 +138,8 @@ where
         c: &mut Context<'_>,
         s: &mut Self::Substream,
         b: &mut [u8],
-    ) -> Poll<YamuxResult<usize>> {
-        Pin::new(s)
-            .poll_read(c, b)
-            .map_err(|e| YamuxError(e.into()))
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(s).poll_read(c, b)
     }
 
     fn write_substream(
@@ -153,46 +147,44 @@ where
         c: &mut Context<'_>,
         s: &mut Self::Substream,
         b: &[u8],
-    ) -> Poll<YamuxResult<usize>> {
-        Pin::new(s)
-            .poll_write(c, b)
-            .map_err(|e| YamuxError(e.into()))
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(s).poll_write(c, b)
     }
 
     fn flush_substream(
         &self,
         c: &mut Context<'_>,
         s: &mut Self::Substream,
-    ) -> Poll<YamuxResult<()>> {
-        Pin::new(s).poll_flush(c).map_err(|e| YamuxError(e.into()))
+    ) -> Poll<io::Result<()>> {
+        Pin::new(s).poll_flush(c)
     }
 
     fn shutdown_substream(
         &self,
         c: &mut Context<'_>,
         s: &mut Self::Substream,
-    ) -> Poll<YamuxResult<()>> {
-        Pin::new(s).poll_close(c).map_err(|e| YamuxError(e.into()))
+    ) -> Poll<io::Result<()>> {
+        Pin::new(s).poll_close(c)
     }
 
     fn destroy_substream(&self, _: Self::Substream) {}
 
-    fn close(&self, c: &mut Context<'_>) -> Poll<YamuxResult<()>> {
+    fn close(&self, c: &mut Context<'_>) -> Poll<io::Result<()>> {
         let mut inner = self.0.lock();
         if let std::task::Poll::Ready(x) = Pin::new(&mut inner.control).poll_close(c) {
-            return Poll::Ready(x.map_err(YamuxError));
+            return Poll::Ready(x.map_err(to_io_error));
         }
         while let std::task::Poll::Ready(x) = inner.incoming.poll_next_unpin(c) {
             match x {
                 Some(Ok(_)) => {} // drop inbound stream
-                Some(Err(e)) => return Poll::Ready(Err(e)),
+                Some(Err(e)) => return Poll::Ready(Err(to_io_error(e))),
                 None => return Poll::Ready(Ok(())),
             }
         }
         Poll::Pending
     }
 
-    fn flush_all(&self, _: &mut Context<'_>) -> Poll<YamuxResult<()>> {
+    fn flush_all(&self, _: &mut Context<'_>) -> Poll<io::Result<()>> {
         Poll::Ready(Ok(()))
     }
 }
@@ -385,23 +377,16 @@ where
     }
 }
 
-/// The Yamux [`StreamMuxer`] error type.
-#[derive(Debug, Error)]
-#[error("yamux error: {0}")]
-pub struct YamuxError(#[from] yamux::ConnectionError);
-
-impl From<YamuxError> for io::Error {
-    fn from(err: YamuxError) -> Self {
-        match err.0 {
-            yamux::ConnectionError::Io(e) => e,
-            e => io::Error::new(io::ErrorKind::Other, e),
-        }
+fn to_io_error(e: yamux::ConnectionError) -> io::Error {
+    match e {
+        yamux::ConnectionError::Io(e) => e,
+        e => io::Error::new(io::ErrorKind::Other, e),
     }
 }
 
 /// The [`futures::stream::Stream`] of incoming substreams.
 pub struct Incoming<T> {
-    stream: BoxStream<'static, Result<yamux::Stream, YamuxError>>,
+    stream: BoxStream<'static, Result<yamux::Stream, yamux::ConnectionError>>,
     _marker: std::marker::PhantomData<T>,
 }
 
@@ -413,7 +398,7 @@ impl<T> fmt::Debug for Incoming<T> {
 
 /// The [`futures::stream::Stream`] of incoming substreams (`!Send`).
 pub struct LocalIncoming<T> {
-    stream: LocalBoxStream<'static, Result<yamux::Stream, YamuxError>>,
+    stream: LocalBoxStream<'static, Result<yamux::Stream, yamux::ConnectionError>>,
     _marker: std::marker::PhantomData<T>,
 }
 
@@ -424,7 +409,7 @@ impl<T> fmt::Debug for LocalIncoming<T> {
 }
 
 impl<T> Stream for Incoming<T> {
-    type Item = Result<yamux::Stream, YamuxError>;
+    type Item = Result<yamux::Stream, yamux::ConnectionError>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
@@ -441,7 +426,7 @@ impl<T> Stream for Incoming<T> {
 impl<T> Unpin for Incoming<T> {}
 
 impl<T> Stream for LocalIncoming<T> {
-    type Item = Result<yamux::Stream, YamuxError>;
+    type Item = Result<yamux::Stream, yamux::ConnectionError>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,

--- a/swarm/src/connection/substream.rs
+++ b/swarm/src/connection/substream.rs
@@ -147,7 +147,7 @@ where
             Poll::Ready(Ok(StreamMuxerEvent::AddressChange(addr))) => {
                 return Poll::Ready(Ok(SubstreamEvent::AddressChange(addr)))
             }
-            Poll::Ready(Err(err)) => return Poll::Ready(Err(err.into())),
+            Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
             Poll::Pending => {}
         }
 
@@ -169,7 +169,7 @@ where
                 }
                 Poll::Ready(Err(err)) => {
                     self.inner.destroy_outbound(outbound);
-                    return Poll::Ready(Err(err.into()));
+                    return Poll::Ready(Err(err));
                 }
             }
         }
@@ -214,7 +214,7 @@ where
         match self.muxer.close(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
-            Poll::Ready(Err(err)) => Poll::Ready(Err(err.into())),
+            Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
         }
     }
 }


### PR DESCRIPTION
# Description

We are already enforcing that the associated type must convert to
`io::Error`. We might as well just make all functions return an
`io::Error` directly.

<!-- Please write a summary of your changes and why you made them.-->

## Links to any relevant issues

<!-- Reference any related issues.-->


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
