### PR TITLE
feat(kad): Limit in-flight Kademlia queries

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -6,9 +6,12 @@
 
 - Remove lifetime from `RecordStore` and use GATs instead. See [PR 3239].
 
+- Limit in-flight Kademlia queries. See [PR 3285].
+
 - Bump MSRV to 1.65.0.
 
 [PR 3239]: https://github.com/libp2p/rust-libp2p/pull/3239
+[PR 3285]: https://github.com/libp2p/rust-libp2p/pull/3285
 
 # 0.42.1
 

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -23,6 +23,7 @@ use crate::protocol::{
     KademliaProtocolConfig,
 };
 use crate::record::{self, Record};
+use crate::MAX_NUM_SUBSTREAMS;
 use futures::prelude::*;
 use futures::stream::SelectAll;
 use instant::Instant;
@@ -39,8 +40,6 @@ use std::task::Waker;
 use std::{
     error, fmt, io, marker::PhantomData, pin::Pin, task::Context, task::Poll, time::Duration,
 };
-
-const MAX_NUM_INBOUND_SUBSTREAMS: usize = 32;
 
 /// A prototype from which [`KademliaHandler`]s can be constructed.
 pub struct KademliaHandlerProto<T> {
@@ -571,7 +570,7 @@ where
             self.protocol_status = ProtocolStatus::Confirmed;
         }
 
-        if self.inbound_substreams.len() == MAX_NUM_INBOUND_SUBSTREAMS {
+        if self.inbound_substreams.len() == MAX_NUM_SUBSTREAMS {
             if let Some(s) = self.inbound_substreams.iter_mut().find(|s| {
                 matches!(
                     s,

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -97,3 +97,5 @@ pub const K_VALUE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(20) };
 ///
 /// The current value is `3`.
 pub const ALPHA_VALUE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(3) };
+
+const MAX_NUM_SUBSTREAMS: usize = 32;

--- a/protocols/kad/src/query/pending_queries.rs
+++ b/protocols/kad/src/query/pending_queries.rs
@@ -1,0 +1,142 @@
+use crate::query::Query;
+use crate::QueryId;
+use fnv::FnvHashMap;
+use std::collections::VecDeque;
+
+/// Wrapper data structure that guarantees fairness of the pending queries by maintaining insertion
+/// order in addition to the hashmap. In order to take advantage of this [`PendingQueries::next()`]
+/// method must be used.
+pub(super) struct PendingQueries<TInner> {
+    // IDs corresponding to `queries`, though for efficiency purposes there might be entries
+    // resent for queries that were already removed.
+    query_ids: VecDeque<QueryId>,
+    queries: FnvHashMap<QueryId, Query<TInner>>,
+}
+
+impl<TInner> Default for PendingQueries<TInner> {
+    fn default() -> Self {
+        Self {
+            query_ids: Default::default(),
+            queries: Default::default(),
+        }
+    }
+}
+
+impl<TInner> PendingQueries<TInner> {
+    pub(super) fn contains_key(&self, id: &QueryId) -> bool {
+        self.queries.contains_key(id)
+    }
+
+    pub(super) fn insert(&mut self, id: QueryId, query: Query<TInner>) -> Option<Query<TInner>> {
+        self.query_ids.push_back(id);
+        self.queries.insert(id, query)
+    }
+
+    pub(super) fn get(&self, id: &QueryId) -> Option<&Query<TInner>> {
+        self.queries.get(id)
+    }
+
+    pub(super) fn get_mut(&mut self, id: &QueryId) -> Option<&mut Query<TInner>> {
+        self.queries.get_mut(id)
+    }
+
+    pub(super) fn remove(&mut self, id: &QueryId) -> Option<Query<TInner>> {
+        // We only remove IDs from the front and back, the rest can remain for some time
+        if self.query_ids.front() == Some(id) {
+            self.query_ids.pop_front();
+        }
+        if self.query_ids.back() == Some(id) {
+            self.query_ids.pop_back();
+        }
+
+        self.queries.remove(id)
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.queries.len()
+    }
+
+    /// Get next pending query in insertion order.
+    pub(super) fn next(&mut self) -> Option<Query<TInner>> {
+        while let Some(query) = self.query_ids.pop_front() {
+            // Query may not exist anymore, check for this.
+            if let Some(query) = self.queries.remove(&query) {
+                return Some(query);
+            }
+        }
+
+        None
+    }
+
+    /// Order of items in this iterator is not guaranteed.
+    pub(super) fn values(&self) -> impl Iterator<Item = &Query<TInner>> {
+        self.queries.values()
+    }
+
+    /// Order of items in this iterator is not guaranteed.
+    pub(super) fn values_mut(&mut self) -> impl Iterator<Item = &mut Query<TInner>> {
+        self.queries.values_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PendingQueries;
+    use crate::query::{FixedPeersIter, Query, QueryId, QueryPeerIter, QueryStats};
+    use std::num::NonZeroUsize;
+
+    #[test]
+    fn basic() {
+        let mut ids = (0..100).map(QueryId).collect::<Vec<_>>();
+        let mut pending_queries = PendingQueries::<()>::default();
+        for &id in &ids {
+            let old_query = pending_queries.insert(
+                id,
+                Query {
+                    id,
+                    peer_iter: QueryPeerIter::Fixed(FixedPeersIter::new(
+                        [],
+                        NonZeroUsize::new(1).unwrap(),
+                    )),
+                    stats: QueryStats::empty(),
+                    inner: (),
+                },
+            );
+
+            assert!(old_query.is_none());
+        }
+
+        assert_eq!(pending_queries.len(), ids.len());
+
+        {
+            let values_keys = pending_queries
+                .values()
+                .map(|query| query.id())
+                .collect::<Vec<_>>();
+            let values_mut_keys = pending_queries
+                .values_mut()
+                .map(|query| query.id())
+                .collect::<Vec<_>>();
+            assert_eq!(values_keys, values_mut_keys);
+            // Order is not guaranteed and must not match due to hashing
+            assert_ne!(values_keys, ids);
+            // Order is not guaranteed and must not match due to hashing
+            assert_ne!(values_mut_keys, ids);
+        }
+
+        for id in &ids {
+            assert!(pending_queries.contains_key(id));
+            assert_eq!(&pending_queries.get(id).unwrap().id, id);
+            assert_eq!(&pending_queries.get_mut(id).unwrap().id, id);
+        }
+
+        {
+            let removed_id = ids.remove(ids.len() / 2);
+            assert_eq!(pending_queries.remove(&removed_id).unwrap().id, removed_id);
+
+            for id in ids {
+                assert_eq!(pending_queries.next().unwrap().id, id);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Limit number of in-flight Kademlia queries to not exceed configured number of substreams

## Notes

I went with a design where each query is first inserted into pending queue and `QueryPool` will maintain at most `32` queries active at any time, any queries that exceed the limit will remain in pending queue.

In order to guarantee insertion order of pending queries I have introduced an abstraction in second commit.

Since constant restricting inbound streams to `32` is now used for outbound too, I moved it up to the root of the crate and changed name to more generic.

## Links to any relevant issues

https://github.com/libp2p/rust-libp2p/discussions/3235
https://github.com/libp2p/rust-libp2p/issues/3236

## Open Questions

Not entirely sure how to test higher-level behavior here.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
