### PR TITLE
protocols/gossipsub: Allow publishing to anything that implements `Into<TopicHash>` 

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Update to `libp2p-swarm` `v0.39.0`.
 
+- Allow publishing with any `impl Into<TopicHash>` as a topic. See [PR 2862].
+
+[PR 2862]: https://github.com/libp2p/rust-libp2p/pull/2862
+
 # 0.40.0
 
 - Update prost requirement from 0.10 to 0.11 which no longer installs the protoc Protobuf compiler.

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -586,22 +586,14 @@ where
         Ok(true)
     }
 
-    /// Publishes a message to a topic in the network.
-    pub fn publish<H: Hasher>(
+    /// Publishes a message with multiple topics to the network.
+    pub fn publish(
         &mut self,
-        topic: Topic<H>,
-        data: impl Into<Vec<u8>>,
-    ) -> Result<MessageId, PublishError> {
-        self.publish_to_topichash(topic.into(), data)
-    }
-
-    /// Publishes a message to a topic in the network using TopicHash.
-    pub fn publish_to_topichash(
-        &mut self,
-        topic: TopicHash,
+        topic: impl Into<TopicHash>,
         data: impl Into<Vec<u8>>,
     ) -> Result<MessageId, PublishError> {
         let data = data.into();
+        let topic = topic.into();
 
         // Transform the data before building a raw_message.
         let transformed_data = self

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -586,6 +586,7 @@ where
         Ok(true)
     }
 
+    /// Publishes a message to a topic in the network.
     pub fn publish<H: Hasher>(
         &mut self,
         topic: Topic<H>,
@@ -594,7 +595,7 @@ where
         self.publish_to_topichash(topic.into(), data)
     }
 
-    /// Publishes a message with multiple topics to the network.
+    /// Publishes a message to a topic in the network using TopicHash.
     pub fn publish_to_topichash(
         &mut self,
         topic: TopicHash,

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -586,10 +586,18 @@ where
         Ok(true)
     }
 
-    /// Publishes a message with multiple topics to the network.
     pub fn publish<H: Hasher>(
         &mut self,
         topic: Topic<H>,
+        data: impl Into<Vec<u8>>,
+    ) -> Result<MessageId, PublishError> {
+        self.publish_to_topichash(topic.into(), data)
+    }
+
+    /// Publishes a message with multiple topics to the network.
+    pub fn publish_to_topichash(
+        &mut self,
+        topic: TopicHash,
         data: impl Into<Vec<u8>>,
     ) -> Result<MessageId, PublishError> {
         let data = data.into();
@@ -597,9 +605,9 @@ where
         // Transform the data before building a raw_message.
         let transformed_data = self
             .data_transform
-            .outbound_transform(&topic.hash(), data.clone())?;
+            .outbound_transform(&topic, data.clone())?;
 
-        let raw_message = self.build_raw_message(topic.into(), transformed_data)?;
+        let raw_message = self.build_raw_message(topic, transformed_data)?;
 
         // calculate the message id from the un-transformed data
         let msg_id = self.config.message_id(&GossipsubMessage {


### PR DESCRIPTION
# Description

I store TopicHashes for gossipsub topics in my app for performance reasons. And rehashing Topics every time I want to publish seems redundant to me.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
