### PR TITLE
refactor(autonat): buffer entire actions instead of events

### DIFF
--- a/protocols/autonat/src/behaviour.rs
+++ b/protocols/autonat/src/behaviour.rs
@@ -209,7 +209,12 @@ pub struct Behaviour {
 
     last_probe: Option<Instant>,
 
-    pending_out_events: VecDeque<<Self as NetworkBehaviour>::OutEvent>,
+    pending_actions: VecDeque<
+        NetworkBehaviourAction<
+            <Self as NetworkBehaviour>::OutEvent,
+            <Self as NetworkBehaviour>::ConnectionHandler,
+        >,
+    >,
 
     probe_id: ProbeId,
 
@@ -237,7 +242,7 @@ impl Behaviour {
             throttled_servers: Vec::new(),
             throttled_clients: Vec::new(),
             last_probe: None,
-            pending_out_events: VecDeque::new(),
+            pending_actions: VecDeque::new(),
             probe_id: ProbeId(0),
             listen_addresses: Default::default(),
             external_addresses: Default::default(),
@@ -334,8 +339,10 @@ impl Behaviour {
                 role_override: Endpoint::Dialer,
             } => {
                 if let Some(event) = self.as_server().on_outbound_connection(&peer, address) {
-                    self.pending_out_events
-                        .push_back(Event::InboundProbe(event));
+                    self.pending_actions
+                        .push_back(NetworkBehaviourAction::GenerateEvent(Event::InboundProbe(
+                            event,
+                        )));
                 }
             }
             ConnectedPoint::Dialer {
@@ -395,8 +402,10 @@ impl Behaviour {
                 error,
             }));
         if let Some(event) = self.as_server().on_outbound_dial_error(peer_id, error) {
-            self.pending_out_events
-                .push_back(Event::InboundProbe(event));
+            self.pending_actions
+                .push_back(NetworkBehaviourAction::GenerateEvent(Event::InboundProbe(
+                    event,
+                )));
         }
     }
 
@@ -431,14 +440,13 @@ impl NetworkBehaviour for Behaviour {
 
     fn poll(&mut self, cx: &mut Context<'_>, params: &mut impl PollParameters) -> Poll<Action> {
         loop {
-            if let Some(event) = self.pending_out_events.pop_front() {
-                return Poll::Ready(NetworkBehaviourAction::GenerateEvent(event));
+            if let Some(event) = self.pending_actions.pop_front() {
+                return Poll::Ready(event);
             }
 
-            let mut is_inner_pending = false;
             match self.inner.poll(cx, params) {
                 Poll::Ready(NetworkBehaviourAction::GenerateEvent(event)) => {
-                    let (mut events, action) = match event {
+                    let (events, action) = match event {
                         request_response::Event::Message {
                             message: request_response::Message::Response { .. },
                             ..
@@ -455,22 +463,35 @@ impl NetworkBehaviour for Behaviour {
                         }
                         request_response::Event::ResponseSent { .. } => (VecDeque::new(), None),
                     };
-                    self.pending_out_events.append(&mut events);
-                    if let Some(action) = action {
-                        return Poll::Ready(action);
-                    }
+
+                    self.pending_actions.extend(
+                        events
+                            .into_iter()
+                            .map(NetworkBehaviourAction::GenerateEvent)
+                            .chain(action),
+                    );
+                    continue;
                 }
-                Poll::Ready(action) => return Poll::Ready(action.map_out(|_| unreachable!())),
-                Poll::Pending => is_inner_pending = true,
+                Poll::Ready(action) => {
+                    self.pending_actions
+                        .push_back(action.map_out(|_| unreachable!()));
+                    continue;
+                }
+                Poll::Pending => {}
             }
 
             match self.as_client().poll_auto_probe(cx) {
-                Poll::Ready(event) => self
-                    .pending_out_events
-                    .push_back(Event::OutboundProbe(event)),
-                Poll::Pending if is_inner_pending => return Poll::Pending,
+                Poll::Ready(event) => {
+                    self.pending_actions
+                        .push_back(NetworkBehaviourAction::GenerateEvent(Event::OutboundProbe(
+                            event,
+                        )));
+                    continue;
+                }
                 Poll::Pending => {}
             }
+
+            return Poll::Pending;
         }
     }
 

--- a/protocols/autonat/src/behaviour/as_client.rs
+++ b/protocols/autonat/src/behaviour/as_client.rs
@@ -109,9 +109,9 @@ impl<'a> HandleInnerEvent for AsClient<'a> {
         &mut self,
         params: &mut impl PollParameters,
         event: request_response::Event<DialRequest, DialResponse>,
-    ) -> (VecDeque<Event>, Option<Action>) {
-        let mut events = VecDeque::new();
-        let mut action = None;
+    ) -> VecDeque<Action> {
+        let mut actions = VecDeque::new();
+
         match event {
             request_response::Event::Message {
                 peer,
@@ -140,13 +140,17 @@ impl<'a> HandleInnerEvent for AsClient<'a> {
                         error: OutboundProbeError::Response(e),
                     },
                 };
-                events.push_back(Event::OutboundProbe(event));
+                actions.push_back(NetworkBehaviourAction::GenerateEvent(Event::OutboundProbe(
+                    event,
+                )));
 
                 if let Some(old) = self.handle_reported_status(response.result.clone().into()) {
-                    events.push_back(Event::StatusChanged {
-                        old,
-                        new: self.nat_status.clone(),
-                    });
+                    actions.push_back(NetworkBehaviourAction::GenerateEvent(
+                        Event::StatusChanged {
+                            old,
+                            new: self.nat_status.clone(),
+                        },
+                    ));
                 }
 
                 if let Ok(address) = response.result {
@@ -158,7 +162,7 @@ impl<'a> HandleInnerEvent for AsClient<'a> {
                         .find_map(|r| (r.addr == address).then_some(r.score))
                         .unwrap_or(AddressScore::Finite(0));
                     if let AddressScore::Finite(finite_score) = score {
-                        action = Some(NetworkBehaviourAction::ReportObservedAddr {
+                        actions.push_back(NetworkBehaviourAction::ReportObservedAddr {
                             address,
                             score: AddressScore::Finite(finite_score + 1),
                         });
@@ -180,17 +184,20 @@ impl<'a> HandleInnerEvent for AsClient<'a> {
                     .remove(&request_id)
                     .unwrap_or_else(|| self.probe_id.next());
 
-                events.push_back(Event::OutboundProbe(OutboundProbeEvent::Error {
-                    probe_id,
-                    peer: Some(peer),
-                    error: OutboundProbeError::OutboundRequest(error),
-                }));
+                actions.push_back(NetworkBehaviourAction::GenerateEvent(Event::OutboundProbe(
+                    OutboundProbeEvent::Error {
+                        probe_id,
+                        peer: Some(peer),
+                        error: OutboundProbeError::OutboundRequest(error),
+                    },
+                )));
 
                 self.schedule_probe.reset(Duration::ZERO);
             }
             _ => {}
         }
-        (events, action)
+
+        actions
     }
 }
 


### PR DESCRIPTION
## Description

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

Previously, we used to buffer events separately and emit actions directly. That is unnecessary. We can have a single place where we return from the `poll` loop and shove all actions into the same buffer.

## Notes

I originally created this because I thought it would fix an issue where I needed to supply type hints as part of implementing https://github.com/libp2p/rust-libp2p/issues/3240. That didn't turn out to be true but I still think that this change is a slight improvement. Feel free to close if you disagree :)

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
