### PR TITLE
feat(mdns): allow setting an initial delay before sending queries to discover peers.

### DIFF
--- a/protocols/mdns/src/lib.rs
+++ b/protocols/mdns/src/lib.rs
@@ -83,6 +83,9 @@ pub const IPV6_MDNS_MULTICAST_ADDRESS: Ipv6Addr = Ipv6Addr::new(0xFF02, 0, 0, 0,
 pub struct Config {
     /// TTL to use for mdns records.
     pub ttl: Duration,
+    /// Initial delay before polling the network for new peers.
+    /// Defaults to 0ms.
+    pub initial_delay: Duration,
     /// Interval at which to poll the network for new peers. This isn't
     /// necessary during normal operation but avoids the case that an
     /// initial packet was lost and not discovering any peers until a new
@@ -97,6 +100,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             ttl: Duration::from_secs(6 * 60),
+            initial_delay: Duration::from_millis(0),
             query_interval: Duration::from_secs(5 * 60),
             enable_ipv6: false,
         }


### PR DESCRIPTION
## Description

feat(mdns): allow setting an initial delay before sending queries to discover peers (#3319)

## Notes

In a similar way to identify behaviour, manage an initial delay before the first mdns query is sent on an interface.

In a docker environment, the first mdns query can be lost if the interface is not ready yet. As the interval query is by default rather large (5 minutes), using an initial delay before the first mdns query is sent would improve the speed of peers discovery.

## Links to any relevant issues

Fixes #3319 

## Open Questions

I have kept the original behaviour, the initial delay is set by default to 0, perhaps this could be set to another default value like for example 500ms as done for identify.

## Change checklist

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
