### PR TITLE
*: Prepare v0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 
 # `libp2p` facade crate
 
-# 0.48.0 [unreleased]
+# 0.48.0
 
 - Update to [`libp2p-swarm-derive` `v0.30.0`](swarm-derive/CHANGELOG.md#0300).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
 
 # 0.48.0
 
+- Update to [`libp2p-core` `v0.36.0`](core/CHANGELOG.md#0360).
+
 - Update to [`libp2p-swarm-derive` `v0.30.0`](swarm-derive/CHANGELOG.md#0300).
 
 - Update to [`libp2p-dcutr` `v0.6.0`](protocols/dcutr/CHANGELOG.md#060).

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.36.0 [unreleased]
+# 0.36.0
 
 - Make RSA keypair support optional. To enable RSA support, `rsa` feature should be enabled.
   See [PR 2860].

--- a/misc/metrics/CHANGELOG.md
+++ b/misc/metrics/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.9.0 [unreleased]
+# 0.9.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 

--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.36.0 [unreleased]
+# 0.36.0
 
 - Update to `libp2p-core` `v0.36.0`
 

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.40.0 [unreleased]
+# 0.40.0
 
 - Update to `libp2p-core` `v0.36.0`
 

--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.7.0 [unreleased]
+# 0.7.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.6.0 [unreleased]
+# 0.6.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 

--- a/protocols/floodsub/CHANGELOG.md
+++ b/protocols/floodsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.39.0 [unreleased]
+# 0.39.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.41.0 [unreleased]
+# 0.41.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.39.0 [unreleased]
+# 0.39.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.40.0 [unreleased]
+# 0.40.0
 
 - Add support for multiple protocol names. Update `Kademlia`, `KademliaConfig`,
   and `KademliaProtocolConfig` accordingly. See [Issue 2837]. See [PR 2846].

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.40.0 [unreleased]
+# 0.40.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.39.0 [unreleased]
+# 0.39.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.12.0 [unreleased]
+# 0.12.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 

--- a/protocols/rendezvous/CHANGELOG.md
+++ b/protocols/rendezvous/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.9.0 [unreleased]
+# 0.9.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.21.0 [unreleased]
+# 0.21.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 

--- a/swarm-derive/CHANGELOG.md
+++ b/swarm-derive/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.30.0 - [unreleased]
+# 0.30.0
 
 - Remove support for removed `NetworkBehaviourEventProcess`. See [PR 2840].
 

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.39.0 - [unreleased]
+# 0.39.0
 
 - Remove deprecated `NetworkBehaviourEventProcess`. See [libp2p-swarm v0.38.0 changelog entry] for
   migration path.

--- a/transports/deflate/CHANGELOG.md
+++ b/transports/deflate/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.36.0 [unreleased]
+# 0.36.0
 
 - Update to `libp2p-core` `v0.36.0`.
 

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.36.0 [unreleased]
+# 0.36.0
 
 - Update to `libp2p-core` `v0.36.0`.
 

--- a/transports/noise/CHANGELOG.md
+++ b/transports/noise/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.39.0 [unreleased]
+# 0.39.0
 
 - Update to `libp2p-core` `v0.36.0`.
 

--- a/transports/plaintext/CHANGELOG.md
+++ b/transports/plaintext/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.36.0 [unreleased]
+# 0.36.0
 
 - Update to `libp2p-core` `v0.36.0`.
 

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.36.0 [unreleased]
+# 0.36.0
 
 - Update to `libp2p-core` `v0.36.0`.
 

--- a/transports/uds/CHANGELOG.md
+++ b/transports/uds/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.35.0 [unreleased]
+# 0.35.0
 
 - Update to `libp2p-core` `v0.36.0`.
 

--- a/transports/wasm-ext/CHANGELOG.md
+++ b/transports/wasm-ext/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.36.0 [unreleased]
+# 0.36.0
 
 - Update to `libp2p-core` `v0.36.0`.
 

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.38.0 [unreleased]
+# 0.38.0
 
 - Update to `libp2p-core` `v0.36.0`.
 


### PR DESCRIPTION
# Description

I suggest we release `libp2p` `v0.48.0` soonish.

I suggest we wait for https://github.com/libp2p/rust-libp2p/pull/2860. Anything else you would like to see included?

TODOs

- [ ] Point out breaking change https://github.com/libp2p/rust-libp2p/pull/2860

## Links to any relevant issues

This will allow @dmitry-markin to use https://github.com/libp2p/rust-libp2p/pull/2846.

This will release https://github.com/libp2p/rust-libp2p/pull/2840 and thus ensures changes as #2840 and https://github.com/libp2p/rust-libp2p/issues/2854 are not in the same release, which in my opinion makes the upgrade procedure easier.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
