### PR TITLE
swarm: Split the `ConnectionHandler::inject_listen_upgrade_error` into two methods

### DIFF
--- a/protocols/relay/src/v2/relay/handler.rs
+++ b/protocols/relay/src/v2/relay/handler.rs
@@ -645,6 +645,26 @@ impl ConnectionHandler for Handler {
         ));
     }
 
+    fn inject_listen_negotiation_error(
+            &mut self,
+            info: Self::UpgradeInfo,
+            error: ConnectionHandlerUpgrErr<<Self::InboundProtocol as InboundUpgradeSend>::Error>,
+        ) {
+        let non_fatal_error = match error {
+              ConnectionHandlerUpgrErr::Upgrade(upgrade::UpgradeError::Apply(
+                upgrade::NegotiationError::Failed,
+            )) => ConnectionHandlerUpgrErr::Upgrade(upgrade::UpgradeError::Apply(
+                upgrade::NegotiationError::Failed,
+            ))
+        };
+
+        self.queued_events.push_back(ConnectionHandlerEvent::Custom(
+            Event::CircuitReqReceiveFailed {
+                error: non_fatal_error,
+            },
+        ));
+    }
+
     fn inject_dial_upgrade_error(
         &mut self,
         open_info: Self::OutboundOpenInfo,

--- a/swarm/src/handler.rs
+++ b/swarm/src/handler.rs
@@ -159,11 +159,11 @@ pub trait ConnectionHandler: Send + 'static {
     ) {
     }
 
-    /// Indicates to the handler that the error occurred during the multistream select protocol execution.
+    /// Indicates to the handler that the error occurred during the multistream select protocol execution but is not related to the given protocol.
     fn inject_listen_negotiation_error(
         &mut self,
-        _: Self::InboundOpenInfo,
-        _: ConnectionHandlerUpgrErr<<Self::InboundProtocol as InboundUpgradeSend>::Error>,
+        info: Self::UpgradeInfo,
+        error: ConnectionHandlerUpgrErr<<Self::InboundProtocol as InboundUpgradeSend>::Error>,
     ){
     }
 

--- a/swarm/src/handler.rs
+++ b/swarm/src/handler.rs
@@ -159,6 +159,14 @@ pub trait ConnectionHandler: Send + 'static {
     ) {
     }
 
+    /// Indicates to the handler that the error occurred during the multistream select protocol execution.
+    fn inject_listen_negotiation_error(
+        &mut self,
+        _: Self::InboundOpenInfo,
+        _: ConnectionHandlerUpgrErr<<Self::InboundProtocol as InboundUpgradeSend>::Error>,
+    ){
+    }
+
     /// Returns until when the connection should be kept alive.
     ///
     /// This method is called by the `Swarm` after each invocation of


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
I am adding a new method i.e. `inject_listen_negotiation_error` to handle errors which occur during the protocol negotiation step. i.e when the `UpgradeInfo::protocol_info` method is called  in order to determine which protocols are supported by the trait implementation. 

## Links to any relevant issues

<!-- Reference any related issues.-->
https://github.com/libp2p/rust-libp2p/issues/2894

## Open Questions
<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates

<!-- The below text will appear as the commit message body once we squash-merge the PR. -->
## Commit message body
