### PR TITLE
libp2p-tls: Allow to specify remote peer ID we intend to connect to

### DIFF
--- a/transports/tls/src/upgrade.rs
+++ b/transports/tls/src/upgrade.rs
@@ -31,7 +31,7 @@ impl Config {
     pub fn new(identity: &identity::Keypair) -> Result<Self, certificate::GenError> {
         Ok(Self {
             server: crate::make_server_config(identity)?,
-            client: crate::make_client_config(identity)?,
+            client: crate::make_client_config(identity, None)?,
         })
     }
 }


### PR DESCRIPTION
# Description

> The public host key allows the peer to calculate the peer ID of the peer it is connecting to. Clients MUST verify that the peer ID derived from the certificate matches the peer ID they intended to connect to, and MUST abort the connection if there is a mismatch.

## Links to any relevant issues

https://github.com/libp2p/rust-libp2p/issues/2946

This does not affect Upgrades but can be useful for QUIC.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
