### PR TITLE
docs(pnet): use backticks for referencing types

### DIFF
--- a/transports/pnet/src/crypt_writer.rs
+++ b/transports/pnet/src/crypt_writer.rs
@@ -55,7 +55,7 @@ impl<W: AsyncWrite> CryptWriter<W> {
     }
 }
 
-/// Write the contents of a Vec<u8> into an AsyncWrite.
+/// Write the contents of a [`Vec<u8>`] into an [`AsyncWrite`].
 ///
 /// The handling 0 byte progress and the Interrupted error was taken from BufWriter in async_std.
 ///


### PR DESCRIPTION
## Description

With the update to Rust 1.66, rustdoc is (rightfully) complaining about us writing bad HTML. `<u8>` is interpreted as an unclosed HTML tag. See https://github.com/libp2p/rust-libp2p/actions/runs/3708901592/jobs/6286942010#step:6:1380 for example.

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes

Need urgent approval please as this is blocking other PRs from merging.

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
