### PR TITLE
core: fix PR number in changelog entry

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 - Remove `StreamMuxer::poll_event` in favor of individual functions: `poll_inbound`, `poll_outbound`
   and `poll_address_change`. Consequently, `StreamMuxerEvent` is also removed. See [PR 2724].
-- Drop `Unpin` requirement from `SubstreamBox`. See [PR XXXX.
+- Drop `Unpin` requirement from `SubstreamBox`. See [PR 2762].
 
 [PR 2724]: https://github.com/libp2p/rust-libp2p/pull/2724
-[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
+[PR 2762]: https://github.com/libp2p/rust-libp2p/pull/2762
 
 # 0.34.0
 


### PR DESCRIPTION
Addendum to #2762.
Replace placeholder in changelog entry with actual PR number