### PR TITLE
docs(roadmap): Mark WebRTC browser-to-server as done

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -77,9 +77,9 @@ https://github.com/libp2p/rust-libp2p/issues/2883.
 
 ### WebRTC support (browser-to-server)
 
-| Category     | Status      | Target Completion | Tracking                                 | Dependencies                                   | Dependents |
-|--------------|-------------|-------------------|------------------------------------------|------------------------------------------------|------------|
-| Connectivity | In progress | Q4/2022           | https://github.com/libp2p/specs/pull/412 | https://github.com/libp2p/test-plans/issues/53 |    [WebRTC (browser-to-browser)](#webrtc-support-browser-to-browser)        |
+| Category     | Status | Target Completion | Tracking                                 | Dependencies                                   | Dependents                                                        |
+|--------------|--------|-------------------|------------------------------------------|------------------------------------------------|-------------------------------------------------------------------|
+| Connectivity | Done   | Q4/2022           | https://github.com/libp2p/specs/pull/412 | https://github.com/libp2p/test-plans/issues/53 | [WebRTC (browser-to-browser)](#webrtc-support-browser-to-browser) |
 
 
 We are currently implementing WebRTC for **browser-to-server** connectivity in

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,7 +79,7 @@ https://github.com/libp2p/rust-libp2p/issues/2883.
 
 | Category     | Status | Target Completion | Tracking                                 | Dependencies                                   | Dependents                                                        |
 |--------------|--------|-------------------|------------------------------------------|------------------------------------------------|-------------------------------------------------------------------|
-| Connectivity | Done   | Q4/2022           | https://github.com/libp2p/specs/pull/412 | https://github.com/libp2p/test-plans/issues/53 | [WebRTC (browser-to-browser)](#webrtc-support-browser-to-browser) |
+| Connectivity | Done   | Q4/2022           | https://github.com/libp2p/specs/pull/412 | https://github.com/libp2p/test-plans/pull/100 | [WebRTC (browser-to-browser)](#webrtc-support-browser-to-browser) |
 
 
 We are currently implementing WebRTC for **browser-to-server** connectivity in


### PR DESCRIPTION
## Description

- Added in https://github.com/libp2p/rust-libp2p/pull/2622
- Interoperability tests added in https://github.com/libp2p/test-plans/pull/100
