### PR TITLE
ci(cache): only save caches on master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,8 @@ jobs:
           target: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - run: cargo check --package libp2p --all-features --target=${{ matrix.target }}
 
@@ -141,6 +143,8 @@ jobs:
           override: true
 
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - run: cargo check --package libp2p --features="${{ matrix.features }}"
 
@@ -162,6 +166,8 @@ jobs:
           override: true
 
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Check rustdoc links
         run: RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links --deny warnings" cargo doc --verbose --workspace --no-deps --all-features --document-private-items
@@ -191,6 +197,8 @@ jobs:
           components: clippy
 
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Run cargo clippy
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
@@ -215,6 +223,8 @@ jobs:
           override: true
 
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Run ipfs-kad example
         run: RUST_LOG=libp2p_swarm=debug,libp2p_kad=trace,libp2p_tcp=debug cargo run --example ipfs-kad --features full


### PR DESCRIPTION
## Description

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

Previously, we would always save certain smaller caches like clippy etc on each PR. This still amounts to a lot of caches. With this patch, we conditionally only save them when the workflow is run on the master branch. This gives most pull requests a good base to work with to speed them up significantly without us keeping around a lot of caches and have GitHub invalidate them constantly.

On master, the condition evaluates to `true` which saves the cache: https://github.com/thomaseizinger/rust-libp2p/actions/runs/3699904381/jobs/6267774899#step:5:3
On pull-requests, the condition evaluates to `false` which skips saving it: https://github.com/thomaseizinger/rust-libp2p/actions/runs/3700055536/jobs/6268096357#step:4:3

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

~Draft until I confirm this works as expected in my fork.~ Confirmed that it works.

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
