### PR TITLE
feat(kademlia)!: use GATs on `RecordStore` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
 
 - Remove `SimpleProtocol` due to being unused. See [`libp2p::core::upgrade`](https://docs.rs/libp2p/0.50.0/libp2p/core/upgrade/index.html) for alternatives. See [PR 3191].
 
+- Bump MSRV to 1.65.0.
+
 - Update individual crates.
     - Update to [`libp2p-dcutr` `v0.9.0`](protocols/dcutr/CHANGELOG.md#090).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p"
 edition = "2021"
-rust-version = "1.62.0"
+rust-version = "1.65.0"
 description = "Peer-to-peer networking library"
 version = "0.51.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/misc/metrics/CHANGELOG.md
+++ b/misc/metrics/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Add `connections_establishment_duration` metric. See [PR 3134].
 
+- Bump MSRV to 1.65.0.
+
 - Update to `libp2p-dcutr` `v0.9.0`.
 
 - Update to `libp2p-ping` `v0.42.0`.

--- a/misc/metrics/Cargo.toml
+++ b/misc/metrics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-metrics"
 edition = "2021"
-rust-version = "1.62.0"
+rust-version = "1.65.0"
 description = "Metrics for libp2p"
 version = "0.12.0"
 authors = ["Max Inden <mail@max-inden.de>"]

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 - Update to `libp2p-swarm` `v0.42.0`.
 
+- Remove lifetime from `RecordStore` and use GATs instead. See [PR 3239].
+
 - Bump MSRV to 1.65.0.
+
+[PR 3239]: https://github.com/libp2p/rust-libp2p/pull/3239
 
 # 0.42.0
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Update to `libp2p-swarm` `v0.42.0`.
 
+- Bump MSRV to 1.65.0.
+
 # 0.42.0
 
 - Update to `libp2p-core` `v0.38.0`.

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libp2p-kad"
 edition = "2021"
-rust-version = "1.62.0"
+rust-version = "1.65.0"
 description = "Kademlia protocol for libp2p"
 version = "0.43.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -401,8 +401,7 @@ impl KademliaConfig {
 
 impl<TStore> Kademlia<TStore>
 where
-    for<'a> TStore: RecordStore<'a>,
-    TStore: Send + 'static,
+    TStore: RecordStore + Send + 'static,
 {
     /// Creates a new `Kademlia` network behaviour with a default configuration.
     pub fn new(id: PeerId, store: TStore) -> Self {
@@ -1987,8 +1986,7 @@ fn exp_decrease(ttl: Duration, exp: u32) -> Duration {
 
 impl<TStore> NetworkBehaviour for Kademlia<TStore>
 where
-    for<'a> TStore: RecordStore<'a>,
-    TStore: Send + 'static,
+    TStore: RecordStore + Send + 'static,
 {
     type ConnectionHandler = KademliaHandlerProto<QueryId>;
     type OutEvent = KademliaEvent;

--- a/protocols/kad/src/jobs.rs
+++ b/protocols/kad/src/jobs.rs
@@ -193,7 +193,7 @@ impl PutRecordJob {
     /// to be run.
     pub fn poll<T>(&mut self, cx: &mut Context<'_>, store: &mut T, now: Instant) -> Poll<Record>
     where
-        for<'a> T: RecordStore<'a>,
+        T: RecordStore,
     {
         if self.inner.check_ready(cx, now) {
             let publish = self.next_publish.map_or(false, |t_pub| now >= t_pub);
@@ -294,7 +294,7 @@ impl AddProviderJob {
         now: Instant,
     ) -> Poll<ProviderRecord>
     where
-        for<'a> T: RecordStore<'a>,
+        T: RecordStore,
     {
         if self.inner.check_ready(cx, now) {
             let records = store

--- a/protocols/kad/src/record/store.rs
+++ b/protocols/kad/src/record/store.rs
@@ -64,36 +64,40 @@ pub enum Error {
 ///      content. Just like a regular record, a provider record is distributed
 ///      to the closest nodes to the key.
 ///
-pub trait RecordStore<'a> {
-    type RecordsIter: Iterator<Item = Cow<'a, Record>>;
-    type ProvidedIter: Iterator<Item = Cow<'a, ProviderRecord>>;
+pub trait RecordStore {
+    type RecordsIter<'a>: Iterator<Item = Cow<'a, Record>>
+    where
+        Self: 'a;
+    type ProvidedIter<'a>: Iterator<Item = Cow<'a, ProviderRecord>>
+    where
+        Self: 'a;
 
     /// Gets a record from the store, given its key.
-    fn get(&'a self, k: &Key) -> Option<Cow<'_, Record>>;
+    fn get(&self, k: &Key) -> Option<Cow<'_, Record>>;
 
     /// Puts a record into the store.
-    fn put(&'a mut self, r: Record) -> Result<()>;
+    fn put(&mut self, r: Record) -> Result<()>;
 
     /// Removes the record with the given key from the store.
-    fn remove(&'a mut self, k: &Key);
+    fn remove(&mut self, k: &Key);
 
     /// Gets an iterator over all (value-) records currently stored.
-    fn records(&'a self) -> Self::RecordsIter;
+    fn records(&self) -> Self::RecordsIter<'_>;
 
     /// Adds a provider record to the store.
     ///
     /// A record store only needs to store a number of provider records
     /// for a key corresponding to the replication factor and should
     /// store those records whose providers are closest to the key.
-    fn add_provider(&'a mut self, record: ProviderRecord) -> Result<()>;
+    fn add_provider(&mut self, record: ProviderRecord) -> Result<()>;
 
     /// Gets a copy of the stored provider records for the given key.
-    fn providers(&'a self, key: &Key) -> Vec<ProviderRecord>;
+    fn providers(&self, key: &Key) -> Vec<ProviderRecord>;
 
     /// Gets an iterator over all stored provider records for which the
     /// node owning the store is itself the provider.
-    fn provided(&'a self) -> Self::ProvidedIter;
+    fn provided(&self) -> Self::ProvidedIter<'_>;
 
     /// Removes a provider record from the store.
-    fn remove_provider(&'a mut self, k: &Key, p: &PeerId);
+    fn remove_provider(&mut self, k: &Key, p: &PeerId);
 }

--- a/protocols/kad/src/record/store/memory.rs
+++ b/protocols/kad/src/record/store/memory.rs
@@ -96,20 +96,20 @@ impl MemoryStore {
     }
 }
 
-impl<'a> RecordStore<'a> for MemoryStore {
-    type RecordsIter =
+impl RecordStore for MemoryStore {
+    type RecordsIter<'a> =
         iter::Map<hash_map::Values<'a, Key, Record>, fn(&'a Record) -> Cow<'a, Record>>;
 
-    type ProvidedIter = iter::Map<
+    type ProvidedIter<'a> = iter::Map<
         hash_set::Iter<'a, ProviderRecord>,
         fn(&'a ProviderRecord) -> Cow<'a, ProviderRecord>,
     >;
 
-    fn get(&'a self, k: &Key) -> Option<Cow<'_, Record>> {
+    fn get(&self, k: &Key) -> Option<Cow<'_, Record>> {
         self.records.get(k).map(Cow::Borrowed)
     }
 
-    fn put(&'a mut self, r: Record) -> Result<()> {
+    fn put(&mut self, r: Record) -> Result<()> {
         if r.value.len() >= self.config.max_value_bytes {
             return Err(Error::ValueTooLarge);
         }
@@ -131,15 +131,15 @@ impl<'a> RecordStore<'a> for MemoryStore {
         Ok(())
     }
 
-    fn remove(&'a mut self, k: &Key) {
+    fn remove(&mut self, k: &Key) {
         self.records.remove(k);
     }
 
-    fn records(&'a self) -> Self::RecordsIter {
+    fn records(&self) -> Self::RecordsIter<'_> {
         self.records.values().map(Cow::Borrowed)
     }
 
-    fn add_provider(&'a mut self, record: ProviderRecord) -> Result<()> {
+    fn add_provider(&mut self, record: ProviderRecord) -> Result<()> {
         let num_keys = self.providers.len();
 
         // Obtain the entry
@@ -189,17 +189,17 @@ impl<'a> RecordStore<'a> for MemoryStore {
         Ok(())
     }
 
-    fn providers(&'a self, key: &Key) -> Vec<ProviderRecord> {
+    fn providers(&self, key: &Key) -> Vec<ProviderRecord> {
         self.providers
             .get(key)
             .map_or_else(Vec::new, |ps| ps.clone().into_vec())
     }
 
-    fn provided(&'a self) -> Self::ProvidedIter {
+    fn provided(&self) -> Self::ProvidedIter<'_> {
         self.provided.iter().map(Cow::Borrowed)
     }
 
-    fn remove_provider(&'a mut self, key: &Key, provider: &PeerId) {
+    fn remove_provider(&mut self, key: &Key, provider: &PeerId) {
         if let hash_map::Entry::Occupied(mut e) = self.providers.entry(key.clone()) {
             let providers = e.get_mut();
             if let Some(i) = providers.iter().position(|p| &p.provider == provider) {


### PR DESCRIPTION
## Description

Previously, we applied a lifetime onto the entire `RecordStore` to workaround Rust not having GATs. With Rust 1.65.0 we now have GATs so we can remove this workaround.

Related https://github.com/libp2p/rust-libp2p/issues/3240. Without this change, we would have to specify HRTB in various places.

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

Depends-On: https://github.com/libp2p/test-plans/pull/90

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
