### PR TITLE
README: Add fuel-core as a notable user

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 
 - [COMIT](https://github.com/comit-network/xmr-btc-swap) - Bitcoin–Monero Cross-chain Atomic Swap.
 - [Forest](https://github.com/ChainSafe/forest) - An implementation of Filecoin written in Rust.
+- [fuel-core](https://github.com/FuelLabs/fuel-core) - A Rust implementation of the Fuel protocol
 - [ipfs-embed](https://github.com/ipfs-rust/ipfs-embed) - A small embeddable ipfs implementation
 used and maintained by [Actyx][https://www.actyx.com].
 - [iroh](https://github.com/n0-computer/iroh) - Next-generation implementation of IPFS for Cloud & Mobile platforms.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 
 - [COMIT](https://github.com/comit-network/xmr-btc-swap) - Bitcoin–Monero Cross-chain Atomic Swap.
 - [Forest](https://github.com/ChainSafe/forest) - An implementation of Filecoin written in Rust.
-- [fuel-core](https://github.com/FuelLabs/fuel-core) - A Rust implementation of the Fuel protocol
+- [fuel-core](https://github.com/FuelLabs/fuel-core) - A Rust implementation of the Fuel protocol.
 - [ipfs-embed](https://github.com/ipfs-rust/ipfs-embed) - A small embeddable ipfs implementation
 used and maintained by [Actyx][https://www.actyx.com].
 - [iroh](https://github.com/n0-computer/iroh) - Next-generation implementation of IPFS for Cloud & Mobile platforms.


### PR DESCRIPTION
# Description
Was working on a metrics integration for `fuel-core`'s p2p module, and realized rust-libp2p had a notable users section. I added Fuel Lab's main client implementation as a notable user of libp2p, which is used extensively in fuel-core's p2p module. Fuel Labs wrote the first optimistic rollup deployed on Ethereum, and is now working on a v2 (which is the client referenced) that runs a fraud-provable execution environment which can be configured to post data and settle on different chains.

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
