### PR TITLE
protocols/identify: fix dev dependencies required for examples/identify

### DIFF
--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -25,12 +25,16 @@ thiserror = "1.0"
 void = "1.0"
 
 [dev-dependencies]
-async-std = "1.6.2"
+async-std = { version = "1.6.2", features = ["attributes"] }
 env_logger = "0.9"
-libp2p = { path = "../..", default-features = false, features = ["identify", "tcp-async-io"] }
-libp2p-mplex = { path = "../../muxers/mplex" }
-libp2p-noise = { path = "../../transports/noise" }
-libp2p-tcp = { path = "../../transports/tcp" }
+libp2p = { path = "../..", default-features = false, features = [
+    "dns-async-std",
+    "mplex",
+    "noise",
+    "tcp-async-io",
+    "websocket",
+    "yamux",
+]}
 
 [build-dependencies]
 prost-build = "0.10"

--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -513,11 +513,11 @@ fn multiaddr_matches_peer_id(addr: &Multiaddr, peer_id: &PeerId) -> bool {
 mod tests {
     use super::*;
     use futures::pin_mut;
+    use libp2p::mplex::MplexConfig;
+    use libp2p::noise;
+    use libp2p::tcp::TcpConfig;
     use libp2p_core::{identity, muxing::StreamMuxerBox, transport, upgrade, PeerId, Transport};
-    use libp2p_mplex::MplexConfig;
-    use libp2p_noise as noise;
     use libp2p_swarm::{Swarm, SwarmEvent};
-    use libp2p_tcp::TcpConfig;
 
     fn transport() -> (
         identity::PublicKey,

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -287,12 +287,12 @@ pub enum UpgradeError {
 mod tests {
     use super::*;
     use futures::channel::oneshot;
+    use libp2p::tcp::TcpConfig;
     use libp2p_core::{
         identity,
         upgrade::{self, apply_inbound, apply_outbound},
         Transport,
     };
-    use libp2p_tcp::TcpConfig;
 
     #[test]
     fn correct_transfer() {


### PR DESCRIPTION
# Description

Fix the identify dev dependencies required for the example added in #2689.
Without them it currently does not compile. I only noticed it because I tried to run the identify tests from within the `protocols/identify` folder.  Not sure why our CI didn't complain. Maybe it's because we test the workspace instead of each package directly? @mxinden @thomaseizinger.
