### PR TITLE
core/muxing: Replace `Into<io::Error>` bound on `StreamMuxer` with `std::error::Error`

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Introduce `StreamMuxerEvent::map_inbound_stream`. See [PR 2691].
 - Remove `{read,write,flush,shutdown,destroy}_substream` functions from `StreamMuxer` trait
   in favor of forcing `StreamMuxer::Substream` to implement `AsyncRead + AsyncWrite`. See [PR 2707].
-- Remove `Into<std::io::Error>` bound from `StreamMuxer::Error`. See [PR 2710].
+- Replace `Into<std::io::Error>` bound on `StreamMuxer::Error` with `std::error::Error`. See [PR 2710].
 
 [PR 2691]: https://github.com/libp2p/rust-libp2p/pull/2691
 [PR 2707]: https://github.com/libp2p/rust-libp2p/pull/2707

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -3,11 +3,11 @@
 - Introduce `StreamMuxerEvent::map_inbound_stream`. See [PR 2691].
 - Remove `{read,write,flush,shutdown,destroy}_substream` functions from `StreamMuxer` trait
   in favor of forcing `StreamMuxer::Substream` to implement `AsyncRead + AsyncWrite`. See [PR 2707].
-- Remove `Into<std::io::Error>` bound from `StreamMuxer::Error`. See [PR XXXX].
+- Remove `Into<std::io::Error>` bound from `StreamMuxer::Error`. See [PR 2710].
 
 [PR 2691]: https://github.com/libp2p/rust-libp2p/pull/2691
 [PR 2707]: https://github.com/libp2p/rust-libp2p/pull/2707
-[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
+[PR 2710]: https://github.com/libp2p/rust-libp2p/pull/2710
 
 # 0.33.0
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -3,9 +3,11 @@
 - Introduce `StreamMuxerEvent::map_inbound_stream`. See [PR 2691].
 - Remove `{read,write,flush,shutdown,destroy}_substream` functions from `StreamMuxer` trait
   in favor of forcing `StreamMuxer::Substream` to implement `AsyncRead + AsyncWrite`. See [PR 2707].
+- Remove `Into<std::io::Error>` bound from `StreamMuxer::Error`. See [PR XXXX].
 
 [PR 2691]: https://github.com/libp2p/rust-libp2p/pull/2691
 [PR 2707]: https://github.com/libp2p/rust-libp2p/pull/2707
+[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
 
 # 0.33.0
 

--- a/core/src/muxing.rs
+++ b/core/src/muxing.rs
@@ -75,7 +75,7 @@ pub trait StreamMuxer {
     type OutboundSubstream;
 
     /// Error type of the muxer
-    type Error: std::error::Error + Send + Sync + 'static;
+    type Error: std::error::Error;
 
     /// Polls for a connection-wide event.
     ///

--- a/core/src/muxing.rs
+++ b/core/src/muxing.rs
@@ -75,7 +75,7 @@ pub trait StreamMuxer {
     type OutboundSubstream;
 
     /// Error type of the muxer
-    type Error;
+    type Error: std::error::Error + Send + Sync + 'static;
 
     /// Polls for a connection-wide event.
     ///

--- a/core/src/muxing.rs
+++ b/core/src/muxing.rs
@@ -52,7 +52,6 @@
 
 use futures::{task::Context, task::Poll, AsyncRead, AsyncWrite};
 use multiaddr::Multiaddr;
-use std::io;
 
 pub use self::boxed::StreamMuxerBox;
 pub use self::boxed::SubstreamBox;
@@ -76,7 +75,7 @@ pub trait StreamMuxer {
     type OutboundSubstream;
 
     /// Error type of the muxer
-    type Error: Into<io::Error>;
+    type Error;
 
     /// Polls for a connection-wide event.
     ///

--- a/core/src/muxing/boxed.rs
+++ b/core/src/muxing/boxed.rs
@@ -39,6 +39,7 @@ impl<T> StreamMuxer for Wrap<T>
 where
     T: StreamMuxer,
     T::Substream: Send + Unpin + 'static,
+    T::Error: Send + Sync + 'static,
 {
     type Substream = SubstreamBox;
     type OutboundSubstream = usize; // TODO: use a newtype
@@ -111,6 +112,7 @@ impl StreamMuxerBox {
         T: StreamMuxer + Send + Sync + 'static,
         T::OutboundSubstream: Send,
         T::Substream: Send + Unpin + 'static,
+        T::Error: Send + Sync + 'static,
     {
         let wrap = Wrap {
             inner: muxer,

--- a/core/src/muxing/boxed.rs
+++ b/core/src/muxing/boxed.rs
@@ -50,16 +50,10 @@ where
         &self,
         cx: &mut Context<'_>,
     ) -> Poll<Result<StreamMuxerEvent<Self::Substream>, Self::Error>> {
-        let event = ready!(self.inner.poll_event(cx).map_err(into_io_error)?);
+        let event = ready!(self.inner.poll_event(cx).map_err(into_io_error)?)
+            .map_inbound_stream(SubstreamBox::new);
 
-        match event {
-            StreamMuxerEvent::AddressChange(a) => {
-                Poll::Ready(Ok(StreamMuxerEvent::AddressChange(a)))
-            }
-            StreamMuxerEvent::InboundSubstream(s) => {
-                Poll::Ready(Ok(StreamMuxerEvent::InboundSubstream(SubstreamBox::new(s))))
-            }
-        }
+        Poll::Ready(Ok(event))
     }
 
     #[inline]

--- a/core/src/muxing/boxed.rs
+++ b/core/src/muxing/boxed.rs
@@ -39,7 +39,6 @@ impl<T> StreamMuxer for Wrap<T>
 where
     T: StreamMuxer,
     T::Substream: Send + Unpin + 'static,
-    T::Error: Into<Box<dyn Error + Send + Sync>>,
 {
     type Substream = SubstreamBox;
     type OutboundSubstream = usize; // TODO: use a newtype
@@ -100,7 +99,7 @@ where
 
 fn into_io_error<E>(err: E) -> io::Error
 where
-    E: Into<Box<dyn Error + Send + Sync>>,
+    E: Error + Send + Sync + 'static,
 {
     io::Error::new(io::ErrorKind::Other, err)
 }
@@ -112,7 +111,6 @@ impl StreamMuxerBox {
         T: StreamMuxer + Send + Sync + 'static,
         T::OutboundSubstream: Send,
         T::Substream: Send + Unpin + 'static,
-        T::Error: Into<Box<dyn Error + Send + Sync>>,
     {
         let wrap = Wrap {
             inner: muxer,

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -302,6 +302,7 @@ impl<T> Multiplexed<T> {
         M: StreamMuxer + Send + Sync + 'static,
         M::Substream: Send + Unpin + 'static,
         M::OutboundSubstream: Send + 'static,
+        M::Error: Send + Sync + 'static,
     {
         boxed(self.map(|(i, m), _| (i, StreamMuxerBox::new(m))))
     }

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -302,6 +302,7 @@ impl<T> Multiplexed<T> {
         M: StreamMuxer + Send + Sync + 'static,
         M::Substream: Send + Unpin + 'static,
         M::OutboundSubstream: Send + 'static,
+        M::Error: Into<Box<dyn Error + Send + Sync>>,
     {
         boxed(self.map(|(i, m), _| (i, StreamMuxerBox::new(m))))
     }

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -302,7 +302,6 @@ impl<T> Multiplexed<T> {
         M: StreamMuxer + Send + Sync + 'static,
         M::Substream: Send + Unpin + 'static,
         M::OutboundSubstream: Send + 'static,
-        M::Error: Into<Box<dyn Error + Send + Sync>>,
     {
         boxed(self.map(|(i, m), _| (i, StreamMuxerBox::new(m))))
     }

--- a/swarm/src/connection.rs
+++ b/swarm/src/connection.rs
@@ -137,40 +137,38 @@ where
     ) -> Poll<Result<Event<THandler::OutEvent>, ConnectionError<THandler::Error>>> {
         loop {
             // Poll the handler for new events.
-            match self.handler.poll(cx) {
+            match self.handler.poll(cx)? {
                 Poll::Pending => {}
-                Poll::Ready(Ok(handler_wrapper::Event::OutboundSubstreamRequest(user_data))) => {
+                Poll::Ready(handler_wrapper::Event::OutboundSubstreamRequest(user_data)) => {
                     self.muxing.open_substream(user_data);
                     continue;
                 }
-                Poll::Ready(Ok(handler_wrapper::Event::Custom(event))) => {
+                Poll::Ready(handler_wrapper::Event::Custom(event)) => {
                     return Poll::Ready(Ok(Event::Handler(event)));
                 }
-                Poll::Ready(Err(err)) => return Poll::Ready(Err(err.into())),
             }
 
             // Perform I/O on the connection through the muxer, informing the handler
             // of new substreams.
-            match self.muxing.poll(cx) {
+            match self.muxing.poll(cx)? {
                 Poll::Pending => {}
-                Poll::Ready(Ok(SubstreamEvent::InboundSubstream { substream })) => {
+                Poll::Ready(SubstreamEvent::InboundSubstream { substream }) => {
                     self.handler
                         .inject_substream(substream, SubstreamEndpoint::Listener);
                     continue;
                 }
-                Poll::Ready(Ok(SubstreamEvent::OutboundSubstream {
+                Poll::Ready(SubstreamEvent::OutboundSubstream {
                     user_data,
                     substream,
-                })) => {
+                }) => {
                     let endpoint = SubstreamEndpoint::Dialer(user_data);
                     self.handler.inject_substream(substream, endpoint);
                     continue;
                 }
-                Poll::Ready(Ok(SubstreamEvent::AddressChange(address))) => {
+                Poll::Ready(SubstreamEvent::AddressChange(address)) => {
                     self.handler.inject_address_change(&address);
                     return Poll::Ready(Ok(Event::AddressChange(address)));
                 }
-                Poll::Ready(Err(err)) => return Poll::Ready(Err(ConnectionError::IO(err))),
             }
 
             return Poll::Pending;

--- a/swarm/src/connection/error.rs
+++ b/swarm/src/connection/error.rs
@@ -75,6 +75,12 @@ impl<THandlerErr> From<handler_wrapper::Error<THandlerErr>> for ConnectionError<
     }
 }
 
+impl<THandlerErr> From<io::Error> for ConnectionError<THandlerErr> {
+    fn from(error: io::Error) -> Self {
+        ConnectionError::IO(error)
+    }
+}
+
 /// Errors that can occur in the context of a pending outgoing `Connection`.
 ///
 /// Note: Addresses for an outbound connection are dialed in parallel. Thus, compared to


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

This allows us to preserve the type information of a muxer's concrete
error as long as possible. For `StreamMuxerBox`, we leverage `io::Error`'s
capability of wrapping any error that implements `Into<Box<dyn Error>>`.

## Links to any relevant issues

<!-- Reference any related issues.-->
~This is a stacked PR on top of https://github.com/libp2p/rust-libp2p/pull/2707 and thus a draft but is otherwise ready to review.~

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] A changelog entry has been made in the appropriate crates
