### PR TITLE
fix(kademlia): downgrade reusable stream dropping warning to debug log

### DIFF
--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -580,7 +580,7 @@ where
                 )
             }) {
                 *s = InboundSubstreamState::Cancelled;
-                log::warn!(
+                log::debug!(
                     "New inbound substream to {:?} exceeds inbound substream limit. \
                     Removed older substream waiting to be reused.",
                     self.remote_peer_id,


### PR DESCRIPTION
## Description

There is nothing wrong about being near the edge of the concurrency Kademlia allows. If there was an older stream about to be reused, it doesn't mean there was anything wrong to warn about.

## Notes

We're trying to maximize concurrency allowed/configured and this generates a lot of unnecessary warnings.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
