### PR TITLE
Refactor `Yamux::close` to use `?`

### DIFF
--- a/muxers/yamux/src/lib.rs
+++ b/muxers/yamux/src/lib.rs
@@ -31,7 +31,7 @@ use libp2p_core::muxing::{StreamMuxer, StreamMuxerEvent};
 use libp2p_core::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use parking_lot::Mutex;
 use std::{
-    fmt, io, iter,
+    fmt, io, iter, mem,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -187,11 +187,9 @@ where
             return Poll::Ready(Ok(()));
         }
 
-        while let Poll::Ready(_inbound_stream) =
-            inner.incoming.poll_next_unpin(c)?
-        {
-            match _inbound_stream {
-                Some(_) => {} // drop inbound stream
+        while let Poll::Ready(maybe_inbound_stream) = inner.incoming.poll_next_unpin(c)? {
+            match maybe_inbound_stream {
+                Some(inbound_stream) => mem::drop(inbound_stream),
                 None => return Poll::Ready(Ok(())),
             }
         }


### PR DESCRIPTION
# Description

(Hopefully) improves readability of the implementation due to reduced noise.

## Links to any relevant issues

Extracted out of https://github.com/libp2p/rust-libp2p/pull/2648.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
