### PR TITLE
fix(webrtc): Don't emit addresses from other interfaces

### DIFF
--- a/transports/webrtc/Cargo.toml
+++ b/transports/webrtc/Cargo.toml
@@ -16,7 +16,7 @@ bytes = "1"
 futures = "0.3"
 futures-timer = "3"
 hex = "0.4"
-if-watch = "2.0"
+if-watch = "3.0"
 libp2p-core = { version = "0.38.0", path = "../../core"  }
 libp2p-noise = { version = "0.41.0", path = "../../transports/noise" }
 log = "0.4"
@@ -34,7 +34,7 @@ tokio-util = { version = "0.7", features = ["compat"], optional = true }
 webrtc = { version = "0.6.0", optional = true }
 
 [features]
-tokio = ["dep:tokio", "dep:tokio-util", "dep:webrtc"]
+tokio = ["dep:tokio", "dep:tokio-util", "dep:webrtc", "if-watch/tokio"]
 pem = ["webrtc?/pem"]
 
 [build-dependencies]


### PR DESCRIPTION
## Description

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

Previously, we would always run `IfWatcher`, even if we were only listening on a specific interface. This patch fixes this behaviour and aligns it with how `libp2p-quic` operates.

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

cc @melekes 

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
