### PR TITLE
protocols/dcutr/examples: Set libp2p-ping to keep conn alive

### DIFF
--- a/protocols/dcutr/examples/client.rs
+++ b/protocols/dcutr/examples/client.rs
@@ -145,7 +145,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let behaviour = Behaviour {
         relay_client: client,
-        ping: Ping::new(PingConfig::new()),
+        ping: Ping::new(PingConfig::new().with_keep_alive(true)),
         identify: Identify::new(IdentifyConfig::new(
             "/TODO/0.0.1".to_string(),
             local_key.public(),


### PR DESCRIPTION
# Description

The example is for testing out the hole punching capabilities only. Thus best to
remove the complexity of connection keep alives via the ping protocol.



<!-- Please write a summary of your changes and why you made them.-->

## Links to any relevant issues

Might make https://github.com/libp2p/rust-libp2p/issues/2609#issuecomment-1135270283 easier to debug. //CC @T2JOESl4m2ZpNC


## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
