### PR TITLE
*: Enforce no clippy warnings for examples

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [alias]
 # Temporary solution to have clippy config in a single place until https://github.com/rust-lang/rust-clippy/blob/master/doc/roadmap-2021.md#lintstoml-configuration is shipped.
-custom-clippy = "clippy --all-features -- -A clippy::type_complexity -A clippy::pedantic -D warnings"
+custom-clippy = "clippy --all-features --all-targets -- -A clippy::type_complexity -A clippy::pedantic -D warnings"

--- a/examples/chat-tokio.rs
+++ b/examples/chat-tokio.rs
@@ -153,14 +153,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     SwarmEvent::NewListenAddr { address, .. } => {
                         println!("Listening on {:?}", address);
                     }
-                    SwarmEvent::Behaviour(MyBehaviourEvent::Floodsub(event)) => {
-                        if let FloodsubEvent::Message(message) = event {
-                            println!(
+                    SwarmEvent::Behaviour(MyBehaviourEvent::Floodsub(FloodsubEvent::Message(message))) => {
+                        println!(
                                 "Received: '{:?}' from {:?}",
                                 String::from_utf8_lossy(&message.data),
                                 message.source
                             );
-                        }
                     }
                     SwarmEvent::Behaviour(MyBehaviourEvent::Mdns(event)) => {
                         match event {

--- a/examples/chat-tokio.rs
+++ b/examples/chat-tokio.rs
@@ -113,7 +113,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut swarm = {
         let mdns = Mdns::new(Default::default()).await?;
         let mut behaviour = MyBehaviour {
-            floodsub: Floodsub::new(peer_id.clone()),
+            floodsub: Floodsub::new(peer_id),
             mdns,
         };
 

--- a/examples/chat-tokio.rs
+++ b/examples/chat-tokio.rs
@@ -91,6 +91,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         mdns: Mdns,
     }
 
+    #[allow(clippy::large_enum_variant)]
     enum MyBehaviourEvent {
         Floodsub(FloodsubEvent),
         Mdns(MdnsEvent),

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -92,6 +92,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         ignored_member: bool,
     }
 
+    #[allow(clippy::large_enum_variant)]
     #[derive(Debug)]
     enum OutEvent {
         Floodsub(FloodsubEvent),

--- a/examples/file-sharing.rs
+++ b/examples/file-sharing.rs
@@ -221,7 +221,7 @@ mod network {
     };
     use libp2p::swarm::{ConnectionHandlerUpgrErr, SwarmBuilder, SwarmEvent};
     use libp2p::{NetworkBehaviour, Swarm};
-    use std::collections::{HashMap, HashSet};
+    use std::collections::{hash_map, HashMap, HashSet};
     use std::iter;
 
     /// Creates the network components, namely:
@@ -524,9 +524,7 @@ mod network {
                     peer_addr,
                     sender,
                 } => {
-                    if self.pending_dial.contains_key(&peer_id) {
-                        todo!("Already dialing peer.");
-                    } else {
+                    if let hash_map::Entry::Vacant(e) = self.pending_dial.entry(peer_id) {
                         self.swarm
                             .behaviour_mut()
                             .kademlia
@@ -536,12 +534,14 @@ mod network {
                             .dial(peer_addr.with(Protocol::P2p(peer_id.into())))
                         {
                             Ok(()) => {
-                                self.pending_dial.insert(peer_id, sender);
+                                e.insert(sender);
                             }
                             Err(e) => {
                                 let _ = sender.send(Err(Box::new(e)));
                             }
                         }
+                    } else {
+                        todo!("Already dialing peer.");
                     }
                 }
                 Command::StartProviding { file_name, sender } => {

--- a/examples/file-sharing.rs
+++ b/examples/file-sharing.rs
@@ -359,10 +359,7 @@ mod network {
             channel: ResponseChannel<FileResponse>,
         ) {
             self.sender
-                .send(Command::RespondFile {
-                    file: file,
-                    channel,
-                })
+                .send(Command::RespondFile { file, channel })
                 .await
                 .expect("Command receiver not to be dropped.");
         }

--- a/examples/gossipsub-chat.rs
+++ b/examples/gossipsub-chat.rs
@@ -101,7 +101,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         // add an explicit peer if one was provided
         if let Some(explicit) = std::env::args().nth(2) {
-            let explicit = explicit.clone();
             match explicit.parse() {
                 Ok(id) => gossipsub.add_explicit_peer(&id),
                 Err(err) => println!("Failed to parse explicit peer id: {:?}", err),

--- a/examples/ipfs-kad.rs
+++ b/examples/ipfs-kad.rs
@@ -34,7 +34,7 @@ use libp2p::{
 };
 use std::{env, error::Error, str::FromStr, time::Duration};
 
-const BOOTNODES: [&'static str; 4] = [
+const BOOTNODES: [&str; 4] = [
     "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
     "QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
     "QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",

--- a/examples/ipfs-private.rs
+++ b/examples/ipfs-private.rs
@@ -146,7 +146,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let local_key = identity::Keypair::generate_ed25519();
     let local_peer_id = PeerId::from(local_key.public());
     println!("using random peer id: {:?}", local_peer_id);
-    for psk in psk {
+    if let Some(psk) = psk {
         println!("using swarm key with fingerprint: {}", psk.fingerprint());
     }
 

--- a/examples/ipfs-private.rs
+++ b/examples/ipfs-private.rs
@@ -92,7 +92,7 @@ fn get_ipfs_path() -> Box<Path> {
 }
 
 /// Read the pre shared key file from the given ipfs directory
-fn get_psk(path: Box<Path>) -> std::io::Result<Option<String>> {
+fn get_psk(path: &Path) -> std::io::Result<Option<String>> {
     let swarm_key_file = path.join("swarm.key");
     match fs::read_to_string(swarm_key_file) {
         Ok(text) => Ok(Some(text)),
@@ -136,9 +136,9 @@ fn parse_legacy_multiaddr(text: &str) -> Result<Multiaddr, Box<dyn Error>> {
 async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
-    let ipfs_path: Box<Path> = get_ipfs_path();
+    let ipfs_path = get_ipfs_path();
     println!("using IPFS_PATH {:?}", ipfs_path);
-    let psk: Option<PreSharedKey> = get_psk(ipfs_path)?
+    let psk: Option<PreSharedKey> = get_psk(&ipfs_path)?
         .map(|text| PreSharedKey::from_str(&text))
         .transpose()?;
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

We were not using `--all-targets` in our custom clippy config, meaning clippy was not running on our examples. Examples should also use idiomatic code.

## Links to any relevant issues

<!-- Reference any related issues.-->


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] A changelog entry has been made in the appropriate crates~
