### PR TITLE
protocols/identify: Extend log message on second identify push

### DIFF
--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Update to `libp2p-swarm` `v0.37.0`.
 
+- Extend log message on second identify push stream with peer ID.
+
 # 0.36.1
 
 - Allow at most one inbound identify push stream.

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::handler::{IdentifyHandler, IdentifyHandlerEvent, IdentifyPush};
+use crate::handler::{IdentifyHandlerEvent, IdentifyHandlerProto, IdentifyPush};
 use crate::protocol::{IdentifyInfo, ReplySubstream, UpgradeError};
 use futures::prelude::*;
 use libp2p_core::{
@@ -54,7 +54,7 @@ pub struct Identify {
     /// Pending replies to send.
     pending_replies: VecDeque<Reply>,
     /// Pending events to be emitted when polled.
-    events: VecDeque<NetworkBehaviourAction<IdentifyEvent, IdentifyHandler>>,
+    events: VecDeque<NetworkBehaviourAction<IdentifyEvent, IdentifyHandlerProto>>,
     /// Peers to which an active push with current information about
     /// the local peer should be sent.
     pending_push: HashSet<PeerId>,
@@ -208,11 +208,11 @@ impl Identify {
 }
 
 impl NetworkBehaviour for Identify {
-    type ConnectionHandler = IdentifyHandler;
+    type ConnectionHandler = IdentifyHandlerProto;
     type OutEvent = IdentifyEvent;
 
     fn new_handler(&mut self) -> Self::ConnectionHandler {
-        IdentifyHandler::new(self.config.initial_delay, self.config.interval)
+        IdentifyHandlerProto::new(self.config.initial_delay, self.config.interval)
     }
 
     fn inject_connection_established(
@@ -296,7 +296,7 @@ impl NetworkBehaviour for Identify {
         &mut self,
         peer_id: PeerId,
         connection: ConnectionId,
-        event: <Self::ConnectionHandler as ConnectionHandler>::OutEvent,
+        event: <<Self::ConnectionHandler as IntoConnectionHandler>::Handler as ConnectionHandler>::OutEvent,
     ) {
         match event {
             IdentifyHandlerEvent::Identified(mut info) => {


### PR DESCRIPTION
# Description

Print remote peer ID when seeing a second identify push stream coming in.

Most of the changes are needed to make `IdentifyHandler` aware of the peer ID of its remote.



<!-- Please write a summary of your changes and why you made them.-->

## Links to any relevant issues

<!-- Reference any related issues.-->


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
