### PR TITLE
.github: introduce interop tests

### DIFF
--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 name: Interoperability Testing
 
 jobs:

--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -1,0 +1,23 @@
+on: [push, pull_request]
+name: Interoperability Testing
+
+jobs:
+  # NOTE: during a pull request run, github creates a merge commit referenced in `github.sha`
+  # that merge commit is not a regular commit. You won't find it with a regular `git checkout SHA` and
+  # tools like `go get repo@SHA` won't find it.
+  #
+  # As a workaround, we generate a path to the actual pull request's commit, it looks like:
+  # `github.com/external-org/go-libp2p@latest-commit-on-their-branch`
+  run-ping-interop-cross-version:
+    uses: "libp2p/test-plans/.github/workflows/run-composition.yml@master"
+    with:
+      composition_file: "ping/_compositions/rust-cross-versions.toml"
+      custom_git_target: github.com/${{ github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
+      custom_git_reference: ${{ github.event.pull_request.head.sha || github.sha }}
+  run-ping-interop-cross-implementation:
+    uses: "libp2p/test-plans/.github/workflows/run-composition.yml@master"
+    with:
+      composition_file: "ping/_compositions/go-rust-interop-latest.toml"
+      custom_git_target: github.com/${{ github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
+      custom_git_reference: ${{ github.event.pull_request.head.sha || github.sha }}
+      custom_interop_target: rust


### PR DESCRIPTION
# Description

Adds two workflows on push & PR:

* `run-ping-interop-cross-version`: runs a Testground interoperability test between multiple versions of rust-libp2p, including master, and the current branch (during a pull request)
* `run-ping-interop-cross-implementation`: runs a Testground interoperability test between go-libp2p and rust-libp2p, including master, and the current branch (during a pull request)

We rely on the https://github.com/libp2p/test-plans/ repository to retrieve and run the tests.

Demonstration:
* passing PR: https://github.com/laurentsenta/rust-libp2p/pull/1
* breaking PR: https://github.com/laurentsenta/rust-libp2p/pull/2

## Links to any relevant issues

Related PR in test-plans: https://github.com/libp2p/test-plans/pull/26

## Open Questions
Known issues:

* The tests take between 20 minutes and 30 minutes on failures
 
## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
