### PR TITLE
fix(tls): add description and repository to Cargo.toml

### DIFF
--- a/transports/tls/Cargo.toml
+++ b/transports/tls/Cargo.toml
@@ -3,6 +3,8 @@ name = "libp2p-tls"
 version = "0.1.0-alpha"
 edition = "2021"
 rust-version = "1.60.0"
+description = "TLS configuration based on libp2p TLS specs."
+repository = "https://github.com/libp2p/rust-libp2p"
 license = "MIT"
 exclude = ["src/test_assets"]
 


### PR DESCRIPTION
## Description

## Notes

Needed for `libp2p` `v0.50.0`. See https://github.com/libp2p/rust-libp2p/pull/3163.