### PR TITLE
docs(roadmap): Mark alpha QUIC as done and add quinn work

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,16 +64,15 @@ roadmap](https://github.com/libp2p/specs/blob/master/ROADMAP.md).
 
 ## Appendix
 
-### QUIC support
+### Alpha QUIC support
 
-| Category     | Status      | Target Completion | Tracking                                          | Dependencies                                                        | Dependents |
-|--------------|-------------|-------------------|---------------------------------------------------|---------------------------------------------------------------------|------------|
-| Connectivity | In progress | Q4/2022           | https://github.com/libp2p/rust-libp2p/issues/2883 | https://github.com/libp2p/test-plans/issues/53 |            |
+| Category     | Status | Target Completion | Tracking                                          | Dependencies                                   | Dependents |
+|--------------|--------|-------------------|---------------------------------------------------|------------------------------------------------|------------|
+| Connectivity | Done   | Q4/2022           | https://github.com/libp2p/rust-libp2p/issues/2883 | https://github.com/libp2p/test-plans/issues/53 |            |
 
 QUIC has been on the roadmap for a long time. It enables various performance improvements as well as
 higher hole punching success rates. We are close to finishing a first version with
-https://github.com/libp2p/rust-libp2p/pull/2289 and will improve from there. See tracking issue
-https://github.com/libp2p/rust-libp2p/issues/2883.
+https://github.com/libp2p/rust-libp2p/pull/2289.
 
 ### WebRTC support (browser-to-server)
 
@@ -118,6 +117,14 @@ cumbersome and inefficient. See https://github.com/libp2p/rust-libp2p/issues/282
 management generic allows users to build advanced and efficient abstractions on top of rust-libp2p
 
 First draft is in https://github.com/libp2p/rust-libp2p/pull/2828
+
+### QUIC - evaluate and move to quinn
+
+| Category     | Status | Target Completion | Tracking                                          | Dependencies | Dependents |
+|--------------|--------|-------------------|---------------------------------------------------|--------------|------------|
+| Connectivity | todo   | Q1/2023           | https://github.com/libp2p/rust-libp2p/issues/2883 |              |            |
+
+We added alpha support for QUIC in Q4/2022 wrapping `quinn-proto`. Evaluate using `quinn` directly, replacing the wrapper.
 
 ### Kademlia efficient querying
 


### PR DESCRIPTION
## Description

- Implementation based on `quinn-proto` was added in https://github.com/libp2p/rust-libp2p/pull/2289
- Add new entry to evaluate using `quinn` directly
