### PR TITLE
Revert "chore: Enforce conventional commit PR title"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 9999
-    commit-message:
-      prefix: "deps"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
+      # Check for updates to GitHub Actions every weekday
       interval: "daily"
-    commit-message:
-      prefix: "deps"

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -24,24 +24,6 @@ pull_request_rules:
     actions:
       queue:
 
-  - name: Conventional Commit PR title
-    conditions:
-      - base=master
-    actions:
-      post_check:
-        success_conditions:
-          - "title~=^(fix|feat|docs|refactor|chore|deps)(\\(.+\\))?!?:"
-        title: |
-          {% if check_succeed %}
-          Title follows Conventional Commit
-          {% else %}
-          Title does not follow Conventional Commit
-          {% endif %}
-        summary: |
-          {% if not check_succeed %}
-          Your pull request title must follow [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/).
-          {% endif %}
-
 queue_rules:
   - name: default
     conditions: []


### PR DESCRIPTION
Reverts libp2p/rust-libp2p#3083

This uses a premium feature of mergify. While we might have the option upgrade to premium in the future, let's revert here for now to unblock other pull requests.

See https://github.com/libp2p/rust-libp2p/pull/3115#issuecomment-1325604928 for details.

//CC @thomaseizinger 