### PR TITLE
transports/tcp/: Call take_error on tokio TcpStream

### DIFF
--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Update to `libp2p-core` `v0.34.0`.
 
+- Call `TcpStream::take_error` in tokio `Provider` to report connection
+  establishment errors early. See also [PR 2458] for the related async-io
+  change.
+
 # 0.33.0
 
 - Update to `libp2p-core` `v0.33.0`.
@@ -16,7 +20,9 @@
 
 # 0.31.1 [2022-02-02]
 
-- Call `TcpSocket::take_error` to report connection establishment errors early.
+- Call `TcpSocket::take_error` to report connection establishment errors early. See [PR 2458].
+
+[PR 2458]: https://github.com/libp2p/rust-libp2p/pull/2458
 
 # 0.31.0 [2022-01-27]
 

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -21,7 +21,7 @@ libc = "0.2.80"
 libp2p-core = { version = "0.34.0", path = "../../core", default-features = false  }
 log = "0.4.11"
 socket2 = { version = "0.4.0", features = ["all"] }
-tokio-crate = { package = "tokio", version = "1.0.1", default-features = false, features = ["net"], optional = true }
+tokio-crate = { package = "tokio", version = "1.19.0", default-features = false, features = ["net"], optional = true }
 
 [features]
 default = ["async-io"]


### PR DESCRIPTION
# Description

See e04e95a for the rational.

With tokio `v1.19.0` released, `TcStream` exposes `take_error`.

This commit applies the same fix from e04e95a to the tokio TCP provider.

<!-- Please write a summary of your changes and why you made them.-->

## Links to any relevant issues

Corresponding merged pull request for the async-std side: https://github.com/libp2p/rust-libp2p/pull/2458/

Tokio pull request: https://github.com/tokio-rs/tokio/pull/4739


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
