### PR TITLE
fix(metrics): Update connections_establishment_duration buckets

### DIFF
--- a/misc/metrics/src/swarm.rs
+++ b/misc/metrics/src/swarm.rs
@@ -396,5 +396,5 @@ impl<TTransErr> From<&libp2p_swarm::PendingInboundConnectionError<TTransErr>>
 }
 
 fn create_connection_establishment_duration_histogram() -> Histogram {
-    Histogram::new(exponential_buckets(1e-3, 2., 10))
+    Histogram::new(exponential_buckets(0.01, 1.5, 20))
 }


### PR DESCRIPTION
## Description

Currently the `libp2p_swarm_connections_establishment_duration` metric has the following buckets:

```
// exponential_buckets(1e-3, 2., 10)

[0.001, 0.002, 0.004, 0.008, 0.016, 0.032, 0.064, 0.128, 0.256, 0.512]
```

It is unlikely that a connection is established in 1ms, even within a datacenter. It is very likely that libp2p connection establishment takes longer than 512ms over the internet.

This commit proposes the following buckets:

```
// exponential_buckets(0.01, 1.5, 20)

[0.01, 0.015, 0.0225, 0.03375, 0.050625, 0.0759375, 0.11390625, 0.170859375, 0.2562890625,
0.38443359375, 0.576650390625, 0.8649755859375, 1.29746337890625, 1.946195068359375,
2.9192926025390626, 4.378938903808594, 6.568408355712891, 9.852612533569337, 14.778918800354004,
22.168378200531006]
```

- Buckets start at 10ms.
- Reasonably high resolution in the sub-second area.
- Largest bucket at 22s, e.g. for a relayed connection.
- Unfortunately rather obscure numbers.



<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

Follow up to https://github.com/libp2p/rust-libp2p/pull/3134.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] ~~A changelog entry has been made in the appropriate crates~~ Not required as https://github.com/libp2p/rust-libp2p/pull/3134 hasn't yet been released.
