### PR TITLE
core/transport: Remove various `Sync` bounds

### DIFF
--- a/core/src/transport.rs
+++ b/core/src/transport.rs
@@ -152,7 +152,7 @@ pub trait Transport {
     /// Boxes the transport, including custom transport errors.
     fn boxed(self) -> boxed::Boxed<Self::Output>
     where
-        Self: Transport + Sized + Send + Sync + 'static,
+        Self: Transport + Sized + Send + 'static,
         Self::Dial: Send + 'static,
         Self::Listener: Send + 'static,
         Self::ListenerUpgrade: Send + 'static,

--- a/core/src/transport/boxed.rs
+++ b/core/src/transport/boxed.rs
@@ -26,7 +26,7 @@ use std::{error::Error, fmt, io, pin::Pin};
 /// Creates a new [`Boxed`] transport from the given transport.
 pub fn boxed<T>(transport: T) -> Boxed<T::Output>
 where
-    T: Transport + Send + Sync + 'static,
+    T: Transport + Send + 'static,
     T::Error: Send + Sync,
     T::Dial: Send + 'static,
     T::Listener: Send + 'static,
@@ -41,7 +41,7 @@ where
 /// and `ListenerUpgrade` futures are `Box`ed and only the `Output`
 /// and `Error` types are captured in type variables.
 pub struct Boxed<O> {
-    inner: Box<dyn Abstract<O> + Send + Sync>,
+    inner: Box<dyn Abstract<O> + Send>,
 }
 
 type Dial<O> = Pin<Box<dyn Future<Output = io::Result<O>> + Send>>;

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -294,7 +294,7 @@ impl<T> Multiplexed<T> {
     /// the [`StreamMuxer`] and custom transport errors.
     pub fn boxed<M>(self) -> super::Boxed<(PeerId, StreamMuxerBox)>
     where
-        T: Transport<Output = (PeerId, M)> + Sized + Send + Sync + 'static,
+        T: Transport<Output = (PeerId, M)> + Sized + Send + 'static,
         T::Dial: Send + 'static,
         T::Listener: Send + 'static,
         T::ListenerUpgrade: Send + 'static,


### PR DESCRIPTION
# Description

With `Transport` becoming non-Clone and having `&mut` self receivers,
the `Sync` requirement no longer makes any sense and we can thus
remove it.

<!-- Please write a summary of your changes and why you made them.-->

## Links to any relevant issues

<!-- Reference any related issues.-->
- Extracted out of https://github.com/libp2p/rust-libp2p/pull/2648.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
