### PR TITLE
Update noise proto to match go-libp2p

### DIFF
--- a/transports/noise/src/io/handshake/payload.proto
+++ b/transports/noise/src/io/handshake/payload.proto
@@ -2,10 +2,12 @@ syntax = "proto3";
 
 package payload.proto;
 
-// Payloads for Noise handshake messages.
+message NoiseExtensions {
+    repeated bytes webtransport_certhashes = 1;
+}
 
 message NoiseHandshakePayload {
-    bytes identity_key = 1;
-    bytes identity_sig = 2;
-    bytes data         = 3;
+  bytes identity_key = 1;
+  bytes identity_sig = 2;
+  optional NoiseExtensions extensions = 4;
 }


### PR DESCRIPTION
# Description
This updates the noise protobuf to match the js and go-libp2p repositories. It replaces the data field with NoiseExtensions.

## Links to any relevant issues

<!-- Reference any related issues.-->


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
