### PR TITLE
fix(kad): Skip invalid multiaddr

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.42.1
 
-- Skip invalid multiaddr in `Peer` `addrs`. See [PR XXX].
+- Skip unparsable multiaddr in `Peer::addrs`. See [PR XXX].
 
 [PR XXX]: https://github.com/libp2p/rust-libp2p/pull/XXX
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.42.1
+
+- Skip invalid multiaddr in `Peer` `addrs`. See [PR XXX].
+
+[PR XXX]: https://github.com/libp2p/rust-libp2p/pull/XXX
+
 # 0.42.0
 
 - Update to `libp2p-core` `v0.38.0`.

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,8 +1,8 @@
 # 0.42.1
 
-- Skip unparsable multiaddr in `Peer::addrs`. See [PR XXX].
+- Skip unparsable multiaddr in `Peer::addrs`. See [PR 3280].
 
-[PR XXX]: https://github.com/libp2p/rust-libp2p/pull/XXX
+[PR 3280]: https://github.com/libp2p/rust-libp2p/pull/3280
 
 # 0.42.0
 

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-kad"
 edition = "2021"
 rust-version = "1.62.0"
 description = "Kademlia protocol for libp2p"
-version = "0.42.0"
+version = "0.42.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -44,7 +44,7 @@ prost-build = "0.11"
 [features]
 serde = ["dep:serde", "bytes/serde"]
 
-# Passing arguments to the docsrs builder in order to properly document cfg's. 
+# Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -35,7 +35,6 @@ use futures::prelude::*;
 use instant::Instant;
 use libp2p_core::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use libp2p_core::{Multiaddr, PeerId};
-use log::debug;
 use prost::Message;
 use std::{borrow::Cow, convert::TryFrom, time::Duration};
 use std::{io, iter};

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -35,6 +35,7 @@ use futures::prelude::*;
 use instant::Instant;
 use libp2p_core::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use libp2p_core::{Multiaddr, PeerId};
+use log::debug;
 use prost::Message;
 use std::{borrow::Cow, convert::TryFrom, time::Duration};
 use std::{io, iter};
@@ -105,10 +106,13 @@ impl TryFrom<proto::message::Peer> for KadPeer {
 
         let mut addrs = Vec::with_capacity(peer.addrs.len());
         for addr in peer.addrs.into_iter() {
-            let as_ma = Multiaddr::try_from(addr).map_err(invalid_data)?;
-            addrs.push(as_ma);
+            match Multiaddr::try_from(addr) {
+                Ok(a) => addrs.push(a),
+                Err(e) => {
+                    debug!("Unable to parse multiaddr: {e:?}");
+                }
+            };
         }
-        debug_assert_eq!(addrs.len(), addrs.capacity());
 
         let connection_ty = proto::message::ConnectionType::from_i32(peer.connection)
             .ok_or_else(|| invalid_data("unknown connection type"))?
@@ -601,6 +605,29 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    #[test]
+    fn skip_invalid_multiaddr() {
+        let valid_multiaddr: Multiaddr = "/ip6/2001:db8::/tcp/1234".parse().unwrap();
+        let valid_multiaddr_bytes = valid_multiaddr.to_vec();
+
+        let invalid_multiaddr = {
+            let a = vec![255; 8];
+            assert!(Multiaddr::try_from(a.clone()).is_err());
+            a
+        };
+
+        let payload = proto::message::Peer {
+            id: PeerId::random().to_bytes(),
+            addrs: vec![valid_multiaddr_bytes, invalid_multiaddr],
+            connection: proto::message::ConnectionType::CanConnect.into(),
+        };
+
+        let peer = KadPeer::try_from(payload).expect("not to fail");
+
+        assert_eq!(peer.multiaddrs, vec![valid_multiaddr])
+    }
 
     /*// TODO: restore
     use self::libp2p_tcp::TcpTransport;

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -108,7 +108,7 @@ impl TryFrom<proto::message::Peer> for KadPeer {
             match Multiaddr::try_from(addr) {
                 Ok(a) => addrs.push(a),
                 Err(e) => {
-                    debug!("Unable to parse multiaddr: {e:?}");
+                    log::debug!("Unable to parse multiaddr: {e}");
                 }
             };
         }


### PR DESCRIPTION
## Description

With this commit `libp2p-kad` no longer discards the whole peer payload in case an addr is invalid, but instead logs the failure, skips the invalid multiaddr and parses the remaining payload.

See https://github.com/libp2p/rust-libp2p/issues/3244 for details.

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes

Targets the `v0.50` branch.

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
