### PR TITLE
libp2p_swarm_derive: Add `crate` parameter to configure `libp2p` crate name

### DIFF
--- a/swarm-derive/src/lib.rs
+++ b/swarm-derive/src/lib.rs
@@ -46,21 +46,43 @@ fn build(ast: &DeriveInput) -> TokenStream {
 fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
     let name = &ast.ident;
     let (_, ty_generics, where_clause) = ast.generics.split_for_impl();
-    let multiaddr = quote! {::libp2p::core::Multiaddr};
-    let trait_to_impl = quote! {::libp2p::swarm::NetworkBehaviour};
-    let either_ident = quote! {::libp2p::core::either::EitherOutput};
-    let network_behaviour_action = quote! {::libp2p::swarm::NetworkBehaviourAction};
-    let into_connection_handler = quote! {::libp2p::swarm::IntoConnectionHandler};
-    let connection_handler = quote! {::libp2p::swarm::ConnectionHandler};
-    let into_proto_select_ident = quote! {::libp2p::swarm::IntoConnectionHandlerSelect};
-    let peer_id = quote! {::libp2p::core::PeerId};
-    let connection_id = quote! {::libp2p::core::connection::ConnectionId};
-    let dial_errors = quote! {Option<&Vec<::libp2p::core::Multiaddr>>};
-    let connected_point = quote! {::libp2p::core::ConnectedPoint};
-    let listener_id = quote! {::libp2p::core::transport::ListenerId};
-    let dial_error = quote! {::libp2p::swarm::DialError};
 
-    let poll_parameters = quote! {::libp2p::swarm::PollParameters};
+    let user_provided_libp2p_prefix = ast
+        .attrs
+        .iter()
+        .filter_map(get_meta_items)
+        .flatten()
+        .filter_map(|meta_item| {
+            if let syn::NestedMeta::Meta(syn::Meta::NameValue(ref m)) = meta_item {
+                if m.path.is_ident("crate") {
+                    if let syn::Lit::Str(ref s) = m.lit {
+                        return Some(syn::parse_str::<syn::TypePath>(&s.value()).unwrap());
+                    }
+                }
+            }
+            None
+        })
+        .next();
+
+    let libp2p_prefix = match user_provided_libp2p_prefix {
+        Some(pfx) => quote! {#pfx},
+        None => quote! {::libp2p},
+    };
+    let multiaddr = quote! {#libp2p_prefix::core::Multiaddr};
+    let trait_to_impl = quote! {#libp2p_prefix::swarm::NetworkBehaviour};
+    let either_ident = quote! {#libp2p_prefix::core::either::EitherOutput};
+    let network_behaviour_action = quote! {#libp2p_prefix::swarm::NetworkBehaviourAction};
+    let into_connection_handler = quote! {#libp2p_prefix::swarm::IntoConnectionHandler};
+    let connection_handler = quote! {#libp2p_prefix::swarm::ConnectionHandler};
+    let into_proto_select_ident = quote! {#libp2p_prefix::swarm::IntoConnectionHandlerSelect};
+    let peer_id = quote! {#libp2p_prefix::core::PeerId};
+    let connection_id = quote! {#libp2p_prefix::core::connection::ConnectionId};
+    let dial_errors = quote! {Option<&Vec<#libp2p_prefix::core::Multiaddr>>};
+    let connected_point = quote! {#libp2p_prefix::core::ConnectedPoint};
+    let listener_id = quote! {#libp2p_prefix::core::transport::ListenerId};
+    let dial_error = quote! {#libp2p_prefix::swarm::DialError};
+
+    let poll_parameters = quote! {#libp2p_prefix::swarm::PollParameters};
 
     // Build the generics.
     let impl_generics = {
@@ -624,7 +646,7 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> TokenStream {
             }
 
             fn poll(&mut self, cx: &mut std::task::Context, poll_params: &mut impl #poll_parameters) -> std::task::Poll<#network_behaviour_action<Self::OutEvent, Self::ConnectionHandler>> {
-                use libp2p::futures::prelude::*;
+                use #libp2p_prefix::futures::prelude::*;
                 #(#poll_stmts)*
                 std::task::Poll::Pending
             }

--- a/swarm-derive/tests/test.rs
+++ b/swarm-derive/tests/test.rs
@@ -134,6 +134,23 @@ fn custom_event() {
 }
 
 #[test]
+fn custom_crate() {
+    use libp2p as mylibp2p;
+    #[allow(dead_code)]
+    #[derive(NetworkBehaviour)]
+    #[behaviour(crate = "mylibp2p")]
+    struct Foo {
+        ping: ping::Behaviour,
+        identify: identify::Behaviour,
+    }
+
+    #[allow(dead_code)]
+    fn foo() {
+        require_net_behaviour::<Foo>();
+    }
+}
+
+#[test]
 fn custom_event_mismatching_field_names() {
     #[allow(dead_code)]
     #[derive(NetworkBehaviour)]


### PR DESCRIPTION
# Description

When importing libp2p with a use statement and a custom alias name, the code generated by the NetworkBehaviour derive macro does not use this alias and does not compile. This PR enhances the derive macro with a new parameter "crate" that can be used to specify the custom alias name.

## Open Questions
None

## Change checklist

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
