### PR TITLE
Update ROADMAP.md based on previous feedback.

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,18 +11,18 @@ roadmap](https://github.com/libp2p/specs/blob/master/ROADMAP.md).
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
 **Table of Contents**
 
-    - [Experimental QUIC support](#experimental-quic-support)
-    - [WebRTC support (browser-to-server)](#webrtc-support-browser-to-server)
-    - [Cross Behaviour communication](#cross-behaviour-communication)
-    - [Generic connection management](#generic-connection-management)
-    - [Kademlia efficient querying](#kademlia-efficient-querying)
-    - [Kademlia client mode](#kademlia-client-mode)
-    - [Optimize Hole punching](#optimize-hole-punching)
-    - [Streaming response protocol aka. the ultimate escape hatch](#streaming-response-protocol-aka-the-ultimate-escape-hatch)
-    - [Improved WASM support](#improved-wasm-support)
-    - [Handshake optimizations](#handshake-optimizations)
-    - [Bitswap implementation](#bitswap-implementation)
-    - [WebTransport](#webtransport)
+- [QUIC support](#quic-support)
+- [WebRTC support (browser-to-server)](#webrtc-support-browser-to-server)
+- [Cross Behaviour communication](#cross-behaviour-communication)
+- [Generic connection management](#generic-connection-management)
+- [Kademlia efficient querying](#kademlia-efficient-querying)
+- [Kademlia client mode](#kademlia-client-mode)
+- [Optimize Hole punching](#optimize-hole-punching)
+- [Streaming response protocol aka. the ultimate escape hatch](#streaming-response-protocol-aka-the-ultimate-escape-hatch)
+- [Improved WASM support](#improved-wasm-support)
+- [Handshake optimizations](#handshake-optimizations)
+- [Bitswap implementation](#bitswap-implementation)
+- [WebTransport](#webtransport)
 
 <!-- markdown-toc end -->
 
@@ -30,7 +30,7 @@ roadmap](https://github.com/libp2p/specs/blob/master/ROADMAP.md).
 
 | Category     | Status      | Target Completion | Tracking                                          | Dependencies                                                        | Dependents |
 |--------------|-------------|-------------------|---------------------------------------------------|---------------------------------------------------------------------|------------|
-| Connectivity | In progress | Q4/2022           | https://github.com/libp2p/rust-libp2p/issues/2883 | [TLS](#tls-support), https://github.com/libp2p/test-plans/issues/53 |            |
+| Connectivity | In progress | Q4/2022           | https://github.com/libp2p/rust-libp2p/issues/2883 | https://github.com/libp2p/test-plans/issues/53 |            |
 
 QUIC has been on the roadmap for a long time. It enables various performance improvements as well as
 higher hole punching success rates. We are close to finishing a first version with

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,6 +27,7 @@ roadmap](https://github.com/libp2p/specs/blob/master/ROADMAP.md).
   - [Kademlia client mode](#kademlia-client-mode)
   - [Optimize Hole punching](#optimize-hole-punching)
   - [Streaming response protocol aka. the ultimate escape hatch](#streaming-response-protocol-aka-the-ultimate-escape-hatch)
+  - [WebRTC support (browser-to-browser)](#webrtc-support-browser-to-browser)
   - [Improved Wasm support](#improved-wasm-support)
   - [Handshake optimizations](#handshake-optimizations)
   - [Bitswap implementation](#bitswap-implementation)
@@ -52,11 +53,11 @@ roadmap](https://github.com/libp2p/specs/blob/master/ROADMAP.md).
 - [***➡️ test-plans/Benchmarking using remote runners***](https://github.com/libp2p/test-plans/blob/master/ROADMAP.md#2-benchmarking-using-remote-runners)
 
 #### Sometime Q2
+- [WebRTC support (browser-to-browser](#webrtc-support-browser-to-browser)
 - [Improved Wasm support](#improved-wasm-support)
 - [Handshake optimizations](#handshake-optimizations)
 
 ### Up Next
-- [WebRTC support (browser-to-browser](#2-webrtc-browser-to-browser)
 - [***➡️ test-plans/Expansive protocol test coverage***](https://github.com/libp2p/test-plans/blob/master/ROADMAP.md#d-expansive-protocol-test-coverage)
 - [Bitswap implementation](#bitswap-implementation)
 - [WebTransport](#webtransport)
@@ -78,7 +79,7 @@ https://github.com/libp2p/rust-libp2p/issues/2883.
 
 | Category     | Status      | Target Completion | Tracking                                 | Dependencies                                   | Dependents |
 |--------------|-------------|-------------------|------------------------------------------|------------------------------------------------|------------|
-| Connectivity | In progress | Q4/2022           | https://github.com/libp2p/specs/pull/412 | https://github.com/libp2p/test-plans/issues/53 |            |
+| Connectivity | In progress | Q4/2022           | https://github.com/libp2p/specs/pull/412 | https://github.com/libp2p/test-plans/issues/53 |    [WebRTC (browser-to-browser)](#webrtc-support-browser-to-browser)        |
 
 
 We are currently implementing WebRTC for **browser-to-server** connectivity in
@@ -163,11 +164,21 @@ for this, and I think we should not change directions here. That said, the ultim
 allowing users to create a stream and do whatever they want with it - will make it easier for
 newcomers to get started.
 
+### WebRTC support (browser-to-browser)
+
+| Category     | Status      | Target Completion | Tracking                                 | Dependencies                                   | Dependents |
+|--------------|-------------|-------------------|------------------------------------------|------------------------------------------------|------------|
+| Connectivity | todo        |     Q2/2023       | https://github.com/libp2p/specs/issues/475 | https://github.com/libp2p/rust-libp2p/pull/2622 https://github.com/libp2p/test-plans/issues/53 |            |
+
+
+Once WebRTC for browser-to-server is complete, we can begin work on **browser-to-browser** and complete the WebRTC connectivity story.
+The specification needs to be written and completed first.
+
 ### Improved Wasm support
 
 | Category             | Status | Target Completion | Tracking                                          | Dependencies | Dependents                                 |
 |----------------------|--------|-------------------|---------------------------------------------------|--------------|--------------------------------------------|
-| Developer ergonomics | todo   | Q2/2023           | https://github.com/libp2p/rust-libp2p/issues/2617 |              | WebRTC browser-to-browser and browser side |
+| Developer ergonomics | todo   | Q2/2023           | https://github.com/libp2p/rust-libp2p/issues/2617 |              | WebRTC browser-to-server and browser side |
 
 The project supports Wasm already today, though the developer experience is cumbersome at best.
 Properly supporting Wasm opens rust-libp2p to hole new set of use-cases. I would love for this to

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-# rust-libp2p Roadmap
+# rust-libp2p Roadmap <!-- omit in toc -->
 
 Below is a high level roadmap for the rust-libp2p project. Items are ordered by priority (high to
 low).
@@ -8,25 +8,62 @@ This is a living document. Input is always welcome e.g. via GitHub issues or pul
 This is the roadmap of the Rust implementation of libp2p. See also the [general libp2p project
 roadmap](https://github.com/libp2p/specs/blob/master/ROADMAP.md).
 
-<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
-**Table of Contents**
+## Table of Contents <!-- omit in toc -->
+- [🛣️ Milestones](#️-milestones)
+  - [2022](#2022)
+    - [Mid Q4 (November)](#mid-q4-november)
+    - [Mid/End of Q4](#midend-of-q4)
+  - [2023](#2023)
+    - [Sometime Q1](#sometime-q1)
+    - [End of Q1 (March)](#end-of-q1-march)
+    - [Sometime Q2](#sometime-q2)
+  - [Up Next](#up-next)
+- [Appendix](#appendix)
+  - [QUIC support](#quic-support)
+  - [WebRTC support (browser-to-server)](#webrtc-support-browser-to-server)
+  - [Cross Behaviour communication](#cross-behaviour-communication)
+  - [Generic connection management](#generic-connection-management)
+  - [Kademlia efficient querying](#kademlia-efficient-querying)
+  - [Kademlia client mode](#kademlia-client-mode)
+  - [Optimize Hole punching](#optimize-hole-punching)
+  - [Streaming response protocol aka. the ultimate escape hatch](#streaming-response-protocol-aka-the-ultimate-escape-hatch)
+  - [Improved Wasm support](#improved-wasm-support)
+  - [Handshake optimizations](#handshake-optimizations)
+  - [Bitswap implementation](#bitswap-implementation)
+  - [WebTransport](#webtransport)
 
+## 🛣️ Milestones
+
+### 2022
+
+#### Mid Q4 (November)
+- [***➡️ test-plans/Interop tests for all existing/developing libp2p transports***](https://github.com/libp2p/test-plans/blob/master/ROADMAP.md#2-interop-test-plans-for-all-existingdeveloping-libp2p-transports)
+- [***➡️ test-plans/Benchmarking using nix-builders***](https://github.com/libp2p/test-plans/blob/master/ROADMAP.md#1-benchmarking-using-nix-builders)
+
+#### Mid/End of Q4
 - [QUIC support](#quic-support)
 - [WebRTC support (browser-to-server)](#webrtc-support-browser-to-server)
-- [Cross Behaviour communication](#cross-behaviour-communication)
-- [Generic connection management](#generic-connection-management)
-- [Kademlia efficient querying](#kademlia-efficient-querying)
-- [Kademlia client mode](#kademlia-client-mode)
-- [Optimize Hole punching](#optimize-hole-punching)
-- [Streaming response protocol aka. the ultimate escape hatch](#streaming-response-protocol-aka-the-ultimate-escape-hatch)
-- [Improved WASM support](#improved-wasm-support)
+
+### 2023
+
+#### Sometime Q1
+
+#### End of Q1 (March)
+- [***➡️ test-plans/Benchmarking using remote runners***](https://github.com/libp2p/test-plans/blob/master/ROADMAP.md#2-benchmarking-using-remote-runners)
+
+#### Sometime Q2
+- [Improved Wasm support](#improved-wasm-support)
 - [Handshake optimizations](#handshake-optimizations)
+
+### Up Next
+- [WebRTC support (browser-to-browser](#2-webrtc-browser-to-browser)
+- [***➡️ test-plans/Expansive protocol test coverage***](https://github.com/libp2p/test-plans/blob/master/ROADMAP.md#d-expansive-protocol-test-coverage)
 - [Bitswap implementation](#bitswap-implementation)
 - [WebTransport](#webtransport)
 
-<!-- markdown-toc end -->
+## Appendix
 
-## QUIC support
+### QUIC support
 
 | Category     | Status      | Target Completion | Tracking                                          | Dependencies                                                        | Dependents |
 |--------------|-------------|-------------------|---------------------------------------------------|---------------------------------------------------------------------|------------|
@@ -34,10 +71,10 @@ roadmap](https://github.com/libp2p/specs/blob/master/ROADMAP.md).
 
 QUIC has been on the roadmap for a long time. It enables various performance improvements as well as
 higher hole punching success rates. We are close to finishing a first version with
-https://github.com/libp2p/rust-libp2p/pull/2289. We will improve from there. See tracking issue
+https://github.com/libp2p/rust-libp2p/pull/2289 and will improve from there. See tracking issue
 https://github.com/libp2p/rust-libp2p/issues/2883.
 
-## WebRTC support (browser-to-server)
+### WebRTC support (browser-to-server)
 
 | Category     | Status      | Target Completion | Tracking                                 | Dependencies                                   | Dependents |
 |--------------|-------------|-------------------|------------------------------------------|------------------------------------------------|------------|
@@ -49,10 +86,10 @@ https://github.com/libp2p/rust-libp2p/pull/2622. More specifically the server si
 browser nodes to connect to rust-libp2p nodes where the latter only have self-signed TLS
 certificates. See https://github.com/libp2p/specs/pull/412 for in-depth motivation.
 
-Long term we should enable rust-libp2p running in the browser via WASM to use the browser's WebRTC
-stack. Though that should only happen after improved WASM support, see below.
+Long term we should enable rust-libp2p running in the browser via Wasm to use the browser's WebRTC
+stack. Though that should only happen after improved Wasm support, see below.
 
-## Cross Behaviour communication
+### Cross Behaviour communication
 
 | Category             | Status | Target Completion | Tracking                                          | Dependencies                                      | Dependents                                    |
 |----------------------|--------|-------------------|---------------------------------------------------|---------------------------------------------------|-----------------------------------------------|
@@ -69,7 +106,7 @@ protocols) between `NetworkBehaviour` implementations.
 Long term we might consider a generic approach for `NetworkBehaviours` to exchange data. Though that
 would deserve its own roadmap item.
 
-## Generic connection management
+### Generic connection management
 
 | Category             | Status | Target Completion | Tracking                                          | Dependencies | Dependents |
 |----------------------|--------|-------------------|---------------------------------------------------|--------------|------------|
@@ -81,7 +118,7 @@ management generic allows users to build advanced and efficient abstractions on 
 
 First draft is in https://github.com/libp2p/rust-libp2p/pull/2828
 
-## Kademlia efficient querying
+### Kademlia efficient querying
 
 | Category     | Status      | Target Completion | Tracking                                        | Dependencies | Dependents |
 |--------------|-------------|-------------------|-------------------------------------------------|--------------|------------|
@@ -91,7 +128,7 @@ Users of rust-libp2p like [iroh](https://github.com/n0-computer/iroh) need this 
 usage of `libp2p-kad`. The rust-libp2p maintainers can pick this up unless iroh folks finish the
 work before that.
 
-## Kademlia client mode
+### Kademlia client mode
 
 | Category     | Status | Target Completion | Tracking                                          | Dependencies                                                    | Dependents |
 |--------------|--------|-------------------|---------------------------------------------------|-----------------------------------------------------------------|------------|
@@ -100,7 +137,7 @@ work before that.
 Kademlia client mode will enhance routing table health and thus have a positive impact on all
 Kademlia operations.
 
-## Optimize Hole punching
+### Optimize Hole punching
 
 | Category     | Status | Target Completion | Tracking | Dependencies | Dependents |
 |--------------|--------|-------------------|----------|--------------|------------|
@@ -115,7 +152,7 @@ action](https://discuss.libp2p.io/t/decentralized-nat-hole-punching-measurement-
 case you want to help. Based on this data we will likely find many optimizations we can do to our
 hole punching stack.
 
-## Streaming response protocol aka. the ultimate escape hatch
+### Streaming response protocol aka. the ultimate escape hatch
 
 | Category             | Status | Target Completion | Tracking                                          | Dependencies | Dependents |
 |----------------------|--------|-------------------|---------------------------------------------------|--------------|------------|
@@ -126,19 +163,19 @@ for this, and I think we should not change directions here. That said, the ultim
 allowing users to create a stream and do whatever they want with it - will make it easier for
 newcomers to get started.
 
-## Improved WASM support
+### Improved Wasm support
 
 | Category             | Status | Target Completion | Tracking                                          | Dependencies | Dependents                                 |
 |----------------------|--------|-------------------|---------------------------------------------------|--------------|--------------------------------------------|
 | Developer ergonomics | todo   | Q2/2023           | https://github.com/libp2p/rust-libp2p/issues/2617 |              | WebRTC browser-to-browser and browser side |
 
-The project supports WASM already today, though the developer experience is cumbersome at best.
-Properly supporting WASM opens rust-libp2p to hole new set of use-cases. I would love for this to
+The project supports Wasm already today, though the developer experience is cumbersome at best.
+Properly supporting Wasm opens rust-libp2p to hole new set of use-cases. I would love for this to
 happen earlier. Though (a) I think we should prioritize improving existing functionality over new
 functionality and (b) we don't have high demand for this feature from the community. (One could
 argue that that demand follows this roadmap item and not the other way round.)
 
-## Handshake optimizations
+### Handshake optimizations
 
 | Category     | Status | Target Completion | Tracking                                                                                                                                                | Dependencies | Dependents |
 |--------------|--------|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|------------|
@@ -151,7 +188,7 @@ requested from any rust-libp2p users.
 Long term, given that this will give us a great performance gain, we should definitely tackle it. It
 also allows us to catch up and thus be consistent with go-libp2p.
 
-## Bitswap implementation
+### Bitswap implementation
 
 | Category | Status | Target Completion | Tracking                                          | Dependencies | Dependents |
 |----------|--------|-------------------|---------------------------------------------------|--------------|------------|
@@ -165,7 +202,7 @@ I would prioritize it below [handshake optimization](#handshake-optimizations) f
 convention of improving existing components over introducing new ones. Users have and can implement
 their own implementations and are thus not blocked on the rust-libp2p project.
 
-## WebTransport
+### WebTransport
 
 | Category                    | Status | Target Completion | Tracking                                          | Dependencies                       | Dependents |
 |-----------------------------|--------|-------------------|---------------------------------------------------|------------------------------------|------------|


### PR DESCRIPTION
# Description
Closing out on the open feedback in https://github.com/libp2p/rust-libp2p/pull/2997 and https://github.com/libp2p/rust-libp2p/pull/3062

## Open Questions
Verbiage to add around interoperability testing that we're doing right now.  go-libp2p can be used for reference: https://github.com/libp2p/go-libp2p/blob/master/ROADMAP.md#benchmarking-and-testing

<!-- The below text will appear as the commit message body once we squash-merge the PR. -->
## Commit message body
Minor cleanups and and linking out to the cross-libp2p effort of interoperability testing.
