### PR TITLE
muxers/mplex/benches: Use combinators to reduce nesting

### DIFF
--- a/muxers/mplex/benches/split_send_size.rs
+++ b/muxers/mplex/benches/split_send_size.rs
@@ -104,26 +104,24 @@ fn run(transport: &mut BenchTransport, payload: &Vec<u8>, listen_addr: &Multiadd
                 }
                 transport::ListenerEvent::Upgrade { upgrade, .. } => {
                     let (_peer, conn) = upgrade.await.unwrap();
-                    match poll_fn(|cx| conn.poll_event(cx)).await {
-                        Ok(muxing::StreamMuxerEvent::InboundSubstream(mut s)) => {
-                            let mut buf = vec![0u8; payload_len];
-                            let mut off = 0;
-                            loop {
-                                // Read in typical chunk sizes of up to 8KiB.
-                                let end = off + std::cmp::min(buf.len() - off, 8 * 1024);
-                                let n = poll_fn(|cx| {
-                                    conn.read_substream(cx, &mut s, &mut buf[off..end])
-                                })
-                                .await
-                                .unwrap();
-                                off += n;
-                                if off == buf.len() {
-                                    return;
-                                }
-                            }
+                    let mut s = poll_fn(|cx| conn.poll_event(cx))
+                        .await
+                        .expect("unexpected error")
+                        .into_inbound_substream()
+                        .expect("Unexpected muxer event");
+
+                    let mut buf = vec![0u8; payload_len];
+                    let mut off = 0;
+                    loop {
+                        // Read in typical chunk sizes of up to 8KiB.
+                        let end = off + std::cmp::min(buf.len() - off, 8 * 1024);
+                        let n = poll_fn(|cx| conn.read_substream(cx, &mut s, &mut buf[off..end]))
+                            .await
+                            .unwrap();
+                        off += n;
+                        if off == buf.len() {
+                            return;
                         }
-                        Ok(_) => panic!("Unexpected muxer event"),
-                        Err(e) => panic!("Unexpected error: {:?}", e),
                     }
                 }
                 _ => panic!("Unexpected listener event"),


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

Instead of matching on the result, we can use combinators to directly
extract the substream from the event.

## Links to any relevant issues

<!-- Reference any related issues.-->

Will make the diff in https://github.com/libp2p/rust-libp2p/pull/2648 smaller.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
