### PR TITLE
transports/noise: Have NoiseAuthenticated::xx use X25519Spec

### DIFF
--- a/transports/noise/src/lib.rs
+++ b/transports/noise/src/lib.rs
@@ -390,12 +390,12 @@ pub struct NoiseAuthenticated<P, C: Zeroize, R> {
     config: NoiseConfig<P, C, R>,
 }
 
-impl NoiseAuthenticated<XX, X25519, ()> {
+impl NoiseAuthenticated<XX, X25519Spec, ()> {
     /// Create a new [`NoiseAuthenticated`] for the `XX` handshake pattern using X25519 DH keys.
     ///
     /// For now, this is the only combination that is guaranteed to be compatible with other libp2p implementations.
     pub fn xx(id_keys: &identity::Keypair) -> Result<Self, NoiseError> {
-        let dh_keys = Keypair::<X25519>::new();
+        let dh_keys = Keypair::<X25519Spec>::new();
         let noise_keys = dh_keys.into_authentic(id_keys)?;
         let config = NoiseConfig::xx(noise_keys);
 


### PR DESCRIPTION
# Description

We support two versions of the Noise XX handshake with X25519, but only one of them is compliant with the specification and thus compliant with other implementations. We should always default to the spec compliant handshake.

Caught via [the libp2p interoperability tests](https://github.com/libp2p/test-plans). A node running `master` would no longer connect to nodes running older versions given that older versions would use the spec compliant Noise handshake.

## Links to any relevant issues

Fixes bug introduced in https://github.com/libp2p/rust-libp2p/pull/2887/

## Open Questions

As a follow up, we might consider dropping support for the non-spec compliant version.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] ~A changelog entry has been made in the appropriate crates~
  - Given that https://github.com/libp2p/rust-libp2p/pull/2887/ has not yet been released, we don't need a changelog entry.
