### PR TITLE
core/muxing: Remove deprecated function

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,9 +1,10 @@
 # 0.33.0 [unreleased]
 
 - Have methods on `Transport` take `&mut self` instead of `self`. See [PR 2529].
-- Remove deprecated function `StreamMuxer::is_remote_acknowledged`
+- Remove deprecated function `StreamMuxer::is_remote_acknowledged`. See [PR 2665].
 
 [PR 2529]: https://github.com/libp2p/rust-libp2p/pull/2529
+[PR 2665]: https://github.com/libp2p/rust-libp2p/pull/2665
 
 # 0.32.1
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.33.0 [unreleased]
 
 - Have methods on `Transport` take `&mut self` instead of `self`. See [PR 2529].
+- Remove deprecated function `StreamMuxer::is_remote_acknowledged`
 
 [PR 2529]: https://github.com/libp2p/rust-libp2p/pull/2529
 

--- a/core/src/muxing.rs
+++ b/core/src/muxing.rs
@@ -203,17 +203,6 @@ pub trait StreamMuxer {
     /// Destroys a substream.
     fn destroy_substream(&self, s: Self::Substream);
 
-    /// Returns `true` if the remote has shown any sign of activity after the muxer has been open.
-    ///
-    /// For optimisation purposes, the connection handshake of libp2p can be very optimistic and is
-    /// allowed to assume that the handshake has succeeded when it didn't in fact succeed. This
-    /// method can be called in order to determine whether the remote has accepted our handshake or
-    /// has potentially not received it yet.
-    #[deprecated(note = "This method is unused and will be removed in the future")]
-    fn is_remote_acknowledged(&self) -> bool {
-        true
-    }
-
     /// Closes this `StreamMuxer`.
     ///
     /// After this has returned `Poll::Ready(Ok(()))`, the muxer has become useless. All


### PR DESCRIPTION
# Description

<!-- Reference any related issues.-->

## Links to any relevant issues

<!-- Reference any related issues.-->

- Extracted out of https://github.com/libp2p/rust-libp2p/pull/2648.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
