### PR TITLE
kad: Change RecordStore trait interface - add results to methods.

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Update to `libp2p-swarm` `v0.41.0`.
 
+- Change interface of the `RecordStore` trait. Add missed results for its operations.
+
 # 0.41.0
 
 - Remove deprecated `set_protocol_name()` from `KademliaConfig` & `KademliaProtocolConfig`.

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -711,7 +711,11 @@ fn put_record() {
                 );
                 assert_eq!(swarms[0].behaviour_mut().queries.size(), 0);
                 for k in records.keys() {
-                    swarms[0].behaviour_mut().store.remove(k);
+                    swarms[0]
+                        .behaviour_mut()
+                        .store
+                        .remove(k)
+                        .expect("Valid response from MemoryStore.");
                 }
                 assert_eq!(swarms[0].behaviour_mut().store.records().count(), 0);
                 // All records have been republished, thus the test is complete.

--- a/protocols/kad/src/jobs.rs
+++ b/protocols/kad/src/jobs.rs
@@ -66,6 +66,7 @@ use futures::prelude::*;
 use futures_timer::Delay;
 use instant::Instant;
 use libp2p_core::PeerId;
+use log::error;
 use std::collections::HashSet;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -229,7 +230,9 @@ impl PutRecordJob {
         if let PeriodicJobState::Running(records) = &mut self.inner.state {
             for r in records {
                 if r.is_expired(now) {
-                    store.remove(&r.key)
+                    if let Err(ref err) = store.remove(&r.key) {
+                        error!("Record removal failed: {:?}", err);
+                    };
                 } else {
                     return Poll::Ready(r);
                 }

--- a/protocols/kad/src/record/store.rs
+++ b/protocols/kad/src/record/store.rs
@@ -44,6 +44,10 @@ pub enum Error {
     /// The store cannot store this value because it is too large.
     #[error("the value is too large to be stored")]
     ValueTooLarge,
+
+    /// The store cannot remove the value.
+    #[error("can't remove the value from the store")]
+    RemoveValueError,
 }
 
 /// Trait for types implementing a record store.
@@ -75,7 +79,7 @@ pub trait RecordStore<'a> {
     fn put(&'a mut self, r: Record) -> Result<()>;
 
     /// Removes the record with the given key from the store.
-    fn remove(&'a mut self, k: &Key);
+    fn remove(&'a mut self, k: &Key) -> Result<()>;
 
     /// Gets an iterator over all (value-) records currently stored.
     fn records(&'a self) -> Self::RecordsIter;

--- a/protocols/kad/src/record/store/memory.rs
+++ b/protocols/kad/src/record/store/memory.rs
@@ -131,8 +131,10 @@ impl<'a> RecordStore<'a> for MemoryStore {
         Ok(())
     }
 
-    fn remove(&'a mut self, k: &Key) {
+    fn remove(&'a mut self, k: &Key) -> Result<()> {
         self.records.remove(k);
+
+        Ok(())
     }
 
     fn records(&'a self) -> Self::RecordsIter {
@@ -234,7 +236,9 @@ mod tests {
             let mut store = MemoryStore::new(PeerId::random());
             assert!(store.put(r.clone()).is_ok());
             assert_eq!(Some(Cow::Borrowed(&r)), store.get(&r.key));
-            store.remove(&r.key);
+            store
+                .remove(&r.key)
+                .expect("Valid response from MemoryStore.");
             assert!(store.get(&r.key).is_none());
         }
         quickcheck(prop as fn(_))


### PR DESCRIPTION
# Description
This PR starts an attempt to modify `RecordStore` trait interface. Currently, some of the operations lack the `Result` and it reduces the expressiveness of the custom implementations. Here is the [discussion](https://github.com/libp2p/rust-libp2p/issues/3035).

The initial version of the PR contains a change for the single operation - `remove` and serves as example with some open questions.

## Changes
- added `Result` for the `remove` operation of the `RecordStore` trait.
- modified usages
- modified tests

## Links to any relevant issues

Original issue: https://github.com/libp2p/rust-libp2p/issues/3035

## Open Questions

There were made four changes for use cases of the `remove method`:
- `remove_record` from Behaviour - it seemed native to just return the result
- `get_record` from Behaviour - it seemed overkill to change the returned value to result here
-  `inject_event` - the system logic doesn't seem to mean returning a result here (or using some other means to propagate an error.
- `poll` from the `PutValueJob` also doesn't seem to mean returning a result here (or using some other means to propagate an error.

Please, verify my assumptions here. 

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation~ Shouldn't be required for this.
- [ ] ~I have added tests that prove my fix is effective or that my feature works.~  I modified tests.
- [x] A changelog entry has been made in the appropriate crates

<!-- The below text will appear as the commit message body once we squash-merge the PR. -->
## Commit message body
Change the interface of the `RecordStore` trait. Add missed results for its operations.