### PR TITLE
swarm: Fix rare test failure of `multiple_addresses_err`

### DIFF
--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -2461,7 +2461,6 @@ mod tests {
 
                 let failed_addresses = errors.into_iter().map(|(addr, _)| addr).collect::<Vec<_>>();
                 let expected_addresses = addresses
-                    .clone()
                     .into_iter()
                     .map(|addr| addr.with(Protocol::P2p(target.into())))
                     .collect::<Vec<_>>();

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -2454,17 +2454,16 @@ mod tests {
                 // multiaddr,
                 error: DialError::Transport(errors),
             } => {
-                assert_eq!(peer_id.unwrap(), target);
+                assert_eq!(target, peer_id.unwrap());
 
                 let failed_addresses = errors.into_iter().map(|(addr, _)| addr).collect::<Vec<_>>();
-                assert_eq!(
-                    failed_addresses,
-                    addresses
-                        .clone()
-                        .into_iter()
-                        .map(|addr| addr.with(Protocol::P2p(target.into())))
-                        .collect::<Vec<_>>()
-                );
+                let expected_addresses = addresses
+                    .clone()
+                    .into_iter()
+                    .map(|addr| addr.with(Protocol::P2p(target.into())))
+                    .collect::<Vec<_>>();
+
+                assert_eq!(expected_addresses, failed_addresses);
             }
             e => panic!("Unexpected event: {e:?}"),
         }

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1624,7 +1624,6 @@ mod tests {
     use libp2p_core::transport::TransportEvent;
     use libp2p_core::Endpoint;
     use quickcheck::{quickcheck, Arbitrary, Gen, QuickCheck};
-    use rand::prelude::SliceRandom;
     use rand::Rng;
 
     // Test execution state.
@@ -2433,19 +2432,18 @@ mod tests {
 
         let mut swarm = new_test_swarm::<_, ()>(DummyConnectionHandler::default()).build();
 
-        let mut addresses = Vec::new();
+        let mut addresses = HashSet::new();
         for _ in 0..3 {
-            addresses.push(multiaddr![Ip4([0, 0, 0, 0]), Tcp(rand::random::<u16>())]);
+            addresses.insert(multiaddr![Ip4([0, 0, 0, 0]), Tcp(rand::random::<u16>())]);
         }
         for _ in 0..5 {
-            addresses.push(multiaddr![Udp(rand::random::<u16>())]);
+            addresses.insert(multiaddr![Udp(rand::random::<u16>())]);
         }
-        addresses.shuffle(&mut rand::thread_rng());
 
         swarm
             .dial(
                 DialOpts::peer_id(target)
-                    .addresses(addresses.clone())
+                    .addresses(addresses.iter().cloned().collect())
                     .build(),
             )
             .unwrap();

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -2432,13 +2432,16 @@ mod tests {
 
         let mut swarm = new_test_swarm::<_, ()>(DummyConnectionHandler::default()).build();
 
-        let mut addresses = HashSet::new();
-        for _ in 0..3 {
-            addresses.insert(multiaddr![Ip4([0, 0, 0, 0]), Tcp(rand::random::<u16>())]);
-        }
-        for _ in 0..5 {
-            addresses.insert(multiaddr![Udp(rand::random::<u16>())]);
-        }
+        let addresses = HashSet::from([
+            multiaddr![Ip4([0, 0, 0, 0]), Tcp(rand::random::<u16>())],
+            multiaddr![Ip4([0, 0, 0, 0]), Tcp(rand::random::<u16>())],
+            multiaddr![Ip4([0, 0, 0, 0]), Tcp(rand::random::<u16>())],
+            multiaddr![Udp(rand::random::<u16>())],
+            multiaddr![Udp(rand::random::<u16>())],
+            multiaddr![Udp(rand::random::<u16>())],
+            multiaddr![Udp(rand::random::<u16>())],
+            multiaddr![Udp(rand::random::<u16>())],
+        ]);
 
         swarm
             .dial(


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Fixes https://github.com/libp2p/rust-libp2p/issues/2874.

## Links to any relevant issues

<!-- Reference any related issues.-->


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] A changelog entry has been made in the appropriate crates~
