### PR TITLE
protocols/request-response: close io after reading response

### DIFF
--- a/protocols/request-response/src/handler/protocol.rs
+++ b/protocols/request-response/src/handler/protocol.rs
@@ -179,9 +179,9 @@ where
         async move {
             let write = self.codec.write_request(&protocol, &mut io, self.request);
             write.await?;
-            io.close().await?;
             let read = self.codec.read_response(&protocol, &mut io);
             let response = read.await?;
+            io.close().await?;
             Ok(response)
         }
         .boxed()


### PR DESCRIPTION
Otherwise `read_response` will be always failing.

# Description

This PR fixes an issue (unless this is not a bug, but a feature 😆) with `OutboundUpgrade` for `RequestProtocol` where IO was closed before reading the response. Note this is different from `inbound_upgrade` above where IO is closed after the response is written (i.e. after we're done with IO).

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
