### PR TITLE
core/muxer: Deprecate `StreamMuxerExt::next_{inbound,outbound}`

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -5,11 +5,11 @@
 - Remove default features. If you previously depended on `secp256k1` or `ecdsa` you need to enable these explicitly 
   now. See [PR 2918].
 
-- Deprecate `StreamMuxerExt::next_{inbound,outbound}`. See [PR XXXX].
+- Deprecate `StreamMuxerExt::next_{inbound,outbound}`. See [PR 3002].
 
 [PR 2915]: https://github.com/libp2p/rust-libp2p/pull/2915
 [PR 2918]: https://github.com/libp2p/rust-libp2p/pull/2918
-[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
+[PR 3002]: https://github.com/libp2p/rust-libp2p/pull/3002
 
 # 0.36.0
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -5,8 +5,11 @@
 - Remove default features. If you previously depended on `secp256k1` or `ecdsa` you need to enable these explicitly 
   now. See [PR 2918].
 
+- Deprecate `StreamMuxerExt::next_{inbound,outbound}`. See [PR XXXX].
+
 [PR 2915]: https://github.com/libp2p/rust-libp2p/pull/2915
 [PR 2918]: https://github.com/libp2p/rust-libp2p/pull/2918
+[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
 
 # 0.36.0
 

--- a/core/src/muxing.rs
+++ b/core/src/muxing.rs
@@ -160,11 +160,19 @@ pub trait StreamMuxerExt: StreamMuxer + Sized {
     }
 
     /// Returns a future that resolves to the next inbound `Substream` opened by the remote.
+    #[deprecated(
+        since = "0.36.1",
+        note = "This future violates the `StreamMuxer` contract because it doesn't call `StreamMuxer::poll`."
+    )]
     fn next_inbound(&mut self) -> NextInbound<'_, Self> {
         NextInbound(self)
     }
 
     /// Returns a future that opens a new outbound `Substream` with the remote.
+    #[deprecated(
+        since = "0.36.1",
+        note = "This future violates the `StreamMuxer` contract because it doesn't call `StreamMuxer::poll`."
+    )]
     fn next_outbound(&mut self) -> NextOutbound<'_, Self> {
         NextOutbound(self)
     }

--- a/core/src/muxing.rs
+++ b/core/src/muxing.rs
@@ -161,7 +161,7 @@ pub trait StreamMuxerExt: StreamMuxer + Sized {
 
     /// Returns a future that resolves to the next inbound `Substream` opened by the remote.
     #[deprecated(
-        since = "0.36.1",
+        since = "0.37.0",
         note = "This future violates the `StreamMuxer` contract because it doesn't call `StreamMuxer::poll`."
     )]
     fn next_inbound(&mut self) -> NextInbound<'_, Self> {
@@ -170,7 +170,7 @@ pub trait StreamMuxerExt: StreamMuxer + Sized {
 
     /// Returns a future that opens a new outbound `Substream` with the remote.
     #[deprecated(
-        since = "0.36.1",
+        since = "0.37.0",
         note = "This future violates the `StreamMuxer` contract because it doesn't call `StreamMuxer::poll`."
     )]
     fn next_outbound(&mut self) -> NextOutbound<'_, Self> {

--- a/muxers/mplex/tests/two_peers.rs
+++ b/muxers/mplex/tests/two_peers.rs
@@ -18,6 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use futures::future::poll_fn;
 use futures::{channel::oneshot, prelude::*};
 use libp2p::core::muxing::StreamMuxerExt;
 use libp2p::core::{upgrade, Transport};
@@ -59,7 +60,10 @@ fn client_to_server_outbound() {
             .await
             .unwrap();
 
-        let mut outbound = client.next_outbound().await.unwrap();
+        // Just calling `poll_outbound` without `poll` is fine here because mplex makes progress through all `poll_` functions. It is hacky though.
+        let mut outbound = poll_fn(|cx| client.poll_outbound_unpin(cx))
+            .await
+            .expect("unexpected error");
 
         let mut buf = Vec::new();
         outbound.read_to_end(&mut buf).await.unwrap();
@@ -73,7 +77,10 @@ fn client_to_server_outbound() {
             .boxed();
 
         let mut client = transport.dial(rx.await.unwrap()).unwrap().await.unwrap();
-        let mut inbound = client.next_inbound().await.unwrap();
+        // Just calling `poll_inbound` without `poll` is fine here because mplex makes progress through all `poll_` functions. It is hacky though.
+        let mut inbound = poll_fn(|cx| client.poll_inbound_unpin(cx))
+            .await
+            .expect("unexpected error");
         inbound.write_all(b"hello world").await.unwrap();
         inbound.close().await.unwrap();
 
@@ -117,7 +124,10 @@ fn client_to_server_inbound() {
             .await
             .unwrap();
 
-        let mut inbound = client.next_inbound().await.unwrap();
+        // Just calling `poll_inbound` without `poll` is fine here because mplex makes progress through all `poll_` functions. It is hacky though.
+        let mut inbound = poll_fn(|cx| client.poll_inbound_unpin(cx))
+            .await
+            .expect("unexpected error");
 
         let mut buf = Vec::new();
         inbound.read_to_end(&mut buf).await.unwrap();
@@ -132,7 +142,10 @@ fn client_to_server_inbound() {
 
         let mut client = transport.dial(rx.await.unwrap()).unwrap().await.unwrap();
 
-        let mut outbound = client.next_outbound().await.unwrap();
+        // Just calling `poll_outbound` without `poll` is fine here because mplex makes progress through all `poll_` functions. It is hacky though.
+        let mut outbound = poll_fn(|cx| client.poll_outbound_unpin(cx))
+            .await
+            .expect("unexpected error");
         outbound.write_all(b"hello world").await.unwrap();
         outbound.close().await.unwrap();
 
@@ -174,7 +187,10 @@ fn protocol_not_match() {
             .await
             .unwrap();
 
-        let mut outbound = client.next_outbound().await.unwrap();
+        // Just calling `poll_outbound` without `poll` is fine here because mplex makes progress through all `poll_` functions. It is hacky though.
+        let mut outbound = poll_fn(|cx| client.poll_outbound_unpin(cx))
+            .await
+            .expect("unexpected error");
 
         let mut buf = Vec::new();
         outbound.read_to_end(&mut buf).await.unwrap();


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

## Links to any relevant issues

<!-- Reference any related issues.-->
- https://github.com/libp2p/rust-libp2p/pull/2952

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] A changelog entry has been made in the appropriate crates
