### PR TITLE
fix(rendezvous): Close outbound streams directly after write

### DIFF
--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -7,7 +7,10 @@
 
 - Update to `libp2p-swarm` `v0.42.0`.
 
+- Close outbound streams directly after finishing to write. See [PR 3345].
+
 [PR 3208]: https://github.com/libp2p/rust-libp2p/pull/3208
+[PR 3345]: https://github.com/libp2p/rust-libp2p/pull/3345
 
 # 0.41.1
 

--- a/protocols/rendezvous/src/handler/outbound.rs
+++ b/protocols/rendezvous/src/handler/outbound.rs
@@ -67,6 +67,8 @@ impl SubstreamHandler for Stream {
                 .send(sent_message.clone())
                 .map_err(Error::WriteMessage)
                 .await?;
+            stream.close().map_err(Error::WriteMessage).await?;
+
             let received_message = stream.try_next().map_err(Error::ReadMessage).await?;
             let received_message = received_message.ok_or(Error::UnexpectedEndOfStream)?;
 
@@ -87,8 +89,6 @@ impl SubstreamHandler for Stream {
                 }
                 (.., other) => return Err(Error::BadMessage(other)),
             };
-
-            stream.close().map_err(Error::WriteMessage).await?;
 
             Ok(event)
         }))


### PR DESCRIPTION
## Description

Call `close` on the outbound substreams directly after the write call, instead of doing it after the following read. 
This is needed due to how our QUIC transport currently closes streams, see #3281 for more info.
With this patch the QUIC `FIN` ends up being send together with our write data and thus received by the remote before it reads and drops the stream.

## Links to any relevant issues

- Fixes #3281.
- The underlying issue on closing substreams in QUIC is described in #3343.

## TODO
- [ ] Add test for QUIC+rendezvous

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
