### PR TITLE
feat: Add Identify + Kademlia chat example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,13 @@ env_logger = "0.9.0"
 clap = { version = "4.0.13", features = ["derive"] }
 tokio = { version = "1.15", features = ["io-util", "io-std", "macros", "rt", "rt-multi-thread"] }
 
+# For kad-identify-chat example
+anyhow = "1.0.66"
+bincode = "1.3.3"
+log = "0.4.17"
+serde = "1.0.147"
+thiserror = "1.0.37"
+
 [workspace]
 members = [
     "core",
@@ -209,6 +216,11 @@ required-features = ["full"]
 
 [[example]]
 name = "distributed-key-value-store"
+required-features = ["full"]
+
+[[example]]
+name = "kad-identify-chat"
+path = "examples/kad-identify-chat/main.rs"
 required-features = ["full"]
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.

--- a/examples/README.md
+++ b/examples/README.md
@@ -57,3 +57,16 @@ A set of examples showcasing how to use rust-libp2p.
   While obviously showcasing how to build a basic file sharing application with the Kademlia and
   Request-Response protocol, the actual goal of this example is **to show how to integrate
   rust-libp2p into a larger application**.
+
+- [Chat with Identify and Kademlia DHT](kad-identify-chat/main.rs)
+
+  The kad-identify-chat example implements simple chat functionality using the `Identify` protocol
+  and the `Kademlia` DHT for peer discovery and routing. Broadcast messages are propagated using the
+  `Gossipsub` behaviour, direct messages are sent using the `RequestResponse` behaviour.
+
+  The primary purpose of this example is to demonstrate how these behaviours interact.
+  
+  A secondary purpose of this example is to show what integration of libp2p in a complete
+  application might look like. This is similar to the [file sharing example](file-sharing.rs),
+  but where that example is purposely more barebones, this example is a bit more expansive and 
+  uses common crates like `thiserror` and `anyhow`. It also uses the tokio runtime instead of async_std.

--- a/examples/kad-identify-chat/README.md
+++ b/examples/kad-identify-chat/README.md
@@ -1,0 +1,108 @@
+# kad-identify-chat
+The kad-identify-chat example implements simple chat functionality using the `Identify` protocol
+and the `Kademlia` DHT for peer discovery and routing. Broadcast messages are propagated using the
+`Gossipsub` behaviour, direct messages are sent using the `RequestResponse` behaviour.
+
+The primary purpose of this example is to demonstrate how these behaviours interact.
+
+A secondary purpose of this example is to show what integration of libp2p in a complete
+application might look like. This is similar to the [file sharing example](../file-sharing.rs),
+but where that example is purposely more barebones, this example is a bit more expansive and
+uses common crates like `thiserror` and `anyhow`. It also uses the tokio runtime instead of async_std.
+
+Finally, it shows a way to organise your business logic using custom `EventHandler` and
+`InstructionHandler` traits. This is by no means *the* way to do it, but it worked well
+in the real-world application this example was derived from.
+
+Note how all business logic is concentrated in only four functions:
+- `MyChatNetworkClient::handle_user_input()`: takes input from the cli and turns it into an
+  `Instruction` for the `Network`.
+- `MyChatNetworkBehaviour::handle_instruction()`: acts on the `Instruction` using one of its
+  composed `NetworkBehaviour`s. Most likely by sending a message through the `Swarm`.
+- `MyChatNetworkBehaviour::handle_event()`: receives events from the `Swarm` and turns them
+  into `Notification`s for `MyChatNetworkClient`.
+- `MyChatNetworkClient::handle_notification()`: receives `Notification`s and acts on them, often
+  by formatting them and displaying them to the user.
+
+# The CLI
+Once peers are running (see below), the following 'commands' can be typed into their consoles:
+- press `<enter>`: sends a broadcast to all known peers through GossipSub. (used below)
+- `dm 2 my message`: sends 'my message' to peer number 2.
+- `ls`: shows the list of `PeerId`s this peer is aware of.
+
+> A note on peer numbers. For this example, peers are started with a peer number. This is then used to deterministically generate their keypair and peer id. This is a convenience for testing and prevents us from having to copy-paste peer ids when sending a dm: when a peer was started with `--peer-no 3`, you can send a message to it 
+> using `dm 3 some message`. 
+
+# Running a network of peers
+
+Running this example shows three peers interacting:
+- Peer 1 is a so-called bootstrap peer. Every peer that joins the network should initially connect to one bootstrap peer to discover the rest of the network. After that initial discovery they no longer need the bootstrap peer. Note that the only differences between a bootstrap peer and a normal peer are: 1) that it does not necessarily connect to a specified bootstrap peer on startup and 2) that at least one bootstrap peer is required to be running at all times so they can be an entrypoint to the network for new joining peers. Note that it is fine to have multiple bootstrap peers in a network for robustness.
+- Peer 2 and 3 connect to the bootstrap peer and register themselves in the Kademlia DHT. They also discover other peers they can reach on the DHT.
+- Peer 2 will send a BROADCAST pubsub message.
+- Peer 3's console shows that the pubsub message reaches peer 3, even though they did not have a direct connection between themselves at the time. The message is relayed through pubsub protocol by peer 1, who has a connection to both peer 2 and 3.
+- Next peer 1 and 3 will automatically reply to the BROADCAST sent by peer 2 with a direct message to peer 2: 
+  - make a direct connection (dialing) to peer 2
+  - send a direct message addressed to peer 2
+- Finally, when the user types `dm 3 foo bar` in the console of peer 2, the console of peer 3 will show that it received the message. This is because even though peer 2 and 4 wiere initially not aware of each other and connected, they learn each other's peer id and listen address through the combination of the Identify protocol and the Kademlia DHT. This allows them to send a direct message using the RequestResponse behaviour.
+ 
+> `RUST_LOG=INFO` is a good starting log level that shows only relevant communication between peers. But if you want to see more details on how the nodes discover each other and communicate, `RUST_LOG=kad_identify_chat=DEBUG` is good. 
+
+To run this example, open three terminals. 
+In terminal 1, run peer 1:
+
+```sh
+$ RUST_LOG=INFO cargo run --features="full" --example kad-identify-chat -- --peer-no 1 
+```
+
+In terminal 2, run peer 2:
+
+```sh
+$ RUST_LOG=INFO cargo run --features="full" --example kad-identify-chat -- --peer-no 2 --bootstrap-peer-no 1 
+```
+
+In terminal 3, run peer 3:
+
+```sh
+$ RUST_LOG=INFO cargo run --features="full" --example kad-identify-chat -- --peer-no 3 --bootstrap-peer-no 1
+```
+
+Let all of them run for a few seconds to ensure that they have discovered each other, then press enter in the terminal of peer 2 to trigger the broadcast message.
+
+Expected behaviour: 
+
+Observe the broadcast message appearing in the log of peer 1 and 3. Note that peer 3 receives the message from peer 1, and not from peer 2 as expected.
+Next, observe the direct messages being sent from both peer 1 and 3. Finally, observe those direct message being received by peer 2. 
+This concludes the interaction. 
+
+## Optional next step
+An optional next step is to add a peer 4 and 5, such that: 
+- peer 5 is connected only to peer 4 (peer 4 is its bootstrap node).
+- peer 4 is only connected to peer 3 (peer 3 is its bootstrap node).
+- we know already that peer 2 and 3 were initially only connected to their bootstrap peer, peer 1.
+
+Peer 5 should also receive a broadcast message from peer 2. It should also be able to send back a dm to peer 2, even though it is not connected to it yet. 
+This will be possible because the listen address for peer 2 will be in the DHT (because of the Identify behaviour), 
+which will be synced to peer 5 as soon as it joins the network.
+
+To run it, first kill all peers from above and restart them. This ensures none of them have a direct connection
+between them, except to their bootstrap node.
+
+Next, in terminal 4, run peer 4:
+
+```sh
+$ RUST_LOG=INFO cargo run --features="full" --example kad-identify-chat -- --peer-no 4 --bootstrap-peer-no 3
+```
+
+In terminal 5, run peer 5:
+
+```sh
+$ RUST_LOG=INFO cargo run --features="full" --example kad-identify-chat -- --peer-no 5  --bootstrap-peer-no 4
+```
+
+Then we execute the same test as before: press enter in the terminal of peer 2.
+
+Expected behaviour: 
+- Peer 3 receives the broadcast from peer 1
+- Peer 4 receives it from peer 3
+- Peer 5 receives it from peer 4
+- They all send back a direct message to peer 2, so we should see a dm from peer 5 in the log of peer 2

--- a/examples/kad-identify-chat/cli.rs
+++ b/examples/kad-identify-chat/cli.rs
@@ -1,0 +1,51 @@
+use std::net::Ipv4Addr;
+
+use clap::Parser;
+use libp2p::identity::{ed25519, Keypair};
+use libp2p::multiaddr::Protocol;
+use libp2p::Multiaddr;
+use libp2p_core::PeerId;
+
+// Peer tcp port will be determined by adding their peer_no to this value
+const LISTEN_PORT_BASE: u16 = 63000;
+
+#[derive(Parser, Debug)]
+#[clap(name = "MyChat networking example")]
+pub struct MyChatCliArgs {
+    /// Fixed value to generate deterministic peer ID.
+    #[clap(long, short)]
+    pub peer_no: u8,
+
+    /// Fixed value to generate deterministic peer ID and port
+    /// e.g. peer_no 1 will always result in
+    #[clap(long, short)]
+    pub bootstrap_peer_no: Option<u8>,
+}
+
+pub fn listen_address_with_peer_id(bootstrap_peer_no: u8) -> Multiaddr {
+    let mut addr = local_listen_address_from_peer_no(bootstrap_peer_no);
+    addr.push(Protocol::P2p(peer_no_to_peer_id(bootstrap_peer_no).into()));
+    addr
+}
+
+pub fn peer_no_to_peer_id(peer_no: u8) -> PeerId {
+    keypair_from_peer_no(peer_no)
+        .public()
+        .to_peer_id()
+}
+
+// Deterministically create a local listen address from the peer number
+pub fn local_listen_address_from_peer_no(peer_no: u8) -> Multiaddr {
+    let mut list_address = Multiaddr::from(Protocol::Ip4(Ipv4Addr::LOCALHOST));
+    list_address.push(Protocol::Tcp(LISTEN_PORT_BASE + peer_no as u16));
+    list_address
+}
+
+// Deterministically create a keypair from the peer number
+pub fn keypair_from_peer_no(peer_no: u8) -> Keypair {
+    // We can unwrap here, because `SecretKey::from_bytes()` can only fail on bad length of
+    // bytes slice. The  length is hardcoded to correct length of 32 here.
+    Keypair::Ed25519(ed25519::Keypair::from(
+        ed25519::SecretKey::from_bytes([peer_no; 32]).unwrap(),
+    ))
+}

--- a/examples/kad-identify-chat/main.rs
+++ b/examples/kad-identify-chat/main.rs
@@ -1,0 +1,81 @@
+//! # Chat example with Identify and Kademlia and Identify
+//!
+//! The kad-identify-chat example implements simple chat functionality using the `Identify` protocol
+//! and the `Kademlia` DHT for peer discovery and routing. Broadcast messages are propagated using the
+//! `Gossipsub` behaviour, direct messages are sent using the `RequestResponse` behaviour.
+//!
+//! The primary purpose of this example is to demonstrate how these behaviours interact.
+//! Please see the docs on [`MyChatNetworkBehaviour`] for more details.
+//! Please see `README.md` for instructions on how to run it.
+//!
+//! A secondary purpose of this example is to show what integration of libp2p in a complete
+//! application might look like. This is similar to the file sharing example,
+//! but where that example is purposely more barebones, this example is a bit more expansive and
+//! uses common crates like `thiserror` and `anyhow`. It also uses the tokio runtime instead of async_std.
+//!
+//! Finally, it shows a way to organise your business logic using custom `EventHandler` and
+//! `InstructionHandler` traits. This is by no means *the* way to do it, but it worked well
+//! in the real-world application this example was derived from.
+//!
+//! Note how all business logic is concentrated in only four functions:
+//! - `MyChatNetworkClient::handle_user_input()`: takes input from the cli and turns it into an
+//! `Instruction` for the `Network`.
+//! - `MyChatNetworkBehaviour::handle_instruction()`: acts on the `Instruction` using one of its
+//! composed `NetworkBehaviour`s. Most likely by sending a message through the `Swarm`.
+//! - `MyChatNetworkBehaviour::handle_event()`: receives events from the `Swarm` and turns them
+//! into `Notification`s for `MyChatNetworkClient`.
+//! - `MyChatNetworkClient::handle_notification()`: receives `Notification`s and acts on them, often
+//! by formatting them and displaying them to the user.
+
+use clap::Parser;
+use tokio::sync::mpsc;
+
+use mychat_network_client::MyChatNetworkClient;
+
+use crate::cli::{
+    MyChatCliArgs, keypair_from_peer_no, listen_address_with_peer_id, local_listen_address_from_peer_no,
+};
+use crate::mychat_behaviour::MyChatNetworkBehaviour;
+use crate::network::network_builder::NetworkBuilder;
+
+mod cli;
+mod mychat_network_client;
+mod network;
+mod mychat_direct_message_protocol;
+mod mychat_behaviour;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    env_logger::init();
+
+    let cli = MyChatCliArgs::parse();
+
+    let (notification_tx, notification_rx) = mpsc::unbounded_channel();
+    let (instruction_tx, instruction_rx) = mpsc::unbounded_channel();
+
+    let keypair = keypair_from_peer_no(cli.peer_no);
+
+    let behaviour = MyChatNetworkBehaviour::new(
+        &keypair,
+        cli.bootstrap_peer_no.map(|peer_no| vec![listen_address_with_peer_id(peer_no)]),
+    )?;
+
+    let mut network_builder =
+        NetworkBuilder::new(keypair, instruction_rx, notification_tx, behaviour)?;
+
+    // We set a custom listen address, based on the peer no
+    network_builder =
+        network_builder.listen_address(local_listen_address_from_peer_no(cli.peer_no));
+
+    let network = network_builder.build()?;
+
+    let client = MyChatNetworkClient::new(*network.peer_id(), instruction_tx, notification_rx);
+
+    // Start network event loop
+    tokio::spawn(network.run());
+
+    // Start client event loop
+    tokio::spawn(client.run()).await??;
+
+    Ok(())
+}

--- a/examples/kad-identify-chat/mychat_behaviour.rs
+++ b/examples/kad-identify-chat/mychat_behaviour.rs
@@ -1,0 +1,487 @@
+use std::borrow::Cow;
+use std::iter;
+
+use async_trait::async_trait;
+use multiaddr::Multiaddr;
+use libp2p::bytes::Bytes;
+use libp2p::gossipsub::{Gossipsub, GossipsubEvent, IdentTopic, MessageAuthenticity};
+use libp2p::identify;
+use libp2p::identity::Keypair;
+use libp2p::kad::store::MemoryStore;
+use libp2p::kad::{Kademlia, KademliaConfig, KademliaEvent};
+use libp2p::multiaddr::Protocol;
+use libp2p::request_response::{
+    ProtocolSupport, RequestResponse, RequestResponseEvent, RequestResponseMessage,
+};
+use libp2p::swarm::{
+    ConnectionError, ConnectionHandler, IntoConnectionHandler,
+    NetworkBehaviour, SwarmEvent,
+};
+use libp2p::PeerId;
+use libp2p::gossipsub;
+use thiserror::Error;
+use tokio::sync::mpsc;
+
+use crate::mychat_direct_message_protocol::{
+    MyChatMessageExchangeCodec, MyChatMessageExchangeProtocol, MyChatMessageRequest,
+    MyChatMessageResponse,
+};
+use crate::mychat_behaviour::MyChatNetworkBehaviourError::{
+    BootstrapError, InvalidBootstrapPeerAddress, PubSubBehaviourError,
+};
+use crate::mychat_direct_message_protocol;
+use crate::network::{Address, Instruction, NetworkError, Notification};
+use crate::network::event_handler::EventHandler;
+use crate::network::instruction_handler::InstructionHandler;
+use crate::network::NetworkError::SendError;
+
+const BROADCAST_TOPIC: &str = "BROADCAST";
+const KADEMLIA_PROTO_NAME: &[u8] = b"/my-chat/kad/1.0.0";
+const IDENTIFY_PROTO_NAME: &str = "/my-chat/ide/1.0.0";
+const GOSSIPSUB_PROTO_ID_PREFIX: &str = "my-chat/gossipsub";
+
+/// This behaviour composes multiple behaviours. It uses the
+/// Identify and Kademlia behaviours for peer discovery.
+/// For the chat functionality, it uses Gossipsub and
+/// RequestResponse behaviours.
+///
+/// - `identify::Behaviour`: when peers connect and they
+///   both support this protocol, they exchange `IdentityInfo`.
+///   `MyChatNetworkBehaviour` then uses this info to add their
+///   listen addresses to the Kademlia DHT.
+///   Without `identify::Behaviour`, the DHT would propagate
+///   the peer ids of peers, but not their listen addresses,
+///   making it impossible for peers to connect to them.
+/// - `Kademlia`: this is the Distributed Hash Table implementation,
+///   primarily used to distribute info about other peers on the
+///   network this peer knows about to connected peers. This is a core
+///   feature of `Kademlia` that triggers automatically.
+///   This enables so-called DHT-routing, which enables peers to send
+///   messages to peers they are not directly connected to.
+/// - `Gossipsub`: this takes care of sending pubsub messages to all
+///   peers this peer is aware of on a certain topic.
+///   Subscribe/unsubscribe messages are also propagated.
+///   This works well in combination with `identify::Behaviour`
+///   and `Kademlia`, because they ensure that Gossipsub messages
+///   not only reach directly connected peers, but all peers that can
+///   be reached through the DHT routing.
+/// - `RequestResponse`: `MyChatMessageExchangeCodec` is a simple
+///   request response protocol, where received messages will
+///   automatically be responded to with a 0 byte. This confirms
+///   to the sender that the message was correctly received.
+///   Consider that analogous to the 'delivered' check on WhatsApp/Signal.
+///   This can only be used to send message to directly connected peers.
+///   It does not use the DHT routing. It expect the local peer to know
+///   the listen address of the peer it is sending a message to.
+///
+///   If we expect peers to not always be able to directly reach
+///   other peers because of networking reasons, we may have
+///   to add the `Relay` behaviour to `MyChatNetworkBehaviour`
+#[derive(NetworkBehaviour)]
+#[behaviour(out_event = "MyChatNetworkBehaviourEvent")]
+pub struct MyChatNetworkBehaviour {
+    /// The Gossipsub pub/sub behaviour is used to send broadcast messages to peers.
+    pub pubsub: Gossipsub,
+    /// Send more detailed identifying info to connected peers, a.o the listen_address.
+    /// This address can then be used to populate the Kademlia DHT.
+    pub identify: identify::Behaviour,
+    /// The Kademlia DHT used to discover peers
+    pub kademlia: Kademlia<MemoryStore>,
+    /// In this case, RequestResponse behaviour is used to send direct messages to peers,
+    /// with delivery confirmation. This means that as long as the network does not return an error to its caller,
+    /// direct messages can be assumed to have been delivered.
+    pub request_response: RequestResponse<MyChatMessageExchangeCodec>,
+}
+
+impl MyChatNetworkBehaviour {
+    pub fn new(
+        keypair: &Keypair,
+        bootstrap_peers: Option<Vec<Multiaddr>>,
+    ) -> Result<MyChatNetworkBehaviour, MyChatNetworkBehaviourError> {
+        let gossipsub_config = gossipsub::GossipsubConfigBuilder::default()
+            .protocol_id_prefix(GOSSIPSUB_PROTO_ID_PREFIX)
+            .build()
+            .map_err(|err| PubSubBehaviourError(err.to_string()))?;
+
+        let mut pubsub = Gossipsub::new(
+            MessageAuthenticity::Signed(keypair.clone()),
+            gossipsub_config,
+        )
+        .map_err(|err| PubSubBehaviourError(err.to_string()))?;
+
+        pubsub
+            .subscribe(&IdentTopic::new(BROADCAST_TOPIC))
+            .map_err(|err| PubSubBehaviourError(err.to_string()))?;
+
+        let identify = identify::Behaviour::new(identify::Config::new(
+            IDENTIFY_PROTO_NAME.to_string(),
+            keypair.public(),
+        ));
+
+        let peer_id = keypair.public().to_peer_id();
+        let mut kademlia = Kademlia::with_config(
+            peer_id,
+            MemoryStore::new(peer_id),
+            KademliaConfig::default()
+                .set_protocol_names(iter::once(Cow::Borrowed(KADEMLIA_PROTO_NAME)).collect())
+                .to_owned(),
+        );
+
+        if let Some(bootstrap_peers) = bootstrap_peers {
+            // First, we add the addresses of the bootstrap nodes to our view of the DHT
+            for peer_address in &bootstrap_peers {
+                let peer_id = extract_peer_id_from_multiaddr(peer_address)?;
+                kademlia.add_address(&peer_id, peer_address.clone());
+            }
+
+            // Next, we add our own info to the DHT. This will then automatically be shared
+            // with the other peers on the DHT. This operation will fail if we are a bootstrap peer.
+            kademlia
+                .bootstrap()
+                .map_err(|err| BootstrapError(err.to_string()))?;
+        }
+
+        Ok(Self {
+            pubsub,
+            identify,
+            kademlia,
+            request_response: RequestResponse::new(
+                MyChatMessageExchangeCodec(),
+                iter::once((MyChatMessageExchangeProtocol(), ProtocolSupport::Full)),
+                Default::default(),
+            ),
+        })
+    }
+
+    fn notify(notification_tx: &mpsc::UnboundedSender<Notification>, notification: Notification) {
+        if let Err(e) = notification_tx.send(notification) {
+            log::error!("Failed to send notification back to router through mpsc channel: {e}");
+        }
+    }
+
+    fn notify_error(notification_tx: &mpsc::UnboundedSender<Notification>, error: NetworkError) {
+        if let Err(e) = notification_tx.send(Notification::Err(error)) {
+            log::error!("Failed to send notification back to router through mpsc channel: {e}");
+        }
+    }
+
+    fn send(&mut self, destination: Address<PeerId>, message: Bytes) -> Result<(), NetworkError> {
+        match destination {
+            Address::DirectMessage(peer_id) => self.send_single(&peer_id, &message)?,
+            Address::Broadcast => {
+                log::debug!("Broadcasting: {message:?}");
+                if let Err(error) = self
+                    .pubsub
+                    .publish(IdentTopic::new(BROADCAST_TOPIC), message)
+                {
+                    log::error!(
+                        "Failed to publish message to the pubsub topic '{}': {}",
+                        BROADCAST_TOPIC,
+                        error
+                    );
+                    return Err(NetworkError::BroadcastError {
+                        reason: format!("{error}"),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn send_single(&mut self, peer_id: &PeerId, message: &Bytes) -> Result<(), NetworkError> {
+        let request_id = self
+            .request_response
+            .send_request(peer_id, MyChatMessageRequest(message.clone()));
+
+        log::debug!(
+            "Sending message to peer {} with id {}: {:?}",
+            peer_id,
+            request_id,
+            message
+        );
+
+        Ok(())
+    }
+
+    fn handle_request_response_message(
+        &mut self,
+        notification_tx: &mpsc::UnboundedSender<Notification>,
+        peer_id: PeerId,
+        message: RequestResponseMessage<MyChatMessageRequest, MyChatMessageResponse>,
+    ) {
+        match message {
+            RequestResponseMessage::Request {
+                request,
+                channel,
+                request_id,
+            } => {
+                log::debug!(
+                    "Received direct message request with id {} from peer {}: {:?}",
+                    request_id,
+                    peer_id,
+                    request.0
+                );
+
+                Self::notify(notification_tx, Notification::Data(request.0));
+
+                log::debug!(
+                    "Acknowledging reception of message with id {request_id} to requesting peer."
+                );
+                if self
+                    .request_response
+                    .send_response(
+                        channel,
+                        MyChatMessageResponse(Bytes::from_static(
+                            mychat_direct_message_protocol::ACK_MESSAGE,
+                        )),
+                    )
+                    .is_err()
+                {
+                    log::error!("Failed to acknowledge reception of message with id {request_id} to requesting peer")
+                }
+            }
+            RequestResponseMessage::Response {
+                response,
+                request_id,
+            } => {
+                if response.0 == Bytes::from_static(mychat_direct_message_protocol::ACK_MESSAGE) {
+                    log::info!(
+                        "Received message reception confirmation from peer {} for request {}",
+                        peer_id,
+                        request_id
+                    );
+                } else {
+                    log::error!(
+                        "Unexpected payload for message reception confirmation from peer {} for request {}: {:?}",
+                        peer_id,
+                        request_id,
+                        response.0
+                    )
+                }
+            }
+        }
+    }
+
+    fn handle_pubsub_event(
+        &mut self,
+        notification_tx: &mpsc::UnboundedSender<Notification>,
+        event: GossipsubEvent,
+    ) {
+        match event {
+            GossipsubEvent::Message { message, .. } => {
+                Self::notify(notification_tx, Notification::Data(message.data.into()));
+            }
+            _ => log::debug!("Received Pubsub event:  {event:?}"),
+        }
+    }
+
+    fn handle_request_response_event(
+        &mut self,
+        notification_tx: &mpsc::UnboundedSender<Notification>,
+        event: RequestResponseEvent<MyChatMessageRequest, MyChatMessageResponse>,
+    ) {
+        match event {
+            RequestResponseEvent::Message {
+                peer: peer_id,
+                message,
+            } => self.handle_request_response_message(notification_tx, peer_id, message),
+            RequestResponseEvent::OutboundFailure {
+                peer: peer_id,
+                error,
+                request_id,
+            } => {
+                Self::notify_error(
+                    notification_tx,
+                    SendError {
+                        peer_id,
+                        reason: format!("Failed sending request with id '{request_id}': {error}"),
+                    },
+                );
+            }
+            RequestResponseEvent::InboundFailure {
+                peer: peer_id,
+                error,
+                request_id,
+            } => {
+                Self::notify_error(
+                    notification_tx,
+                    NetworkError::ReceiveError {
+                        peer_id,
+                        reason: format!(
+                            "Could not handle incoming request with id '{request_id}': {error}"
+                        ),
+                    },
+                );
+            }
+            _ => log::trace!("Unhandled RequestResponseEvent event: {event:?}"),
+        }
+    }
+
+    /// When we receive IdentityInfo, if the peer supports our Kademlia protocol, we add
+    /// their listen addresses to the DHT, so they will be propagated to other peers.
+    fn handle_identify_event(&mut self, identify_event: Box<identify::Event>) {
+        log::debug!("Received identify::Event: {:?}", *identify_event);
+
+        if let identify::Event::Received {
+            peer_id,
+            info:
+                identify::Info {
+                    listen_addrs,
+                    protocols,
+                    ..
+                },
+        } = *identify_event
+        {
+            if protocols
+                .iter()
+                .any(|p| p.as_bytes() == KADEMLIA_PROTO_NAME)
+            {
+                for addr in listen_addrs {
+                    log::debug!("Adding received IdentifyInfo matching protocol '{}' to the DHT. Peer: {}, addr: {}", String::from_utf8_lossy(KADEMLIA_PROTO_NAME), peer_id, addr);
+                    self.kademlia.add_address(&peer_id, addr);
+                }
+            }
+        }
+    }
+
+    fn handle_non_functional_event(
+        &mut self,
+        event: SwarmEvent<
+            <MyChatNetworkBehaviour as NetworkBehaviour>::OutEvent,
+            <<<MyChatNetworkBehaviour as NetworkBehaviour>::ConnectionHandler as IntoConnectionHandler>::Handler as ConnectionHandler>::Error,
+        >,
+    ) {
+        match event {
+            SwarmEvent::NewListenAddr { address, .. } => {
+                log::info!("Listening on {address:?}")
+            }
+            SwarmEvent::OutgoingConnectionError { peer_id, error } => match peer_id {
+                None => log::error!("Could not connect: {}", error),
+                Some(peer_id) => log::error!("Could not connect to peer '{}': {}", peer_id, error),
+            },
+            SwarmEvent::ConnectionClosed {
+                peer_id,
+                cause: Some(ConnectionError::Handler(error)),
+                ..
+            } => {
+                log::error!(
+                    "Connection to peer {} closed because of an error: {}",
+                    peer_id,
+                    error
+                );
+            }
+            _ => log::trace!("Unhandled Swarm event: {event:?}"),
+        }
+    }
+}
+
+fn extract_peer_id_from_multiaddr(
+    address_with_peer_id: &Multiaddr,
+) -> Result<PeerId, MyChatNetworkBehaviourError> {
+    match address_with_peer_id.iter().last() {
+        Some(Protocol::P2p(hash)) => PeerId::from_multihash(hash).map_err(|multihash| {
+            InvalidBootstrapPeerAddress(format!(
+                "Invalid PeerId '{multihash:?}' in Multiaddr '{address_with_peer_id}'"
+            ))
+        }),
+        _ => Err(InvalidBootstrapPeerAddress(
+            "Multiaddr does not contain peer_id".to_string(),
+        )),
+    }
+}
+
+#[async_trait]
+impl InstructionHandler for MyChatNetworkBehaviour {
+    async fn handle_instruction(
+        &mut self,
+        notification_tx: &mpsc::UnboundedSender<Notification>,
+        instruction: Instruction,
+    ) {
+        match instruction {
+            Instruction::Send {
+                destination,
+                message,
+            } => {
+                if let Err(error) = self.send(destination, message) {
+                    Self::notify(notification_tx, Notification::Err(error));
+                }
+            }
+            Instruction::PeerList => {
+                Self::notify(
+                    notification_tx,
+                    Notification::PeerList(self.pubsub.all_peers().map(|peer| *peer.0).collect()),
+                );
+            }
+        }
+    }
+}
+#[async_trait]
+impl EventHandler for MyChatNetworkBehaviour {
+    async fn handle_event(
+        &mut self,
+        notification_tx: &mpsc::UnboundedSender<Notification>,
+        event: SwarmEvent<
+            <MyChatNetworkBehaviour as NetworkBehaviour>::OutEvent,
+            <<<MyChatNetworkBehaviour as NetworkBehaviour>::ConnectionHandler as IntoConnectionHandler>::Handler as ConnectionHandler>::Error
+        >,
+    ) {
+        match event {
+            SwarmEvent::Behaviour(MyChatNetworkBehaviourEvent::Pubsub(event)) => {
+                self.handle_pubsub_event(notification_tx, event)
+            }
+            SwarmEvent::Behaviour(MyChatNetworkBehaviourEvent::RequestResponse(event)) => {
+                self.handle_request_response_event(notification_tx, event)
+            }
+            SwarmEvent::Behaviour(MyChatNetworkBehaviourEvent::IdentifyEvent(e)) => {
+                self.handle_identify_event(e)
+            }
+            non_functional_event => self.handle_non_functional_event(non_functional_event),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum MyChatNetworkBehaviourEvent {
+    Pubsub(GossipsubEvent),
+    KademliaEvent(Box<KademliaEvent>),
+    IdentifyEvent(Box<identify::Event>),
+    RequestResponse(RequestResponseEvent<MyChatMessageRequest, MyChatMessageResponse>),
+}
+
+impl From<GossipsubEvent> for MyChatNetworkBehaviourEvent {
+    fn from(event: GossipsubEvent) -> Self {
+        MyChatNetworkBehaviourEvent::Pubsub(event)
+    }
+}
+
+impl From<KademliaEvent> for MyChatNetworkBehaviourEvent {
+    fn from(event: KademliaEvent) -> Self {
+        MyChatNetworkBehaviourEvent::KademliaEvent(Box::new(event))
+    }
+}
+
+impl From<identify::Event> for MyChatNetworkBehaviourEvent {
+    fn from(event: identify::Event) -> Self {
+        MyChatNetworkBehaviourEvent::IdentifyEvent(Box::new(event))
+    }
+}
+
+impl From<RequestResponseEvent<MyChatMessageRequest, MyChatMessageResponse>>
+    for MyChatNetworkBehaviourEvent
+{
+    fn from(event: RequestResponseEvent<MyChatMessageRequest, MyChatMessageResponse>) -> Self {
+        MyChatNetworkBehaviourEvent::RequestResponse(event)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum MyChatNetworkBehaviourError {
+    // This error is deliberately generic, because we don't want to break the error API
+    // when we change the pubsub behaviour.
+    #[error("Could not construct composed pubsub behaviour: {0}")]
+    PubSubBehaviourError(String),
+    #[error("Failed bootstrap with the DHT: {0}")]
+    BootstrapError(String),
+    #[error("The address for the bootstrap peer is invalid: {0}")]
+    InvalidBootstrapPeerAddress(String),
+}

--- a/examples/kad-identify-chat/mychat_direct_message_protocol.rs
+++ b/examples/kad-identify-chat/mychat_direct_message_protocol.rs
@@ -1,0 +1,110 @@
+/// Simple message exchange protocol for MyChat
+use std::io;
+
+use async_trait::async_trait;
+use libp2p::bytes::Bytes;
+use libp2p::core::upgrade::{read_length_prefixed, write_length_prefixed};
+use libp2p::futures::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use libp2p::request_response::{ProtocolName, RequestResponseCodec};
+
+/// This is the maximum size in bytes of the message that we accept. This is
+/// necessary in order to avoid DoS attacks where the remote sends us huge messages repeatedly.
+pub const MAX_DIRECT_MESSAGE_ACCEPT_SIZE: usize = 1_000_000;
+
+/// This request response protocol for the MyChat network is used to send direct messages between peers.
+///
+/// The protocol can be used to send any bytes between peers, as long as the message size is not
+/// greater than MAX_DIRECT_MESSAGE_ACCEPT_SIZE.
+///
+/// If a peer does not respond to a message, a specific event is raised.
+/// In the case of MyChat, this protocol is used to send one-way messages to peers, expecting only
+/// a 0-byte in the immediate response. This confirms delivery. Peers respond with actual content
+/// in later, async messages using this same protocol.
+#[derive(Debug, Clone)]
+pub struct MyChatMessageExchangeProtocol();
+#[derive(Clone)]
+pub struct MyChatMessageExchangeCodec();
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MyChatMessageRequest(pub Bytes);
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MyChatMessageResponse(pub Bytes);
+
+pub const ACK_MESSAGE: &[u8; 1] = &[0];
+const DM_PROTO_NAME: &[u8] = b"/my-chat/dm/1.0.0";
+
+impl ProtocolName for MyChatMessageExchangeProtocol {
+    fn protocol_name(&self) -> &[u8] {
+        DM_PROTO_NAME
+    }
+}
+
+#[async_trait]
+impl RequestResponseCodec for MyChatMessageExchangeCodec {
+    type Protocol = MyChatMessageExchangeProtocol;
+    type Request = MyChatMessageRequest;
+    type Response = MyChatMessageResponse;
+
+    async fn read_request<T>(
+        &mut self,
+        _: &MyChatMessageExchangeProtocol,
+        io: &mut T,
+    ) -> io::Result<Self::Request>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        let vec = read_length_prefixed(io, MAX_DIRECT_MESSAGE_ACCEPT_SIZE).await?;
+
+        if vec.is_empty() {
+            return Err(io::ErrorKind::UnexpectedEof.into());
+        }
+
+        Ok(MyChatMessageRequest(vec.into()))
+    }
+
+    async fn read_response<T>(
+        &mut self,
+        _: &MyChatMessageExchangeProtocol,
+        io: &mut T,
+    ) -> io::Result<Self::Response>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        let vec = read_length_prefixed(io, MAX_DIRECT_MESSAGE_ACCEPT_SIZE).await?;
+
+        if vec.is_empty() {
+            return Err(io::ErrorKind::UnexpectedEof.into());
+        }
+
+        Ok(MyChatMessageResponse(vec.into()))
+    }
+
+    async fn write_request<T>(
+        &mut self,
+        _: &MyChatMessageExchangeProtocol,
+        io: &mut T,
+        MyChatMessageRequest(data): MyChatMessageRequest,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        write_length_prefixed(io, data).await?;
+        io.close().await?;
+
+        Ok(())
+    }
+
+    async fn write_response<T>(
+        &mut self,
+        _: &MyChatMessageExchangeProtocol,
+        io: &mut T,
+        MyChatMessageResponse(data): MyChatMessageResponse,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        write_length_prefixed(io, data).await?;
+        io.close().await?;
+
+        Ok(())
+    }
+}

--- a/examples/kad-identify-chat/mychat_network_client.rs
+++ b/examples/kad-identify-chat/mychat_network_client.rs
@@ -1,0 +1,199 @@
+use std::fmt::Debug;
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::Context;
+use libp2p::PeerId;
+use tokio::io::{self, AsyncBufReadExt, BufReader, Lines, Stdin};
+use tokio::sync::mpsc;
+use tokio::time::sleep;
+
+use crate::network::{Address, Instruction, Notification};
+
+use crate::cli::keypair_from_peer_no;
+use serde::{Serialize, Deserialize};
+
+/// The `NetworkClient` ireads user input from standard input and transforms it
+/// into `Instruction`s. It then sends the `Instruction` on the mpsc channel that the `Network`
+/// listens to.
+///
+/// It receives `Notification`s from the `Network` on the notification channel.
+pub struct MyChatNetworkClient {
+    peer_id: PeerId,
+    instruction_tx: mpsc::UnboundedSender<Instruction>,
+    notification_rx: mpsc::UnboundedReceiver<Notification>,
+    stdin: Lines<BufReader<Stdin>>,
+}
+
+impl MyChatNetworkClient {
+    pub fn new(
+        peer_id: PeerId,
+        instruction_tx: mpsc::UnboundedSender<Instruction>,
+        notification_rx: mpsc::UnboundedReceiver<Notification>,
+    ) -> MyChatNetworkClient {
+        MyChatNetworkClient {
+            peer_id,
+            instruction_tx,
+            notification_rx,
+            stdin: BufReader::new(io::stdin()).lines(),
+        }
+    }
+
+    pub async fn run(mut self) -> anyhow::Result<()> {
+        log::info!("Start network client event loop.");
+        loop {
+            tokio::select! {
+                Ok(Some(line)) = self.stdin.next_line() => {
+                    Self::handle_user_input(self.peer_id, self.instruction_tx.clone(), &line).await?
+                }
+                Some(notification) = self.notification_rx.recv() =>  {
+                     Self::handle_notification(self.peer_id, self.instruction_tx.clone(), notification).await?
+                }
+                else => {
+                    log::info!("Both stdin and notification channel closed. Ending client");
+                    break Ok(())
+
+                }
+            }
+        }
+    }
+
+    async fn handle_user_input(
+        local_peer_id: PeerId,
+        instruction_tx: mpsc::UnboundedSender<Instruction>,
+        input: &str,
+    ) -> anyhow::Result<()> {
+        if input == "ls" {
+            Self::request_peer_list(instruction_tx.clone()).await?
+        } else if input.starts_with("dm") {
+            let split: Vec<&str> = input.split_whitespace().collect();
+            let message = Message::DirectMessage {
+                source: local_peer_id,
+                data: split[2..].join(" ")
+            };
+
+            Self::send_dm_to_peer_no(
+                instruction_tx.clone(),
+                u8::from_str(split[1]).context(format!(
+                    "Can't send DM: peer no is not an integer: {}",
+                    split[1]
+                ))?,
+                message,
+            )
+            .await?;
+        } else {
+            Self::send_broadcast(local_peer_id, instruction_tx.clone()).await?
+        }
+
+        Ok(())
+    }
+
+    async fn handle_notification(
+        local_peer_id: PeerId,
+        instruction_tx: mpsc::UnboundedSender<Instruction>,
+        notification: Notification,
+    ) -> anyhow::Result<()> {
+        match notification {
+            Notification::Data(payload) => {
+                let message: Message = bincode::deserialize(&payload)?;
+                match message {
+                    Message::Ack { source } => {
+                        log::info!("Received ACK from peer {source} on broadcast");
+                    }
+                    Message::Broadcast { source } => {
+                        log::info!("Received BROADCAST message from peer {source}");
+                        tokio::spawn(async move {
+                            sleep(Duration::from_secs(1)).await;
+
+                            let _ = Self::send_dm(
+                                instruction_tx,
+                                source,
+                                Message::Ack {
+                                    source: local_peer_id,
+                                },
+                            )
+                            .await;
+                        });
+                    }
+                    Message::DirectMessage { source, data } => {
+                        log::info!("Received DM from peer {source}: {data}");
+                    }
+                }
+            }
+            Notification::Err(error) => {
+                log::error!("Received error from network: {error}")
+            }
+            Notification::PeerList(peer_list) => {
+                log::info!("Peer list: {peer_list:?}")
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn request_peer_list(
+        instruction_tx: mpsc::UnboundedSender<Instruction>,
+    ) -> anyhow::Result<()> {
+        let instruction = Instruction::PeerList;
+        Ok(instruction_tx.send(instruction)?)
+    }
+
+    async fn send_dm_to_peer_no(
+        instruction_tx: mpsc::UnboundedSender<Instruction>,
+        to_peer_no: u8,
+        message: Message,
+    ) -> anyhow::Result<()> {
+        Self::send_dm(
+            instruction_tx,
+            keypair_from_peer_no(to_peer_no).public().to_peer_id(),
+            message,
+        )
+        .await
+    }
+
+    async fn send_dm(
+        instruction_tx: mpsc::UnboundedSender<Instruction>,
+        to_peer_id: PeerId,
+        message: Message,
+    ) -> anyhow::Result<()> {
+        let instruction = Instruction::Send {
+            destination: Address::DirectMessage(to_peer_id.clone()),
+            message: bincode::serialize(&message)?.into(),
+        };
+        instruction_tx.send(instruction)?;
+
+        log::info!(
+            "Direct message sent to peer: '{}': {:?}",
+            to_peer_id,
+            message
+        );
+
+        Ok(())
+    }
+
+    async fn send_broadcast(
+        from_peer_id: PeerId,
+        instruction_tx: mpsc::UnboundedSender<Instruction>,
+    ) -> anyhow::Result<()> {
+        let instruction = Instruction::Send {
+            destination: Address::Broadcast,
+            message: bincode::serialize(&Message::Broadcast {
+                source: from_peer_id,
+            })?
+            .into(),
+        };
+
+        instruction_tx.send(instruction)?;
+
+        log::info!("Broadcast sent to Network");
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+enum Message {
+    Ack { source: PeerId },
+    Broadcast { source: PeerId },
+    DirectMessage { source: PeerId, data: String },
+}

--- a/examples/kad-identify-chat/network/event_handler.rs
+++ b/examples/kad-identify-chat/network/event_handler.rs
@@ -1,0 +1,20 @@
+use async_trait::async_trait;
+use libp2p::swarm::{ConnectionHandler, IntoConnectionHandler, NetworkBehaviour, SwarmEvent};
+use tokio::sync::mpsc;
+use crate::network::Notification;
+
+
+#[async_trait]
+pub trait EventHandler
+where
+    Self: NetworkBehaviour,
+{
+    async fn handle_event(
+        &mut self,
+        notification_tx: &mpsc::UnboundedSender<Notification>,
+        event: SwarmEvent<
+            Self::OutEvent,
+            <<Self::ConnectionHandler as IntoConnectionHandler>::Handler as ConnectionHandler>::Error,
+        >,
+    );
+}

--- a/examples/kad-identify-chat/network/instruction_handler.rs
+++ b/examples/kad-identify-chat/network/instruction_handler.rs
@@ -1,0 +1,17 @@
+use async_trait::async_trait;
+use libp2p::swarm::NetworkBehaviour;
+use tokio::sync::mpsc;
+use crate::network::{Instruction, Notification};
+
+
+#[async_trait]
+pub trait InstructionHandler
+where
+    Self: NetworkBehaviour,
+{
+    async fn handle_instruction(
+        &mut self,
+        notification_tx: &mpsc::UnboundedSender<Notification>,
+        instruction: Instruction,
+    );
+}

--- a/examples/kad-identify-chat/network/mod.rs
+++ b/examples/kad-identify-chat/network/mod.rs
@@ -1,0 +1,120 @@
+extern crate core;
+
+use std::fmt::Debug;
+
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::sync::mpsc;
+
+use libp2p::futures::StreamExt;
+pub use libp2p::PeerId;
+use libp2p::Swarm;
+use libp2p::swarm::NetworkBehaviour;
+use event_handler::EventHandler;
+use instruction_handler::InstructionHandler;
+
+pub mod network_builder;
+pub mod instruction_handler;
+pub mod event_handler;
+
+///
+/// The `Network` is a convenience wrapper around the `Swarm` for a `NetworkBehaviour`.
+/// It can be constructed with the `NetworkBuilder` for convenience.
+///
+/// Communication between the `Network` and its client(s) happens only through mpsc channels,
+/// and is fully async.
+///
+///
+/// The `Network`:
+/// - receives `Instructions`, which it passes on to the `InstructionHandler` trait implemented
+///   on the swarm's NetworkBehaviour.
+/// - receives events from the swarm and passes them on to the `EventHandler` trait implemented
+///   on the swarm's `NetworkBehaviour`. The `EventHandler` can notify the `Network`'s client
+///   by sending a `Notification`.
+///
+/// The `Network` does not know or care what the Instructions and Notifications contain. It is up to
+/// the client(s) to give them meaning.
+///
+pub struct Network<TBehaviour>
+    where
+        TBehaviour: NetworkBehaviour,
+{
+    instruction_rx: mpsc::UnboundedReceiver<Instruction>,
+    notification_tx: mpsc::UnboundedSender<Notification>,
+    swarm: Swarm<TBehaviour>,
+}
+
+impl<TBehaviour> Network<TBehaviour>
+    where
+        TBehaviour: NetworkBehaviour + EventHandler + InstructionHandler,
+{
+    pub fn new(
+        instruction_rx: mpsc::UnboundedReceiver<Instruction>,
+        notification_tx: mpsc::UnboundedSender<Notification>,
+        swarm: Swarm<TBehaviour>,
+    ) -> Self {
+        Network { instruction_rx, notification_tx, swarm }
+    }
+
+    pub async fn run(mut self) {
+        loop {
+            tokio::select! {
+                event = self.swarm.select_next_some() => self.swarm.behaviour_mut().handle_event(&self.notification_tx, event).await,
+                Some(instruction) = self.instruction_rx.recv() =>  self.swarm.behaviour_mut().handle_instruction(&self.notification_tx, instruction).await,
+                else => {
+                    log::warn!("Both swarm and instruction receiver closed. Ending event loop");
+                    break
+
+                }
+            }
+        }
+    }
+
+    pub fn peer_id(&self) -> &PeerId {
+        self.swarm.local_peer_id()
+    }
+}
+
+/// An instruction for the network to do something. Most likely to send a message of some sort
+#[derive(Debug, Clone)]
+pub enum Instruction {
+    /// Instruct the network to send a message
+    Send {
+        destination: Address<PeerId>,
+        message: Bytes,
+    },
+    /// Instruct the network to provide a list of all peers it is aware of
+    PeerList,
+}
+
+/// A notification from the network to one of its consumers.
+/// Either arbitrary data, the list of known peers or an error.
+#[derive(Debug)]
+pub enum Notification {
+    Data(Bytes),
+    PeerList(Vec<PeerId>),
+    Err(NetworkError),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message<T: Debug + Clone> {
+    pub source: PeerId,
+    pub body: T,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Address<A: Debug + Clone> {
+    Broadcast,
+    DirectMessage(A),
+}
+
+#[derive(Debug, Error)]
+pub enum NetworkError {
+    #[error("Failed to send broadcast: `{reason:?}`")]
+    BroadcastError { reason: String },
+    #[error("Failed to send request to party `{peer_id:?}`: `{reason:?}`")]
+    SendError { peer_id: PeerId, reason: String },
+    #[error("Failed to receive complete message from party `{peer_id:?}`: `{reason:?}`")]
+    ReceiveError { peer_id: PeerId, reason: String },
+}

--- a/examples/kad-identify-chat/network/network_builder.rs
+++ b/examples/kad-identify-chat/network/network_builder.rs
@@ -1,0 +1,113 @@
+use std::io;
+
+use thiserror::Error;
+use tokio::sync::mpsc;
+
+use identity::Keypair;
+use libp2p::{identity, mplex, multiaddr, Multiaddr, noise, PeerId, Transport, TransportError};
+use libp2p::core::muxing::StreamMuxerBox;
+use libp2p::core::transport;
+use libp2p::core::transport::upgrade;
+use libp2p::noise::NoiseError;
+use libp2p::swarm::{NetworkBehaviour, SwarmBuilder};
+use libp2p_tcp::tokio::Tcp;
+
+use crate::network::{Instruction, Network, Notification};
+use crate::network::event_handler::EventHandler;
+use crate::network::instruction_handler::InstructionHandler;
+
+pub struct NetworkBuilder<TBehaviour> {
+    keypair: Keypair,
+    instruction_rx: mpsc::UnboundedReceiver<Instruction>,
+    notification_tx: mpsc::UnboundedSender<Notification>,
+    transport: transport::Boxed<(PeerId, StreamMuxerBox)>,
+    listen_address: Multiaddr,
+    behaviour: TBehaviour,
+}
+
+#[allow(dead_code)]
+impl<TBehaviour> NetworkBuilder<TBehaviour>
+    where
+        TBehaviour: NetworkBehaviour + EventHandler + InstructionHandler,
+{
+    pub fn new(
+        keypair: Keypair,
+        instruction_rx: mpsc::UnboundedReceiver<Instruction>,
+        notification_tx: mpsc::UnboundedSender<Notification>,
+        behaviour: TBehaviour,
+    ) -> Result<NetworkBuilder<TBehaviour>, NetworkBuilderError> {
+        Ok(NetworkBuilder {
+            transport: Self::default_transport(&keypair)?,
+            listen_address: Self::default_listen_address()?,
+            keypair,
+            instruction_rx,
+            notification_tx,
+            behaviour,
+        })
+    }
+
+    pub fn listen_address(mut self, address: Multiaddr) -> Self {
+        self.listen_address = address;
+        self
+    }
+
+    pub fn transport(mut self, transport: transport::Boxed<(PeerId, StreamMuxerBox)>) -> Self {
+        self.transport = transport;
+        self
+    }
+
+    /// Listen on all interfaces, on a random port
+    fn default_listen_address() -> Result<Multiaddr, NetworkBuilderError> {
+        Ok("/ip4/0.0.0.0/tcp/0".parse()?)
+    }
+
+    fn default_transport(
+        keypair: &Keypair,
+    ) -> Result<transport::Boxed<(PeerId, StreamMuxerBox)>, NetworkBuilderError> {
+        // Create a keypair for authenticated encryption of the transport.
+        let noise_keys = noise::Keypair::<noise::X25519Spec>::new().into_authentic(keypair)?;
+
+        Ok(
+            libp2p_tcp::Transport::<Tcp>::new(libp2p_tcp::Config::default().nodelay(true))
+                .upgrade(upgrade::Version::V1)
+                .authenticate(noise::NoiseConfig::xx(noise_keys).into_authenticated())
+                .multiplex(mplex::MplexConfig::new())
+                .boxed(),
+        )
+    }
+
+    pub fn build(self) -> Result<Network<TBehaviour>, NetworkBuilderError> {
+        let mut swarm = {
+            SwarmBuilder::with_executor(
+                self.transport,
+                self.behaviour,
+                PeerId::from(self.keypair.public()),
+                Box::new(|fut| {
+                    // We want the connection background tasks to be spawned
+                    // onto the tokio runtime.
+                    tokio::spawn(fut);
+                }),
+            )
+                .build()
+        };
+        swarm.listen_on(self.listen_address)?;
+
+        log::info!("Local PeerId: {}", swarm.local_peer_id());
+
+        Ok(Network::new(
+            self.instruction_rx,
+            self.notification_tx,
+            swarm,
+        ))
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum NetworkBuilderError {
+    #[error(transparent)]
+    BuildError(#[from] TransportError<io::Error>),
+    #[error(transparent)]
+    TransportError(#[from] NoiseError),
+    #[error(transparent)]
+    ListenAddressError(#[from] multiaddr::Error),
+}


### PR DESCRIPTION
## Description

The kad-identify-chat example implements simple chat functionality using the `Identify` protocol
and the `Kademlia` DHT for peer discovery and routing. Broadcast messages are propagated using the
`Gossipsub` behaviour, direct messages are sent using the `RequestResponse` behaviour.

The primary purpose of this example is to demonstrate how these behaviours interact, as Identify and Kademlia are not used together in any other example.

A secondary purpose of this example is to show what integration of libp2p in a complete
application might look like. This part is similar to the file sharing example,
but where that example is purposely more barebones, this example is a bit more expansive and
uses common crates like `thiserror` and `anyhow`. It also uses the tokio runtime instead of async_std.

## Notes

The reason for adding a new example is that I could not find an example that showed how to use Identify with Kademlia for peer discovery and routing. I realize the example is on the big side, and I have continuously tried to balance between realism and simplicity. Let me know if you see areas where this can be simplified, without compromising the realism.

## Open Questions
 

## Change checklist
* [x]  I have performed a self-review of my own code
* [x]  I have made corresponding changes to the documentation
* N/A I have added tests that prove my fix is effective or that my feature works 
* N/A  A changelog entry has been made in the appropriate crates

