### PR TITLE
protocols/gossipsub: Enable the `protobuf` feature of prometheus-client

### DIFF
--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -31,7 +31,8 @@ serde = { version = "1", optional = true, features = ["derive"] }
 wasm-timer = "0.2.5"
 instant = "0.1.11"
 # Metrics dependencies
-prometheus-client = "0.18.0"
+# TODO: Change to v0.19 once the version has been released.
+prometheus-client = { git = "https://github.com/ackintosh/client_rust.git", rev = "5e145bb0cb52ab4ff01c862a6117fb61ee107f17", features = ["protobuf"] }
 
 [dev-dependencies]
 async-std = "1.6.3"

--- a/protocols/gossipsub/src/metrics.rs
+++ b/protocols/gossipsub/src/metrics.rs
@@ -23,7 +23,7 @@
 
 use std::collections::HashMap;
 
-use prometheus_client::encoding::text::Encode;
+use prometheus_client::encoding::Encode;
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::{Family, MetricConstructor};
 use prometheus_client::metrics::gauge::Gauge;

--- a/protocols/gossipsub/src/topic.rs
+++ b/protocols/gossipsub/src/topic.rs
@@ -20,7 +20,7 @@
 
 use crate::rpc_proto;
 use base64::encode;
-use prometheus_client::encoding::text::Encode;
+use prometheus_client::encoding::Encode;
 use prost::Message;
 use sha2::{Digest, Sha256};
 use std::fmt;

--- a/protocols/gossipsub/src/types.rs
+++ b/protocols/gossipsub/src/types.rs
@@ -22,7 +22,7 @@
 use crate::rpc_proto;
 use crate::TopicHash;
 use libp2p_core::{connection::ConnectionId, PeerId};
-use prometheus_client::encoding::text::Encode;
+use prometheus_client::encoding::Encode;
 use prost::Message;
 use std::fmt;
 use std::fmt::Debug;


### PR DESCRIPTION
👷 This PR is a work in progress 👷 

# Description

<!-- Please write a summary of your changes and why you made them.-->

The latest revision of prometheus-client has [OpenMetrics protobuf support](https://github.com/prometheus/client_rust/pull/83). Which will be released in [v0.19](https://github.com/prometheus/client_rust/blob/master/CHANGELOG.md#0190---unreleased).

Prior to the release, I'm working to enable the `protobuf` feature on gossipsub metrics.

<!--
## Links to any relevant issues
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
