### PR TITLE
fix(swarm)!: make on_connection_handler_event impl mandatory.

### DIFF
--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -9,19 +9,21 @@
 - Add `estblished_in` to `SwarmEvent::ConnectionEstablished`. See [PR 3134].
 
 - Remove deprecated `inject_*` methods from `NetworkBehaviour` and `ConnectionHandler`.
-  see [PR 3264].
+  Make the implementation of `on_swarm_event` and `on_connection_handler_event`
+  both mandatory. See [PR 3264] and [PR 3364].
 
 - Update to `libp2p-swarm-derive` `v0.32.0`.
 
 - Remove type parameter from `PendingOutboundConnectionError` and `PendingInboundConnectionError`.
   These two types are always used with `std::io::Error`. See [PR 3272].
 
-- Replace `SwarmBuilder::connection_event_buffer_size` with `SwarmBuilder::per_connection_event_buffer_size` . 
+- Replace `SwarmBuilder::connection_event_buffer_size` with `SwarmBuilder::per_connection_event_buffer_size` .
   The configured value now applies _per_ connection.
   The default values remains 7.
   If you have previously set `connection_event_buffer_size` you should re-evaluate what a good size for a _per connection_ buffer is.
   See [PR 3188].
 
+[PR 3364]: https://github.com/libp2p/rust-libp2p/pull/3364
 [PR 3170]: https://github.com/libp2p/rust-libp2p/pull/3170
 [PR 3134]: https://github.com/libp2p/rust-libp2p/pull/3134
 [PR 3153]: https://github.com/libp2p/rust-libp2p/pull/3153

--- a/swarm/src/behaviour.rs
+++ b/swarm/src/behaviour.rs
@@ -172,8 +172,7 @@ pub trait NetworkBehaviour: 'static {
         _connection_id: ConnectionId,
         _event: <<Self::ConnectionHandler as IntoConnectionHandler>::Handler as
         ConnectionHandler>::OutEvent,
-    ) {
-    }
+    );
 
     /// Polls for things that swarm should do.
     ///


### PR DESCRIPTION
## Description
Sorry I missed this on https://github.com/libp2p/rust-libp2p/pull/3264

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
