### PR TITLE
fix: revert "refactor(relay): introduce `Handler::new` functions"

### DIFF
--- a/protocols/relay/src/behaviour/handler.rs
+++ b/protocols/relay/src/behaviour/handler.rs
@@ -351,7 +351,19 @@ impl IntoConnectionHandler for Prototype {
             // Deny all substreams on relayed connection.
             Either::Right(dummy::ConnectionHandler)
         } else {
-            Either::Left(Handler::new(self.config, endpoint.clone()))
+            Either::Left(Handler {
+                endpoint: endpoint.clone(),
+                config: self.config,
+                queued_events: Default::default(),
+                pending_error: Default::default(),
+                reservation_request_future: Default::default(),
+                circuit_accept_futures: Default::default(),
+                circuit_deny_futures: Default::default(),
+                alive_lend_out_substreams: Default::default(),
+                circuits: Default::default(),
+                active_reservation: Default::default(),
+                keep_alive: KeepAlive::Yes,
+            })
         }
     }
 
@@ -420,22 +432,6 @@ pub struct Handler {
 }
 
 impl Handler {
-    fn new(config: Config, endpoint: ConnectedPoint) -> Handler {
-        Handler {
-            endpoint,
-            config,
-            queued_events: Default::default(),
-            pending_error: Default::default(),
-            reservation_request_future: Default::default(),
-            circuit_accept_futures: Default::default(),
-            circuit_deny_futures: Default::default(),
-            alive_lend_out_substreams: Default::default(),
-            circuits: Default::default(),
-            active_reservation: Default::default(),
-            keep_alive: KeepAlive::Yes,
-        }
-    }
-
     fn on_fully_negotiated_inbound(
         &mut self,
         FullyNegotiatedInbound {


### PR DESCRIPTION
Reverts libp2p/rust-libp2p#3326

This was merged by accident, as it is a stacked PR that will be [retargeted](https://github.blog/changelog/2020-05-19-pull-request-retargeting/) once the base PR merges into master.