### PR TITLE
ci: install `protoc` from repositories where possible

### DIFF
--- a/.github/workflows/cache-factory.yml
+++ b/.github/workflows/cache-factory.yml
@@ -34,7 +34,7 @@ jobs:
         rust: ${{ fromJSON(needs.gather_msrv_versions.outputs.versions) }}
     steps:
       - name: Install Protoc
-        uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
+        run: sudo apt-get install protobuf-compiler
 
       - uses: actions/checkout@v3
 
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Protoc
-        uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
+        run: sudo apt-get install protobuf-compiler
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,7 @@ jobs:
         crate: ${{ fromJSON(needs.gather_published_crates.outputs.members) }}
     steps:
       - name: Install Protoc
-        uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        run: sudo apt-get install protobuf-compiler
 
       - uses: actions/checkout@v3
 
@@ -101,9 +99,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Protoc
+        if: matrix.os != "ubuntu-latest"
         uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Protoc
+        if: matrix.os == "ubuntu-latest"
+        run: sudo apt-get install protobuf-compiler
 
       - uses: actions/checkout@v3
 
@@ -130,9 +133,7 @@ jobs:
           - features: "mdns tcp dns async-std"
     steps:
       - name: Install Protoc
-        uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        run: sudo apt-get install protobuf-compiler
 
       - uses: actions/checkout@v3
 
@@ -153,9 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Protoc
-        uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        run: sudo apt-get install protobuf-compiler
 
       - uses: actions/checkout@v3
 
@@ -183,9 +182,7 @@ jobs:
         ]
     steps:
       - name: Install Protoc
-        uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        run: sudo apt-get install protobuf-compiler
 
       - uses: actions/checkout@v3
 
@@ -210,9 +207,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Protoc
-        uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        run: sudo apt-get install protobuf-compiler
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,13 +99,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Protoc
-        if: matrix.os != "ubuntu-latest"
+        if: ${{ matrix.os != "ubuntu-latest" }}
         uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Protoc
-        if: matrix.os == "ubuntu-latest"
+        if: ${{ matrix.os == "ubuntu-latest" }}
         run: sudo apt-get install protobuf-compiler
 
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,13 +99,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Protoc
-        if: ${{ matrix.os != "ubuntu-latest" }}
+        if: ${{ matrix.os != 'ubuntu-latest' }}
         uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Protoc
-        if: ${{ matrix.os == "ubuntu-latest" }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo apt-get install protobuf-compiler
 
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

With the addition of more CI jobs, we are constantly running into API limits on setting up protoc. For all jobs that run on ubuntu, we can install it from `apt` instead.

On ubuntu 22.04, which is what `ubuntu-latest` points to, this installs `protoc v3.12.4`.

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
