### PR TITLE
refactor(swarm)!: refactor ListenUpgradeError and DialUpgradeError

### DIFF
--- a/examples/file-sharing.rs
+++ b/examples/file-sharing.rs
@@ -216,7 +216,8 @@ mod network {
     use libp2p::kad::{GetProvidersOk, Kademlia, KademliaEvent, QueryId, QueryResult};
     use libp2p::multiaddr::Protocol;
     use libp2p::request_response::{self, ProtocolSupport, RequestId, ResponseChannel};
-    use libp2p::swarm::{ConnectionHandlerUpgrErr, NetworkBehaviour, Swarm, SwarmEvent};
+    use libp2p::swarm::{NetworkBehaviour, Swarm, SwarmEvent};
+    use libp2p_core::UpgradeError;
     use std::collections::{hash_map, HashMap, HashSet};
     use std::iter;
 
@@ -403,10 +404,7 @@ mod network {
 
         async fn handle_event(
             &mut self,
-            event: SwarmEvent<
-                ComposedEvent,
-                EitherError<ConnectionHandlerUpgrErr<io::Error>, io::Error>,
-            >,
+            event: SwarmEvent<ComposedEvent, EitherError<UpgradeError<io::Error>, io::Error>>,
         ) {
             match event {
                 SwarmEvent::Behaviour(ComposedEvent::Kademlia(

--- a/misc/metrics/CHANGELOG.md
+++ b/misc/metrics/CHANGELOG.md
@@ -6,13 +6,13 @@
 
 - Bump MSRV to 1.65.0.
 
-- Update to `libp2p-dcutr` `v0.9.0`.
+- Update to `libp2p-dcutr` `v0.9.0` and introduce `dcutr::EventType::DirectConnectionUpgradeTimedOut`.
 
 - Update to `libp2p-ping` `v0.42.0`.
 
 - Update to `libp2p-kad` `v0.43.0`.
 
-- Update to `libp2p-relay` `v0.15.0`.
+- Update to `libp2p-relay` `v0.15.0` and introduce `relay::EventType::CircuitReqOutboundConectTimedOut`.
 
 - Update to `libp2p-identify` `v0.42.0`.
 

--- a/misc/metrics/src/dcutr.rs
+++ b/misc/metrics/src/dcutr.rs
@@ -53,6 +53,7 @@ enum EventType {
     RemoteInitiatedDirectConnectionUpgrade,
     DirectConnectionUpgradeSucceeded,
     DirectConnectionUpgradeFailed,
+    DirectConnectionUpgradeTimedOut,
 }
 
 impl From<&libp2p_dcutr::Event> for EventType {
@@ -73,6 +74,9 @@ impl From<&libp2p_dcutr::Event> for EventType {
                 remote_peer_id: _,
                 error: _,
             } => EventType::DirectConnectionUpgradeFailed,
+            libp2p_dcutr::Event::DirectConnectionUpgradeTimedout { .. } => {
+                EventType::DirectConnectionUpgradeTimedOut
+            }
         }
     }
 }

--- a/misc/metrics/src/dcutr.rs
+++ b/misc/metrics/src/dcutr.rs
@@ -53,7 +53,6 @@ enum EventType {
     RemoteInitiatedDirectConnectionUpgrade,
     DirectConnectionUpgradeSucceeded,
     DirectConnectionUpgradeFailed,
-    DirectConnectionUpgradeTimedOut,
 }
 
 impl From<&libp2p_dcutr::Event> for EventType {
@@ -74,9 +73,6 @@ impl From<&libp2p_dcutr::Event> for EventType {
                 remote_peer_id: _,
                 error: _,
             } => EventType::DirectConnectionUpgradeFailed,
-            libp2p_dcutr::Event::DirectConnectionUpgradeTimedout { .. } => {
-                EventType::DirectConnectionUpgradeTimedOut
-            }
         }
     }
 }

--- a/misc/metrics/src/identify.rs
+++ b/misc/metrics/src/identify.rs
@@ -129,9 +129,6 @@ impl super::Recorder<libp2p_identify::Event> for Metrics {
             libp2p_identify::Event::Error { .. } => {
                 self.error.inc();
             }
-            libp2p_identify::Event::Timeout => {
-                self.error.inc();
-            }
             libp2p_identify::Event::Pushed { .. } => {
                 self.pushed.inc();
             }

--- a/misc/metrics/src/identify.rs
+++ b/misc/metrics/src/identify.rs
@@ -129,6 +129,9 @@ impl super::Recorder<libp2p_identify::Event> for Metrics {
             libp2p_identify::Event::Error { .. } => {
                 self.error.inc();
             }
+            libp2p_identify::Event::Timeout => {
+                self.error.inc();
+            }
             libp2p_identify::Event::Pushed { .. } => {
                 self.pushed.inc();
             }

--- a/misc/metrics/src/relay.rs
+++ b/misc/metrics/src/relay.rs
@@ -59,7 +59,6 @@ enum EventType {
     CircuitReqDenyFailed,
     CircuitReqOutboundConnectFailed,
     CircuitReqAccepted,
-    CircuitReqTimedOut,
     CircuitReqAcceptFailed,
     CircuitClosed,
 }
@@ -78,9 +77,6 @@ impl From<&libp2p_relay::Event> for EventType {
             libp2p_relay::Event::ReservationTimedOut { .. } => EventType::ReservationTimedOut,
             libp2p_relay::Event::CircuitReqReceiveFailed { .. } => {
                 EventType::CircuitReqReceiveFailed
-            }
-            libp2p_relay::Event::CircuitReqOutboundConectTimedOut { .. } => {
-                EventType::CircuitReqTimedOut
             }
             libp2p_relay::Event::CircuitReqDenied { .. } => EventType::CircuitReqDenied,
             libp2p_relay::Event::CircuitReqOutboundConnectFailed { .. } => {

--- a/misc/metrics/src/relay.rs
+++ b/misc/metrics/src/relay.rs
@@ -59,6 +59,7 @@ enum EventType {
     CircuitReqDenyFailed,
     CircuitReqOutboundConnectFailed,
     CircuitReqAccepted,
+    CircuitReqTimedOut,
     CircuitReqAcceptFailed,
     CircuitClosed,
 }
@@ -77,6 +78,9 @@ impl From<&libp2p_relay::Event> for EventType {
             libp2p_relay::Event::ReservationTimedOut { .. } => EventType::ReservationTimedOut,
             libp2p_relay::Event::CircuitReqReceiveFailed { .. } => {
                 EventType::CircuitReqReceiveFailed
+            }
+            libp2p_relay::Event::CircuitReqOutboundConectTimedOut { .. } => {
+                EventType::CircuitReqTimedOut
             }
             libp2p_relay::Event::CircuitReqDenied { .. } => EventType::CircuitReqDenied,
             libp2p_relay::Event::CircuitReqOutboundConnectFailed { .. } => {

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 - Update to `libp2p-core` `v0.39.0`.
 
-- Update to `libp2p-swarm` `v0.42.0`.
+- Update to `libp2p-swarm` `v0.42.0`. Update to the `libp2p_swarm::handler::ConnectionEvent` `DialTimeout` introduction and consequential changes.
+  With that introduce `Event::DirectConnectionUpgradeTimedout`. See [PR 3307].
 
 - Declare `InboundUpgradeError` and `OutboundUpgradeError` as type aliases instead of renames.
   This is a workaround for a missing feature in `cargo semver-checks`. See [PR 3213].
@@ -15,6 +16,7 @@
 [PR 3153]: https://github.com/libp2p/rust-libp2p/pull/3153
 [issue 2217]: https://github.com/libp2p/rust-libp2p/issues/2217
 [PR 3214]: https://github.com/libp2p/rust-libp2p/pull/3214
+[PR 3307]: https://github.com/libp2p/rust-libp2p/pull/3307
 
 # 0.8.0
 

--- a/protocols/dcutr/src/behaviour_impl.rs
+++ b/protocols/dcutr/src/behaviour_impl.rs
@@ -57,9 +57,6 @@ pub enum Event {
         remote_peer_id: PeerId,
         error: Error,
     },
-    DirectConnectionUpgradeTimedout {
-        remote_peer_id: PeerId,
-    },
 }
 
 #[derive(Debug, Error)]
@@ -68,6 +65,8 @@ pub enum Error {
     Dial,
     #[error("Failed to establish substream: {0}.")]
     Handler(UpgradeError<void::Void>),
+    #[error("Timeout expired upgrading the direct connection.")]
+    Timeout,
 }
 
 pub struct Behaviour {
@@ -247,8 +246,9 @@ impl NetworkBehaviour for Behaviour {
             }
             Either::Left(handler::relayed::Event::InboundNegotiationTimedout) => {
                 self.queued_actions.push_back(
-                    NetworkBehaviourAction::GenerateEvent(Event::DirectConnectionUpgradeTimedout {
+                    NetworkBehaviourAction::GenerateEvent(Event::DirectConnectionUpgradeFailed {
                         remote_peer_id: event_source,
+                        error: Error::Timeout,
                     })
                     .into(),
                 );

--- a/protocols/dcutr/src/handler/direct.rs
+++ b/protocols/dcutr/src/handler/direct.rs
@@ -22,11 +22,9 @@
 
 use libp2p_core::connection::ConnectionId;
 use libp2p_core::upgrade::DeniedUpgrade;
+use libp2p_core::UpgradeError;
 use libp2p_swarm::handler::ConnectionEvent;
-use libp2p_swarm::{
-    ConnectionHandler, ConnectionHandlerEvent, ConnectionHandlerUpgrErr, KeepAlive,
-    SubstreamProtocol,
-};
+use libp2p_swarm::{ConnectionHandler, ConnectionHandlerEvent, KeepAlive, SubstreamProtocol};
 use std::task::{Context, Poll};
 use void::Void;
 
@@ -52,7 +50,7 @@ impl Handler {
 impl ConnectionHandler for Handler {
     type InEvent = void::Void;
     type OutEvent = Event;
-    type Error = ConnectionHandlerUpgrErr<std::io::Error>;
+    type Error = UpgradeError<std::io::Error>;
     type InboundProtocol = DeniedUpgrade;
     type OutboundProtocol = DeniedUpgrade;
     type OutboundOpenInfo = Void;
@@ -103,6 +101,7 @@ impl ConnectionHandler for Handler {
             ConnectionEvent::FullyNegotiatedInbound(_)
             | ConnectionEvent::FullyNegotiatedOutbound(_)
             | ConnectionEvent::DialUpgradeError(_)
+            | ConnectionEvent::DialTimeout(_)
             | ConnectionEvent::ListenUpgradeError(_)
             | ConnectionEvent::AddressChange(_) => {}
         }

--- a/protocols/dcutr/src/handler/relayed.rs
+++ b/protocols/dcutr/src/handler/relayed.rs
@@ -227,13 +227,6 @@ impl Handler {
                     },
                 ));
             }
-            ConnectionHandlerUpgrErr::Timer => {
-                self.queued_events.push_back(ConnectionHandlerEvent::Custom(
-                    Event::InboundNegotiationFailed {
-                        error: ConnectionHandlerUpgrErr::Timer,
-                    },
-                ));
-            }
             ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(NegotiationError::Failed)) => {
                 // The remote merely doesn't support the DCUtR protocol.
                 // This is no reason to close the connection, which may

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 - Update to `libp2p-core` `v0.39.0`.
 
-- Update to `libp2p-swarm` `v0.42.0`.
+- Update to `libp2p-swarm` `v0.42.0`. Update to the `libp2p_swarm::handler::ConnectionEvent` `DialTimeout`
+  introduction and consequential changes. See [PR 3307].
+
+[PR 3307]: https://github.com/libp2p/rust-libp2p/pull/3307
 
 # 0.43.0
 

--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -295,7 +295,7 @@ impl ConnectionHandler for GossipsubHandler {
         if let Some(error) = self.upgrade_errors.pop_front() {
             let reported_error = match error {
                 // Timeout errors get mapped to NegotiationTimeout and we close the connection.
-                ConnectionHandlerUpgrErr::Timeout | ConnectionHandlerUpgrErr::Timer => {
+                ConnectionHandlerUpgrErr::Timeout => {
                     Some(GossipsubHandlerError::NegotiationTimeout)
                 }
                 // There was an error post negotiation, close the connection.

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -6,7 +6,7 @@
   previously Push requests were prioritized. see [PR 3208].
 
 - Update to `libp2p-swarm` `v0.42.0`. Update to the `libp2p_swarm::handler::ConnectionEvent` `DialTimeout`
-  introduction and consequential changes. With that introduce `Event::Timeout`. See [PR 3307].
+  introduction and consequential changes. With that introduce `Error`. See [PR 3307].
 
 
 [PR 3208]: https://github.com/libp2p/rust-libp2p/pull/3208

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -5,9 +5,12 @@
 - Move I/O from `Behaviour` to `Handler`. Handle `Behaviour`'s Identify and Push requests independently by incoming order,
   previously Push requests were prioritized. see [PR 3208].
 
-- Update to `libp2p-swarm` `v0.42.0`.
+- Update to `libp2p-swarm` `v0.42.0`. Update to the `libp2p_swarm::handler::ConnectionEvent` `DialTimeout`
+  introduction and consequential changes. With that introduce `Event::Timeout`. See [PR 3307].
+
 
 [PR 3208]: https://github.com/libp2p/rust-libp2p/pull/3208
+[PR 3307]: https://github.com/libp2p/rust-libp2p/pull/3307
 
 # 0.41.1
 

--- a/protocols/identify/src/behaviour.rs
+++ b/protocols/identify/src/behaviour.rs
@@ -25,9 +25,9 @@ use libp2p_core::{
 };
 use libp2p_swarm::behaviour::{ConnectionClosed, ConnectionEstablished, DialFailure, FromSwarm};
 use libp2p_swarm::{
-    dial_opts::DialOpts, AddressScore, ConnectionHandler, ConnectionHandlerUpgrErr, DialError,
-    ExternalAddresses, IntoConnectionHandler, ListenAddresses, NetworkBehaviour,
-    NetworkBehaviourAction, NotifyHandler, PollParameters,
+    dial_opts::DialOpts, AddressScore, ConnectionHandler, DialError, ExternalAddresses,
+    IntoConnectionHandler, ListenAddresses, NetworkBehaviour, NetworkBehaviourAction,
+    NotifyHandler, PollParameters,
 };
 use lru::LruCache;
 use std::num::NonZeroUsize;
@@ -303,6 +303,9 @@ impl NetworkBehaviour for Behaviour {
                         error,
                     }));
             }
+            handler::Event::IdentificationTimedout => self
+                .events
+                .push_back(NetworkBehaviourAction::GenerateEvent(Event::Timeout)),
         }
     }
 
@@ -459,8 +462,11 @@ pub enum Event {
         /// The peer with whom the error originated.
         peer_id: PeerId,
         /// The error that occurred.
-        error: ConnectionHandlerUpgrErr<UpgradeError>,
+        error: libp2p_core::UpgradeError<UpgradeError>,
     },
+
+    /// Timeout expired while attempting to identify the remote.
+    Timeout,
 }
 
 fn supported_protocols(params: &impl PollParameters) -> Vec<String> {

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 - Update to `libp2p-core` `v0.39.0`.
 
-- Update to `libp2p-swarm` `v0.42.0`.
+- Update to `libp2p-swarm` `v0.42.0`. Update to the `libp2p_swarm::handler::ConnectionEvent` `DialTimeout`
+  introduction and consequential changes. With that introduce `KademliaHandlerQueryErr::Timeout`. See [PR 3307].
 
 - Remove lifetime from `RecordStore` and use GATs instead. See [PR 3239].
 
 - Bump MSRV to 1.65.0.
 
 [PR 3239]: https://github.com/libp2p/rust-libp2p/pull/3239
+[PR 3307]: https://github.com/libp2p/rust-libp2p/pull/3307
 
 # 0.42.1
 

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 - Update to `libp2p-core` `v0.39.0`.
 
-- Update to `libp2p-swarm` `v0.42.0`.
+- Update to `libp2p-swarm` `v0.42.0`. Update to the `libp2p_swarm::handler::ConnectionEvent` `DialTimeout`
+  introduction and consequential changes. See [PR 3307].
+
+[PR 3307]: https://github.com/libp2p/rust-libp2p/pull/3307
 
 # 0.41.0
 

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -9,9 +9,13 @@
 
 - Update to `libp2p-core` `v0.39.0`.
 
-- Update to `libp2p-swarm` `v0.42.0`.
+- Update to `libp2p-swarm` `v0.42.0`. Update to the `libp2p_swarm::handler::ConnectionEvent` `DialTimeout` introduction and consequential changes.
+  With that introduce `Event::CircuitReqOutboundConnectTimedOut` and `client::Event::ReservationReqTimedOut`
+  and `client::Event::OutboundCircuitReqTimedOut`. See [PR XXXX].
+
 
 [PR 3238]: https://github.com/libp2p/rust-libp2p/pull/3238
+[PR 3307]: https://github.com/libp2p/rust-libp2p/pull/3307
 [discussion 2174]: https://github.com/libp2p/rust-libp2p/issues/2174
 
 # 0.14.0

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -10,8 +10,7 @@
 - Update to `libp2p-core` `v0.39.0`.
 
 - Update to `libp2p-swarm` `v0.42.0`. Update to the `libp2p_swarm::handler::ConnectionEvent` `DialTimeout` introduction and consequential changes.
-  With that introduce `Event::CircuitReqOutboundConnectTimedOut` and `client::Event::ReservationReqTimedOut`
-  and `client::Event::OutboundCircuitReqTimedOut`. See [PR XXXX].
+  With that introduce `behaviour::OutboundError` and `client::InboundError`. See [PR XXXX].
 
 
 [PR 3238]: https://github.com/libp2p/rust-libp2p/pull/3238

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -10,7 +10,8 @@
 - Update to `libp2p-core` `v0.39.0`.
 
 - Update to `libp2p-swarm` `v0.42.0`. Update to the `libp2p_swarm::handler::ConnectionEvent` `DialTimeout` introduction and consequential changes.
-  With that introduce `behaviour::OutboundError` and `client::InboundError`. See [PR XXXX].
+  With that introduce `behaviour::OutboundError` and `client::InboundError`.
+  Remove unneeded `inbound_hop::UpgradeError` as all `inbound_hop` upgrade errors are Fatal. See [PR 3307].
 
 
 [PR 3238]: https://github.com/libp2p/rust-libp2p/pull/3238

--- a/protocols/relay/src/behaviour.rs
+++ b/protocols/relay/src/behaviour.rs
@@ -136,14 +136,14 @@ pub enum Event {
     /// Accepting an inbound reservation request failed.
     ReservationReqAcceptFailed {
         src_peer_id: PeerId,
-        error: inbound_hop::UpgradeError,
+        error: inbound_hop::FatalUpgradeError,
     },
     /// An inbound reservation request has been denied.
     ReservationReqDenied { src_peer_id: PeerId },
     /// Denying an inbound reservation request has failed.
     ReservationReqDenyFailed {
         src_peer_id: PeerId,
-        error: inbound_hop::UpgradeError,
+        error: inbound_hop::FatalUpgradeError,
     },
     /// An inbound reservation has timed out.
     ReservationTimedOut { src_peer_id: PeerId },
@@ -160,7 +160,7 @@ pub enum Event {
     CircuitReqDenyFailed {
         src_peer_id: PeerId,
         dst_peer_id: PeerId,
-        error: inbound_hop::UpgradeError,
+        error: inbound_hop::FatalUpgradeError,
     },
     /// An inbound cirucit request has been accepted.
     CircuitReqAccepted {
@@ -177,7 +177,7 @@ pub enum Event {
     CircuitReqAcceptFailed {
         src_peer_id: PeerId,
         dst_peer_id: PeerId,
-        error: inbound_hop::UpgradeError,
+        error: inbound_hop::FatalUpgradeError,
     },
     /// An inbound circuit has closed.
     CircuitClosed {

--- a/protocols/relay/src/behaviour/handler.rs
+++ b/protocols/relay/src/behaviour/handler.rs
@@ -503,7 +503,6 @@ impl Handler {
     ) {
         let non_fatal_error = match error {
             ConnectionHandlerUpgrErr::Timeout => ConnectionHandlerUpgrErr::Timeout,
-            ConnectionHandlerUpgrErr::Timer => ConnectionHandlerUpgrErr::Timer,
             ConnectionHandlerUpgrErr::Upgrade(upgrade::UpgradeError::Select(
                 upgrade::NegotiationError::Failed,
             )) => ConnectionHandlerUpgrErr::Upgrade(upgrade::UpgradeError::Select(
@@ -547,9 +546,6 @@ impl Handler {
         let (non_fatal_error, status) = match error {
             ConnectionHandlerUpgrErr::Timeout => {
                 (ConnectionHandlerUpgrErr::Timeout, Status::ConnectionFailed)
-            }
-            ConnectionHandlerUpgrErr::Timer => {
-                (ConnectionHandlerUpgrErr::Timer, Status::ConnectionFailed)
             }
             ConnectionHandlerUpgrErr::Upgrade(upgrade::UpgradeError::Select(
                 upgrade::NegotiationError::Failed,

--- a/protocols/relay/src/lib.rs
+++ b/protocols/relay/src/lib.rs
@@ -59,7 +59,9 @@ pub mod outbound {
 
 /// Everything related to the relay protocol from a client's perspective.
 pub mod client {
-    pub use crate::priv_client::{new, transport::Transport, Behaviour, Connection, Event};
+    pub use crate::priv_client::{
+        new, transport::Transport, Behaviour, Connection, Event, InboundError,
+    };
 
     pub mod transport {
         pub use crate::priv_client::transport::Error;

--- a/protocols/relay/src/priv_client/handler.rs
+++ b/protocols/relay/src/priv_client/handler.rs
@@ -348,7 +348,6 @@ impl Handler {
     ) {
         let non_fatal_error = match error {
             ConnectionHandlerUpgrErr::Timeout => ConnectionHandlerUpgrErr::Timeout,
-            ConnectionHandlerUpgrErr::Timer => ConnectionHandlerUpgrErr::Timer,
             ConnectionHandlerUpgrErr::Upgrade(upgrade::UpgradeError::Select(
                 upgrade::NegotiationError::Failed,
             )) => ConnectionHandlerUpgrErr::Upgrade(upgrade::UpgradeError::Select(
@@ -393,7 +392,6 @@ impl Handler {
             OutboundOpenInfo::Reserve { mut to_listener } => {
                 let non_fatal_error = match error {
                     ConnectionHandlerUpgrErr::Timeout => ConnectionHandlerUpgrErr::Timeout,
-                    ConnectionHandlerUpgrErr::Timer => ConnectionHandlerUpgrErr::Timer,
                     ConnectionHandlerUpgrErr::Upgrade(upgrade::UpgradeError::Select(
                         upgrade::NegotiationError::Failed,
                     )) => ConnectionHandlerUpgrErr::Upgrade(upgrade::UpgradeError::Select(
@@ -456,7 +454,6 @@ impl Handler {
             OutboundOpenInfo::Connect { send_back } => {
                 let non_fatal_error = match error {
                     ConnectionHandlerUpgrErr::Timeout => ConnectionHandlerUpgrErr::Timeout,
-                    ConnectionHandlerUpgrErr::Timer => ConnectionHandlerUpgrErr::Timer,
                     ConnectionHandlerUpgrErr::Upgrade(upgrade::UpgradeError::Select(
                         upgrade::NegotiationError::Failed,
                     )) => ConnectionHandlerUpgrErr::Upgrade(upgrade::UpgradeError::Select(

--- a/protocols/rendezvous/CHANGELOG.md
+++ b/protocols/rendezvous/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 - Update to `libp2p-core` `v0.39.0`.
 
-- Update to `libp2p-swarm` `v0.42.0`.
+- Update to `libp2p-swarm` `v0.42.0`. Update to the `libp2p_swarm::handler::ConnectionEvent` `DialTimeout`
+  introduction and consequential changes. See [PR 3307].
+
+[PR 3307]: https://github.com/libp2p/rust-libp2p/pull/3307
 
 # 0.11.0
 

--- a/protocols/rendezvous/src/substream_handler.rs
+++ b/protocols/rendezvous/src/substream_handler.rs
@@ -396,6 +396,7 @@ where
             // TODO: Handle upgrade errors properly
             ConnectionEvent::AddressChange(_)
             | ConnectionEvent::ListenUpgradeError(_)
+            | ConnectionEvent::DialTimeout(_)
             | ConnectionEvent::DialUpgradeError(_) => {}
         }
     }

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -9,10 +9,12 @@
   and refer to its types via `request_response::`. For example: `request_response::Behaviour` or `request_response::Event`.
   See [PR 3159].
 
-- Update to `libp2p-swarm` `v0.42.0`.
+- Update to `libp2p-swarm` `v0.42.0`. Update to the `libp2p_swarm::handler::ConnectionEvent` `DialTimeout`
+  introduction and consequential changes. See [PR 3307].
 
 [discussion 2174]: https://github.com/libp2p/rust-libp2p/discussions/2174
 [PR 3159]: https://github.com/libp2p/rust-libp2p/pull/3159
+[PR 3307]: https://github.com/libp2p/rust-libp2p/pull/3307
 
 # 0.23.0
 

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Remove uncontructed variant `Timer` from `ConnectionHandlerUpgrErr`.
   Make `ListenUpgradeError::error` an `UpgradeError` instead of `ConnectionHandlerUpgrErr`, in case of timeout expiration we
   just log the error as we don't know which ConnectionHandler should handle the error.
+  Make `DialUpgradeError::error` an `UpgradeError` instead of `ConnectionHandlerUpgrErr`, and introduce `ConnectionEvent::DialTimeout`
+  for the situations where that upgrading an outbound substream to the given protocol has expired its timeout.
+  See [PR 3307]
 
 - Update to `libp2p-core` `v0.39.0`.
 
@@ -24,6 +27,7 @@
 [PR 3153]: https://github.com/libp2p/rust-libp2p/pull/3153
 [PR 3260]: https://github.com/libp2p/rust-libp2p/pull/3260
 [PR 3272]: https://github.com/libp2p/rust-libp2p/pull/3272
+[PR 3307]: https://github.com/libp2p/rust-libp2p/pull/3307
 
 # 0.41.1
 

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 0.42.0 [unreleased]
 
 - Remove uncontructed variant `Timer` from `ConnectionHandlerUpgrErr`.
+  Make `ListenUpgradeError::error` an `UpgradeError` instead of `ConnectionHandlerUpgrErr`, in case of timeout expiration we
+  just log the error as we don't know which ConnectionHandler should handle the error.
 
 - Update to `libp2p-core` `v0.39.0`.
 

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.42.0 [unreleased]
 
+- Remove uncontructed variant `Timer` from `ConnectionHandlerUpgrErr`.
+
 - Update to `libp2p-core` `v0.39.0`.
 
 - Removed deprecated Swarm constructors. For transition notes see [0.41.0](#0.41.0). See [PR 3170].

--- a/swarm/src/behaviour/toggle.rs
+++ b/swarm/src/behaviour/toggle.rs
@@ -212,7 +212,6 @@ where
 
         let err = match err {
             ConnectionHandlerUpgrErr::Timeout => ConnectionHandlerUpgrErr::Timeout,
-            ConnectionHandlerUpgrErr::Timer => ConnectionHandlerUpgrErr::Timer,
             ConnectionHandlerUpgrErr::Upgrade(err) => {
                 ConnectionHandlerUpgrErr::Upgrade(err.map_err(|err| match err {
                     EitherError::A(e) => e,

--- a/swarm/src/behaviour/toggle.rs
+++ b/swarm/src/behaviour/toggle.rs
@@ -20,9 +20,9 @@
 
 use crate::behaviour::FromSwarm;
 use crate::handler::{
-    AddressChange, ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent,
-    ConnectionHandlerUpgrErr, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
-    IntoConnectionHandler, KeepAlive, ListenUpgradeError, SubstreamProtocol,
+    AddressChange, ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, DialUpgradeError,
+    FullyNegotiatedInbound, FullyNegotiatedOutbound, IntoConnectionHandler, KeepAlive,
+    ListenUpgradeError, SubstreamProtocol,
 };
 use crate::upgrade::SendWrapper;
 use crate::{NetworkBehaviour, NetworkBehaviourAction, PollParameters};
@@ -210,19 +210,12 @@ where
             ),
         };
 
-        let err = match err {
-            ConnectionHandlerUpgrErr::Timeout => ConnectionHandlerUpgrErr::Timeout,
-            ConnectionHandlerUpgrErr::Upgrade(err) => {
-                ConnectionHandlerUpgrErr::Upgrade(err.map_err(|err| match err {
-                    EitherError::A(e) => e,
-                    EitherError::B(v) => void::unreachable(v),
-                }))
-            }
-        };
-
         inner.on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
             info,
-            error: err,
+            error: err.map_err(|err| match err {
+                EitherError::A(e) => e,
+                EitherError::B(v) => void::unreachable(v),
+            }),
         }));
     }
 }

--- a/swarm/src/connection.rs
+++ b/swarm/src/connection.rs
@@ -239,12 +239,17 @@ where
                     ));
                     continue;
                 }
-                Poll::Ready(Some((info, Err(error)))) => {
-                    handler.on_connection_event(ConnectionEvent::ListenUpgradeError(
-                        ListenUpgradeError { info, error },
-                    ));
-                    continue;
-                }
+                Poll::Ready(Some((info, Err(error)))) => match error {
+                    ConnectionHandlerUpgrErr::Upgrade(error) => {
+                        handler.on_connection_event(ConnectionEvent::ListenUpgradeError(
+                            ListenUpgradeError { info, error },
+                        ));
+                        continue;
+                    }
+                    ConnectionHandlerUpgrErr::Timeout => {
+                        log::debug!("Timeout expired during an inbound substream negotiation")
+                    }
+                },
             }
 
             // Ask the handler whether it wants the connection (and the handler itself)

--- a/swarm/src/dummy.rs
+++ b/swarm/src/dummy.rs
@@ -108,7 +108,6 @@ impl crate::handler::ConnectionHandler for ConnectionHandler {
             }) => void::unreachable(protocol),
             ConnectionEvent::DialUpgradeError(DialUpgradeError { info: _, error }) => match error {
                 ConnectionHandlerUpgrErr::Timeout => unreachable!(),
-                ConnectionHandlerUpgrErr::Timer => unreachable!(),
                 ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(e)) => void::unreachable(e),
                 ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(_)) => {
                     unreachable!("Denied upgrade does not support any protocols")

--- a/swarm/src/dummy.rs
+++ b/swarm/src/dummy.rs
@@ -2,7 +2,7 @@ use crate::behaviour::{FromSwarm, NetworkBehaviour, NetworkBehaviourAction, Poll
 use crate::handler::{
     ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
 };
-use crate::{ConnectionHandlerEvent, ConnectionHandlerUpgrErr, KeepAlive, SubstreamProtocol};
+use crate::{ConnectionHandlerEvent, KeepAlive, SubstreamProtocol};
 use libp2p_core::connection::ConnectionId;
 use libp2p_core::upgrade::DeniedUpgrade;
 use libp2p_core::PeerId;
@@ -106,10 +106,10 @@ impl crate::handler::ConnectionHandler for ConnectionHandler {
             ConnectionEvent::FullyNegotiatedOutbound(FullyNegotiatedOutbound {
                 protocol, ..
             }) => void::unreachable(protocol),
+            ConnectionEvent::DialTimeout(_) => unreachable!(),
             ConnectionEvent::DialUpgradeError(DialUpgradeError { info: _, error }) => match error {
-                ConnectionHandlerUpgrErr::Timeout => unreachable!(),
-                ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(e)) => void::unreachable(e),
-                ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(_)) => {
+                UpgradeError::Apply(e) => void::unreachable(e),
+                UpgradeError::Select(_) => {
                     unreachable!("Denied upgrade does not support any protocols")
                 }
             },

--- a/swarm/src/handler.rs
+++ b/swarm/src/handler.rs
@@ -249,7 +249,7 @@ pub struct DialUpgradeError<OOI, OP: OutboundUpgradeSend> {
 /// that upgrading an inbound substream to the given protocol has failed.
 pub struct ListenUpgradeError<IOI, IP: InboundUpgradeSend> {
     pub info: IOI,
-    pub error: ConnectionHandlerUpgrErr<IP::Error>,
+    pub error: UpgradeError<IP::Error>,
 }
 
 /// Configuration of inbound or outbound substream protocol(s)

--- a/swarm/src/handler.rs
+++ b/swarm/src/handler.rs
@@ -435,8 +435,6 @@ impl<TConnectionUpgrade, TOutboundOpenInfo, TCustom, TErr>
 pub enum ConnectionHandlerUpgrErr<TUpgrErr> {
     /// The opening attempt timed out before the negotiation was fully completed.
     Timeout,
-    /// There was an error in the timer used.
-    Timer,
     /// Error while upgrading the substream to the protocol we want.
     Upgrade(UpgradeError<TUpgrErr>),
 }
@@ -449,7 +447,6 @@ impl<TUpgrErr> ConnectionHandlerUpgrErr<TUpgrErr> {
     {
         match self {
             ConnectionHandlerUpgrErr::Timeout => ConnectionHandlerUpgrErr::Timeout,
-            ConnectionHandlerUpgrErr::Timer => ConnectionHandlerUpgrErr::Timer,
             ConnectionHandlerUpgrErr::Upgrade(e) => ConnectionHandlerUpgrErr::Upgrade(f(e)),
         }
     }
@@ -464,9 +461,6 @@ where
             ConnectionHandlerUpgrErr::Timeout => {
                 write!(f, "Timeout error while opening a substream")
             }
-            ConnectionHandlerUpgrErr::Timer => {
-                write!(f, "Timer error while opening a substream")
-            }
             ConnectionHandlerUpgrErr::Upgrade(err) => write!(f, "{err}"),
         }
     }
@@ -479,7 +473,6 @@ where
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             ConnectionHandlerUpgrErr::Timeout => None,
-            ConnectionHandlerUpgrErr::Timer => None,
             ConnectionHandlerUpgrErr::Upgrade(err) => Some(err),
         }
     }

--- a/swarm/src/handler.rs
+++ b/swarm/src/handler.rs
@@ -207,6 +207,8 @@ pub enum ConnectionEvent<'a, IP: InboundUpgradeSend, OP: OutboundUpgradeSend, IO
     AddressChange(AddressChange<'a>),
     /// Informs the handler that upgrading an outbound substream to the given protocol has failed.
     DialUpgradeError(DialUpgradeError<OOI, OP>),
+    /// Informs the handler that upgrading an outbound substream to the given protocol has expired its timeout.
+    DialTimeout(DialTimeout<OOI>),
     /// Informs the handler that upgrading an inbound substream to the given protocol has failed.
     ListenUpgradeError(ListenUpgradeError<IOI, IP>),
 }
@@ -242,7 +244,13 @@ pub struct AddressChange<'a> {
 /// that upgrading an outbound substream to the given protocol has failed.
 pub struct DialUpgradeError<OOI, OP: OutboundUpgradeSend> {
     pub info: OOI,
-    pub error: ConnectionHandlerUpgrErr<OP::Error>,
+    pub error: UpgradeError<OP::Error>,
+}
+
+/// [`ConnectionEvent`] variant that informs the handler
+/// that upgrading an outbound substream has expired its timeout.
+pub struct DialTimeout<OOI> {
+    pub info: OOI,
 }
 
 /// [`ConnectionEvent`] variant that informs the handler

--- a/swarm/src/handler/either.rs
+++ b/swarm/src/handler/either.rs
@@ -179,24 +179,6 @@ where
                 },
             ))),
             ConnectionEvent::DialUpgradeError(DialUpgradeError {
-                error: ConnectionHandlerUpgrErr::Timer,
-                info: Either::Left(info),
-            }) => Ok(Either::Left(ConnectionEvent::DialUpgradeError(
-                DialUpgradeError {
-                    error: ConnectionHandlerUpgrErr::Timer,
-                    info,
-                },
-            ))),
-            ConnectionEvent::DialUpgradeError(DialUpgradeError {
-                error: ConnectionHandlerUpgrErr::Timer,
-                info: Either::Right(info),
-            }) => Ok(Either::Right(ConnectionEvent::DialUpgradeError(
-                DialUpgradeError {
-                    error: ConnectionHandlerUpgrErr::Timer,
-                    info,
-                },
-            ))),
-            ConnectionEvent::DialUpgradeError(DialUpgradeError {
                 error: ConnectionHandlerUpgrErr::Timeout,
                 info: Either::Left(info),
             }) => Ok(Either::Left(ConnectionEvent::DialUpgradeError(
@@ -247,24 +229,6 @@ where
             }) => Ok(Either::Right(ConnectionEvent::ListenUpgradeError(
                 ListenUpgradeError {
                     error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(error)),
-                    info,
-                },
-            ))),
-            ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
-                error: ConnectionHandlerUpgrErr::Timer,
-                info: Either::Left(info),
-            }) => Ok(Either::Left(ConnectionEvent::ListenUpgradeError(
-                ListenUpgradeError {
-                    error: ConnectionHandlerUpgrErr::Timer,
-                    info,
-                },
-            ))),
-            ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
-                error: ConnectionHandlerUpgrErr::Timer,
-                info: Either::Right(info),
-            }) => Ok(Either::Right(ConnectionEvent::ListenUpgradeError(
-                ListenUpgradeError {
-                    error: ConnectionHandlerUpgrErr::Timer,
                     info,
                 },
             ))),

--- a/swarm/src/handler/either.rs
+++ b/swarm/src/handler/either.rs
@@ -19,9 +19,9 @@
 // DEALINGS IN THE SOFTWARE.
 
 use crate::handler::{
-    ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, ConnectionHandlerUpgrErr,
-    DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound, InboundUpgradeSend,
-    IntoConnectionHandler, KeepAlive, ListenUpgradeError, OutboundUpgradeSend, SubstreamProtocol,
+    ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, DialTimeout, DialUpgradeError,
+    FullyNegotiatedInbound, FullyNegotiatedOutbound, InboundUpgradeSend, IntoConnectionHandler,
+    KeepAlive, ListenUpgradeError, OutboundUpgradeSend, SubstreamProtocol,
 };
 use crate::upgrade::SendWrapper;
 use either::Either;
@@ -143,59 +143,51 @@ where
                 FullyNegotiatedOutbound { protocol, info },
             ))),
             ConnectionEvent::DialUpgradeError(DialUpgradeError {
-                error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(EitherError::A(error))),
+                error: UpgradeError::Apply(EitherError::A(error)),
                 info: Either::Left(info),
             }) => Ok(Either::Left(ConnectionEvent::DialUpgradeError(
                 DialUpgradeError {
-                    error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(error)),
+                    error: UpgradeError::Apply(error),
                     info,
                 },
             ))),
             ConnectionEvent::DialUpgradeError(DialUpgradeError {
-                error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(EitherError::B(error))),
+                error: UpgradeError::Apply(EitherError::B(error)),
                 info: Either::Right(info),
             }) => Ok(Either::Right(ConnectionEvent::DialUpgradeError(
                 DialUpgradeError {
-                    error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(error)),
+                    error: UpgradeError::Apply(error),
                     info,
                 },
             ))),
             ConnectionEvent::DialUpgradeError(DialUpgradeError {
-                error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(error)),
+                error: UpgradeError::Select(error),
                 info: Either::Left(info),
             }) => Ok(Either::Left(ConnectionEvent::DialUpgradeError(
                 DialUpgradeError {
-                    error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(error)),
+                    error: UpgradeError::Select(error),
                     info,
                 },
             ))),
             ConnectionEvent::DialUpgradeError(DialUpgradeError {
-                error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(error)),
+                error: UpgradeError::Select(error),
                 info: Either::Right(info),
             }) => Ok(Either::Right(ConnectionEvent::DialUpgradeError(
                 DialUpgradeError {
-                    error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(error)),
+                    error: UpgradeError::Select(error),
                     info,
                 },
             ))),
-            ConnectionEvent::DialUpgradeError(DialUpgradeError {
-                error: ConnectionHandlerUpgrErr::Timeout,
+            ConnectionEvent::DialTimeout(DialTimeout {
                 info: Either::Left(info),
-            }) => Ok(Either::Left(ConnectionEvent::DialUpgradeError(
-                DialUpgradeError {
-                    error: ConnectionHandlerUpgrErr::Timeout,
-                    info,
-                },
-            ))),
-            ConnectionEvent::DialUpgradeError(DialUpgradeError {
-                error: ConnectionHandlerUpgrErr::Timeout,
+            }) => Ok(Either::Left(ConnectionEvent::DialTimeout(DialTimeout {
+                info,
+            }))),
+            ConnectionEvent::DialTimeout(DialTimeout {
                 info: Either::Right(info),
-            }) => Ok(Either::Right(ConnectionEvent::DialUpgradeError(
-                DialUpgradeError {
-                    error: ConnectionHandlerUpgrErr::Timeout,
-                    info,
-                },
-            ))),
+            }) => Ok(Either::Right(ConnectionEvent::DialTimeout(DialTimeout {
+                info,
+            }))),
             ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
                 error: UpgradeError::Apply(EitherError::A(error)),
                 info: Either::Left(info),

--- a/swarm/src/handler/either.rs
+++ b/swarm/src/handler/either.rs
@@ -197,56 +197,38 @@ where
                 },
             ))),
             ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
-                error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(EitherError::A(error))),
+                error: UpgradeError::Apply(EitherError::A(error)),
                 info: Either::Left(info),
             }) => Ok(Either::Left(ConnectionEvent::ListenUpgradeError(
                 ListenUpgradeError {
-                    error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(error)),
+                    error: UpgradeError::Apply(error),
                     info,
                 },
             ))),
             ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
-                error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(EitherError::B(error))),
+                error: UpgradeError::Apply(EitherError::B(error)),
                 info: Either::Right(info),
             }) => Ok(Either::Right(ConnectionEvent::ListenUpgradeError(
                 ListenUpgradeError {
-                    error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(error)),
+                    error: UpgradeError::Apply(error),
                     info,
                 },
             ))),
             ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
-                error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(error)),
+                error: UpgradeError::Select(error),
                 info: Either::Left(info),
             }) => Ok(Either::Left(ConnectionEvent::ListenUpgradeError(
                 ListenUpgradeError {
-                    error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(error)),
+                    error: UpgradeError::Select(error),
                     info,
                 },
             ))),
             ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
-                error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(error)),
+                error: UpgradeError::Select(error),
                 info: Either::Right(info),
             }) => Ok(Either::Right(ConnectionEvent::ListenUpgradeError(
                 ListenUpgradeError {
-                    error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(error)),
-                    info,
-                },
-            ))),
-            ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
-                error: ConnectionHandlerUpgrErr::Timeout,
-                info: Either::Left(info),
-            }) => Ok(Either::Left(ConnectionEvent::ListenUpgradeError(
-                ListenUpgradeError {
-                    error: ConnectionHandlerUpgrErr::Timeout,
-                    info,
-                },
-            ))),
-            ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
-                error: ConnectionHandlerUpgrErr::Timeout,
-                info: Either::Right(info),
-            }) => Ok(Either::Right(ConnectionEvent::ListenUpgradeError(
-                ListenUpgradeError {
-                    error: ConnectionHandlerUpgrErr::Timeout,
+                    error: UpgradeError::Select(error),
                     info,
                 },
             ))),

--- a/swarm/src/handler/multi.rs
+++ b/swarm/src/handler/multi.rs
@@ -92,18 +92,6 @@ where
         >,
     ) {
         match error {
-            ConnectionHandlerUpgrErr::Timer => {
-                for (k, h) in &mut self.handlers {
-                    if let Some(i) = info.take(k) {
-                        h.on_connection_event(ConnectionEvent::ListenUpgradeError(
-                            ListenUpgradeError {
-                                info: i,
-                                error: ConnectionHandlerUpgrErr::Timer,
-                            },
-                        ));
-                    }
-                }
-            }
             ConnectionHandlerUpgrErr::Timeout => {
                 for (k, h) in &mut self.handlers {
                     if let Some(i) = info.take(k) {

--- a/swarm/src/handler/multi.rs
+++ b/swarm/src/handler/multi.rs
@@ -22,9 +22,9 @@
 //! indexed by some key.
 
 use crate::handler::{
-    AddressChange, ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, DialUpgradeError,
-    FullyNegotiatedInbound, FullyNegotiatedOutbound, IntoConnectionHandler, KeepAlive,
-    ListenUpgradeError, SubstreamProtocol,
+    AddressChange, ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, DialTimeout,
+    DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound, IntoConnectionHandler,
+    KeepAlive, ListenUpgradeError, SubstreamProtocol,
 };
 use crate::upgrade::{InboundUpgradeSend, OutboundUpgradeSend, UpgradeInfoSend};
 use crate::NegotiatedSubstream;
@@ -274,6 +274,13 @@ where
                     }));
                 } else {
                     log::error!("DialUpgradeError: no handler for protocol")
+                }
+            }
+            ConnectionEvent::DialTimeout(DialTimeout { info: (key, arg) }) => {
+                if let Some(h) = self.handlers.get_mut(&key) {
+                    h.on_connection_event(ConnectionEvent::DialTimeout(DialTimeout { info: arg }));
+                } else {
+                    log::error!("DialTimeout: no handler for protocol")
                 }
             }
             ConnectionEvent::ListenUpgradeError(listen_upgrade_error) => {

--- a/swarm/src/handler/one_shot.rs
+++ b/swarm/src/handler/one_shot.rs
@@ -213,7 +213,12 @@ where
             }
             ConnectionEvent::DialUpgradeError(DialUpgradeError { error, .. }) => {
                 if self.pending_error.is_none() {
-                    self.pending_error = Some(error);
+                    self.pending_error = Some(ConnectionHandlerUpgrErr::Upgrade(error));
+                }
+            }
+            ConnectionEvent::DialTimeout(_) => {
+                if self.pending_error.is_none() {
+                    self.pending_error = Some(ConnectionHandlerUpgrErr::Timeout)
                 }
             }
             ConnectionEvent::AddressChange(_) | ConnectionEvent::ListenUpgradeError(_) => {}

--- a/swarm/src/handler/pending.rs
+++ b/swarm/src/handler/pending.rs
@@ -99,6 +99,7 @@ impl ConnectionHandler for PendingConnectionHandler {
             }
             ConnectionEvent::AddressChange(_)
             | ConnectionEvent::DialUpgradeError(_)
+            | ConnectionEvent::DialTimeout(_)
             | ConnectionEvent::ListenUpgradeError(_) => {}
         }
     }

--- a/swarm/src/handler/select.rs
+++ b/swarm/src/handler/select.rs
@@ -226,39 +226,20 @@ where
         >,
     ) {
         match error {
-            ConnectionHandlerUpgrErr::Timeout => {
+            UpgradeError::Select(NegotiationError::Failed) => {
                 self.proto1
                     .on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
                         info: i1,
-                        error: ConnectionHandlerUpgrErr::Timeout,
+                        error: UpgradeError::Select(NegotiationError::Failed),
                     }));
 
                 self.proto2
                     .on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
                         info: i2,
-                        error: ConnectionHandlerUpgrErr::Timeout,
+                        error: UpgradeError::Select(NegotiationError::Failed),
                     }));
             }
-            ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(NegotiationError::Failed)) => {
-                self.proto1
-                    .on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
-                        info: i1,
-                        error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(
-                            NegotiationError::Failed,
-                        )),
-                    }));
-
-                self.proto2
-                    .on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
-                        info: i2,
-                        error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(
-                            NegotiationError::Failed,
-                        )),
-                    }));
-            }
-            ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(
-                NegotiationError::ProtocolError(e),
-            )) => {
+            UpgradeError::Select(NegotiationError::ProtocolError(e)) => {
                 let (e1, e2);
                 match e {
                     ProtocolError::IoError(e) => {
@@ -283,26 +264,26 @@ where
                 self.proto1
                     .on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
                         info: i1,
-                        error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(e1)),
+                        error: UpgradeError::Select(e1),
                     }));
                 self.proto2
                     .on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
                         info: i2,
-                        error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(e2)),
+                        error: UpgradeError::Select(e2),
                     }));
             }
-            ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(EitherError::A(e))) => {
+            UpgradeError::Apply(EitherError::A(e)) => {
                 self.proto1
                     .on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
                         info: i1,
-                        error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(e)),
+                        error: UpgradeError::Apply(e),
                     }));
             }
-            ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(EitherError::B(e))) => {
+            UpgradeError::Apply(EitherError::B(e)) => {
                 self.proto2
                     .on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
                         info: i2,
-                        error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(e)),
+                        error: UpgradeError::Apply(e),
                     }));
             }
         }

--- a/swarm/src/handler/select.rs
+++ b/swarm/src/handler/select.rs
@@ -165,13 +165,6 @@ where
         match self {
             DialUpgradeError {
                 info: EitherOutput::First(info),
-                error: ConnectionHandlerUpgrErr::Timer,
-            } => Either::Left(DialUpgradeError {
-                info,
-                error: ConnectionHandlerUpgrErr::Timer,
-            }),
-            DialUpgradeError {
-                info: EitherOutput::First(info),
                 error: ConnectionHandlerUpgrErr::Timeout,
             } => Either::Left(DialUpgradeError {
                 info,
@@ -190,13 +183,6 @@ where
             } => Either::Left(DialUpgradeError {
                 info,
                 error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(err)),
-            }),
-            DialUpgradeError {
-                info: EitherOutput::Second(info),
-                error: ConnectionHandlerUpgrErr::Timer,
-            } => Either::Right(DialUpgradeError {
-                info,
-                error: ConnectionHandlerUpgrErr::Timer,
             }),
             DialUpgradeError {
                 info: EitherOutput::Second(info),
@@ -240,19 +226,6 @@ where
         >,
     ) {
         match error {
-            ConnectionHandlerUpgrErr::Timer => {
-                self.proto1
-                    .on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
-                        info: i1,
-                        error: ConnectionHandlerUpgrErr::Timer,
-                    }));
-
-                self.proto2
-                    .on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
-                        info: i2,
-                        error: ConnectionHandlerUpgrErr::Timer,
-                    }));
-            }
             ConnectionHandlerUpgrErr::Timeout => {
                 self.proto1
                     .on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {

--- a/swarm/src/keep_alive.rs
+++ b/swarm/src/keep_alive.rs
@@ -112,6 +112,7 @@ impl crate::handler::ConnectionHandler for ConnectionHandler {
                 protocol, ..
             }) => void::unreachable(protocol),
             ConnectionEvent::DialUpgradeError(_)
+            | ConnectionEvent::DialTimeout(_)
             | ConnectionEvent::ListenUpgradeError(_)
             | ConnectionEvent::AddressChange(_) => {}
         }

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -113,10 +113,13 @@ pub use connection::{
 };
 pub use executor::Executor;
 pub use handler::{
-    ConnectionHandler, ConnectionHandlerEvent, ConnectionHandlerSelect, ConnectionHandlerUpgrErr,
-    IntoConnectionHandler, IntoConnectionHandlerSelect, KeepAlive, OneShotHandler,
-    OneShotHandlerConfig, SubstreamProtocol,
+    ConnectionHandler, ConnectionHandlerEvent, ConnectionHandlerSelect, IntoConnectionHandler,
+    IntoConnectionHandlerSelect, KeepAlive, OneShotHandler, OneShotHandlerConfig,
+    SubstreamProtocol,
 };
+
+#[deprecated(since = "0.42.0", note = "Shouldn't be required by end users")]
+pub type ConnectionHandlerUpgrErr<TUpgrErr> = handler::ConnectionHandlerUpgrErr<TUpgrErr>;
 #[cfg(feature = "macros")]
 pub use libp2p_swarm_derive::NetworkBehaviour;
 pub use registry::{AddAddressResult, AddressRecord, AddressScore};


### PR DESCRIPTION
## Description

Addresses #2894

## Notes

In the protocols, moved the `TimedOut` variants from nested `UpgradeError`'s to `Event` variants themselves. Like `identify` `dcutr` and `relay`. 
**Per commit review is suggested.**

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
