### PR TITLE
refactor(dcutr): remove ActionBuilder.

### DIFF
--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.9.0 [unreleased]
 
+- Remove no longer required `ActionBuilder` from `Behaviour` implementation. See [PR 3304].
+
 - Update to `libp2p-core` `v0.39.0`.
 
 - Update to `libp2p-swarm` `v0.42.0`.
@@ -15,6 +17,7 @@
 [PR 3153]: https://github.com/libp2p/rust-libp2p/pull/3153
 [issue 2217]: https://github.com/libp2p/rust-libp2p/issues/2217
 [PR 3214]: https://github.com/libp2p/rust-libp2p/pull/3214
+[PR 3304]: https://github.com/libp2p/rust-libp2p/pull/3304
 
 # 0.8.0
 

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -1,7 +1,5 @@
 # 0.9.0 [unreleased]
 
-- Remove no longer required `ActionBuilder` from `Behaviour` implementation. See [PR 3304].
-
 - Update to `libp2p-core` `v0.39.0`.
 
 - Update to `libp2p-swarm` `v0.42.0`.
@@ -17,7 +15,6 @@
 [PR 3153]: https://github.com/libp2p/rust-libp2p/pull/3153
 [issue 2217]: https://github.com/libp2p/rust-libp2p/issues/2217
 [PR 3214]: https://github.com/libp2p/rust-libp2p/pull/3214
-[PR 3304]: https://github.com/libp2p/rust-libp2p/pull/3304
 
 # 0.8.0
 


### PR DESCRIPTION
## Description

addresses #3299

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

We are now getting the `observed_addresses` at different places, i.e. previously we had `PollParameters` on `poll` with what I assume would be the list of updated `external_addresses` that would be then used to calculate the list of `observed_addresses`. Now we get the list of `observed_addresses` from the `ExternalAddrs` which is updated on `NewExternalAddr`, but will it make a difference that it might be updated when an `Event` has already been added to `queued_events`?

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
