### PR TITLE
fix(kad): Skip invalid multiaddr

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 [PR 3239]: https://github.com/libp2p/rust-libp2p/pull/3239
 
+# 0.42.1
+
+- Skip unparsable multiaddr in `Peer::addrs`. See [PR 3280].
+
+[PR 3280]: https://github.com/libp2p/rust-libp2p/pull/3280
+
 # 0.42.0
 
 - Update to `libp2p-core` `v0.38.0`.


### PR DESCRIPTION
## Description

With this commit `libp2p-kad` no longer discards the whole peer payload in case an addr is invalid, but instead logs the failure, skips the invalid multiaddr and parses the remaining payload.

See https://github.com/libp2p/rust-libp2p/issues/3244 for details.

Co-authored-by: Thomas Eizinger <thomas@eizinger.io>

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes

Merge #3280 from `v0.50` into `master`.

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
