### PR TITLE
test(noise): replace `libsodium-sys-stable` with pure-Rust `dryoc`

### DIFF
--- a/transports/noise/Cargo.toml
+++ b/transports/noise/Cargo.toml
@@ -35,7 +35,6 @@ env_logger = "0.10.0"
 libp2p = { path = "../..", features = ["full"] }
 quickcheck = { package = "quickcheck-ext", path = "../../misc/quickcheck-ext" }
 dryoc = "0.4.2"
-ed25519-compact = "2.0.2"
 
 [build-dependencies]
 prost-build = "0.11"

--- a/transports/noise/Cargo.toml
+++ b/transports/noise/Cargo.toml
@@ -34,7 +34,7 @@ async-io = "1.2.0"
 env_logger = "0.10.0"
 libp2p = { path = "../..", features = ["full"] }
 quickcheck = { package = "quickcheck-ext", path = "../../misc/quickcheck-ext" }
-libsodium-sys-stable = { version = "1.19.22", features = ["fetch-latest"] }
+dryoc = "0.4.2"
 ed25519-compact = "2.0.2"
 
 [build-dependencies]

--- a/transports/noise/src/protocol/x25519.rs
+++ b/transports/noise/src/protocol/x25519.rs
@@ -285,9 +285,6 @@ impl snow::types::Dh for Keypair<X25519> {
 mod tests {
     use super::*;
     use libp2p_core::identity::ed25519;
-    // Use the droyc crypto_sign imports for testing
-    use dryoc::classic::crypto_sign_ed25519::crypto_sign_ed25519_pk_to_curve25519;
-    use dryoc::classic::crypto_sign_ed25519::crypto_sign_ed25519_sk_to_curve25519;
     use quickcheck::*;
     use x25519_dalek::StaticSecret;
 
@@ -338,7 +335,8 @@ mod tests {
     ) -> Option<[u8; 32]> {
         let mut out = [0u8; 32];
 
-        crypto_sign_ed25519_pk_to_curve25519(&mut out, k).ok()?;
+        dryoc::classic::crypto_sign_ed25519::crypto_sign_ed25519_pk_to_curve25519(&mut out, k)
+            .ok()?;
 
         Some(out)
     }
@@ -348,7 +346,7 @@ mod tests {
     ) -> [u8; 32] {
         let mut out = [0u8; 32];
 
-        crypto_sign_ed25519_sk_to_curve25519(&mut out, k);
+        dryoc::classic::crypto_sign_ed25519::crypto_sign_ed25519_sk_to_curve25519(&mut out, k);
 
         out
     }

--- a/transports/noise/src/protocol/x25519.rs
+++ b/transports/noise/src/protocol/x25519.rs
@@ -284,8 +284,6 @@ impl snow::types::Dh for Keypair<X25519> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    // Use the ed25519_compact for testing
-    use ed25519_compact;
     use libp2p_core::identity::ed25519;
     // Use the droyc crypto_sign imports for testing
     use dryoc::classic::crypto_sign_ed25519::crypto_sign_ed25519_pk_to_curve25519;
@@ -301,11 +299,8 @@ mod tests {
             let ed25519 = ed25519::Keypair::generate();
             let x25519 = Keypair::from(SecretKey::from_ed25519(&ed25519.secret()));
 
-            let dryoc_sec =
-                ed25519_sk_to_curve25519(&ed25519_compact::SecretKey::new(ed25519.encode()));
-            let dryoc_pub = ed25519_pk_to_curve25519(&ed25519_compact::PublicKey::new(
-                ed25519.public().encode(),
-            ));
+            let dryoc_sec = ed25519_sk_to_curve25519(&ed25519.encode());
+            let dryoc_pub = ed25519_pk_to_curve25519(&ed25519.public().encode());
 
             let our_pub = x25519.public.0;
             // libsodium does the [clamping] of the scalar upon key construction,
@@ -338,7 +333,9 @@ mod tests {
         quickcheck(prop as fn() -> _);
     }
 
-    pub fn ed25519_pk_to_curve25519(k: &ed25519_compact::PublicKey) -> Option<[u8; 32]> {
+    pub fn ed25519_pk_to_curve25519(
+        k: &dryoc::classic::crypto_sign_ed25519::PublicKey,
+    ) -> Option<[u8; 32]> {
         let mut out = [0u8; 32];
 
         crypto_sign_ed25519_pk_to_curve25519(&mut out, k).ok()?;
@@ -346,7 +343,9 @@ mod tests {
         Some(out)
     }
 
-    pub fn ed25519_sk_to_curve25519(k: &ed25519_compact::SecretKey) -> [u8; 32] {
+    pub fn ed25519_sk_to_curve25519(
+        k: &dryoc::classic::crypto_sign_ed25519::SecretKey,
+    ) -> [u8; 32] {
         let mut out = [0u8; 32];
 
         crypto_sign_ed25519_sk_to_curve25519(&mut out, k);

--- a/transports/noise/src/protocol/x25519.rs
+++ b/transports/noise/src/protocol/x25519.rs
@@ -287,23 +287,23 @@ mod tests {
     // Use the ed25519_compact for testing
     use ed25519_compact;
     use libp2p_core::identity::ed25519;
-    // Use the libsodium-sys-stable crypto_sign imports for testing
+    // Use the droyc crypto_sign imports for testing
     use dryoc::classic::crypto_sign_ed25519::crypto_sign_ed25519_pk_to_curve25519;
     use dryoc::classic::crypto_sign_ed25519::crypto_sign_ed25519_sk_to_curve25519;
     use quickcheck::*;
     use x25519_dalek::StaticSecret;
 
     // ed25519 to x25519 keypair conversion must yield the same results as
-    // obtained through libsodium.
+    // obtained through dryoc.
     #[test]
-    fn prop_ed25519_to_x25519_matches_libsodium() {
+    fn prop_ed25519_to_x25519_matches_dryoc() {
         fn prop() -> bool {
             let ed25519 = ed25519::Keypair::generate();
             let x25519 = Keypair::from(SecretKey::from_ed25519(&ed25519.secret()));
 
-            let sodium_sec =
+            let dryoc_sec =
                 ed25519_sk_to_curve25519(&ed25519_compact::SecretKey::new(ed25519.encode()));
-            let sodium_pub = ed25519_pk_to_curve25519(&ed25519_compact::PublicKey::new(
+            let dryoc_pub = ed25519_pk_to_curve25519(&ed25519_compact::PublicKey::new(
                 ed25519.public().encode(),
             ));
 
@@ -317,7 +317,7 @@ mod tests {
             // [clamping]: http://www.lix.polytechnique.fr/~smith/ECC/#scalar-clamping
             let our_sec = StaticSecret::from((x25519.secret.0).0).to_bytes();
 
-            sodium_sec.as_ref() == Some(&our_sec) && sodium_pub.as_ref() == Some(&our_pub.0)
+            dryoc_sec == our_sec && dryoc_pub.as_ref() == Some(&our_pub.0)
         }
 
         quickcheck(prop as fn() -> _);
@@ -346,11 +346,11 @@ mod tests {
         Some(out)
     }
 
-    pub fn ed25519_sk_to_curve25519(k: &ed25519_compact::SecretKey) -> Option<[u8; 32]> {
+    pub fn ed25519_sk_to_curve25519(k: &ed25519_compact::SecretKey) -> [u8; 32] {
         let mut out = [0u8; 32];
 
         crypto_sign_ed25519_sk_to_curve25519(&mut out, k);
 
-        Some(out)
+        out
     }
 }

--- a/transports/noise/src/protocol/x25519.rs
+++ b/transports/noise/src/protocol/x25519.rs
@@ -288,8 +288,8 @@ mod tests {
     use ed25519_compact;
     use libp2p_core::identity::ed25519;
     // Use the libsodium-sys-stable crypto_sign imports for testing
-    use libsodium_sys::crypto_sign_ed25519_pk_to_curve25519;
-    use libsodium_sys::crypto_sign_ed25519_sk_to_curve25519;
+    use dryoc::classic::crypto_sign_ed25519::crypto_sign_ed25519_pk_to_curve25519;
+    use dryoc::classic::crypto_sign_ed25519::crypto_sign_ed25519_sk_to_curve25519;
     use quickcheck::*;
     use x25519_dalek::StaticSecret;
 
@@ -340,23 +340,17 @@ mod tests {
 
     pub fn ed25519_pk_to_curve25519(k: &ed25519_compact::PublicKey) -> Option<[u8; 32]> {
         let mut out = [0u8; 32];
-        unsafe {
-            if crypto_sign_ed25519_pk_to_curve25519(out.as_mut_ptr(), k.as_ptr()) == 0 {
-                Some(out)
-            } else {
-                None
-            }
-        }
+
+        crypto_sign_ed25519_pk_to_curve25519(&mut out, k).ok()?;
+
+        Some(out)
     }
 
     pub fn ed25519_sk_to_curve25519(k: &ed25519_compact::SecretKey) -> Option<[u8; 32]> {
         let mut out = [0u8; 32];
-        unsafe {
-            if crypto_sign_ed25519_sk_to_curve25519(out.as_mut_ptr(), k.as_ptr()) == 0 {
-                Some(out)
-            } else {
-                None
-            }
-        }
+
+        crypto_sign_ed25519_sk_to_curve25519(&mut out, k);
+
+        Some(out)
     }
 }


### PR DESCRIPTION
## Description

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

We are currently relying on `libsodium-sys-stable` for some testing of the `libp2p-noise` crypto. That library has a build-script which downloads the latest `libsodium-sys` library. Build-scripts slow down the compilation process and having them perform network calls is not great either.

`dryoc` implements a libsodium compatible API in pure Rust and is recommended here: https://github.com/The-DevX-Initiative/RCIG_Coordination_Repo/blob/main/Awesome_Rust_Cryptography.md#collections-of-cryptographic-primitives

This also removes two unsafe blocks because we no longer need to perform FFI.

## Notes

@pinkforest You contributed the change to `libsodium-sys-stable` previously. Any feedback on why this wouldn't be a good idea?

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
