### PR TITLE
ci(dependabot): disable automatic rebase of PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,11 @@ updates:
     open-pull-requests-limit: 9999
     commit-message:
       prefix: "deps"
+    rebase-strategy: "disabled"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     commit-message:
       prefix: "deps"
+    rebase-strategy: "disabled"


### PR DESCRIPTION
## Description

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

Currently, we have dependabot configured to automatically rebase PRs as soon as the base branches changes. This however causes two problems:

1. It unnecessarily consumes CI resources because dependabot rebases all open dependency PRs at once upon every merge of a PR into `master`.
2. It does not interact well with our strategy of dismissing reviews on updates to the PR: https://github.com/libp2p/rust-libp2p/pull/3226#event-8074236930

Overall, the rebasing of dependency PRs is a way to fix merge conflicts and to ensure that CI still passes even on the latest version of the base branch. The latter is already ensured by our merge queue and the former can be triggered manually with `@dependabot rebase`, thus disabling automatic rebasing is the better configuration for our setup.

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
