### PR TITLE
fix(autonat): Skip unparsable multiaddr

### DIFF
--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -10,6 +10,13 @@
 
 [PR 3153]: https://github.com/libp2p/rust-libp2p/pull/3153
 
+# 0.9.1
+
+- Skip unparsable multiaddr in `DialRequest::from_bytes`. See [PR 3351].
+
+[PR 3351]: https://github.com/libp2p/rust-libp2p/pull/3351
+
+
 # 0.9.0
 
 - Update to `libp2p-core` `v0.38.0`.

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -44,8 +44,8 @@ rustc-args = ["--cfg", "docsrs"]
 
 [[example]]
 name = "client"
-path = "examples/autonat_client.rs" 
+path = "examples/autonat_client.rs"
 
 [[example]]
 name = "server"
-path = "examples/autonat_server.rs" 
+path = "examples/autonat_server.rs"


### PR DESCRIPTION
## Description
With this commit `libp2p-autonat` no longer discards the whole remote payload in case an addr is unparsable, but instead logs the failure and skips the unparsable multiaddr.

See libp2p#3244 for details.

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes
This now targets `master`
<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
