### PR TITLE
refactor(swarm): simplify `DialOpts`

### DIFF
--- a/swarm/src/dial_opts.rs
+++ b/swarm/src/dial_opts.rs
@@ -36,7 +36,7 @@ use std::num::NonZeroU8;
 ///
 /// - [`DialOpts::unknown_peer_id`] dialing an unknown peer
 #[derive(Debug)]
-pub struct DialOpts(pub(super) Opts);
+pub struct DialOpts(Opts);
 
 impl DialOpts {
     /// Dial a known peer.
@@ -200,7 +200,7 @@ impl From<PeerId> for DialOpts {
 /// - [`DialOpts::peer_id`] dialing a known peer
 /// - [`DialOpts::unknown_peer_id`] dialing an unknown peer
 #[derive(Debug)]
-pub(super) enum Opts {
+enum Opts {
     WithPeerId(WithPeerId),
     WithPeerIdWithAddresses(WithPeerIdWithAddresses),
     WithoutPeerIdWithAddress(WithoutPeerIdWithAddress),
@@ -208,10 +208,10 @@ pub(super) enum Opts {
 
 #[derive(Debug)]
 pub struct WithPeerId {
-    pub(crate) peer_id: PeerId,
-    pub(crate) condition: PeerCondition,
-    pub(crate) role_override: Endpoint,
-    pub(crate) dial_concurrency_factor_override: Option<NonZeroU8>,
+    peer_id: PeerId,
+    condition: PeerCondition,
+    role_override: Endpoint,
+    dial_concurrency_factor_override: Option<NonZeroU8>,
 }
 
 impl WithPeerId {
@@ -262,12 +262,12 @@ impl WithPeerId {
 
 #[derive(Debug)]
 pub struct WithPeerIdWithAddresses {
-    pub(crate) peer_id: PeerId,
-    pub(crate) condition: PeerCondition,
-    pub(crate) addresses: Vec<Multiaddr>,
-    pub(crate) extend_addresses_through_behaviour: bool,
-    pub(crate) role_override: Endpoint,
-    pub(crate) dial_concurrency_factor_override: Option<NonZeroU8>,
+    peer_id: PeerId,
+    condition: PeerCondition,
+    addresses: Vec<Multiaddr>,
+    extend_addresses_through_behaviour: bool,
+    role_override: Endpoint,
+    dial_concurrency_factor_override: Option<NonZeroU8>,
 }
 
 impl WithPeerIdWithAddresses {
@@ -323,8 +323,8 @@ impl WithoutPeerId {
 
 #[derive(Debug)]
 pub struct WithoutPeerIdWithAddress {
-    pub(crate) address: Multiaddr,
-    pub(crate) role_override: Endpoint,
+    address: Multiaddr,
+    role_override: Endpoint,
 }
 
 impl WithoutPeerIdWithAddress {

--- a/swarm/src/dial_opts.rs
+++ b/swarm/src/dial_opts.rs
@@ -94,12 +94,12 @@ impl DialOpts {
     /// See <https://github.com/multiformats/rust-multiaddr/issues/73>.
     pub(crate) fn get_or_parse_peer_id(&self) -> Result<Option<PeerId>, Multihash> {
         if let Some(peer_id) = self.peer_id {
-            return Ok(Some(peer_id))
+            return Ok(Some(peer_id));
         }
 
         let first_address = match self.addresses.first() {
             Some(first_address) => first_address,
-            None => return Ok(None)
+            None => return Ok(None),
         };
 
         let maybe_peer_id = first_address

--- a/swarm/src/dial_opts.rs
+++ b/swarm/src/dial_opts.rs
@@ -204,7 +204,7 @@ impl WithPeerId {
             peer_id: Some(self.peer_id),
             condition: self.condition,
             addresses: vec![],
-            extend_addresses_through_behaviour: false,
+            extend_addresses_through_behaviour: true,
             role_override: self.role_override,
             dial_concurrency_factor_override: self.dial_concurrency_factor_override,
         }


### PR DESCRIPTION
## Description

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

Instead of tracking an inner enum, move all fields of `Opts` into `DialOpts`, setting them directly once we construct them. This makes the getters a lot simpler to implement and reduces code duplication.

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

Helps with implementing https://github.com/libp2p/rust-libp2p/pull/3328#discussion_r1071118288.
Draft until https://github.com/libp2p/rust-libp2p/pull/3318 is merged because it is stacked on top of it.

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
