### PR TITLE
ci(cache): override rust version in cache factory for MSRV cache

### DIFF
--- a/.github/workflows/cache-factory.yml
+++ b/.github/workflows/cache-factory.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: ${{ matrix.rust }}
+          override: true
 
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
         with:
@@ -63,6 +64,7 @@ jobs:
       - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: stable
+          override: true
 
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
         with:


### PR DESCRIPTION
## Description

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

Previously, we forgot to override the default Rust version used to the newly installed one for the MSRV cache. This caused `swatinem/rust-cache` to compute the wrong cache key. See https://github.com/libp2p/rust-libp2p/actions/runs/3697491863/jobs/6262555434#step:5:21 for example.

This caused all pull-requests to not actually find this cache and rebuild everything from scratch: https://github.com/libp2p/rust-libp2p/actions/runs/3699757580/jobs/6267459677#step:6:21

With this patch, we are now considering the correct Rust version: https://github.com/thomaseizinger/rust-libp2p/actions/runs/3699821930/jobs/6267596081#step:5:21

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
