### PR TITLE
feat(swarm): introduce `ToSwarm` type alias

### DIFF
--- a/protocols/autonat/src/behaviour.rs
+++ b/protocols/autonat/src/behaviour.rs
@@ -209,7 +209,12 @@ pub struct Behaviour {
 
     last_probe: Option<Instant>,
 
-    pending_out_events: VecDeque<<Self as NetworkBehaviour>::OutEvent>,
+    pending_actions: VecDeque<
+        NetworkBehaviourAction<
+            <Self as NetworkBehaviour>::OutEvent,
+            <Self as NetworkBehaviour>::ConnectionHandler,
+        >,
+    >,
 
     probe_id: ProbeId,
 
@@ -237,7 +242,7 @@ impl Behaviour {
             throttled_servers: Vec::new(),
             throttled_clients: Vec::new(),
             last_probe: None,
-            pending_out_events: VecDeque::new(),
+            pending_actions: VecDeque::new(),
             probe_id: ProbeId(0),
             listen_addresses: Default::default(),
             external_addresses: Default::default(),
@@ -334,8 +339,10 @@ impl Behaviour {
                 role_override: Endpoint::Dialer,
             } => {
                 if let Some(event) = self.as_server().on_outbound_connection(&peer, address) {
-                    self.pending_out_events
-                        .push_back(Event::InboundProbe(event));
+                    self.pending_actions
+                        .push_back(NetworkBehaviourAction::GenerateEvent(Event::InboundProbe(
+                            event,
+                        )));
                 }
             }
             ConnectedPoint::Dialer {
@@ -395,8 +402,10 @@ impl Behaviour {
                 error,
             }));
         if let Some(event) = self.as_server().on_outbound_dial_error(peer_id, error) {
-            self.pending_out_events
-                .push_back(Event::InboundProbe(event));
+            self.pending_actions
+                .push_back(NetworkBehaviourAction::GenerateEvent(Event::InboundProbe(
+                    event,
+                )));
         }
     }
 
@@ -431,14 +440,13 @@ impl NetworkBehaviour for Behaviour {
 
     fn poll(&mut self, cx: &mut Context<'_>, params: &mut impl PollParameters) -> Poll<Action> {
         loop {
-            if let Some(event) = self.pending_out_events.pop_front() {
-                return Poll::Ready(NetworkBehaviourAction::GenerateEvent(event));
+            if let Some(event) = self.pending_actions.pop_front() {
+                return Poll::Ready(event);
             }
 
-            let mut is_inner_pending = false;
             match self.inner.poll(cx, params) {
                 Poll::Ready(NetworkBehaviourAction::GenerateEvent(event)) => {
-                    let (mut events, action) = match event {
+                    let (events, action) = match event {
                         request_response::Event::Message {
                             message: request_response::Message::Response { .. },
                             ..
@@ -455,22 +463,35 @@ impl NetworkBehaviour for Behaviour {
                         }
                         request_response::Event::ResponseSent { .. } => (VecDeque::new(), None),
                     };
-                    self.pending_out_events.append(&mut events);
-                    if let Some(action) = action {
-                        return Poll::Ready(action);
-                    }
+
+                    self.pending_actions.extend(
+                        events
+                            .into_iter()
+                            .map(NetworkBehaviourAction::GenerateEvent)
+                            .chain(action),
+                    );
+                    continue;
                 }
-                Poll::Ready(action) => return Poll::Ready(action.map_out(|_| unreachable!())),
-                Poll::Pending => is_inner_pending = true,
+                Poll::Ready(action) => {
+                    self.pending_actions
+                        .push_back(action.map_out(|_| unreachable!()));
+                    continue;
+                }
+                Poll::Pending => {}
             }
 
             match self.as_client().poll_auto_probe(cx) {
-                Poll::Ready(event) => self
-                    .pending_out_events
-                    .push_back(Event::OutboundProbe(event)),
-                Poll::Pending if is_inner_pending => return Poll::Pending,
+                Poll::Ready(event) => {
+                    self.pending_actions
+                        .push_back(NetworkBehaviourAction::GenerateEvent(Event::OutboundProbe(
+                            event,
+                        )));
+                    continue;
+                }
                 Poll::Pending => {}
             }
+
+            return Poll::Pending;
         }
     }
 

--- a/protocols/autonat/src/behaviour/as_server.rs
+++ b/protocols/autonat/src/behaviour/as_server.rs
@@ -19,17 +19,19 @@
 // DEALINGS IN THE SOFTWARE.
 
 use super::{
-    Action, AutoNatCodec, Config, DialRequest, DialResponse, Event, HandleInnerEvent, ProbeId,
+    AutoNatCodec, Config, DialRequest, DialResponse, Event, HandleInnerEvent, ProbeId,
     ResponseError,
 };
+use crate::Behaviour;
 use instant::Instant;
 use libp2p_core::{connection::ConnectionId, multiaddr::Protocol, Multiaddr, PeerId};
 use libp2p_request_response::{
     self as request_response, InboundFailure, RequestId, ResponseChannel,
 };
+use libp2p_swarm::behaviour::ToSwarm;
 use libp2p_swarm::{
     dial_opts::{DialOpts, PeerCondition},
-    DialError, NetworkBehaviour, NetworkBehaviourAction, PollParameters,
+    DialError, NetworkBehaviour, PollParameters,
 };
 use std::{
     collections::{HashMap, HashSet, VecDeque},
@@ -98,7 +100,7 @@ impl<'a> HandleInnerEvent for AsServer<'a> {
         &mut self,
         _params: &mut impl PollParameters,
         event: request_response::Event<DialRequest, DialResponse>,
-    ) -> (VecDeque<Event>, Option<Action>) {
+    ) -> (VecDeque<Event>, Option<ToSwarm<Behaviour>>) {
         let mut events = VecDeque::new();
         let mut action = None;
         match event {
@@ -130,7 +132,7 @@ impl<'a> HandleInnerEvent for AsServer<'a> {
                             addresses: addrs.clone(),
                         }));
 
-                        action = Some(NetworkBehaviourAction::Dial {
+                        action = Some(ToSwarm::<Behaviour>::Dial {
                             opts: DialOpts::peer_id(peer)
                                 .condition(PeerCondition::Always)
                                 .override_dial_concurrency_factor(NonZeroU8::new(1).expect("1 > 0"))

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -67,6 +67,7 @@ use crate::types::{
 };
 use crate::types::{GossipsubRpc, PeerConnections, PeerKind};
 use crate::{rpc_proto, TopicScoreParams};
+use libp2p_swarm::behaviour::ToSwarm;
 use std::{cmp::Ordering::Equal, fmt::Debug};
 use wasm_timer::Interval;
 
@@ -3443,11 +3444,7 @@ where
         }
     }
 
-    fn poll(
-        &mut self,
-        cx: &mut Context<'_>,
-        _: &mut impl PollParameters,
-    ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
+    fn poll(&mut self, cx: &mut Context<'_>, _: &mut impl PollParameters) -> Poll<ToSwarm<Self>> {
         if let Some(event) = self.events.pop_front() {
             return Poll::Ready(event.map_in(|e: Arc<GossipsubHandlerIn>| {
                 // clone send event reference if others references are present

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -41,12 +41,11 @@ use fnv::{FnvHashMap, FnvHashSet};
 use instant::Instant;
 use libp2p_core::{connection::ConnectionId, ConnectedPoint, Multiaddr, PeerId};
 use libp2p_swarm::behaviour::{
-    AddressChange, ConnectionClosed, ConnectionEstablished, DialFailure, FromSwarm,
+    AddressChange, ConnectionClosed, ConnectionEstablished, DialFailure, FromSwarm, ToSwarm,
 };
 use libp2p_swarm::{
     dial_opts::{self, DialOpts},
-    DialError, ExternalAddresses, ListenAddresses, NetworkBehaviour, NetworkBehaviourAction,
-    NotifyHandler, PollParameters,
+    DialError, ExternalAddresses, ListenAddresses, NetworkBehaviour, NotifyHandler, PollParameters,
 };
 use log::{debug, info, warn};
 use smallvec::SmallVec;
@@ -101,7 +100,7 @@ pub struct Kademlia<TStore> {
     connection_idle_timeout: Duration,
 
     /// Queued events to return when the behaviour is being polled.
-    queued_events: VecDeque<NetworkBehaviourAction<KademliaEvent, KademliaHandlerProto<QueryId>>>,
+    queued_events: VecDeque<ToSwarm<Self>>,
 
     listen_addresses: ListenAddresses,
 
@@ -521,20 +520,19 @@ where
         match self.kbuckets.entry(&key) {
             kbucket::Entry::Present(mut entry, _) => {
                 if entry.value().insert(address) {
-                    self.queued_events
-                        .push_back(NetworkBehaviourAction::GenerateEvent(
-                            KademliaEvent::RoutingUpdated {
-                                peer: *peer,
-                                is_new_peer: false,
-                                addresses: entry.value().clone(),
-                                old_peer: None,
-                                bucket_range: self
-                                    .kbuckets
-                                    .bucket(&key)
-                                    .map(|b| b.range())
-                                    .expect("Not kbucket::Entry::SelfEntry."),
-                            },
-                        ))
+                    self.queued_events.push_back(ToSwarm::GenerateEvent(
+                        KademliaEvent::RoutingUpdated {
+                            peer: *peer,
+                            is_new_peer: false,
+                            addresses: entry.value().clone(),
+                            old_peer: None,
+                            bucket_range: self
+                                .kbuckets
+                                .bucket(&key)
+                                .map(|b| b.range())
+                                .expect("Not kbucket::Entry::SelfEntry."),
+                        },
+                    ))
                 }
                 RoutingUpdate::Success
             }
@@ -551,20 +549,19 @@ where
                 };
                 match entry.insert(addresses.clone(), status) {
                     kbucket::InsertResult::Inserted => {
-                        self.queued_events
-                            .push_back(NetworkBehaviourAction::GenerateEvent(
-                                KademliaEvent::RoutingUpdated {
-                                    peer: *peer,
-                                    is_new_peer: true,
-                                    addresses,
-                                    old_peer: None,
-                                    bucket_range: self
-                                        .kbuckets
-                                        .bucket(&key)
-                                        .map(|b| b.range())
-                                        .expect("Not kbucket::Entry::SelfEntry."),
-                                },
-                            ));
+                        self.queued_events.push_back(ToSwarm::GenerateEvent(
+                            KademliaEvent::RoutingUpdated {
+                                peer: *peer,
+                                is_new_peer: true,
+                                addresses,
+                                old_peer: None,
+                                bucket_range: self
+                                    .kbuckets
+                                    .bucket(&key)
+                                    .map(|b| b.range())
+                                    .expect("Not kbucket::Entry::SelfEntry."),
+                            },
+                        ));
                         RoutingUpdate::Success
                     }
                     kbucket::InsertResult::Full => {
@@ -573,7 +570,7 @@ where
                     }
                     kbucket::InsertResult::Pending { disconnected } => {
                         let handler = self.new_handler();
-                        self.queued_events.push_back(NetworkBehaviourAction::Dial {
+                        self.queued_events.push_back(ToSwarm::Dial {
                             opts: DialOpts::peer_id(disconnected.into_preimage()).build(),
                             handler,
                         });
@@ -728,15 +725,14 @@ where
         let stats = QueryStats::empty();
 
         if let Some(record) = record {
-            self.queued_events
-                .push_back(NetworkBehaviourAction::GenerateEvent(
-                    KademliaEvent::OutboundQueryProgressed {
-                        id,
-                        result: QueryResult::GetRecord(Ok(GetRecordOk::FoundRecord(record))),
-                        step,
-                        stats,
-                    },
-                ));
+            self.queued_events.push_back(ToSwarm::GenerateEvent(
+                KademliaEvent::OutboundQueryProgressed {
+                    id,
+                    result: QueryResult::GetRecord(Ok(GetRecordOk::FoundRecord(record))),
+                    step,
+                    stats,
+                },
+            ));
         }
 
         id
@@ -976,18 +972,17 @@ where
         let stats = QueryStats::empty();
 
         if !providers.is_empty() {
-            self.queued_events
-                .push_back(NetworkBehaviourAction::GenerateEvent(
-                    KademliaEvent::OutboundQueryProgressed {
-                        id,
-                        result: QueryResult::GetProviders(Ok(GetProvidersOk::FoundProviders {
-                            key,
-                            providers,
-                        })),
-                        step,
-                        stats,
-                    },
-                ));
+            self.queued_events.push_back(ToSwarm::GenerateEvent(
+                KademliaEvent::OutboundQueryProgressed {
+                    id,
+                    result: QueryResult::GetProviders(Ok(GetProvidersOk::FoundProviders {
+                        key,
+                        providers,
+                    })),
+                    step,
+                    stats,
+                },
+            ));
         }
         id
     }
@@ -1135,20 +1130,19 @@ where
                 }
                 if let Some(address) = address {
                     if entry.value().insert(address) {
-                        self.queued_events
-                            .push_back(NetworkBehaviourAction::GenerateEvent(
-                                KademliaEvent::RoutingUpdated {
-                                    peer,
-                                    is_new_peer: false,
-                                    addresses: entry.value().clone(),
-                                    old_peer: None,
-                                    bucket_range: self
-                                        .kbuckets
-                                        .bucket(&key)
-                                        .map(|b| b.range())
-                                        .expect("Not kbucket::Entry::SelfEntry."),
-                                },
-                            ))
+                        self.queued_events.push_back(ToSwarm::GenerateEvent(
+                            KademliaEvent::RoutingUpdated {
+                                peer,
+                                is_new_peer: false,
+                                addresses: entry.value().clone(),
+                                old_peer: None,
+                                bucket_range: self
+                                    .kbuckets
+                                    .bucket(&key)
+                                    .map(|b| b.range())
+                                    .expect("Not kbucket::Entry::SelfEntry."),
+                            },
+                        ))
                     }
                 }
             }
@@ -1169,16 +1163,14 @@ where
                 }
                 match (address, self.kbucket_inserts) {
                     (None, _) => {
-                        self.queued_events
-                            .push_back(NetworkBehaviourAction::GenerateEvent(
-                                KademliaEvent::UnroutablePeer { peer },
-                            ));
+                        self.queued_events.push_back(ToSwarm::GenerateEvent(
+                            KademliaEvent::UnroutablePeer { peer },
+                        ));
                     }
                     (Some(a), KademliaBucketInserts::Manual) => {
-                        self.queued_events
-                            .push_back(NetworkBehaviourAction::GenerateEvent(
-                                KademliaEvent::RoutablePeer { peer, address: a },
-                            ));
+                        self.queued_events.push_back(ToSwarm::GenerateEvent(
+                            KademliaEvent::RoutablePeer { peer, address: a },
+                        ));
                     }
                     (Some(a), KademliaBucketInserts::OnConnected) => {
                         let addresses = Addresses::new(a);
@@ -1195,25 +1187,20 @@ where
                                         .map(|b| b.range())
                                         .expect("Not kbucket::Entry::SelfEntry."),
                                 };
-                                self.queued_events
-                                    .push_back(NetworkBehaviourAction::GenerateEvent(event));
+                                self.queued_events.push_back(ToSwarm::GenerateEvent(event));
                             }
                             kbucket::InsertResult::Full => {
                                 debug!("Bucket full. Peer not added to routing table: {}", peer);
                                 let address = addresses.first().clone();
-                                self.queued_events.push_back(
-                                    NetworkBehaviourAction::GenerateEvent(
-                                        KademliaEvent::RoutablePeer { peer, address },
-                                    ),
-                                );
+                                self.queued_events.push_back(ToSwarm::GenerateEvent(
+                                    KademliaEvent::RoutablePeer { peer, address },
+                                ));
                             }
                             kbucket::InsertResult::Pending { disconnected } => {
                                 let address = addresses.first().clone();
-                                self.queued_events.push_back(
-                                    NetworkBehaviourAction::GenerateEvent(
-                                        KademliaEvent::PendingRoutablePeer { peer, address },
-                                    ),
-                                );
+                                self.queued_events.push_back(ToSwarm::GenerateEvent(
+                                    KademliaEvent::PendingRoutablePeer { peer, address },
+                                ));
 
                                 // `disconnected` might already be in the process of re-connecting.
                                 // In other words `disconnected` might have already re-connected but
@@ -1223,7 +1210,7 @@ where
                                 // Only try dialing peer if not currently connected.
                                 if !self.connected_peers.contains(disconnected.preimage()) {
                                     let handler = self.new_handler();
-                                    self.queued_events.push_back(NetworkBehaviourAction::Dial {
+                                    self.queued_events.push_back(ToSwarm::Dial {
                                         opts: DialOpts::peer_id(disconnected.into_preimage())
                                             .build(),
                                         handler,
@@ -1627,16 +1614,15 @@ where
             // If the (alleged) publisher is the local node, do nothing. The record of
             // the original publisher should never change as a result of replication
             // and the publisher is always assumed to have the "right" value.
-            self.queued_events
-                .push_back(NetworkBehaviourAction::NotifyHandler {
-                    peer_id: source,
-                    handler: NotifyHandler::One(connection),
-                    event: KademliaHandlerIn::PutRecordRes {
-                        key: record.key,
-                        value: record.value,
-                        request_id,
-                    },
-                });
+            self.queued_events.push_back(ToSwarm::NotifyHandler {
+                peer_id: source,
+                handler: NotifyHandler::One(connection),
+                event: KademliaHandlerIn::PutRecordRes {
+                    key: record.key,
+                    value: record.value,
+                    request_id,
+                },
+            });
             return;
         }
 
@@ -1687,40 +1673,37 @@ where
                             record.key,
                             record.value.len()
                         );
-                        self.queued_events
-                            .push_back(NetworkBehaviourAction::GenerateEvent(
-                                KademliaEvent::InboundRequest {
-                                    request: InboundRequest::PutRecord {
-                                        source,
-                                        connection,
-                                        record: None,
-                                    },
+                        self.queued_events.push_back(ToSwarm::GenerateEvent(
+                            KademliaEvent::InboundRequest {
+                                request: InboundRequest::PutRecord {
+                                    source,
+                                    connection,
+                                    record: None,
                                 },
-                            ));
+                            },
+                        ));
                     }
                     Err(e) => {
                         info!("Record not stored: {:?}", e);
-                        self.queued_events
-                            .push_back(NetworkBehaviourAction::NotifyHandler {
-                                peer_id: source,
-                                handler: NotifyHandler::One(connection),
-                                event: KademliaHandlerIn::Reset(request_id),
-                            });
+                        self.queued_events.push_back(ToSwarm::NotifyHandler {
+                            peer_id: source,
+                            handler: NotifyHandler::One(connection),
+                            event: KademliaHandlerIn::Reset(request_id),
+                        });
 
                         return;
                     }
                 },
                 KademliaStoreInserts::FilterBoth => {
-                    self.queued_events
-                        .push_back(NetworkBehaviourAction::GenerateEvent(
-                            KademliaEvent::InboundRequest {
-                                request: InboundRequest::PutRecord {
-                                    source,
-                                    connection,
-                                    record: Some(record.clone()),
-                                },
+                    self.queued_events.push_back(ToSwarm::GenerateEvent(
+                        KademliaEvent::InboundRequest {
+                            request: InboundRequest::PutRecord {
+                                source,
+                                connection,
+                                record: Some(record.clone()),
                             },
-                        ));
+                        },
+                    ));
                 }
             }
         }
@@ -1732,16 +1715,15 @@ where
         // closest nodes to the target. In addition returning
         // [`KademliaHandlerIn::PutRecordRes`] does not reveal any internal
         // information to a possibly malicious remote node.
-        self.queued_events
-            .push_back(NetworkBehaviourAction::NotifyHandler {
-                peer_id: source,
-                handler: NotifyHandler::One(connection),
-                event: KademliaHandlerIn::PutRecordRes {
-                    key: record.key,
-                    value: record.value,
-                    request_id,
-                },
-            })
+        self.queued_events.push_back(ToSwarm::NotifyHandler {
+            peer_id: source,
+            handler: NotifyHandler::One(connection),
+            event: KademliaHandlerIn::PutRecordRes {
+                key: record.key,
+                value: record.value,
+                request_id,
+            },
+        })
     }
 
     /// Processes a provider record received from a peer.
@@ -1760,22 +1742,20 @@ where
                         return;
                     }
 
-                    self.queued_events
-                        .push_back(NetworkBehaviourAction::GenerateEvent(
-                            KademliaEvent::InboundRequest {
-                                request: InboundRequest::AddProvider { record: None },
-                            },
-                        ));
+                    self.queued_events.push_back(ToSwarm::GenerateEvent(
+                        KademliaEvent::InboundRequest {
+                            request: InboundRequest::AddProvider { record: None },
+                        },
+                    ));
                 }
                 KademliaStoreInserts::FilterBoth => {
-                    self.queued_events
-                        .push_back(NetworkBehaviourAction::GenerateEvent(
-                            KademliaEvent::InboundRequest {
-                                request: InboundRequest::AddProvider {
-                                    record: Some(record),
-                                },
+                    self.queued_events.push_back(ToSwarm::GenerateEvent(
+                        KademliaEvent::InboundRequest {
+                            request: InboundRequest::AddProvider {
+                                record: Some(record),
                             },
-                        ));
+                        },
+                    ));
                 }
             }
         }
@@ -1848,12 +1828,11 @@ where
                     .position(|(p, _)| p == &peer_id)
                     .map(|p| q.inner.pending_rpcs.remove(p))
             }) {
-                self.queued_events
-                    .push_back(NetworkBehaviourAction::NotifyHandler {
-                        peer_id,
-                        event,
-                        handler: NotifyHandler::Any,
-                    });
+                self.queued_events.push_back(ToSwarm::NotifyHandler {
+                    peer_id,
+                    event,
+                    handler: NotifyHandler::Any,
+                });
             }
 
             self.connected_peers.insert(peer_id);
@@ -2047,24 +2026,22 @@ where
             KademliaHandlerEvent::FindNodeReq { key, request_id } => {
                 let closer_peers = self.find_closest(&kbucket::Key::new(key), &source);
 
-                self.queued_events
-                    .push_back(NetworkBehaviourAction::GenerateEvent(
-                        KademliaEvent::InboundRequest {
-                            request: InboundRequest::FindNode {
-                                num_closer_peers: closer_peers.len(),
-                            },
+                self.queued_events.push_back(ToSwarm::GenerateEvent(
+                    KademliaEvent::InboundRequest {
+                        request: InboundRequest::FindNode {
+                            num_closer_peers: closer_peers.len(),
                         },
-                    ));
+                    },
+                ));
 
-                self.queued_events
-                    .push_back(NetworkBehaviourAction::NotifyHandler {
-                        peer_id: source,
-                        handler: NotifyHandler::One(connection),
-                        event: KademliaHandlerIn::FindNodeRes {
-                            closer_peers,
-                            request_id,
-                        },
-                    });
+                self.queued_events.push_back(ToSwarm::NotifyHandler {
+                    peer_id: source,
+                    handler: NotifyHandler::One(connection),
+                    event: KademliaHandlerIn::FindNodeRes {
+                        closer_peers,
+                        request_id,
+                    },
+                });
             }
 
             KademliaHandlerEvent::FindNodeRes {
@@ -2078,26 +2055,24 @@ where
                 let provider_peers = self.provider_peers(&key, &source);
                 let closer_peers = self.find_closest(&kbucket::Key::new(key), &source);
 
-                self.queued_events
-                    .push_back(NetworkBehaviourAction::GenerateEvent(
-                        KademliaEvent::InboundRequest {
-                            request: InboundRequest::GetProvider {
-                                num_closer_peers: closer_peers.len(),
-                                num_provider_peers: provider_peers.len(),
-                            },
+                self.queued_events.push_back(ToSwarm::GenerateEvent(
+                    KademliaEvent::InboundRequest {
+                        request: InboundRequest::GetProvider {
+                            num_closer_peers: closer_peers.len(),
+                            num_provider_peers: provider_peers.len(),
                         },
-                    ));
+                    },
+                ));
 
-                self.queued_events
-                    .push_back(NetworkBehaviourAction::NotifyHandler {
-                        peer_id: source,
-                        handler: NotifyHandler::One(connection),
-                        event: KademliaHandlerIn::GetProvidersRes {
-                            closer_peers,
-                            provider_peers,
-                            request_id,
-                        },
-                    });
+                self.queued_events.push_back(ToSwarm::NotifyHandler {
+                    peer_id: source,
+                    handler: NotifyHandler::One(connection),
+                    event: KademliaHandlerIn::GetProvidersRes {
+                        closer_peers,
+                        provider_peers,
+                        request_id,
+                    },
+                });
             }
 
             KademliaHandlerEvent::GetProvidersRes {
@@ -2119,20 +2094,19 @@ where
                         *providers_found += provider_peers.len();
                         let providers = provider_peers.iter().map(|p| p.node_id).collect();
 
-                        self.queued_events
-                            .push_back(NetworkBehaviourAction::GenerateEvent(
-                                KademliaEvent::OutboundQueryProgressed {
-                                    id: user_data,
-                                    result: QueryResult::GetProviders(Ok(
-                                        GetProvidersOk::FoundProviders {
-                                            key: key.clone(),
-                                            providers,
-                                        },
-                                    )),
-                                    step: step.clone(),
-                                    stats,
-                                },
-                            ));
+                        self.queued_events.push_back(ToSwarm::GenerateEvent(
+                            KademliaEvent::OutboundQueryProgressed {
+                                id: user_data,
+                                result: QueryResult::GetProviders(Ok(
+                                    GetProvidersOk::FoundProviders {
+                                        key: key.clone(),
+                                        providers,
+                                    },
+                                )),
+                                step: step.clone(),
+                                stats,
+                            },
+                        ));
                         *step = step.next();
                     }
                 }
@@ -2177,26 +2151,24 @@ where
 
                 let closer_peers = self.find_closest(&kbucket::Key::new(key), &source);
 
-                self.queued_events
-                    .push_back(NetworkBehaviourAction::GenerateEvent(
-                        KademliaEvent::InboundRequest {
-                            request: InboundRequest::GetRecord {
-                                num_closer_peers: closer_peers.len(),
-                                present_locally: record.is_some(),
-                            },
+                self.queued_events.push_back(ToSwarm::GenerateEvent(
+                    KademliaEvent::InboundRequest {
+                        request: InboundRequest::GetRecord {
+                            num_closer_peers: closer_peers.len(),
+                            present_locally: record.is_some(),
                         },
-                    ));
+                    },
+                ));
 
-                self.queued_events
-                    .push_back(NetworkBehaviourAction::NotifyHandler {
-                        peer_id: source,
-                        handler: NotifyHandler::One(connection),
-                        event: KademliaHandlerIn::GetRecordRes {
-                            record,
-                            closer_peers,
-                            request_id,
-                        },
-                    });
+                self.queued_events.push_back(ToSwarm::NotifyHandler {
+                    peer_id: source,
+                    handler: NotifyHandler::One(connection),
+                    event: KademliaHandlerIn::GetRecordRes {
+                        record,
+                        closer_peers,
+                        request_id,
+                    },
+                });
             }
 
             KademliaHandlerEvent::GetRecordRes {
@@ -2220,17 +2192,16 @@ where
                                 record,
                             };
 
-                            self.queued_events
-                                .push_back(NetworkBehaviourAction::GenerateEvent(
-                                    KademliaEvent::OutboundQueryProgressed {
-                                        id: user_data,
-                                        result: QueryResult::GetRecord(Ok(
-                                            GetRecordOk::FoundRecord(record),
-                                        )),
-                                        step: step.clone(),
-                                        stats,
-                                    },
-                                ));
+                            self.queued_events.push_back(ToSwarm::GenerateEvent(
+                                KademliaEvent::OutboundQueryProgressed {
+                                    id: user_data,
+                                    result: QueryResult::GetRecord(Ok(GetRecordOk::FoundRecord(
+                                        record,
+                                    ))),
+                                    step: step.clone(),
+                                    stats,
+                                },
+                            ));
 
                             *step = step.next();
                         } else {
@@ -2291,11 +2262,7 @@ where
         };
     }
 
-    fn poll(
-        &mut self,
-        cx: &mut Context<'_>,
-        _: &mut impl PollParameters,
-    ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
+    fn poll(&mut self, cx: &mut Context<'_>, _: &mut impl PollParameters) -> Poll<ToSwarm<Self>> {
         let now = Instant::now();
 
         // Calculate the available capacity for queries triggered by background jobs.
@@ -2354,7 +2321,7 @@ where
                     addresses: value,
                     old_peer: entry.evicted.map(|n| n.key.into_preimage()),
                 };
-                return Poll::Ready(NetworkBehaviourAction::GenerateEvent(event));
+                return Poll::Ready(ToSwarm::GenerateEvent(event));
             }
 
             // Look for a finished query.
@@ -2362,12 +2329,12 @@ where
                 match self.queries.poll(now) {
                     QueryPoolState::Finished(q) => {
                         if let Some(event) = self.query_finished(q) {
-                            return Poll::Ready(NetworkBehaviourAction::GenerateEvent(event));
+                            return Poll::Ready(ToSwarm::GenerateEvent(event));
                         }
                     }
                     QueryPoolState::Timeout(q) => {
                         if let Some(event) = self.query_timeout(q) {
-                            return Poll::Ready(NetworkBehaviourAction::GenerateEvent(event));
+                            return Poll::Ready(ToSwarm::GenerateEvent(event));
                         }
                     }
                     QueryPoolState::Waiting(Some((query, peer_id))) => {
@@ -2386,16 +2353,15 @@ where
                         }
 
                         if self.connected_peers.contains(&peer_id) {
-                            self.queued_events
-                                .push_back(NetworkBehaviourAction::NotifyHandler {
-                                    peer_id,
-                                    event,
-                                    handler: NotifyHandler::Any,
-                                });
+                            self.queued_events.push_back(ToSwarm::NotifyHandler {
+                                peer_id,
+                                event,
+                                handler: NotifyHandler::Any,
+                            });
                         } else if &peer_id != self.kbuckets.local_key().preimage() {
                             query.inner.pending_rpcs.push((peer_id, event));
                             let handler = self.new_handler();
-                            self.queued_events.push_back(NetworkBehaviourAction::Dial {
+                            self.queued_events.push_back(ToSwarm::Dial {
                                 opts: DialOpts::peer_id(peer_id).build(),
                                 handler,
                             });

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -5,9 +5,14 @@
 
 - Add `estblished_in` to `SwarmEvent::ConnectionEstablished`. See [PR 3134].
 
+- Introduce `ToSwarm` type alias as an alternative to `NetworkBehaviourAction`.
+  `ToSwarm` should generally be preferred because it only requires the corresponding `NetworkBehaviour` as a type parameter.
+  See [PR XXXX].
+
 [PR 3170]: https://github.com/libp2p/rust-libp2p/pull/3170
 [PR 3134]: https://github.com/libp2p/rust-libp2p/pull/3134
 [PR 3153]: https://github.com/libp2p/rust-libp2p/pull/3153
+[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
 
 # 0.41.1
 

--- a/swarm/src/behaviour/either.rs
+++ b/swarm/src/behaviour/either.rs
@@ -18,9 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::behaviour::{
-    self, inject_from_swarm, NetworkBehaviour, NetworkBehaviourAction, PollParameters,
-};
+use crate::behaviour::{self, inject_from_swarm, NetworkBehaviour, PollParameters, ToSwarm};
 use crate::handler::either::IntoEitherHandler;
 use either::Either;
 use libp2p_core::{Multiaddr, PeerId};
@@ -97,7 +95,7 @@ where
         &mut self,
         cx: &mut Context<'_>,
         params: &mut impl PollParameters,
-    ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
+    ) -> Poll<ToSwarm<Self>> {
         let event = match self {
             Either::Left(behaviour) => futures::ready!(behaviour.poll(cx, params))
                 .map_out(Either::Left)

--- a/swarm/src/behaviour/toggle.rs
+++ b/swarm/src/behaviour/toggle.rs
@@ -18,14 +18,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::behaviour::{inject_from_swarm, FromSwarm};
+use crate::behaviour::{inject_from_swarm, FromSwarm, ToSwarm};
 use crate::handler::{
     ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, ConnectionHandlerUpgrErr,
     DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound, IntoConnectionHandler,
     KeepAlive, ListenUpgradeError, SubstreamProtocol,
 };
 use crate::upgrade::SendWrapper;
-use crate::{NetworkBehaviour, NetworkBehaviourAction, PollParameters};
+use crate::{NetworkBehaviour, PollParameters};
 use either::Either;
 use libp2p_core::{
     either::{EitherError, EitherOutput},
@@ -108,7 +108,7 @@ where
         &mut self,
         cx: &mut Context<'_>,
         params: &mut impl PollParameters,
-    ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
+    ) -> Poll<ToSwarm<Self>> {
         if let Some(inner) = self.inner.as_mut() {
             inner.poll(cx, params).map(|action| {
                 action.map_handler(|h| ToggleIntoConnectionHandler { inner: Some(h) })

--- a/swarm/src/dial_opts.rs
+++ b/swarm/src/dial_opts.rs
@@ -26,7 +26,7 @@ use std::num::NonZeroU8;
 /// Options to configure a dial to a known or unknown peer.
 ///
 /// Used in [`Swarm::dial`](crate::Swarm::dial) and
-/// [`NetworkBehaviourAction::Dial`](crate::behaviour::NetworkBehaviourAction::Dial).
+/// [`NetworkBehaviourAction::Dial`](crate::behaviour::ToSwarm::Dial).
 ///
 /// To construct use either of:
 ///

--- a/swarm/src/dummy.rs
+++ b/swarm/src/dummy.rs
@@ -1,4 +1,4 @@
-use crate::behaviour::{FromSwarm, NetworkBehaviour, NetworkBehaviourAction, PollParameters};
+use crate::behaviour::{FromSwarm, NetworkBehaviour, PollParameters, ToSwarm};
 use crate::handler::{
     ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
 };
@@ -25,11 +25,7 @@ impl NetworkBehaviour for Behaviour {
         void::unreachable(event)
     }
 
-    fn poll(
-        &mut self,
-        _: &mut Context<'_>,
-        _: &mut impl PollParameters,
-    ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
+    fn poll(&mut self, _: &mut Context<'_>, _: &mut impl PollParameters) -> Poll<ToSwarm<Self>> {
         Poll::Pending
     }
 

--- a/swarm/src/keep_alive.rs
+++ b/swarm/src/keep_alive.rs
@@ -1,4 +1,4 @@
-use crate::behaviour::{FromSwarm, NetworkBehaviour, NetworkBehaviourAction, PollParameters};
+use crate::behaviour::{FromSwarm, NetworkBehaviour, PollParameters, ToSwarm};
 use crate::handler::{
     ConnectionEvent, ConnectionHandlerEvent, FullyNegotiatedInbound, FullyNegotiatedOutbound,
     KeepAlive, SubstreamProtocol,
@@ -30,11 +30,7 @@ impl NetworkBehaviour for Behaviour {
         void::unreachable(event)
     }
 
-    fn poll(
-        &mut self,
-        _: &mut Context<'_>,
-        _: &mut impl PollParameters,
-    ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
+    fn poll(&mut self, _: &mut Context<'_>, _: &mut impl PollParameters) -> Poll<ToSwarm<Self>> {
         Poll::Pending
     }
 

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -704,7 +704,7 @@ where
     /// order in which addresses are used to connect to) as well as
     /// how long the address is retained in the list, depending on
     /// how frequently it is reported by the `NetworkBehaviour` via
-    /// [`NetworkBehaviourAction::ReportObservedAddr`] or explicitly
+    /// [`ToSwarm::ReportObservedAddr`] or explicitly
     /// through this method.
     pub fn add_external_address(&mut self, a: Multiaddr, s: AddressScore) -> AddAddressResult {
         let result = self.external_addrs.add(a.clone(), s);
@@ -2061,7 +2061,7 @@ mod tests {
 
     /// Establishes multiple connections between two peers,
     /// after which one peer disconnects the other
-    /// using [`NetworkBehaviourAction::CloseConnection`] returned by a [`NetworkBehaviour`].
+    /// using [`ToSwarm::CloseConnection`] returned by a [`NetworkBehaviour`].
     ///
     /// The test expects both behaviours to be notified via pairs of
     /// [`NetworkBehaviour::inject_connection_established`] / [`NetworkBehaviour::inject_connection_closed`] calls.
@@ -2129,7 +2129,7 @@ mod tests {
 
     /// Establishes multiple connections between two peers,
     /// after which one peer closes a single connection
-    /// using [`NetworkBehaviourAction::CloseConnection`] returned by a [`NetworkBehaviour`].
+    /// using [`ToSwarm::CloseConnection`] returned by a [`NetworkBehaviour`].
     ///
     /// The test expects both behaviours to be notified via pairs of
     /// [`NetworkBehaviour::inject_connection_established`] / [`NetworkBehaviour::inject_connection_closed`] calls.

--- a/swarm/src/test.rs
+++ b/swarm/src/test.rs
@@ -20,7 +20,7 @@
 
 use crate::behaviour::{
     ConnectionClosed, ConnectionEstablished, DialFailure, ExpiredExternalAddr, ExpiredListenAddr,
-    FromSwarm, ListenerClosed, ListenerError, NewExternalAddr, NewListenAddr, NewListener,
+    FromSwarm, ListenerClosed, ListenerError, NewExternalAddr, NewListenAddr, NewListener, ToSwarm,
 };
 use crate::{
     ConnectionHandler, IntoConnectionHandler, NetworkBehaviour, NetworkBehaviourAction,
@@ -80,11 +80,7 @@ where
         self.addresses.get(p).map_or(Vec::new(), |v| v.clone())
     }
 
-    fn poll(
-        &mut self,
-        _: &mut Context,
-        _: &mut impl PollParameters,
-    ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
+    fn poll(&mut self, _: &mut Context, _: &mut impl PollParameters) -> Poll<ToSwarm<Self>> {
         self.next_action.take().map_or(Poll::Pending, Poll::Ready)
     }
 
@@ -466,11 +462,7 @@ where
         self.inner.inject_event(p, c, e);
     }
 
-    fn poll(
-        &mut self,
-        cx: &mut Context,
-        args: &mut impl PollParameters,
-    ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
+    fn poll(&mut self, cx: &mut Context, args: &mut impl PollParameters) -> Poll<ToSwarm<Self>> {
         self.poll += 1;
         self.inner.poll(cx, args)
     }

--- a/swarm/tests/swarm_derive.rs
+++ b/swarm/tests/swarm_derive.rs
@@ -21,6 +21,7 @@
 use futures::StreamExt;
 use libp2p_identify as identify;
 use libp2p_ping as ping;
+use libp2p_swarm::behaviour::ToSwarm;
 use libp2p_swarm::{behaviour::FromSwarm, dummy, NetworkBehaviour, SwarmEvent};
 use std::fmt::Debug;
 
@@ -372,9 +373,7 @@ fn generated_out_event_derive_debug() {
 fn custom_out_event_no_type_parameters() {
     use libp2p_core::connection::ConnectionId;
     use libp2p_core::PeerId;
-    use libp2p_swarm::{
-        ConnectionHandler, IntoConnectionHandler, NetworkBehaviourAction, PollParameters,
-    };
+    use libp2p_swarm::{ConnectionHandler, IntoConnectionHandler, PollParameters};
     use std::task::Context;
     use std::task::Poll;
 
@@ -399,11 +398,7 @@ fn custom_out_event_no_type_parameters() {
             void::unreachable(message);
         }
 
-        fn poll(
-            &mut self,
-            _ctx: &mut Context,
-            _: &mut impl PollParameters,
-        ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
+        fn poll(&mut self, _ctx: &mut Context, _: &mut impl PollParameters) -> Poll<ToSwarm<Self>> {
             Poll::Pending
         }
 


### PR DESCRIPTION
## Description

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

The `NetworkBehaviourAction` type is often clunky to name because it has several type parameters. Usually, those can all be inferred from the corresponding `NetworkBehaviour`. However, that would require us to add bounds to the type definition which generally not a good idea because those bounds creep easily into upper layers where you don't want them.

This PR instead adds a type alias for `NetworkBehaviourAction` called `ToSwarm` which is just a `NetworkBehaviourAction` with all parameters inferred from a `NetworkBehaviour`.

Resolves https://github.com/libp2p/rust-libp2p/issues/3123.

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

At the moment, this is just an experiment.

This might be easier after we merge https://github.com/libp2p/rust-libp2p/pull/3254 where we remove the `THandler` type parameter from `NetworkBehaviourAction`.

At the moment, this only compiles by adding type annotations everywhere which is kind of unacceptable. I opened an issue on rust-lang/rust for that: https://github.com/rust-lang/rust/issues/105680.

<!-- Any notes or remarks you'd like to make about the PR. -->

Depends-On: https://github.com/libp2p/rust-libp2p/pull/3239 to remove the build failures in `libp2p-kad`.

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
