### PR TITLE
identify: Fix Identify protocol link in module doc.

### DIFF
--- a/protocols/identify/src/lib.rs
+++ b/protocols/identify/src/lib.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! Implementation of the [Identify] protocol.
+//! Implementation of the [Identify](https://github.com/libp2p/specs/blob/master/identify/README.md) protocol.
 //!
 //! This implementation of the protocol periodically exchanges
 //! [`Info`] messages between the peers on an established connection.


### PR DESCRIPTION
# Description
The documentation is currently pointing to the [deprecated type](https://docs.rs/libp2p/latest/libp2p/identify/type.Identify.html) 
## Links to any relevant issues

<!-- Reference any related issues.-->


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
