### PR TITLE
fix(gossipsub): allow clippy beta lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,10 +178,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - rust-version: stable
-          - rust-version: beta
-            rustflags: "-A clippy::unchecked_duration_subtraction"
+        rust-version: [
+          stable,
+          beta
+        ]
     steps:
       - name: Install Protoc
         run: sudo apt-get install protobuf-compiler
@@ -203,8 +203,6 @@ jobs:
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: custom-clippy # cargo alias to allow reuse of config locally
-        env:
-          RUSTFLAGS: ${{ matrix.rustflags }}
 
   ipfs-integration-test:
     name: IPFS Integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,9 @@ jobs:
           stable,
           beta
         ]
+        include:
+            rust-version: beta
+            rustflags: "-A clippy::unchecked_duration_subtraction"
     steps:
       - name: Install Protoc
         run: sudo apt-get install protobuf-compiler
@@ -203,6 +206,8 @@ jobs:
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: custom-clippy # cargo alias to allow reuse of config locally
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
 
   ipfs-integration-test:
     name: IPFS Integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,12 +178,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust-version: [
-          stable,
-          beta
-        ]
         include:
-            rust-version: beta
+          - rust-version: stable
+          - rust-version: beta
             rustflags: "-A clippy::unchecked_duration_subtraction"
     steps:
       - name: Install Protoc

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1416,6 +1416,7 @@ where
                                 peer_score.add_penalty(peer_id, 1);
 
                                 // check the flood cutoff
+								#[allow(clippy::unchecked_duration_subtraction)] // False-positive: https://github.com/rust-lang/rust-clippy/issues/10061
                                 let flood_cutoff = (backoff_time
                                     + self.config.graft_flood_threshold())
                                     - self.config.prune_backoff();

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1416,6 +1416,8 @@ where
                                 peer_score.add_penalty(peer_id, 1);
 
                                 // check the flood cutoff
+                                // See: https://github.com/rust-lang/rust-clippy/issues/10061
+								#[allow(clippy::unchecked_duration_subtraction, unknown_lints)]
                                 let flood_cutoff = (backoff_time
                                     + self.config.graft_flood_threshold())
                                     - self.config.prune_backoff();

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1417,7 +1417,7 @@ where
 
                                 // check the flood cutoff
                                 // See: https://github.com/rust-lang/rust-clippy/issues/10061
-								#[allow(clippy::unchecked_duration_subtraction, unknown_lints)]
+								#[allow(unknown_lints, clippy::unchecked_duration_subtraction)]
                                 let flood_cutoff = (backoff_time
                                     + self.config.graft_flood_threshold())
                                     - self.config.prune_backoff();

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1416,7 +1416,8 @@ where
                                 peer_score.add_penalty(peer_id, 1);
 
                                 // check the flood cutoff
-								#[allow(clippy::unchecked_duration_subtraction)] // False-positive: https://github.com/rust-lang/rust-clippy/issues/10061
+                                // False-positive: https://github.com/rust-lang/rust-clippy/issues/10061
+                                #[allow(clippy::unchecked_duration_subtraction)]
                                 let flood_cutoff = (backoff_time
                                     + self.config.graft_flood_threshold())
                                     - self.config.prune_backoff();

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1416,8 +1416,6 @@ where
                                 peer_score.add_penalty(peer_id, 1);
 
                                 // check the flood cutoff
-                                // False-positive: https://github.com/rust-lang/rust-clippy/issues/10061
-                                #[allow(clippy::unchecked_duration_subtraction)]
                                 let flood_cutoff = (backoff_time
                                     + self.config.graft_flood_threshold())
                                     - self.config.prune_backoff();

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1417,7 +1417,7 @@ where
 
                                 // check the flood cutoff
                                 // See: https://github.com/rust-lang/rust-clippy/issues/10061
-								#[allow(unknown_lints, clippy::unchecked_duration_subtraction)]
+                                #[allow(unknown_lints, clippy::unchecked_duration_subtraction)]
                                 let flood_cutoff = (backoff_time
                                     + self.config.graft_flood_threshold())
                                     - self.config.prune_backoff();


### PR DESCRIPTION
## Description

It doesn't appear that https://github.com/rust-lang/rust-clippy/issues/10061 is going to be fixed any time soon. In the meantime, our CI is "red" which is misleading because we purposely don't require this CI check. It will however hit stable in ~ 2 weeks at which point our required clippy CI check will fail.

Suppress clippy lint with an `allow` to make it pass.

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes

cc @umgefahren

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
