### PR TITLE
core/muxing: Rename `close` to `poll_close`

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.33.0 [unreleased]
 
 - Have methods on `Transport` take `&mut self` instead of `self`. See [PR 2529].
+- Rename `StreamMuxer::close` to `StreamMuxer::poll_close`
 
 [PR 2529]: https://github.com/libp2p/rust-libp2p/pull/2529
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,10 +1,11 @@
 # 0.33.0 [unreleased]
 
 - Have methods on `Transport` take `&mut self` instead of `self`. See [PR 2529].
-- Rename `StreamMuxer::close` to `StreamMuxer::poll_close`
+- Rename `StreamMuxer::close` to `StreamMuxer::poll_close`. See [PR 2666].
 - Remove deprecated function `StreamMuxer::is_remote_acknowledged`. See [PR 2665].
 
 [PR 2529]: https://github.com/libp2p/rust-libp2p/pull/2529
+[PR 2666]: https://github.com/libp2p/rust-libp2p/pull/2666
 [PR 2665]: https://github.com/libp2p/rust-libp2p/pull/2665
 
 # 0.32.1

--- a/core/src/either.rs
+++ b/core/src/either.rs
@@ -346,10 +346,10 @@ where
         }
     }
 
-    fn close(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_close(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match self {
-            EitherOutput::First(inner) => inner.close(cx).map_err(|e| e.into()),
-            EitherOutput::Second(inner) => inner.close(cx).map_err(|e| e.into()),
+            EitherOutput::First(inner) => inner.poll_close(cx).map_err(|e| e.into()),
+            EitherOutput::Second(inner) => inner.poll_close(cx).map_err(|e| e.into()),
         }
     }
 

--- a/core/src/muxing.rs
+++ b/core/src/muxing.rs
@@ -226,7 +226,7 @@ pub trait StreamMuxer {
     /// >           that the remote is properly informed of the shutdown. However, apart from
     /// >           properly informing the remote, there is no difference between this and
     /// >           immediately dropping the muxer.
-    fn close(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
+    fn poll_close(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
 
     /// Flush this `StreamMuxer`.
     ///
@@ -617,8 +617,8 @@ impl StreamMuxer for StreamMuxerBox {
     }
 
     #[inline]
-    fn close(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.close(cx)
+    fn poll_close(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_close(cx)
     }
 
     #[inline]
@@ -758,8 +758,8 @@ where
     }
 
     #[inline]
-    fn close(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.close(cx).map_err(|e| e.into())
+    fn poll_close(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_close(cx).map_err(|e| e.into())
     }
 
     #[inline]

--- a/core/src/muxing/singleton.rs
+++ b/core/src/muxing/singleton.rs
@@ -149,7 +149,7 @@ where
 
     fn destroy_substream(&self, _: Self::Substream) {}
 
-    fn close(&self, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+    fn poll_close(&self, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         // The `StreamMuxer` trait requires that `close()` implies `flush_all()`.
         self.flush_all(cx)
     }

--- a/core/tests/util.rs
+++ b/core/tests/util.rs
@@ -32,7 +32,7 @@ where
         loop {
             match std::mem::replace(&mut self.state, CloseMuxerState::Done) {
                 CloseMuxerState::Close(muxer) => {
-                    if !muxer.close(cx)?.is_ready() {
+                    if !muxer.poll_close(cx)?.is_ready() {
                         self.state = CloseMuxerState::Close(muxer);
                         return Poll::Pending;
                     }

--- a/muxers/mplex/src/lib.rs
+++ b/muxers/mplex/src/lib.rs
@@ -169,7 +169,7 @@ where
         self.io.lock().drop_stream(sub.id);
     }
 
-    fn close(&self, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+    fn poll_close(&self, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         self.io.lock().poll_close(cx)
     }
 

--- a/muxers/yamux/src/lib.rs
+++ b/muxers/yamux/src/lib.rs
@@ -177,7 +177,7 @@ where
 
     fn destroy_substream(&self, _: Self::Substream) {}
 
-    fn close(&self, c: &mut Context<'_>) -> Poll<YamuxResult<()>> {
+    fn poll_close(&self, c: &mut Context<'_>) -> Poll<YamuxResult<()>> {
         let mut inner = self.0.lock();
         if let std::task::Poll::Ready(x) = Pin::new(&mut inner.control).poll_close(c) {
             return Poll::Ready(x.map_err(YamuxError));

--- a/swarm/src/connection/pool.rs
+++ b/swarm/src/connection/pool.rs
@@ -686,7 +686,7 @@ where
                     if let Err(error) = error {
                         self.spawn(
                             poll_fn(move |cx| {
-                                if let Err(e) = ready!(muxer.close(cx)) {
+                                if let Err(e) = ready!(muxer.poll_close(cx)) {
                                     log::debug!(
                                         "Failed to close connection {:?} to peer {}: {:?}",
                                         id,

--- a/swarm/src/connection/substream.rs
+++ b/swarm/src/connection/substream.rs
@@ -211,7 +211,7 @@ where
     type Output = Result<(), IoError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match self.muxer.close(cx) {
+        match self.muxer.poll_close(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
             Poll::Ready(Err(err)) => Poll::Ready(Err(err.into())),


### PR DESCRIPTION
# Description

It is common practise to prefix functions that return a `Poll` with
`poll_`.

<!-- Please write a summary of your changes and why you made them.-->

## Links to any relevant issues

<!-- Reference any related issues.-->

- Extracted out of https://github.com/libp2p/rust-libp2p/pull/2648.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
