### PR TITLE
protocols/{relay,dcutr}: Replace `std::time::SystemTime` with `instant::SystemTime`

### DIFF
--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Update to `libp2p-swarm` `v0.40.0`.
 
+- Fix WASM compilation. See [PR 2991].
+
+[PR 2991]: https://github.com/libp2p/rust-libp2p/pull/2991/
+
 # 0.6.0
 
 - Update to `libp2p-swarm` `v0.39.0`.

--- a/protocols/dcutr/src/protocol/outbound.rs
+++ b/protocols/dcutr/src/protocol/outbound.rs
@@ -22,11 +22,11 @@ use crate::message_proto::{hole_punch, HolePunch};
 use asynchronous_codec::Framed;
 use futures::{future::BoxFuture, prelude::*};
 use futures_timer::Delay;
+use instant::Instant;
 use libp2p_core::{multiaddr::Protocol, upgrade, Multiaddr};
 use libp2p_swarm::NegotiatedSubstream;
 use std::convert::TryFrom;
 use std::iter;
-use std::time::Instant;
 use thiserror::Error;
 
 pub struct Upgrade {

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Update to `libp2p-swarm` `v0.40.0`.
 
+- Fix WASM compilation. See [PR XXXX].
+
+[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX/
+
 # 0.12.0
 
 - Update to `libp2p-swarm` `v0.39.0`.

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 - Update to `libp2p-swarm` `v0.40.0`.
 
-- Fix WASM compilation. See [PR XXXX].
+- Fix WASM compilation. See [PR 2991].
 
-[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX/
+[PR 2991]: https://github.com/libp2p/rust-libp2p/pull/2991/
 
 # 0.12.0
 

--- a/protocols/relay/src/v2/protocol/inbound_hop.rs
+++ b/protocols/relay/src/v2/protocol/inbound_hop.rs
@@ -23,11 +23,11 @@ use crate::v2::protocol::{HOP_PROTOCOL_NAME, MAX_MESSAGE_SIZE};
 use asynchronous_codec::{Framed, FramedParts};
 use bytes::Bytes;
 use futures::{future::BoxFuture, prelude::*};
+use instant::{Duration, SystemTime};
 use libp2p_core::{upgrade, Multiaddr, PeerId};
 use libp2p_swarm::NegotiatedSubstream;
 use std::convert::TryInto;
 use std::iter;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
 pub struct Upgrade {
@@ -142,7 +142,7 @@ impl ReservationReq {
             reservation: Some(Reservation {
                 addrs: addrs.into_iter().map(|a| a.to_vec()).collect(),
                 expire: (SystemTime::now() + self.reservation_duration)
-                    .duration_since(UNIX_EPOCH)
+                    .duration_since(SystemTime::UNIX_EPOCH)
                     .unwrap()
                     .as_secs(),
                 voucher: None,

--- a/protocols/relay/src/v2/protocol/outbound_hop.rs
+++ b/protocols/relay/src/v2/protocol/outbound_hop.rs
@@ -24,11 +24,11 @@ use asynchronous_codec::{Framed, FramedParts};
 use bytes::Bytes;
 use futures::{future::BoxFuture, prelude::*};
 use futures_timer::Delay;
+use instant::{Duration, SystemTime};
 use libp2p_core::{upgrade, Multiaddr, PeerId};
 use libp2p_swarm::NegotiatedSubstream;
 use std::convert::TryFrom;
 use std::iter;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
 pub enum Upgrade {
@@ -134,7 +134,7 @@ impl upgrade::OutboundUpgrade<NegotiatedSubstream> for Upgrade {
                         .expire
                         .checked_sub(
                             SystemTime::now()
-                                .duration_since(UNIX_EPOCH)
+                                .duration_since(SystemTime::UNIX_EPOCH)
                                 .unwrap()
                                 .as_secs(),
                         )


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

I tried to safeguard against this by banning `std::time::SystemTime::now` via clippy.toml but unfortunately, it doesn't work because `instant` re-exports `std` when not compiling for wasm so it still gets flagged.

## Links to any relevant issues

<!-- Reference any related issues.-->
- Fixes https://github.com/libp2p/rust-libp2p/issues/2984

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] A changelog entry has been made in the appropriate crates
