### PR TITLE
Add Subspace to the list of projects using rust-libp2p

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,4 @@ Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 - https://github.com/ipfs-rust/ipfs-embed
 - https://www.actyx.com/developers/
 - https://github.com/starcoinorg/starcoin
+- https://github.com/subspace/subspace


### PR DESCRIPTION
# Description

As suggested on the community call

## Links to any relevant issues
