### PR TITLE
refactor(relay): directly store actions instead of events

### DIFF
--- a/protocols/relay/src/priv_client.rs
+++ b/protocols/relay/src/priv_client.rs
@@ -201,52 +201,47 @@ impl NetworkBehaviour for Behaviour {
             Either::Right(v) => void::unreachable(v),
         };
 
-        match handler_event {
-            handler::Event::ReservationReqAccepted { renewal, limit } => self
-                .queued_actions
-                .push_back(Event::ReservationReqAccepted {
+        let event = match handler_event {
+            handler::Event::ReservationReqAccepted { renewal, limit } => {
+                Event::ReservationReqAccepted {
                     relay_peer_id: event_source,
                     renewal,
                     limit,
-                }),
+                }
+            }
             handler::Event::ReservationReqFailed { renewal, error } => {
-                self.queued_actions.push_back(Event::ReservationReqFailed {
+                Event::ReservationReqFailed {
                     relay_peer_id: event_source,
                     renewal,
                     error,
-                })
+                }
             }
             handler::Event::OutboundCircuitEstablished { limit } => {
-                self.queued_actions
-                    .push_back(Event::OutboundCircuitEstablished {
-                        relay_peer_id: event_source,
-                        limit,
-                    })
+                Event::OutboundCircuitEstablished {
+                    relay_peer_id: event_source,
+                    limit,
+                }
             }
-            handler::Event::OutboundCircuitReqFailed { error } => {
-                self.queued_actions
-                    .push_back(Event::OutboundCircuitReqFailed {
-                        relay_peer_id: event_source,
-                        error,
-                    })
+            handler::Event::OutboundCircuitReqFailed { error } => Event::OutboundCircuitReqFailed {
+                relay_peer_id: event_source,
+                error,
+            },
+            handler::Event::InboundCircuitEstablished { src_peer_id, limit } => {
+                Event::InboundCircuitEstablished { src_peer_id, limit }
             }
-            handler::Event::InboundCircuitEstablished { src_peer_id, limit } => self
-                .queued_actions
-                .push_back(Event::InboundCircuitEstablished { src_peer_id, limit }),
-            handler::Event::InboundCircuitReqFailed { error } => {
-                self.queued_actions
-                    .push_back(Event::InboundCircuitReqFailed {
-                        relay_peer_id: event_source,
-                        error,
-                    })
+            handler::Event::InboundCircuitReqFailed { error } => Event::InboundCircuitReqFailed {
+                relay_peer_id: event_source,
+                error,
+            },
+            handler::Event::InboundCircuitReqDenied { src_peer_id } => {
+                Event::InboundCircuitReqDenied { src_peer_id }
             }
-            handler::Event::InboundCircuitReqDenied { src_peer_id } => self
-                .queued_actions
-                .push_back(Event::InboundCircuitReqDenied { src_peer_id }),
-            handler::Event::InboundCircuitReqDenyFailed { src_peer_id, error } => self
-                .queued_actions
-                .push_back(Event::InboundCircuitReqDenyFailed { src_peer_id, error }),
-        }
+            handler::Event::InboundCircuitReqDenyFailed { src_peer_id, error } => {
+                Event::InboundCircuitReqDenyFailed { src_peer_id, error }
+            }
+        };
+
+        self.queued_actions.push_back(event);
     }
 
     fn poll(


### PR DESCRIPTION
## Description

Storing `NetworkBehaviourAction`s within the behaviour is more flexible than only storing `OutEvent`s. Additionally, I find expression-oriented code easier to reason about because it typically doesn't contain side-effects.

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes

This will reduce the diff in https://github.com/libp2p/rust-libp2p/pull/3328.

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
