### PR TITLE
deps: Update to multiaddr v0.16.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ libp2p-swarm = { version = "0.41.0", path = "swarm" }
 libp2p-uds = { version = "0.37.0", path = "transports/uds", optional = true }
 libp2p-wasm-ext = { version = "0.38.0", path = "transports/wasm-ext", optional = true }
 libp2p-yamux = { version = "0.42.0", path = "muxers/yamux", optional = true }
-multiaddr = { version = "0.15.0" }
+multiaddr = { version = "0.16.0" }
 parking_lot = "0.12.0"
 pin-project = "1.0.0"
 smallvec = "1.6.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,7 +22,7 @@ instant = "0.1.11"
 lazy_static = "1.2"
 libsecp256k1 = { version = "0.7.0", optional = true }
 log = "0.4"
-multiaddr = { version = "0.15.0" }
+multiaddr = { version = "0.16.0" }
 multihash = { version = "0.16", default-features = false, features = ["std", "multihash-impl", "identity", "sha2"] }
 multistream-select = { version = "0.12", path = "../misc/multistream-select" }
 p256 = { version = "0.11.1", default-features = false, features = ["ecdsa"], optional = true }


### PR DESCRIPTION
## Description

Update `multiaddr` dependency from `v0.15.0` to `v.0.16.0`. 

## Links to any relevant issues

Unblocks #2289.

