### PR TITLE
feat: Allow `BandwidthLogging` to be used with more transports

### DIFF
--- a/transports/tcp/src/provider/async_io.rs
+++ b/transports/tcp/src/provider/async_io.rs
@@ -48,6 +48,8 @@ use std::task::{Context, Poll};
 /// ```
 pub type Transport = crate::Transport<Tcp>;
 
+pub type Stream = Async<net::TcpStream>;
+
 #[derive(Copy, Clone)]
 #[doc(hidden)]
 pub enum Tcp {}

--- a/transports/tcp/src/provider/tokio.rs
+++ b/transports/tcp/src/provider/tokio.rs
@@ -52,6 +52,8 @@ use std::task::{Context, Poll};
 /// ```
 pub type Transport = crate::Transport<Tcp>;
 
+pub type Stream = TcpStream;
+
 #[derive(Copy, Clone)]
 #[doc(hidden)]
 pub enum Tcp {}


### PR DESCRIPTION
## Description

Previously, `BandwidthLogging` implied that `Transport::Output` implements `AsyncRead + AsyncWrite`. For transports like WebRTC and QUIC, this is not true as those transports directly provide a multiplexed and authenticated connection. Thus, `BandwidthLogging` could not be used with those transports.

In the spirit of "all problems in computer science can be solved by an additional layer of indirection", we introduce a layer of indirection in how we introduce `BandwidthSinks` into the wrapped transport. We enforce all `Transport::Output`s that we want to log to implement `WithBandwidthSinks`. This allows us to define a specific strategy for each technology. Unfortunately, we cannot implement generically over all `AsyncRead + AsyncWrite` types without specialization, meaning we now have to list all types we want it implemented on.

For WebRTC, `WithBandwidthSinks` constructs a `Connection` wrapper that implements `StreamMuxer` but also updates the `BandwidthSinks` upon each `StreamMuxer::poll` call. 

Fixes #3157.

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes

@melekes I did some quick local testing and things seem to compile with this abstraction. It needs some more filling in:

1. Implementations of `WithBandwidthSinks` for all our streams of our transports.
2. Actual tracking of bytes sent and received in `libp2p-webrtc`.

Can I take you up on your "offer" in https://github.com/libp2p/rust-libp2p/issues/3157 and you continue implementing things from here? :)

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
