### PR TITLE
fix(ci): avoid rate limits on GitHub API by supplying auth token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Install Protoc
         uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v3
 
@@ -92,6 +94,8 @@ jobs:
     steps:
       - name: Install Protoc
         uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v3
 
@@ -117,6 +121,8 @@ jobs:
     steps:
       - name: Install Protoc
         uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v3
 
@@ -138,6 +144,8 @@ jobs:
     steps:
       - name: Install Protoc
         uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v3
 
@@ -164,6 +172,8 @@ jobs:
     steps:
       - name: Install Protoc
         uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v3
 
@@ -187,6 +197,8 @@ jobs:
     steps:
       - name: Install Protoc
         uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Protoc
-      uses: arduino/setup-protoc@v1
+      uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Checkout 
       uses: actions/checkout@v3
     - name: Install nightly toolchain


### PR DESCRIPTION
## Description

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

This follows the recommendation in the `Usage` section of the action: https://github.com/arduino/setup-protoc#usage
We won't need it once #3024 is landed but the failing CIs are annoying enough to warrant a temporary fix.

Example of a failing CI run: https://github.com/libp2p/rust-libp2p/actions/runs/3630150537/jobs/6123169342

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
