### PR TITLE
core: Remove `ProtocolName` trait in favor of always using strings

### DIFF
--- a/core/src/either.rs
+++ b/core/src/either.rs
@@ -22,7 +22,7 @@ use crate::muxing::StreamMuxerEvent;
 use crate::{
     muxing::StreamMuxer,
     transport::{ListenerId, Transport, TransportError, TransportEvent},
-    Multiaddr, ProtocolName,
+    Multiaddr,
 };
 use futures::{
     io::{IoSlice, IoSliceMut},
@@ -310,20 +310,6 @@ where
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum EitherName {
-    A(ProtocolName),
-    B(ProtocolName),
-}
-
-impl EitherName {
-    fn protocol_name(&self) -> &str {
-        match self {
-            EitherName::A(a) => a.protocol_name(),
-            EitherName::B(b) => b.protocol_name(),
-        }
-    }
-}
 #[pin_project(project = EitherTransportProj)]
 #[derive(Debug)]
 #[must_use = "transports do nothing unless polled"]

--- a/core/src/either.rs
+++ b/core/src/either.rs
@@ -311,13 +311,13 @@ where
 }
 
 #[derive(Debug, Clone)]
-pub enum EitherName<A, B> {
-    A(A),
-    B(B),
+pub enum EitherName {
+    A(ProtocolName),
+    B(ProtocolName),
 }
 
-impl<A: ProtocolName, B: ProtocolName> ProtocolName for EitherName<A, B> {
-    fn protocol_name(&self) -> &[u8] {
+impl EitherName {
+    fn protocol_name(&self) -> &str {
         match self {
             EitherName::A(a) => a.protocol_name(),
             EitherName::B(b) => b.protocol_name(),

--- a/core/src/upgrade.rs
+++ b/core/src/upgrade.rs
@@ -135,21 +135,26 @@ pub use multistream_select::{NegotiatedComplete, NegotiationError, ProtocolError
 //     }
 // }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProtocolName(Cow<'static, str>);
 
 impl ProtocolName {
     fn protocol_name(&self) -> &str {
-	self.0.as_ref()
+        self.0.as_ref()
     }
 }
 
 impl AsRef<str> for ProtocolName {
     fn as_ref(&self) -> &str {
-	self.0.as_ref()
+        self.0.as_ref()
     }
 }
 
-
+impl AsRef<[u8]> for ProtocolName {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref().as_bytes()
+    }
+}
 
 /// Common trait for upgrades that can be applied on inbound substreams, outbound substreams,
 /// or both.

--- a/core/src/upgrade/apply.rs
+++ b/core/src/upgrade/apply.rs
@@ -100,7 +100,7 @@ where
     U: InboundUpgrade<Negotiated<C>>,
 {
     Init {
-        future: ListenerSelectFuture<C, NameWrap<U::Info>>,
+        future: ListenerSelectFuture<C, NameWrap<ProtocolName>>,
         upgrade: U,
     },
     Upgrade {
@@ -251,8 +251,8 @@ type NameWrapIter<I> = iter::Map<I, fn(<I as Iterator>::Item) -> NameWrap<<I as 
 #[derive(Clone)]
 struct NameWrap<N>(N);
 
-impl<N: ProtocolName> AsRef<[u8]> for NameWrap<N> {
+impl<N> AsRef<[u8]> for NameWrap<N> {
     fn as_ref(&self) -> &[u8] {
-        self.0.protocol_name()
+        self.0.protocol_name().as_bytes()
     }
 }

--- a/core/src/upgrade/denied.rs
+++ b/core/src/upgrade/denied.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo, ProtocolName};
+use crate::upgrade::{InboundUpgrade, OutboundUpgrade, ProtocolName, UpgradeInfo};
 use futures::future;
 use std::iter;
 use void::Void;

--- a/core/src/upgrade/denied.rs
+++ b/core/src/upgrade/denied.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
+use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo, ProtocolName};
 use futures::future;
 use std::iter;
 use void::Void;
@@ -29,8 +29,7 @@ use void::Void;
 pub struct DeniedUpgrade;
 
 impl UpgradeInfo for DeniedUpgrade {
-    type Info = &'static [u8];
-    type InfoIter = iter::Empty<Self::Info>;
+    type InfoIter = iter::Empty<ProtocolName>;
 
     fn protocol_info(&self) -> Self::InfoIter {
         iter::empty()
@@ -42,7 +41,7 @@ impl<C> InboundUpgrade<C> for DeniedUpgrade {
     type Error = Void;
     type Future = future::Pending<Result<Self::Output, Self::Error>>;
 
-    fn upgrade_inbound(self, _: C, _: Self::Info) -> Self::Future {
+    fn upgrade_inbound(self, _: C, _: ProtocolName) -> Self::Future {
         future::pending()
     }
 }
@@ -52,7 +51,7 @@ impl<C> OutboundUpgrade<C> for DeniedUpgrade {
     type Error = Void;
     type Future = future::Pending<Result<Self::Output, Self::Error>>;
 
-    fn upgrade_outbound(self, _: C, _: Self::Info) -> Self::Future {
+    fn upgrade_outbound(self, _: C, _: ProtocolName) -> Self::Future {
         future::pending()
     }
 }

--- a/core/src/upgrade/either.rs
+++ b/core/src/upgrade/either.rs
@@ -20,7 +20,7 @@
 
 use crate::{
     either::{EitherError, EitherFuture2, EitherName, EitherOutput},
-    upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo},
+    upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo, ProtocolName},
 };
 
 /// A type to represent two possible upgrade types (inbound or outbound).
@@ -35,7 +35,6 @@ where
     A: UpgradeInfo,
     B: UpgradeInfo,
 {
-    type Info = EitherName<A::Info, B::Info>;
     type InfoIter = EitherIter<
         <A::InfoIter as IntoIterator>::IntoIter,
         <B::InfoIter as IntoIterator>::IntoIter,
@@ -58,7 +57,7 @@ where
     type Error = EitherError<EA, EB>;
     type Future = EitherFuture2<A::Future, B::Future>;
 
-    fn upgrade_inbound(self, sock: C, info: Self::Info) -> Self::Future {
+    fn upgrade_inbound(self, sock: C, info: ProtocolName) -> Self::Future {
         match (self, info) {
             (EitherUpgrade::A(a), EitherName::A(info)) => {
                 EitherFuture2::A(a.upgrade_inbound(sock, info))
@@ -80,7 +79,7 @@ where
     type Error = EitherError<EA, EB>;
     type Future = EitherFuture2<A::Future, B::Future>;
 
-    fn upgrade_outbound(self, sock: C, info: Self::Info) -> Self::Future {
+    fn upgrade_outbound(self, sock: C, info: EitherName) -> Self::Future {
         match (self, info) {
             (EitherUpgrade::A(a), EitherName::A(info)) => {
                 EitherFuture2::A(a.upgrade_outbound(sock, info))
@@ -105,7 +104,7 @@ where
     A: Iterator,
     B: Iterator,
 {
-    type Item = EitherName<A::Item, B::Item>;
+    type Item = EitherName;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {

--- a/core/src/upgrade/from_fn.rs
+++ b/core/src/upgrade/from_fn.rs
@@ -70,8 +70,7 @@ pub struct FromFnUpgrade<F> {
     fun: F,
 }
 
-impl<F> UpgradeInfo for FromFnUpgrade<F>
-{
+impl<F> UpgradeInfo for FromFnUpgrade<F> {
     type InfoIter = iter::Once<ProtocolName>;
 
     fn protocol_info(&self) -> Self::InfoIter {

--- a/core/src/upgrade/map.rs
+++ b/core/src/upgrade/map.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo, ProtocolName};
+use crate::upgrade::{InboundUpgrade, OutboundUpgrade, ProtocolName, UpgradeInfo};
 use futures::prelude::*;
 use std::{pin::Pin, task::Context, task::Poll};
 

--- a/core/src/upgrade/map.rs
+++ b/core/src/upgrade/map.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
+use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo, ProtocolName};
 use futures::prelude::*;
 use std::{pin::Pin, task::Context, task::Poll};
 
@@ -39,7 +39,6 @@ impl<U, F> UpgradeInfo for MapInboundUpgrade<U, F>
 where
     U: UpgradeInfo,
 {
-    type Info = U::Info;
     type InfoIter = U::InfoIter;
 
     fn protocol_info(&self) -> Self::InfoIter {
@@ -56,7 +55,7 @@ where
     type Error = U::Error;
     type Future = MapFuture<U::Future, F>;
 
-    fn upgrade_inbound(self, sock: C, info: Self::Info) -> Self::Future {
+    fn upgrade_inbound(self, sock: C, info: ProtocolName) -> Self::Future {
         MapFuture {
             inner: self.upgrade.upgrade_inbound(sock, info),
             map: Some(self.fun),
@@ -72,7 +71,7 @@ where
     type Error = U::Error;
     type Future = U::Future;
 
-    fn upgrade_outbound(self, sock: C, info: Self::Info) -> Self::Future {
+    fn upgrade_outbound(self, sock: C, info: ProtocolName) -> Self::Future {
         self.upgrade.upgrade_outbound(sock, info)
     }
 }
@@ -94,7 +93,6 @@ impl<U, F> UpgradeInfo for MapOutboundUpgrade<U, F>
 where
     U: UpgradeInfo,
 {
-    type Info = U::Info;
     type InfoIter = U::InfoIter;
 
     fn protocol_info(&self) -> Self::InfoIter {
@@ -110,7 +108,7 @@ where
     type Error = U::Error;
     type Future = U::Future;
 
-    fn upgrade_inbound(self, sock: C, info: Self::Info) -> Self::Future {
+    fn upgrade_inbound(self, sock: C, info: ProtocolName) -> Self::Future {
         self.upgrade.upgrade_inbound(sock, info)
     }
 }
@@ -124,7 +122,7 @@ where
     type Error = U::Error;
     type Future = MapFuture<U::Future, F>;
 
-    fn upgrade_outbound(self, sock: C, info: Self::Info) -> Self::Future {
+    fn upgrade_outbound(self, sock: C, info: ProtocolName) -> Self::Future {
         MapFuture {
             inner: self.upgrade.upgrade_outbound(sock, info),
             map: Some(self.fun),
@@ -149,7 +147,6 @@ impl<U, F> UpgradeInfo for MapInboundUpgradeErr<U, F>
 where
     U: UpgradeInfo,
 {
-    type Info = U::Info;
     type InfoIter = U::InfoIter;
 
     fn protocol_info(&self) -> Self::InfoIter {
@@ -166,7 +163,7 @@ where
     type Error = T;
     type Future = MapErrFuture<U::Future, F>;
 
-    fn upgrade_inbound(self, sock: C, info: Self::Info) -> Self::Future {
+    fn upgrade_inbound(self, sock: C, info: ProtocolName) -> Self::Future {
         MapErrFuture {
             fut: self.upgrade.upgrade_inbound(sock, info),
             fun: Some(self.fun),
@@ -182,7 +179,7 @@ where
     type Error = U::Error;
     type Future = U::Future;
 
-    fn upgrade_outbound(self, sock: C, info: Self::Info) -> Self::Future {
+    fn upgrade_outbound(self, sock: C, info: ProtocolName) -> Self::Future {
         self.upgrade.upgrade_outbound(sock, info)
     }
 }
@@ -204,7 +201,6 @@ impl<U, F> UpgradeInfo for MapOutboundUpgradeErr<U, F>
 where
     U: UpgradeInfo,
 {
-    type Info = U::Info;
     type InfoIter = U::InfoIter;
 
     fn protocol_info(&self) -> Self::InfoIter {
@@ -221,7 +217,7 @@ where
     type Error = T;
     type Future = MapErrFuture<U::Future, F>;
 
-    fn upgrade_outbound(self, sock: C, info: Self::Info) -> Self::Future {
+    fn upgrade_outbound(self, sock: C, info: ProtocolName) -> Self::Future {
         MapErrFuture {
             fut: self.upgrade.upgrade_outbound(sock, info),
             fun: Some(self.fun),
@@ -237,7 +233,7 @@ where
     type Error = U::Error;
     type Future = U::Future;
 
-    fn upgrade_inbound(self, sock: C, info: Self::Info) -> Self::Future {
+    fn upgrade_inbound(self, sock: C, info: ProtocolName) -> Self::Future {
         self.upgrade.upgrade_inbound(sock, info)
     }
 }

--- a/core/src/upgrade/optional.rs
+++ b/core/src/upgrade/optional.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo, ProtocolName};
+use crate::upgrade::{InboundUpgrade, OutboundUpgrade, ProtocolName, UpgradeInfo};
 
 /// Upgrade that can be disabled at runtime.
 ///

--- a/core/src/upgrade/optional.rs
+++ b/core/src/upgrade/optional.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
+use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo, ProtocolName};
 
 /// Upgrade that can be disabled at runtime.
 ///
@@ -43,7 +43,6 @@ impl<T> UpgradeInfo for OptionalUpgrade<T>
 where
     T: UpgradeInfo,
 {
-    type Info = T::Info;
     type InfoIter = Iter<<T::InfoIter as IntoIterator>::IntoIter>;
 
     fn protocol_info(&self) -> Self::InfoIter {
@@ -59,7 +58,7 @@ where
     type Error = T::Error;
     type Future = T::Future;
 
-    fn upgrade_inbound(self, sock: C, info: Self::Info) -> Self::Future {
+    fn upgrade_inbound(self, sock: C, info: ProtocolName) -> Self::Future {
         if let Some(inner) = self.0 {
             inner.upgrade_inbound(sock, info)
         } else {
@@ -76,7 +75,7 @@ where
     type Error = T::Error;
     type Future = T::Future;
 
-    fn upgrade_outbound(self, sock: C, info: Self::Info) -> Self::Future {
+    fn upgrade_outbound(self, sock: C, info: ProtocolName) -> Self::Future {
         if let Some(inner) = self.0 {
             inner.upgrade_outbound(sock, info)
         } else {

--- a/core/src/upgrade/pending.rs
+++ b/core/src/upgrade/pending.rs
@@ -26,51 +26,44 @@ use void::Void;
 
 /// Implementation of [`UpgradeInfo`], [`InboundUpgrade`] and [`OutboundUpgrade`] that always
 /// returns a pending upgrade.
-#[derive(Debug, Copy, Clone)]
-pub struct PendingUpgrade<P> {
-    protocol_name: P,
+#[derive(Debug, Clone)]
+pub struct PendingUpgrade {
+    protocol_name: ProtocolName,
 }
 
-impl<P> PendingUpgrade<P> {
-    pub fn new(protocol_name: P) -> Self {
+impl PendingUpgrade {
+    pub fn new(protocol_name: ProtocolName) -> Self {
         Self { protocol_name }
     }
 }
 
-impl<P> UpgradeInfo for PendingUpgrade<P>
-where
-    P: ProtocolName + Clone,
+impl UpgradeInfo for PendingUpgrade
 {
-    type Info = P;
-    type InfoIter = iter::Once<P>;
+    type InfoIter = iter::Once<ProtocolName>;
 
     fn protocol_info(&self) -> Self::InfoIter {
         iter::once(self.protocol_name.clone())
     }
 }
 
-impl<C, P> InboundUpgrade<C> for PendingUpgrade<P>
-where
-    P: ProtocolName + Clone,
+impl<C> InboundUpgrade<C> for PendingUpgrade
 {
     type Output = Void;
     type Error = Void;
     type Future = future::Pending<Result<Self::Output, Self::Error>>;
 
-    fn upgrade_inbound(self, _: C, _: Self::Info) -> Self::Future {
+    fn upgrade_inbound(self, _: C, _: ProtocolName) -> Self::Future {
         future::pending()
     }
 }
 
-impl<C, P> OutboundUpgrade<C> for PendingUpgrade<P>
-where
-    P: ProtocolName + Clone,
+impl<C> OutboundUpgrade<C> for PendingUpgrade
 {
     type Output = Void;
     type Error = Void;
     type Future = future::Pending<Result<Self::Output, Self::Error>>;
 
-    fn upgrade_outbound(self, _: C, _: Self::Info) -> Self::Future {
+    fn upgrade_outbound(self, _: C, _: ProtocolName) -> Self::Future {
         future::pending()
     }
 }

--- a/core/src/upgrade/pending.rs
+++ b/core/src/upgrade/pending.rs
@@ -37,8 +37,7 @@ impl PendingUpgrade {
     }
 }
 
-impl UpgradeInfo for PendingUpgrade
-{
+impl UpgradeInfo for PendingUpgrade {
     type InfoIter = iter::Once<ProtocolName>;
 
     fn protocol_info(&self) -> Self::InfoIter {
@@ -46,8 +45,7 @@ impl UpgradeInfo for PendingUpgrade
     }
 }
 
-impl<C> InboundUpgrade<C> for PendingUpgrade
-{
+impl<C> InboundUpgrade<C> for PendingUpgrade {
     type Output = Void;
     type Error = Void;
     type Future = future::Pending<Result<Self::Output, Self::Error>>;
@@ -57,8 +55,7 @@ impl<C> InboundUpgrade<C> for PendingUpgrade
     }
 }
 
-impl<C> OutboundUpgrade<C> for PendingUpgrade
-{
+impl<C> OutboundUpgrade<C> for PendingUpgrade {
     type Output = Void;
     type Error = Void;
     type Future = future::Pending<Result<Self::Output, Self::Error>>;

--- a/core/src/upgrade/ready.rs
+++ b/core/src/upgrade/ready.rs
@@ -25,51 +25,44 @@ use std::iter;
 use void::Void;
 
 /// Implementation of [`UpgradeInfo`], [`InboundUpgrade`] and [`OutboundUpgrade`] that directly yields the substream.
-#[derive(Debug, Copy, Clone)]
-pub struct ReadyUpgrade<P> {
-    protocol_name: P,
+#[derive(Debug, Clone)]
+pub struct ReadyUpgrade {
+    protocol_name: ProtocolName,
 }
 
-impl<P> ReadyUpgrade<P> {
-    pub fn new(protocol_name: P) -> Self {
+impl ReadyUpgrade {
+    pub fn new(protocol_name: ProtocolName) -> Self {
         Self { protocol_name }
     }
 }
 
-impl<P> UpgradeInfo for ReadyUpgrade<P>
-where
-    P: ProtocolName + Clone,
+impl UpgradeInfo for ReadyUpgrade
 {
-    type Info = P;
-    type InfoIter = iter::Once<P>;
+    type InfoIter = iter::Once<ProtocolName>;
 
     fn protocol_info(&self) -> Self::InfoIter {
         iter::once(self.protocol_name.clone())
     }
 }
 
-impl<C, P> InboundUpgrade<C> for ReadyUpgrade<P>
-where
-    P: ProtocolName + Clone,
+impl<C> InboundUpgrade<C> for ReadyUpgrade
 {
     type Output = C;
     type Error = Void;
     type Future = future::Ready<Result<Self::Output, Self::Error>>;
 
-    fn upgrade_inbound(self, stream: C, _: Self::Info) -> Self::Future {
+    fn upgrade_inbound(self, stream: C, _: ProtocolName) -> Self::Future {
         future::ready(Ok(stream))
     }
 }
 
-impl<C, P> OutboundUpgrade<C> for ReadyUpgrade<P>
-where
-    P: ProtocolName + Clone,
+impl<C> OutboundUpgrade<C> for ReadyUpgrade
 {
     type Output = C;
     type Error = Void;
     type Future = future::Ready<Result<Self::Output, Self::Error>>;
 
-    fn upgrade_outbound(self, stream: C, _: Self::Info) -> Self::Future {
+    fn upgrade_outbound(self, stream: C, _: ProtocolName) -> Self::Future {
         future::ready(Ok(stream))
     }
 }

--- a/core/src/upgrade/ready.rs
+++ b/core/src/upgrade/ready.rs
@@ -36,8 +36,7 @@ impl ReadyUpgrade {
     }
 }
 
-impl UpgradeInfo for ReadyUpgrade
-{
+impl UpgradeInfo for ReadyUpgrade {
     type InfoIter = iter::Once<ProtocolName>;
 
     fn protocol_info(&self) -> Self::InfoIter {
@@ -45,8 +44,7 @@ impl UpgradeInfo for ReadyUpgrade
     }
 }
 
-impl<C> InboundUpgrade<C> for ReadyUpgrade
-{
+impl<C> InboundUpgrade<C> for ReadyUpgrade {
     type Output = C;
     type Error = Void;
     type Future = future::Ready<Result<Self::Output, Self::Error>>;
@@ -56,8 +54,7 @@ impl<C> InboundUpgrade<C> for ReadyUpgrade
     }
 }
 
-impl<C> OutboundUpgrade<C> for ReadyUpgrade
-{
+impl<C> OutboundUpgrade<C> for ReadyUpgrade {
     type Output = C;
     type Error = Void;
     type Future = future::Ready<Result<Self::Output, Self::Error>>;

--- a/core/src/upgrade/select.rs
+++ b/core/src/upgrade/select.rs
@@ -44,7 +44,6 @@ where
     A: UpgradeInfo,
     B: UpgradeInfo,
 {
-    type Info = EitherName<A::Info, B::Info>;
     type InfoIter = InfoIterChain<
         <A::InfoIter as IntoIterator>::IntoIter,
         <B::InfoIter as IntoIterator>::IntoIter,
@@ -67,7 +66,7 @@ where
     type Error = EitherError<EA, EB>;
     type Future = EitherFuture2<A::Future, B::Future>;
 
-    fn upgrade_inbound(self, sock: C, info: Self::Info) -> Self::Future {
+    fn upgrade_inbound(self, sock: C, info: EitherName) -> Self::Future {
         match info {
             EitherName::A(info) => EitherFuture2::A(self.0.upgrade_inbound(sock, info)),
             EitherName::B(info) => EitherFuture2::B(self.1.upgrade_inbound(sock, info)),
@@ -84,7 +83,7 @@ where
     type Error = EitherError<EA, EB>;
     type Future = EitherFuture2<A::Future, B::Future>;
 
-    fn upgrade_outbound(self, sock: C, info: Self::Info) -> Self::Future {
+    fn upgrade_outbound(self, sock: C, info: EitherName) -> Self::Future {
         match info {
             EitherName::A(info) => EitherFuture2::A(self.0.upgrade_outbound(sock, info)),
             EitherName::B(info) => EitherFuture2::B(self.1.upgrade_outbound(sock, info)),
@@ -101,7 +100,7 @@ where
     A: Iterator,
     B: Iterator,
 {
-    type Item = EitherName<A::Item, B::Item>;
+    type Item = EitherName;
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(info) = self.0.next() {

--- a/core/tests/transport_upgrade.rs
+++ b/core/tests/transport_upgrade.rs
@@ -32,8 +32,7 @@ use std::{io, pin::Pin};
 struct HelloUpgrade {}
 
 impl UpgradeInfo for HelloUpgrade {
-    type Info = &'static str;
-    type InfoIter = std::iter::Once<Self::Info>;
+    type InfoIter = std::iter::Once<ProtocolName>;
 
     fn protocol_info(&self) -> Self::InfoIter {
         std::iter::once("/hello/1")
@@ -48,7 +47,7 @@ where
     type Error = io::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
 
-    fn upgrade_inbound(self, mut socket: C, _: Self::Info) -> Self::Future {
+    fn upgrade_inbound(self, mut socket: C, _: ProtocolName) -> Self::Future {
         Box::pin(async move {
             let mut buf = [0u8; 5];
             socket.read_exact(&mut buf).await.unwrap();
@@ -66,7 +65,7 @@ where
     type Error = io::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
 
-    fn upgrade_outbound(self, mut socket: C, _: Self::Info) -> Self::Future {
+    fn upgrade_outbound(self, mut socket: C, _: ProtocolName) -> Self::Future {
         Box::pin(async move {
             socket.write_all(b"hello").await.unwrap();
             socket.flush().await.unwrap();

--- a/swarm/src/handler/multi.rs
+++ b/swarm/src/handler/multi.rs
@@ -397,9 +397,9 @@ where
 
 /// Index and protocol name pair used as `UpgradeInfo::Info`.
 #[derive(Debug, Clone)]
-pub struct IndexedProtoName<H>(usize, H);
+pub struct IndexedProtoName(usize, ProtocolName);
 
-impl<H: ProtocolName> ProtocolName for IndexedProtoName<H> {
+impl IndexedProtoName {
     fn protocol_name(&self) -> &[u8] {
         self.1.protocol_name()
     }
@@ -455,8 +455,7 @@ where
     H: UpgradeInfoSend,
     K: Send + 'static,
 {
-    type Info = IndexedProtoName<H::Info>;
-    type InfoIter = std::vec::IntoIter<Self::Info>;
+    type InfoIter = std::vec::IntoIter<IndexedProtoName>;
 
     fn protocol_info(&self) -> Self::InfoIter {
         self.upgrades
@@ -478,7 +477,7 @@ where
     type Error = (K, <H as InboundUpgradeSend>::Error);
     type Future = BoxFuture<'static, Result<Self::Output, Self::Error>>;
 
-    fn upgrade_inbound(mut self, resource: NegotiatedSubstream, info: Self::Info) -> Self::Future {
+    fn upgrade_inbound(mut self, resource: NegotiatedSubstream, info: ProtocolName) -> Self::Future {
         let IndexedProtoName(index, info) = info;
         let (key, upgrade) = self.upgrades.remove(index);
         upgrade
@@ -500,7 +499,7 @@ where
     type Error = (K, <H as OutboundUpgradeSend>::Error);
     type Future = BoxFuture<'static, Result<Self::Output, Self::Error>>;
 
-    fn upgrade_outbound(mut self, resource: NegotiatedSubstream, info: Self::Info) -> Self::Future {
+    fn upgrade_outbound(mut self, resource: NegotiatedSubstream, info: ProtocolName) -> Self::Future {
         let IndexedProtoName(index, info) = info;
         let (key, upgrade) = self.upgrades.remove(index);
         upgrade

--- a/swarm/src/handler/pending.rs
+++ b/swarm/src/handler/pending.rs
@@ -47,8 +47,8 @@ impl ConnectionHandler for PendingConnectionHandler {
     type InEvent = Void;
     type OutEvent = Void;
     type Error = Void;
-    type InboundProtocol = PendingUpgrade<String>;
-    type OutboundProtocol = PendingUpgrade<String>;
+    type InboundProtocol = PendingUpgrade;
+    type OutboundProtocol = PendingUpgrade;
     type OutboundOpenInfo = Void;
     type InboundOpenInfo = ();
 

--- a/swarm/src/upgrade.rs
+++ b/swarm/src/upgrade.rs
@@ -22,6 +22,7 @@ use crate::NegotiatedSubstream;
 
 use futures::prelude::*;
 use libp2p_core::upgrade;
+use std::iter;
 
 /// Implemented automatically on all types that implement [`UpgradeInfo`](upgrade::UpgradeInfo)
 /// and `Send + 'static`.
@@ -29,23 +30,17 @@ use libp2p_core::upgrade;
 /// Do not implement this trait yourself. Instead, please implement
 /// [`UpgradeInfo`](upgrade::UpgradeInfo).
 pub trait UpgradeInfoSend: Send + 'static {
-    /// Equivalent to [`UpgradeInfo::Info`](upgrade::UpgradeInfo::Info).
-    type Info: upgrade::ProtocolName + Clone + Send + 'static;
+/// Equivalent to [`UpgradeInfo::Info`](upgrade::UpgradeInfo::Info).
+//type Info: upgrade::ProtocolName + Clone + Send + 'static;
     /// Equivalent to [`UpgradeInfo::InfoIter`](upgrade::UpgradeInfo::InfoIter).
-    type InfoIter: Iterator<Item = Self::Info> + Send + 'static;
+    type InfoIter: Iterator<Item = upgrade::ProtocolName> + Send + 'static;
 
     /// Equivalent to [`UpgradeInfo::protocol_info`](upgrade::UpgradeInfo::protocol_info).
     fn protocol_info(&self) -> Self::InfoIter;
 }
 
-impl<T> UpgradeInfoSend for T
-where
-    T: upgrade::UpgradeInfo + Send + 'static,
-    T::Info: Send + 'static,
-    <T::InfoIter as IntoIterator>::IntoIter: Send + 'static,
-{
-    type Info = T::Info;
-    type InfoIter = <T::InfoIter as IntoIterator>::IntoIter;
+impl UpgradeInfoSend for upgrade::ProtocolName {
+    type InfoIter = iter::Once<upgrade::ProtocolName>;
 
     fn protocol_info(&self) -> Self::InfoIter {
         upgrade::UpgradeInfo::protocol_info(self).into_iter()
@@ -66,13 +61,12 @@ pub trait OutboundUpgradeSend: UpgradeInfoSend {
     type Future: Future<Output = Result<Self::Output, Self::Error>> + Send + 'static;
 
     /// Equivalent to [`OutboundUpgrade::upgrade_outbound`](upgrade::OutboundUpgrade::upgrade_outbound).
-    fn upgrade_outbound(self, socket: NegotiatedSubstream, info: Self::Info) -> Self::Future;
+    fn upgrade_outbound(self, socket: NegotiatedSubstream, info: upgrade::ProtocolName) -> Self::Future;
 }
 
-impl<T, TInfo> OutboundUpgradeSend for T
+impl<T> OutboundUpgradeSend for T
 where
-    T: upgrade::OutboundUpgrade<NegotiatedSubstream, Info = TInfo> + UpgradeInfoSend<Info = TInfo>,
-    TInfo: upgrade::ProtocolName + Clone + Send + 'static,
+    T: upgrade::OutboundUpgrade<NegotiatedSubstream> + UpgradeInfoSend,
     T::Output: Send + 'static,
     T::Error: Send + 'static,
     T::Future: Send + 'static,
@@ -81,7 +75,7 @@ where
     type Error = T::Error;
     type Future = T::Future;
 
-    fn upgrade_outbound(self, socket: NegotiatedSubstream, info: TInfo) -> Self::Future {
+    fn upgrade_outbound(self, socket: NegotiatedSubstream, info: upgrade::ProtocolName) -> Self::Future {
         upgrade::OutboundUpgrade::upgrade_outbound(self, socket, info)
     }
 }
@@ -100,13 +94,12 @@ pub trait InboundUpgradeSend: UpgradeInfoSend {
     type Future: Future<Output = Result<Self::Output, Self::Error>> + Send + 'static;
 
     /// Equivalent to [`InboundUpgrade::upgrade_inbound`](upgrade::InboundUpgrade::upgrade_inbound).
-    fn upgrade_inbound(self, socket: NegotiatedSubstream, info: Self::Info) -> Self::Future;
+    fn upgrade_inbound(self, socket: NegotiatedSubstream, info: upgrade::ProtocolName) -> Self::Future;
 }
 
-impl<T, TInfo> InboundUpgradeSend for T
+impl<T> InboundUpgradeSend for T
 where
-    T: upgrade::InboundUpgrade<NegotiatedSubstream, Info = TInfo> + UpgradeInfoSend<Info = TInfo>,
-    TInfo: upgrade::ProtocolName + Clone + Send + 'static,
+    T: upgrade::InboundUpgrade<NegotiatedSubstream> + UpgradeInfoSend,
     T::Output: Send + 'static,
     T::Error: Send + 'static,
     T::Future: Send + 'static,
@@ -115,7 +108,7 @@ where
     type Error = T::Error;
     type Future = T::Future;
 
-    fn upgrade_inbound(self, socket: NegotiatedSubstream, info: TInfo) -> Self::Future {
+    fn upgrade_inbound(self, socket: NegotiatedSubstream, info: upgrade::ProtocolName) -> Self::Future {
         upgrade::InboundUpgrade::upgrade_inbound(self, socket, info)
     }
 }
@@ -129,7 +122,6 @@ where
 pub struct SendWrapper<T>(pub T);
 
 impl<T: UpgradeInfoSend> upgrade::UpgradeInfo for SendWrapper<T> {
-    type Info = T::Info;
     type InfoIter = T::InfoIter;
 
     fn protocol_info(&self) -> Self::InfoIter {
@@ -142,7 +134,7 @@ impl<T: OutboundUpgradeSend> upgrade::OutboundUpgrade<NegotiatedSubstream> for S
     type Error = T::Error;
     type Future = T::Future;
 
-    fn upgrade_outbound(self, socket: NegotiatedSubstream, info: T::Info) -> Self::Future {
+    fn upgrade_outbound(self, socket: NegotiatedSubstream, info: upgrade::ProtocolName) -> Self::Future {
         OutboundUpgradeSend::upgrade_outbound(self.0, socket, info)
     }
 }
@@ -152,7 +144,7 @@ impl<T: InboundUpgradeSend> upgrade::InboundUpgrade<NegotiatedSubstream> for Sen
     type Error = T::Error;
     type Future = T::Future;
 
-    fn upgrade_inbound(self, socket: NegotiatedSubstream, info: T::Info) -> Self::Future {
+    fn upgrade_inbound(self, socket: NegotiatedSubstream, info: upgrade::ProtocolName) -> Self::Future {
         InboundUpgradeSend::upgrade_inbound(self.0, socket, info)
     }
 }


### PR DESCRIPTION
@thomaseizinger 