### PR TITLE
fix(ci): apply shorter timeout to cache download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2 # Fail cache download after 2 minutes.
+
 jobs:
   test:
     name: Test ${{ matrix.crate }}


### PR DESCRIPTION
## Description

Sometimes, GitHub Actions gets stuck in downloading the cache. My hypothesis is that because we have so many jobs, some of them get rate-limited and end up failing the download.

Typically, GitHub Actions downloads with a speed of 100MB/s. With the maximum allowed cache size of 10GB, any cache download should not take longer than 100 seconds. With this patch, we set the timeout to 120 seconds for the continuous integration workflow.

Upon failure, the job will continue with a cache-miss which is nice because it means the workflow will continue and not fail.

More information here: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#cache-segment-restore-timeout

Example workflows:

- https://github.com/libp2p/rust-libp2p/actions/runs/3992478158/jobs/6848975863
- https://github.com/libp2p/rust-libp2p/actions/runs/3992492999/jobs/6848989008
- https://github.com/libp2p/rust-libp2p/actions/runs/3992564680/jobs/6849012006

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
