### PR TITLE
fix(autonat): Skip unparsable multiaddr

### DIFF
--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -1,8 +1,8 @@
 # 0.9.1
 
-- Skip unparsable multiaddr in `DialRequest::from_bytes`. See [PR 3300].
+- Skip unparsable multiaddr in `DialRequest::from_bytes`. See [PR 3351].
 
-[PR 3300]: https://github.com/libp2p/rust-libp2p/pull/3300
+[PR 3351]: https://github.com/libp2p/rust-libp2p/pull/3351
 
 # 0.9.0
 

--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.9.1
+
+- Skip unparsable multiaddr in `DialRequest::from_bytes`. See [PR 3300].
+
+[PR 3300]: https://github.com/libp2p/rust-libp2p/pull/3300
+
 # 0.9.0
 
 - Update to `libp2p-core` `v0.38.0`.

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-autonat"
 edition = "2021"
 rust-version = "1.62.0"
 description = "NAT and firewall detection for libp2p"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["David Craven <david@craven.ch>", "Elena Frank <elena.frank@protonmail.com>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -31,7 +31,7 @@ env_logger = "0.9"
 clap = { version = "4.0.13", features = ["derive"] }
 libp2p = { path = "../..", features = ["full"] }
 
-# Passing arguments to the docsrs builder in order to properly document cfg's. 
+# Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
## Description

With this commit `libp2p-autonat` no longer discards the whole remote payload in case an addr is unparsable, but instead logs the failure and skips the unparsable multiaddr.

See libp2p#3244 for details.

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes

Hopefully the last missing piece (minus the backport to master) for https://github.com/libp2p/rust-libp2p/issues/3244 to close.

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
