### PR TITLE
core/either: Use `io::Result` type alias instead of renaming io::Error

### DIFF
--- a/core/src/either.rs
+++ b/core/src/either.rs
@@ -28,7 +28,7 @@ use futures::{
     prelude::*,
 };
 use pin_project::pin_project;
-use std::{fmt, io::Error as IoError, pin::Pin, task::Context, task::Poll};
+use std::{fmt, io, pin::Pin, task::Context, task::Poll};
 
 #[derive(Debug, Copy, Clone)]
 pub enum EitherError<A, B> {
@@ -80,7 +80,7 @@ where
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut [u8],
-    ) -> Poll<Result<usize, IoError>> {
+    ) -> Poll<io::Result<usize>> {
         match self.project() {
             EitherOutputProj::First(a) => AsyncRead::poll_read(a, cx, buf),
             EitherOutputProj::Second(b) => AsyncRead::poll_read(b, cx, buf),
@@ -91,7 +91,7 @@ where
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         bufs: &mut [IoSliceMut<'_>],
-    ) -> Poll<Result<usize, IoError>> {
+    ) -> Poll<io::Result<usize>> {
         match self.project() {
             EitherOutputProj::First(a) => AsyncRead::poll_read_vectored(a, cx, bufs),
             EitherOutputProj::Second(b) => AsyncRead::poll_read_vectored(b, cx, bufs),
@@ -108,7 +108,7 @@ where
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
-    ) -> Poll<Result<usize, IoError>> {
+    ) -> Poll<io::Result<usize>> {
         match self.project() {
             EitherOutputProj::First(a) => AsyncWrite::poll_write(a, cx, buf),
             EitherOutputProj::Second(b) => AsyncWrite::poll_write(b, cx, buf),
@@ -119,21 +119,21 @@ where
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         bufs: &[IoSlice<'_>],
-    ) -> Poll<Result<usize, IoError>> {
+    ) -> Poll<io::Result<usize>> {
         match self.project() {
             EitherOutputProj::First(a) => AsyncWrite::poll_write_vectored(a, cx, bufs),
             EitherOutputProj::Second(b) => AsyncWrite::poll_write_vectored(b, cx, bufs),
         }
     }
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), IoError>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         match self.project() {
             EitherOutputProj::First(a) => AsyncWrite::poll_flush(a, cx),
             EitherOutputProj::Second(b) => AsyncWrite::poll_flush(b, cx),
         }
     }
 
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), IoError>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         match self.project() {
             EitherOutputProj::First(a) => AsyncWrite::poll_close(a, cx),
             EitherOutputProj::Second(b) => AsyncWrite::poll_close(b, cx),
@@ -203,7 +203,7 @@ where
 {
     type Substream = EitherOutput<A::Substream, B::Substream>;
     type OutboundSubstream = EitherOutbound<A, B>;
-    type Error = IoError;
+    type Error = io::Error;
 
     fn poll_event(
         &self,


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

Using the type alias is more idiomatic because it avoids renaming types on import.

## Links to any relevant issues

<!-- Reference any related issues.-->


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
