### PR TITLE
swarm-derive/: Derive Debug for generated OutEvent

### DIFF
--- a/swarm-derive/src/lib.rs
+++ b/swarm-derive/src/lib.rs
@@ -159,6 +159,7 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
                     let visibility = &ast.vis;
 
                     Some(quote! {
+                        #[derive(::std::fmt::Debug)]
                         #visibility enum #name #impl_generics {
                             #(#fields),*
                         }

--- a/swarm-derive/tests/test.rs
+++ b/swarm-derive/tests/test.rs
@@ -21,6 +21,7 @@
 use futures::prelude::*;
 use libp2p::swarm::{NetworkBehaviour, SwarmEvent};
 use libp2p_swarm_derive::*;
+use std::fmt::Debug;
 
 /// Small utility to check that a type implements `NetworkBehaviour`.
 #[allow(dead_code)]
@@ -475,4 +476,22 @@ fn event_process() {
             }
         };
     }
+}
+
+#[test]
+fn generated_out_event_derive_debug() {
+    #[allow(dead_code)]
+    #[derive(NetworkBehaviour)]
+    struct Foo {
+        ping: libp2p::ping::Ping,
+    }
+
+    fn require_debug<T>()
+    where
+        T: NetworkBehaviour,
+        <T as NetworkBehaviour>::OutEvent: Debug,
+    {
+    }
+
+    require_debug::<Foo>();
 }

--- a/swarm-derive/tests/test.rs
+++ b/swarm-derive/tests/test.rs
@@ -276,7 +276,10 @@ fn custom_event_mismatching_field_names() {
 fn bound() {
     #[allow(dead_code)]
     #[derive(NetworkBehaviour)]
-    struct Foo<T: Copy + NetworkBehaviour> {
+    struct Foo<T: Copy + NetworkBehaviour>
+    where
+        <T as NetworkBehaviour>::OutEvent: Debug,
+    {
         ping: libp2p::ping::Ping,
         bar: T,
     }
@@ -289,6 +292,7 @@ fn where_clause() {
     struct Foo<T>
     where
         T: Copy + NetworkBehaviour,
+        <T as NetworkBehaviour>::OutEvent: Debug,
     {
         ping: libp2p::ping::Ping,
         bar: T,


### PR DESCRIPTION
# Description

When generating an `OutEvent` `enum` definition for a user, derive `Debug`
for that `enum`.

Why not derive `Clone`, `PartialEq` and `Eq` for the generated `enum`
definition?

While I think it is fine to require all sub-`OutEvent`s to implement
`Debug`, I don't think the same applies to traits like `Clone`. I
suggest users that need `Clone` to define their own `OutEvent`.

<!-- Please write a summary of your changes and why you made them.-->

## Links to any relevant issues

Depends on https://github.com/libp2p/rust-libp2p/pull/2819.

See also discussion in https://github.com/libp2p/rust-libp2p/pull/2751#issuecomment-1183048334.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
