### PR TITLE
.github/workflows: Re-activate documentation of private items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     - uses: Swatinem/rust-cache@6720f05bc48b77f96918929a9019fb2203ff71f8 # v2.0.0
 
     - name: Check rustdoc links
-      run: RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links --deny warnings" cargo doc --verbose --workspace --no-deps --all-features
+      run: RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links --deny warnings" cargo doc --verbose --workspace --no-deps --all-features --document-private-items
 
   check-clippy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

Removing `--document-private-items` in https://github.com/libp2p/rust-libp2p/pull/2936 was a mistake. This means we miss out on broken intra-doc links on private items which we still use quite a lot. They are helpful for maintainers even if the resulting struct is not publicly exposed.

cc @ddimaria 

## Links to any relevant issues

<!-- Reference any related issues.-->
- https://github.com/libp2p/rust-libp2p/pull/2936

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~A changelog entry has been made in the appropriate crates~
