### PR TITLE
core/muxing: Remove `Unpin` requirement from `StreamMuxer::Substream`

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 - Remove `StreamMuxer::poll_event` in favor of individual functions: `poll_inbound`, `poll_outbound`
   and `poll_address_change`. Consequently, `StreamMuxerEvent` is also removed. See [PR 2724].
-- Drop `Unpin` requirement from `SubstreamBox`. See [PR 2762].
+- Drop `Unpin` requirement from `SubstreamBox`. See [PR 2762] and [PR 2776].
 
 [PR 2724]: https://github.com/libp2p/rust-libp2p/pull/2724
 [PR 2762]: https://github.com/libp2p/rust-libp2p/pull/2762
+[PR 2776]: https://github.com/libp2p/rust-libp2p/pull/2776
 
 # 0.34.0
 

--- a/core/src/muxing/boxed.rs
+++ b/core/src/muxing/boxed.rs
@@ -29,7 +29,7 @@ where
 impl<T> StreamMuxer for Wrap<T>
 where
     T: StreamMuxer,
-    T::Substream: Send + Unpin + 'static,
+    T::Substream: Send + 'static,
     T::Error: Send + Sync + 'static,
 {
     type Substream = SubstreamBox;
@@ -71,7 +71,7 @@ impl StreamMuxerBox {
     pub fn new<T>(muxer: T) -> StreamMuxerBox
     where
         T: StreamMuxer + Send + Sync + 'static,
-        T::Substream: Send + Unpin + 'static,
+        T::Substream: Send + 'static,
         T::Error: Send + Sync + 'static,
     {
         let wrap = Wrap { inner: muxer };

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -300,7 +300,7 @@ impl<T> Multiplexed<T> {
         T::ListenerUpgrade: Send + 'static,
         T::Error: Send + Sync,
         M: StreamMuxer + Send + Sync + 'static,
-        M::Substream: Send + Unpin + 'static,
+        M::Substream: Send + 'static,
         M::Error: Send + Sync + 'static,
     {
         boxed(self.map(|(i, m), _| (i, StreamMuxerBox::new(m))))


### PR DESCRIPTION
# Description

Without removing this bound too, PR #2762 does not actually have any
user-facing changes.

<!-- Please write a summary of your changes and why you made them.-->

## Links to any relevant issues

<!-- Reference any related issues.-->


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] A changelog entry has been made in the appropriate crates
