### PR TITLE
remove usage of Code::Identity in core/src/peer_id.rs

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.39.0
+
+- Remove usage of identity multihash, as it's being deprecated upstream. See [PR 3311]
+
+[PR 3311]: https://github.com/libp2p/rust-libp2p/pull/3311
+
 # 0.38.0
 
 - Remove deprecated functions `StreamMuxerExt::next_{inbound,outbound}`. See [PR 3031].


### PR DESCRIPTION
## Description

Remove usage of Code::Identity in core/src/peer_id.rs, to fix #3276.

## Links to any relevant issues

 #3276

## Open Questions

I'm unsure how to test this change thoroughly. I couldn't get `cargo test` to compile, even on the master branch.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
