### PR TITLE
swarm/CHANGELOG: Merge unreleased section v0.36.2 with v0.37.0

### DIFF
--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 - Update to `libp2p-core` `v0.34.0`.
 
-# 0.36.2 [unreleased]
-
 - Extend log message when exceeding inbound negotiating streams with peer ID and limit. See [PR 2716].
 
 [PR 2716]: https://github.com/libp2p/rust-libp2p/pull/2716/


### PR DESCRIPTION
Follow up to https://github.com/libp2p/rust-libp2p/pull/2707