### PR TITLE
protocols/identify: Change default cache size to 100

### DIFF
--- a/protocols/identify/src/identify.rs
+++ b/protocols/identify/src/identify.rs
@@ -131,7 +131,7 @@ impl IdentifyConfig {
             initial_delay: Duration::from_millis(500),
             interval: Duration::from_secs(5 * 60),
             push_listen_addr_updates: false,
-            cache_size: 0,
+            cache_size: 100,
         }
     }
 


### PR DESCRIPTION
# Description

`IdentifyConfig` struct's member `cache_size` now defaults to `100`

## Links to any relevant issues

https://github.com/libp2p/rust-libp2p/issues/2933

## Open Questions

https://github.com/libp2p/rust-libp2p/blob/1da75b2b253f7073166b0aa532bf05a6d2158187/protocols/identify/src/identify.rs#L750-L756

Can we remove the line `.with_cache_size(100)` now?

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
