### PR TITLE
Revert "transports/dns/: Don't feature flag std::io import"

### DIFF
--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -65,6 +65,7 @@ use libp2p_core::{
 };
 use parking_lot::Mutex;
 use smallvec::SmallVec;
+#[cfg(any(feature = "async-std", feature = "tokio"))]
 use std::io;
 use std::{
     convert::TryFrom,


### PR DESCRIPTION
This reverts commit 813e3d86e6a3fb5dca3067d127e3252bcb046d2a.

See why CI didn't fail.
https://github.com/libp2p/rust-libp2p/pull/3027#issuecomment-1279458489
