### PR TITLE
*: Replace _serde with dep:serde in Cargo.toml

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "1.0"
 unsigned-varint = "0.7"
 void = "1"
 zeroize = "1"
-_serde = { package = "serde", version = "1", optional = true, features = ["derive"] }
+serde = { version = "1", optional = true, features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ring = { version = "0.16.9", features = ["alloc", "std"], default-features = false }
@@ -62,7 +62,7 @@ prost-build = "0.11"
 default = [ "secp256k1", "ecdsa" ]
 secp256k1 = [ "libsecp256k1" ]
 ecdsa = [ "p256" ]
-serde = ["multihash/serde-codec", "_serde"]
+serde = ["multihash/serde-codec", "dep:serde"]
 
 [[bench]]
 name = "peer_id"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -35,9 +35,6 @@
 //!   define how to upgrade each individual substream to use a protocol.
 //!   See the `upgrade` module.
 
-#[cfg(feature = "serde")]
-extern crate _serde as serde;
-
 #[allow(clippy::derive_partial_eq_without_eq)]
 mod keys_proto {
     include!(concat!(env!("OUT_DIR"), "/keys_proto.rs"));

--- a/core/src/peer_id.rs
+++ b/core/src/peer_id.rs
@@ -183,7 +183,7 @@ impl From<PeerId> for Vec<u8> {
 impl Serialize for PeerId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: _serde::Serializer,
+        S: serde::Serializer,
     {
         if serializer.is_human_readable() {
             serializer.serialize_str(&self.to_base58())

--- a/core/tests/serde.rs
+++ b/core/tests/serde.rs
@@ -4,8 +4,6 @@ use std::str::FromStr;
 
 use libp2p_core::PeerId;
 
-extern crate _serde as serde;
-
 #[test]
 pub fn serialize_peer_id_json() {
     let peer_id = PeerId::from_str("12D3KooWRNw2pJC9748Fmq4WNV27HoSTcX3r37132FLkQMrbKAiC").unwrap();

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -29,7 +29,7 @@ unsigned-varint = { version = "0.7", features = ["asynchronous_codec"] }
 void = "1.0"
 futures-timer = "3.0.2"
 instant = "0.1.11"
-_serde = { package = "serde", version = "1.0", optional = true, features = ["derive"] }
+serde = { version = "1.0", optional = true, features = ["derive"] }
 thiserror = "1"
 
 [dev-dependencies]
@@ -43,4 +43,4 @@ quickcheck = "0.9.0"
 prost-build = "0.11"
 
 [features]
-serde = ["_serde", "bytes/serde"]
+serde = ["dep:serde", "bytes/serde"]

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -39,9 +39,6 @@
 //       be useful later for record store
 #![allow(dead_code)]
 
-#[cfg(feature = "serde")]
-extern crate _serde as serde;
-
 pub mod handler;
 pub mod kbucket;
 pub mod protocol;

--- a/protocols/kad/src/record.rs
+++ b/protocols/kad/src/record.rs
@@ -32,7 +32,6 @@ use std::hash::{Hash, Hasher};
 
 /// The (opaque) key of a record.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(crate = "_serde"))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Key(Bytes);
 


### PR DESCRIPTION
Remove extern crate serde everywhere else.

# Description

New Cargo.toml `dep:` syntax removes the need of renaming `serde` to `_serde`.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
