### PR TITLE
*: Fix clippy warnings introduced by Rust 1.65 release

### DIFF
--- a/examples/distributed-key-value-store.rs
+++ b/examples/distributed-key-value-store.rs
@@ -74,6 +74,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         mdns: Mdns,
     }
 
+    #[allow(clippy::large_enum_variant)]
     enum MyBehaviourEvent {
         Kademlia(KademliaEvent),
         Mdns(MdnsEvent),

--- a/protocols/identify/src/handler.rs
+++ b/protocols/identify/src/handler.rs
@@ -91,6 +91,7 @@ pub struct Handler {
 
 /// Event produced by the `IdentifyHandler`.
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum Event {
     /// We obtained identification information from the remote.
     Identified(Info),

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -2402,6 +2402,7 @@ pub struct PeerRecord {
 ///
 /// See [`NetworkBehaviour::poll`].
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum KademliaEvent {
     /// An inbound request has been received and handled.
     //

--- a/swarm-derive/tests/test.rs
+++ b/swarm-derive/tests/test.rs
@@ -302,6 +302,7 @@ fn with_either() {
 fn custom_event_with_either() {
     use either::Either;
 
+    #[allow(clippy::large_enum_variant)]
     enum BehaviourOutEvent {
         Kad(libp2p::kad::KademliaEvent),
         PingOrIdentify(Either<ping::Event, identify::Event>),


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

Until we land https://github.com/libp2p/rust-libp2p/issues/2951, we are hit with some unfortunate CI errors every Rust stable release. This PR fixes those for the recent 1.65 release.

Clippy's large-enum-variant lint can generally be set to `allow` until someone performs benchmarking that boxing the variant actually increases performance.

## Links to any relevant issues

<!-- Reference any related issues.-->


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~A changelog entry has been made in the appropriate crates~

<!-- The below text will appear as the commit message body once we squash-merge the PR. -->
## Commit message body
