### PR TITLE
transports/dns/: Don't feature flag std::io import

### DIFF
--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -65,7 +65,6 @@ use libp2p_core::{
 };
 use parking_lot::Mutex;
 use smallvec::SmallVec;
-#[cfg(any(feature = "async-std", feature = "tokio"))]
 use std::io;
 use std::{
     convert::TryFrom,


### PR DESCRIPTION
# Description

Functions like `parse_dnsaddr_txt` depend on the `std::io` import. Given that the function is not feature flagged, compilation without features fails.

## Links to any relevant issues

Discovered while releasing `v0.49.0`. Would like to get this in before continuing the `v0.49.0` release. https://github.com/libp2p/rust-libp2p/pull/2931

## Open Questions

Even though `libp2p-dns` is useless without either the async-io or tokio feature flag, I do still think that it should compile without. Objections?

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
