### PR TITLE
ci(mergify): dismiss approvals on push once `send-it` is applied

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -24,6 +24,16 @@ pull_request_rules:
     actions:
       queue:
 
+  - name: Remove reviews on updates after PR is queued for merging
+    conditions:
+      - base=master
+      - label=send-it
+      - author!=@libp2p/rust-libp2p-maintainers
+    actions:
+      dismiss_reviews:
+        message: Approvals have been dismissed because the PR was updated after the `send-it` label was applied.
+        changes_requested: false
+
 queue_rules:
   - name: default
     conditions: []


### PR DESCRIPTION
## Description

Currently, a user can push code after it has been approved and the `send-it` label applied. We only want to merge code that we actually looked at. Use mergify to dismiss approvals in such circumstances.

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
