### PR TITLE
ci: ensure PR titles are no longer than 72 characters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,3 +299,12 @@ jobs:
             ci
             refactor
           require_scope: false
+
+      - name: Check PR title length
+        run: |
+          title_length=${#github.event.pull_request.title}
+          if [ $title_length -gt 72 ]
+          then
+            echo "PR title is too long (greater than 72 characters)"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,8 @@ jobs:
 
       - name: Check PR title length
         run: |
-          title_length=${#github.event.pull_request.title}
+          title="${{ github.event.pull_request.title }}"
+          title_length=${#title}
           if [ $title_length -gt 72 ]
           then
             echo "PR title is too long (greater than 72 characters)"


### PR DESCRIPTION
## Description

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

GitHub wraps the titles of commits if they are longer than 72 characters. See https://github.com/libp2p/rust-libp2p/commit/fbd4192e2abe5e0270686dfd7acc5e321f3ace17 for example.

There is a convention that titles should be no more than 50 characters: https://cbea.ms/git-commit/#limit-50
This however makes crafting the message quite difficult, esp. with our use of conventional commit messages, thus limiting it to 72 seems more reasonable as that is where tooling (.e.g GitHub) seems to "break".

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

This pull request has been brought to you by chat.openai:

<details>
<summary>Conversation with chat.openai</summary>
<img src="https://user-images.githubusercontent.com/5486389/208656595-7598ef7d-6830-4311-bda5-d837b3c64672.png">
</details>


## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
