### PR TITLE
misc/multistream-select: Replace msg.get(0) with msg.first()

### DIFF
--- a/misc/multistream-select/src/protocol.rs
+++ b/misc/multistream-select/src/protocol.rs
@@ -179,7 +179,7 @@ impl Message {
 
         // If it starts with a `/`, ends with a line feed without any
         // other line feeds in-between, it must be a protocol name.
-        if msg.get(0) == Some(&b'/')
+        if msg.first() == Some(&b'/')
             && msg.last() == Some(&b'\n')
             && !msg[..msg.len() - 1].contains(&b'\n')
         {


### PR DESCRIPTION
# Description

Fix clippy warning: 

```
error: accessing first element with `msg.get(0)`                                                                                              
   --> misc/multistream-select/src/protocol.rs:182:12                                                                                         
    |                                                                                                                                         
182 |         if msg.get(0) == Some(&b'/')                                                                                                    
    |            ^^^^^^^^^^ help: try: `msg.first()`                                                                                          
    |                                                                                                                                         
    = note: `-D clippy::get-first` implied by `-D warnings`                                                                                   
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#get_first                                 
```

<!-- Please write a summary of your changes and why you made them.-->

## Links to any relevant issues

Fails CI on https://github.com/libp2p/rust-libp2p/pull/2786

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
