### PR TITLE
core/muxing: Remove the `StreamMuxer::flush_all` function

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.33.0 [unreleased]
 
 - Have methods on `Transport` take `&mut self` instead of `self`. See [PR 2529].
+- Remove `StreamMuxer::flush_all`
 
 [PR 2529]: https://github.com/libp2p/rust-libp2p/pull/2529
 

--- a/core/src/either.rs
+++ b/core/src/either.rs
@@ -352,13 +352,6 @@ where
             EitherOutput::Second(inner) => inner.close(cx).map_err(|e| e.into()),
         }
     }
-
-    fn flush_all(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        match self {
-            EitherOutput::First(inner) => inner.flush_all(cx).map_err(|e| e.into()),
-            EitherOutput::Second(inner) => inner.flush_all(cx).map_err(|e| e.into()),
-        }
-    }
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/core/src/muxing.rs
+++ b/core/src/muxing.rs
@@ -227,13 +227,6 @@ pub trait StreamMuxer {
     /// >           properly informing the remote, there is no difference between this and
     /// >           immediately dropping the muxer.
     fn close(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
-
-    /// Flush this `StreamMuxer`.
-    ///
-    /// This drains any write buffers of substreams and delivers any pending shutdown notifications
-    /// due to `shutdown_substream` or `close`. One may thus shutdown groups of substreams
-    /// followed by a final `flush_all` instead of having to do `flush_substream` for each.
-    fn flush_all(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
 }
 
 /// Event about a connection, reported by an implementation of [`StreamMuxer`].
@@ -620,11 +613,6 @@ impl StreamMuxer for StreamMuxerBox {
     fn close(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.close(cx)
     }
-
-    #[inline]
-    fn flush_all(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.flush_all(cx)
-    }
 }
 
 struct Wrap<T>
@@ -760,10 +748,5 @@ where
     #[inline]
     fn close(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.close(cx).map_err(|e| e.into())
-    }
-
-    #[inline]
-    fn flush_all(&self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.flush_all(cx).map_err(|e| e.into())
     }
 }

--- a/core/src/muxing/singleton.rs
+++ b/core/src/muxing/singleton.rs
@@ -149,7 +149,7 @@ where
 
     fn destroy_substream(&self, _: Self::Substream) {}
 
-    fn poll_close(&self, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+    fn poll_close(&self, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         Poll::Ready(Ok(()))
     }
 }

--- a/core/src/muxing/singleton.rs
+++ b/core/src/muxing/singleton.rs
@@ -149,12 +149,7 @@ where
 
     fn destroy_substream(&self, _: Self::Substream) {}
 
-    fn close(&self, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        // The `StreamMuxer` trait requires that `close()` implies `flush_all()`.
-        self.flush_all(cx)
-    }
-
-    fn flush_all(&self, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        AsyncWrite::poll_flush(Pin::new(&mut *self.inner.lock()), cx)
+    fn close(&self, _: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Poll::Ready(Ok(()))
     }
 }

--- a/muxers/mplex/src/lib.rs
+++ b/muxers/mplex/src/lib.rs
@@ -172,10 +172,6 @@ where
     fn close(&self, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         self.io.lock().poll_close(cx)
     }
-
-    fn flush_all(&self, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        self.io.lock().poll_flush(cx)
-    }
 }
 
 /// Active attempt to open an outbound substream.

--- a/muxers/yamux/src/lib.rs
+++ b/muxers/yamux/src/lib.rs
@@ -191,10 +191,6 @@ where
         }
         Poll::Pending
     }
-
-    fn flush_all(&self, _: &mut Context<'_>) -> Poll<YamuxResult<()>> {
-        Poll::Ready(Ok(()))
-    }
 }
 
 /// The yamux configuration.


### PR DESCRIPTION
# Description

`libp2p-core` provides the `StreamMuxer` abstraction so it can provide
functionality that abstracts over this trait.

We never use the `flush_all` function as part of our abstractions.
No one else is going to use it so we can remove it from the abstraction.

<!-- Please write a summary of your changes and why you made them.-->

## Links to any relevant issues

- Extracted out of https://github.com/libp2p/rust-libp2p/pull/2648.

<!-- Reference any related issues.-->


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
