### PR TITLE
ci: fix path to interop test plan composition file

### DIFF
--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -26,7 +26,7 @@ jobs:
   run-ping-interop-cross-implementation:
     uses: "libp2p/test-plans/.github/workflows/run-composition.yml@master"
     with:
-      composition_file: "ping/_compositions/go-rust-interop-latest.toml"
+      composition_file: "ping/_compositions/all-interop-latest.toml"
       custom_git_target: github.com/${{ github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
       custom_git_reference: ${{ github.event.pull_request.head.sha || github.sha }}
       custom_interop_target: rust


### PR DESCRIPTION
## Description

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

The interoperability workflow definition file for the ping workflow was moved in https://github.com/libp2p/test-plans/pull/70 which breaks our CI.

Related: https://github.com/libp2p/go-libp2p/pull/1933/files

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
