### PR TITLE
swarm/src/handler: Document responsibility limiting inbound streams

### DIFF
--- a/swarm/src/handler.rs
+++ b/swarm/src/handler.rs
@@ -116,6 +116,12 @@ pub trait ConnectionHandler: Send + 'static {
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo>;
 
     /// Injects the output of a successful upgrade on a new inbound substream.
+    ///
+    /// Note that it is up to the [`ConnectionHandler`] implementation to manage the lifetime of the
+    /// negotiated inbound substreams. E.g. the implementation has to enforce a limit on the number
+    /// of simultaneously open negotiated inbound substreams. In other words it is up to the
+    /// [`ConnectionHandler`] implementation to stop a malicious remote node to open and keep alive
+    /// an excessive amount of inbound substreams.
     fn inject_fully_negotiated_inbound(
         &mut self,
         protocol: <Self::InboundProtocol as InboundUpgradeSend>::Output,


### PR DESCRIPTION
# Description

Document that the `ConnectionHandler` implementation has to enforce a limit on
the number of inbound substreams.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
