### PR TITLE
core/identity: allow clippy::large-enum-variant on `Keypair`

### DIFF
--- a/core/src/identity.rs
+++ b/core/src/identity.rs
@@ -64,6 +64,7 @@ use std::convert::{TryFrom, TryInto};
 /// ```
 ///
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum Keypair {
     /// An Ed25519 keypair.
     Ed25519(ed25519::Keypair),


### PR DESCRIPTION
# Description

Fix clippy lint when compiling `libp2p-core` with `default-features = false`.
Occurs e.g. when running `cargo custom-clippy` within the `transports/tcp` directory.
