### PR TITLE
protocols/rendezvous: Remove unnecessary mapping to `StreamMuxerBox`

### DIFF
--- a/protocols/rendezvous/tests/harness.rs
+++ b/protocols/rendezvous/tests/harness.rs
@@ -57,7 +57,6 @@ where
             MplexConfig::new(),
         ))
         .timeout(Duration::from_secs(5))
-        .map(|(peer, muxer), _| (peer, StreamMuxerBox::new(muxer)))
         .boxed();
 
     SwarmBuilder::new(transport, behaviour_fn(peer_id, identity), peer_id)


### PR DESCRIPTION
# Description

Calling `.boxed()` will already map the muxer in a `StreamMuxer` box.
This mapping is therefore unnecessary.

<!-- Please write a summary of your changes and why you made them.-->

## Links to any relevant issues

- Extracted out of https://github.com/libp2p/rust-libp2p/pull/2648.

<!-- Reference any related issues.-->


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
