### PR TITLE
*: fix `clippy::derive-partial-eq-without-eq`

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -38,6 +38,7 @@
 #[cfg(feature = "serde")]
 extern crate _serde as serde;
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 mod keys_proto {
     include!(concat!(env!("OUT_DIR"), "/keys_proto.rs"));
 }
@@ -46,6 +47,7 @@ mod envelope_proto {
     include!(concat!(env!("OUT_DIR"), "/envelope_proto.rs"));
 }
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 mod peer_record_proto {
     include!(concat!(env!("OUT_DIR"), "/peer_record_proto.rs"));
 }

--- a/core/src/peer_record.rs
+++ b/core/src/peer_record.rs
@@ -13,7 +13,7 @@ const DOMAIN_SEP: &str = "libp2p-routing-state";
 ///
 /// Peer records are designed to be distributable and carry a signature by being wrapped in a signed envelope.
 /// For more information see RFC0003 of the libp2p specifications: <https://github.com/libp2p/specs/blob/master/RFC/0003-routing-records.md>
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct PeerRecord {
     peer_id: PeerId,
     seq: u64,

--- a/core/src/signed_envelope.rs
+++ b/core/src/signed_envelope.rs
@@ -8,7 +8,7 @@ use unsigned_varint::encode::usize_buffer;
 /// A signed envelope contains an arbitrary byte string payload, a signature of the payload, and the public key that can be used to verify the signature.
 ///
 /// For more details see libp2p RFC0002: <https://github.com/libp2p/specs/blob/master/RFC/0002-signed-envelopes.md>
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SignedEnvelope {
     key: PublicKey,
     payload_type: Vec<u8>,

--- a/misc/multistream-select/src/protocol.rs
+++ b/misc/multistream-select/src/protocol.rs
@@ -179,7 +179,7 @@ impl Message {
 
         // If it starts with a `/`, ends with a line feed without any
         // other line feeds in-between, it must be a protocol name.
-        if msg.get(0) == Some(&b'/')
+        if msg.first() == Some(&b'/')
             && msg.last() == Some(&b'\n')
             && !msg[..msg.len() - 1].contains(&b'\n')
         {

--- a/protocols/autonat/src/behaviour.rs
+++ b/protocols/autonat/src/behaviour.rs
@@ -130,7 +130,7 @@ impl ProbeId {
 }
 
 /// Event produced by [`Behaviour`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Event {
     /// Event on an inbound probe.
     InboundProbe(InboundProbeEvent),

--- a/protocols/autonat/src/behaviour/as_client.rs
+++ b/protocols/autonat/src/behaviour/as_client.rs
@@ -40,7 +40,7 @@ use std::{
 };
 
 /// Outbound probe failed or was aborted.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OutboundProbeError {
     /// Probe was aborted because no server is known, or all servers
     /// are throttled through [`Config::throttle_server_period`].
@@ -54,7 +54,7 @@ pub enum OutboundProbeError {
     Response(ResponseError),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OutboundProbeEvent {
     /// A dial-back request was sent to a remote peer.
     Request {

--- a/protocols/autonat/src/behaviour/as_server.rs
+++ b/protocols/autonat/src/behaviour/as_server.rs
@@ -38,7 +38,7 @@ use std::{
 };
 
 /// Inbound probe failed.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InboundProbeError {
     /// Receiving the dial-back request or sending a response failed.
     InboundRequest(InboundFailure),
@@ -46,7 +46,7 @@ pub enum InboundProbeError {
     Response(ResponseError),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InboundProbeEvent {
     /// A dial-back request was received from a remote peer.
     Request {

--- a/protocols/autonat/src/lib.rs
+++ b/protocols/autonat/src/lib.rs
@@ -31,6 +31,7 @@ pub use self::{
 };
 pub use libp2p_request_response::{InboundFailure, OutboundFailure};
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 mod structs_proto {
     include!(concat!(env!("OUT_DIR"), "/structs.rs"));
 }

--- a/protocols/dcutr/src/lib.rs
+++ b/protocols/dcutr/src/lib.rs
@@ -30,6 +30,7 @@ pub use protocol::{
     PROTOCOL_NAME,
 };
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 mod message_proto {
     include!(concat!(env!("OUT_DIR"), "/holepunch.pb.rs"));
 }

--- a/protocols/floodsub/src/lib.rs
+++ b/protocols/floodsub/src/lib.rs
@@ -28,6 +28,7 @@ pub mod protocol;
 mod layer;
 mod topic;
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 mod rpc_proto {
     include!(concat!(env!("OUT_DIR"), "/floodsub.pb.rs"));
 }

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -50,7 +50,7 @@ pub enum ValidationMode {
 }
 
 /// Selector for custom Protocol Id
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum GossipsubVersion {
     V1_0,
     V1_1,

--- a/protocols/gossipsub/src/rpc_proto.rs
+++ b/protocols/gossipsub/src/rpc_proto.rs
@@ -17,6 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
+#![allow(clippy::derive_partial_eq_without_eq)]
 
 include!(concat!(env!("OUT_DIR"), "/gossipsub.pb.rs"));
 

--- a/protocols/gossipsub/src/types.rs
+++ b/protocols/gossipsub/src/types.rs
@@ -86,7 +86,7 @@ declare_message_id_type!(MessageId, "MessageId");
 // filter duplicates quickly without performing the overhead of decompression.
 declare_message_id_type!(FastMessageId, "FastMessageId");
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PeerConnections {
     /// The kind of protocol the peer supports.
     pub kind: PeerKind,

--- a/protocols/identify/src/lib.rs
+++ b/protocols/identify/src/lib.rs
@@ -51,6 +51,7 @@ mod handler;
 mod identify;
 mod protocol;
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 mod structs_proto {
     include!(concat!(env!("OUT_DIR"), "/structs.rs"));
 }

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -52,6 +52,7 @@ mod behaviour;
 mod jobs;
 mod query;
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 mod dht_proto {
     include!(concat!(env!("OUT_DIR"), "/dht.pb.rs"));
 }

--- a/protocols/relay/src/v2.rs
+++ b/protocols/relay/src/v2.rs
@@ -21,6 +21,7 @@
 //! Implementation of the [libp2p circuit relay v2
 //! specification](https://github.com/libp2p/specs/issues/314).
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 mod message_proto {
     include!(concat!(env!("OUT_DIR"), "/message_v2.pb.rs"));
 }

--- a/protocols/relay/src/v2/protocol.rs
+++ b/protocols/relay/src/v2/protocol.rs
@@ -31,7 +31,7 @@ pub const STOP_PROTOCOL_NAME: &[u8; 32] = b"/libp2p/circuit/relay/0.2.0/stop";
 
 const MAX_MESSAGE_SIZE: usize = 4096;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Limit {
     duration: Option<Duration>,
     data_in_bytes: Option<u64>,

--- a/protocols/rendezvous/src/codec.rs
+++ b/protocols/rendezvous/src/codec.rs
@@ -182,7 +182,7 @@ impl NewRegistration {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Registration {
     pub namespace: Namespace,
     pub record: PeerRecord,
@@ -594,6 +594,7 @@ impl From<UnmappableStatusCode> for ConversionError {
 #[error("The response code ({0:?}) cannot be mapped to our ErrorCode enum")]
 pub struct UnmappableStatusCode(wire::message::ResponseStatus);
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 mod wire {
     include!(concat!(env!("OUT_DIR"), "/rendezvous.pb.rs"));
 }

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -147,7 +147,7 @@ pub enum RequestResponseEvent<TRequest, TResponse, TChannelResponse = TResponse>
 
 /// Possible failures occurring in the context of sending
 /// an outbound request and receiving the response.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OutboundFailure {
     /// The request could not be sent because a dialing attempt failed.
     DialFailure,
@@ -184,7 +184,7 @@ impl std::error::Error for OutboundFailure {}
 
 /// Possible failures occurring in the context of receiving an
 /// inbound request and sending a response.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InboundFailure {
     /// The inbound request timed out, either while reading the
     /// incoming request or before a response is sent, e.g. if

--- a/transports/noise/src/io/handshake.rs
+++ b/transports/noise/src/io/handshake.rs
@@ -20,6 +20,7 @@
 
 //! Noise protocol handshake I/O.
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 mod payload_proto {
     include!(concat!(env!("OUT_DIR"), "/payload.proto.rs"));
 }

--- a/transports/plaintext/src/lib.rs
+++ b/transports/plaintext/src/lib.rs
@@ -35,6 +35,7 @@ use void::Void;
 
 mod error;
 mod handshake;
+#[allow(clippy::derive_partial_eq_without_eq)]
 mod structs_proto {
     include!(concat!(env!("OUT_DIR"), "/structs.rs"));
 }


### PR DESCRIPTION
# Description

Fix clippy lint [derive_partial_eq_without_eq](https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq) introduced with clippy `0.1.63`. 
Within `prost` this lint can/ will not be fixed (see https://github.com/tokio-rs/prost/issues/661 and https://github.com/tokio-rs/prost/pull/678), therefore we need to add an explicit `#[allow(clippy::derive_partial_eq_without_eq)]` flag for code generated by prost.

Edit: The reason why it can not be fixed within `prost` is because the lint returns some false positives. See https://github.com/tokio-rs/prost/runs/7192713936?check_suite_focus=true. According to https://github.com/rust-lang/rust-clippy/issues/8970 this is already fixed on nightly, so once a new clippy version is published we could remove the explicit ``#[allow(..)]` again.