### PR TITLE
core/muxing: Drop `Unpin` requirement from `SubstreamBox`

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 - Remove `StreamMuxer::poll_event` in favor of individual functions: `poll_inbound`, `poll_outbound`
   and `poll_address_change`. Consequently, `StreamMuxerEvent` is also removed. See [PR 2724].
+- Drop `Unpin` requirement from `SubstreamBox`. See [PR XXXX.
 
 [PR 2724]: https://github.com/libp2p/rust-libp2p/pull/2724
+[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
 
 # 0.34.0
 

--- a/core/src/muxing/boxed.rs
+++ b/core/src/muxing/boxed.rs
@@ -17,7 +17,7 @@ pub struct StreamMuxerBox {
 ///
 /// A [`SubstreamBox`] erases the concrete type it is given and only retains its `AsyncRead`
 /// and `AsyncWrite` capabilities.
-pub struct SubstreamBox(Box<dyn AsyncReadWrite + Send + Unpin>);
+pub struct SubstreamBox(Pin<Box<dyn AsyncReadWrite + Send>>);
 
 struct Wrap<T>
 where
@@ -106,8 +106,8 @@ impl StreamMuxer for StreamMuxerBox {
 
 impl SubstreamBox {
     /// Construct a new [`SubstreamBox`] from something that implements [`AsyncRead`] and [`AsyncWrite`].
-    pub fn new<S: AsyncRead + AsyncWrite + Send + Unpin + 'static>(stream: S) -> Self {
-        Self(Box::new(stream))
+    pub fn new<S: AsyncRead + AsyncWrite + Send + 'static>(stream: S) -> Self {
+        Self(Box::pin(stream))
     }
 }
 
@@ -118,7 +118,7 @@ impl fmt::Debug for SubstreamBox {
 }
 
 /// Workaround because Rust does not allow `Box<dyn AsyncRead + AsyncWrite>`.
-trait AsyncReadWrite: AsyncRead + AsyncWrite + Unpin {
+trait AsyncReadWrite: AsyncRead + AsyncWrite {
     /// Helper function to capture the erased inner type.
     ///
     /// Used to make the [`Debug`] implementation of [`SubstreamBox`] more useful.
@@ -127,7 +127,7 @@ trait AsyncReadWrite: AsyncRead + AsyncWrite + Unpin {
 
 impl<S> AsyncReadWrite for S
 where
-    S: AsyncRead + AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite,
 {
     fn type_name(&self) -> &'static str {
         std::any::type_name::<S>()
@@ -136,44 +136,44 @@ where
 
 impl AsyncRead for SubstreamBox {
     fn poll_read(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<std::io::Result<usize>> {
-        Pin::new(&mut self.get_mut().0).poll_read(cx, buf)
+        self.0.as_mut().poll_read(cx, buf)
     }
 
     fn poll_read_vectored(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         bufs: &mut [IoSliceMut<'_>],
     ) -> Poll<std::io::Result<usize>> {
-        Pin::new(&mut self.get_mut().0).poll_read_vectored(cx, bufs)
+        self.0.as_mut().poll_read_vectored(cx, bufs)
     }
 }
 
 impl AsyncWrite for SubstreamBox {
     fn poll_write(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<std::io::Result<usize>> {
-        Pin::new(&mut self.get_mut().0).poll_write(cx, buf)
+        self.0.as_mut().poll_write(cx, buf)
     }
 
     fn poll_write_vectored(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         bufs: &[IoSlice<'_>],
     ) -> Poll<std::io::Result<usize>> {
-        Pin::new(&mut self.get_mut().0).poll_write_vectored(cx, bufs)
+        self.0.as_mut().poll_write_vectored(cx, bufs)
     }
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.get_mut().0).poll_flush(cx)
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        self.0.as_mut().poll_flush(cx)
     }
 
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.get_mut().0).poll_close(cx)
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        self.0.as_mut().poll_close(cx)
     }
 }


### PR DESCRIPTION
# Description

We are already boxing the type, might as well pin it.

<!-- Please write a summary of your changes and why you made them.-->

## Links to any relevant issues

<!-- Reference any related issues.-->
https://github.com/libp2p/rust-libp2p/issues/2722.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] A changelog entry has been made in the appropriate crates
