### PR TITLE
feat(quic): Wake transport when adding a new dialer or listener

### DIFF
--- a/transports/quic/CHANGELOG.md
+++ b/transports/quic/CHANGELOG.md
@@ -7,7 +7,10 @@
 - Add opt-in support for the `/quic` codepoint, interpreted as QUIC version draft-29.
   See [PR 3151].
 
+- Wake the transport's task when a new dialer or listener is added. See [3342].
+
 [PR 3151]: https://github.com/libp2p/rust-libp2p/pull/3151
+[PR 3342]: https://github.com/libp2p/rust-libp2p/pull/3342
 
 # 0.7.0-alpha
 

--- a/transports/quic/tests/smoke.rs
+++ b/transports/quic/tests/smoke.rs
@@ -102,7 +102,7 @@ async fn ipv4_dial_ipv6() {
 /// See https://github.com/libp2p/rust-libp2p/pull/3306 for context.
 #[cfg(feature = "async-std")]
 #[async_std::test]
-async fn wrapped_with_dns() {
+async fn wrapped_with_delay() {
     let _ = env_logger::try_init();
 
     struct DialDelay(Arc<Mutex<Boxed<(PeerId, StreamMuxerBox)>>>);
@@ -175,7 +175,7 @@ async fn wrapped_with_dns() {
         (id, DialDelay(Arc::new(Mutex::new(transport))).boxed())
     };
 
-    // Spawn a
+    // Spawn A
     let a_addr = start_listening(&mut a_transport, "/ip6/::1/udp/0/quic-v1").await;
     let listener = async_std::task::spawn(async move {
         let (upgrade, _) = a_transport
@@ -188,7 +188,7 @@ async fn wrapped_with_dns() {
         peer_id
     });
 
-    // Spawn b
+    // Spawn B
     //
     // Note that the dial is spawned on a different task than the transport allowing the transport
     // task to poll the transport once and then suspend, waiting for the wakeup from the dial.

--- a/transports/quic/tests/smoke.rs
+++ b/transports/quic/tests/smoke.rs
@@ -1,12 +1,15 @@
 #![cfg(any(feature = "async-std", feature = "tokio"))]
 
 use futures::channel::{mpsc, oneshot};
+use futures::future::BoxFuture;
 use futures::future::{poll_fn, Either};
 use futures::stream::StreamExt;
 use futures::{future, AsyncReadExt, AsyncWriteExt, FutureExt, SinkExt};
+use futures_timer::Delay;
 use libp2p_core::either::EitherOutput;
 use libp2p_core::muxing::{StreamMuxerBox, StreamMuxerExt, SubstreamBox};
 use libp2p_core::transport::{Boxed, OrTransport, TransportEvent};
+use libp2p_core::transport::{ListenerId, TransportError};
 use libp2p_core::{multiaddr::Protocol, upgrade, Multiaddr, PeerId, Transport};
 use libp2p_noise as noise;
 use libp2p_quic as quic;
@@ -19,6 +22,10 @@ use std::io;
 use std::num::NonZeroU8;
 use std::task::Poll;
 use std::time::Duration;
+use std::{
+    pin::Pin,
+    sync::{Arc, Mutex},
+};
 
 #[cfg(feature = "tokio")]
 #[tokio::test]
@@ -85,6 +92,113 @@ async fn ipv4_dial_ipv6() {
     let a_addr = start_listening(&mut a_transport, "/ip6/::1/udp/0/quic-v1").await;
     let ((a_connected, _, _), (b_connected, _)) =
         connect(&mut a_transport, &mut b_transport, a_addr).await;
+
+    assert_eq!(a_connected, b_peer_id);
+    assert_eq!(b_connected, a_peer_id);
+}
+
+/// Tests that a [`Transport::dial`] wakes up the task previously polling [`Transport::poll`].
+///
+/// See https://github.com/libp2p/rust-libp2p/pull/3306 for context.
+#[cfg(feature = "async-std")]
+#[async_std::test]
+async fn wrapped_with_dns() {
+    let _ = env_logger::try_init();
+
+    struct FakeDns(Arc<Mutex<Boxed<(PeerId, StreamMuxerBox)>>>);
+
+    impl Transport for FakeDns {
+        type Output = (PeerId, StreamMuxerBox);
+        type Error = std::io::Error;
+        type ListenerUpgrade = Pin<Box<dyn Future<Output = io::Result<Self::Output>> + Send>>;
+        type Dial = BoxFuture<'static, Result<Self::Output, Self::Error>>;
+
+        fn listen_on(
+            &mut self,
+            addr: Multiaddr,
+        ) -> Result<ListenerId, TransportError<Self::Error>> {
+            self.0.lock().unwrap().listen_on(addr)
+        }
+
+        fn remove_listener(&mut self, id: ListenerId) -> bool {
+            self.0.lock().unwrap().remove_listener(id)
+        }
+
+        fn address_translation(
+            &self,
+            listen: &Multiaddr,
+            observed: &Multiaddr,
+        ) -> Option<Multiaddr> {
+            self.0.lock().unwrap().address_translation(listen, observed)
+        }
+
+        /// Delayed dial, i.e. calling [`Transport::dial`] on the inner [`Transport`] not within the
+        /// synchronous [`Transport::dial`] method, but within the [`Future`] returned by the outer
+        /// [`Transport::dial`].
+        fn dial(&mut self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+            let t = self.0.clone();
+            Ok(async move {
+                // Simulate DNS lookup. Giving the `Transport::poll` the chance to return
+                // `Poll::Pending` and thus suspending its task, waiting for a wakeup from the dial
+                // on the inner transport below.
+                Delay::new(Duration::from_millis(1)).await;
+
+                let dial = t.lock().unwrap().dial(addr).map_err(|e| match e {
+                    TransportError::MultiaddrNotSupported(_) => {
+                        panic!()
+                    }
+                    TransportError::Other(e) => e,
+                })?;
+                dial.await
+            }
+            .boxed())
+        }
+
+        fn dial_as_listener(
+            &mut self,
+            addr: Multiaddr,
+        ) -> Result<Self::Dial, TransportError<Self::Error>> {
+            self.0.lock().unwrap().dial_as_listener(addr)
+        }
+
+        fn poll(
+            self: Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> Poll<TransportEvent<Self::ListenerUpgrade, Self::Error>> {
+            Pin::new(&mut *self.0.lock().unwrap()).poll(cx)
+        }
+    }
+
+    let (a_peer_id, mut a_transport) = create_default_transport::<quic::async_std::Provider>();
+    let (b_peer_id, mut b_transport) = {
+        let (id, transport) = create_default_transport::<quic::async_std::Provider>();
+        (id, FakeDns(Arc::new(Mutex::new(transport))).boxed())
+    };
+
+    // Spawn a
+    let a_addr = start_listening(&mut a_transport, "/ip6/::1/udp/0/quic-v1").await;
+    let listener = async_std::task::spawn(async move {
+        let (upgrade, _) = a_transport
+            .select_next_some()
+            .await
+            .into_incoming()
+            .unwrap();
+        let (peer_id, _) = upgrade.await.unwrap();
+
+        peer_id
+    });
+
+    // Spawn b
+    //
+    // Note that the dial is spawned on a different task than the transport allowing the transport
+    // task to poll the transport once and then suspend, waiting for the wakeup from the dial.
+    let dial = async_std::task::spawn({
+        let dial = b_transport.dial(a_addr).unwrap();
+        async { dial.await.unwrap().0 }
+    });
+    async_std::task::spawn(async move { b_transport.next().await });
+
+    let (a_connected, b_connected) = future::join(listener, dial).await;
 
     assert_eq!(a_connected, b_peer_id);
     assert_eq!(b_connected, a_peer_id);

--- a/transports/quic/tests/smoke.rs
+++ b/transports/quic/tests/smoke.rs
@@ -141,7 +141,7 @@ async fn wrapped_with_dns() {
                 // Simulate DNS lookup. Giving the `Transport::poll` the chance to return
                 // `Poll::Pending` and thus suspending its task, waiting for a wakeup from the dial
                 // on the inner transport below.
-                Delay::new(Duration::from_millis(1)).await;
+                Delay::new(Duration::from_millis(100)).await;
 
                 let dial = t.lock().unwrap().dial(addr).map_err(|e| match e {
                     TransportError::MultiaddrNotSupported(_) => {

--- a/transports/quic/tests/smoke.rs
+++ b/transports/quic/tests/smoke.rs
@@ -105,9 +105,9 @@ async fn ipv4_dial_ipv6() {
 async fn wrapped_with_dns() {
     let _ = env_logger::try_init();
 
-    struct FakeDns(Arc<Mutex<Boxed<(PeerId, StreamMuxerBox)>>>);
+    struct DialDelay(Arc<Mutex<Boxed<(PeerId, StreamMuxerBox)>>>);
 
-    impl Transport for FakeDns {
+    impl Transport for DialDelay {
         type Output = (PeerId, StreamMuxerBox);
         type Error = std::io::Error;
         type ListenerUpgrade = Pin<Box<dyn Future<Output = io::Result<Self::Output>> + Send>>;
@@ -172,7 +172,7 @@ async fn wrapped_with_dns() {
     let (a_peer_id, mut a_transport) = create_default_transport::<quic::async_std::Provider>();
     let (b_peer_id, mut b_transport) = {
         let (id, transport) = create_default_transport::<quic::async_std::Provider>();
-        (id, FakeDns(Arc::new(Mutex::new(transport))).boxed())
+        (id, DialDelay(Arc::new(Mutex::new(transport))).boxed())
     };
 
     // Spawn a


### PR DESCRIPTION
## Description

Wake `quic::GenTransport` if a new dialer or listener is added.

## Notes

This re-adds #3306 with the solution initially drafted by @mxinden for waking the transport if a new dialer is added. 
I added to also wake the transport if a new listener was pushed. The `SelectAll` around the listeners itself doesn't wake the task if a new element is pushed. This is not a major problem since the user would call `poll` again after a `listen_on` call and thus registering a new waker, but it solves the edge cast of a user doing something like this:
```rust
match quic_transport.poll_next(cx) {
   Poll::Ready(event) => return event,
   Poll::Pending => {}
}
quic_transport.listen_on(addr);
return Poll::Pending
```

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] <s>.A changelog entry has been made in the appropriate crates</s>
