### PR TITLE
swarm: Provide peer_id to inject_dial_failure on connection limit error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@
 
 - Update to [`libp2p-noise` `v0.39.1`](transports/noise/CHANGELOG.md#0391).
 
+- Update to [`libp2p-swarm` `v0.39.1`](swarm/CHANGELOG.md#0391).
+
 # 0.48.0
 
 - Update to [`libp2p-core` `v0.36.0`](core/CHANGELOG.md#0360).

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 [PR 2857]: https://github.com/libp2p/rust-libp2p/pull/2857
 
+- Fixed panic caused by `None` being passed into `NetworkBehaviour::inject_dial_failure` on `DialError::ConnectionLimit`.
+
+[PR 2928]: https://github.com/libp2p/rust-libp2p/pull/2928
+
+
 # 0.39.0
 
 - Remove deprecated `NetworkBehaviourEventProcess`. See [libp2p-swarm v0.38.0 changelog entry] for

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 [PR 2857]: https://github.com/libp2p/rust-libp2p/pull/2857
 
-- Fixed panic caused by `None` being passed into `NetworkBehaviour::inject_dial_failure` on `DialError::ConnectionLimit`.
+- Pass actual `PeerId` of dial to `NetworkBehaviour::inject_dial_failure` on `DialError::ConnectionLimit`. See [PR 2928].
 
 [PR 2928]: https://github.com/libp2p/rust-libp2p/pull/2928
 

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -535,7 +535,7 @@ where
             Ok(_connection_id) => Ok(()),
             Err((connection_limit, handler)) => {
                 let error = DialError::ConnectionLimit(connection_limit);
-                self.behaviour.inject_dial_failure(None, handler, &error);
+                self.behaviour.inject_dial_failure(peer_id, handler, &error);
                 Err(error)
             }
         }


### PR DESCRIPTION
# Description
<!-- Please write a summary of your changes and why you made them.-->
This will fix the panic by providing the `peer_id` to `inject_dial_failure`

## Links to any relevant issues
<!-- Reference any related issues.-->
#2906

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
