### PR TITLE
README: Add HotShot as notable user

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 - [COMIT](https://github.com/comit-network/xmr-btc-swap) - Bitcoin–Monero Cross-chain Atomic Swap.
 - [Forest](https://github.com/ChainSafe/forest) - An implementation of Filecoin written in Rust.
 - [fuel-core](https://github.com/FuelLabs/fuel-core) - A Rust implementation of the Fuel protocol.
+- [HotShot](https://github.com/EspressoSystems/HotShot) - Decentralized sequencer in Rust developed by [Espresso Systems](https://www.espressosys.com/).
 - [ipfs-embed](https://github.com/ipfs-rust/ipfs-embed) - A small embeddable ipfs implementation
 used and maintained by [Actyx][https://www.actyx.com].
 - [iroh](https://github.com/n0-computer/iroh) - Next-generation implementation of IPFS for Cloud & Mobile platforms.


### PR DESCRIPTION
## Description

We (Espresso Systems) are developing a [decentralized sequencer](https://www.espressosys.com/blog/espresso-hotshot-consensus-designed-for-rollups) that uses libp2p as a networking layer. We recently open sourced, and our usage lives [here](https://github.com/EspressoSystems/HotShot).

