### PR TITLE
feat(ci): download `cargo-semver-checks` instead of building it

### DIFF
--- a/.github/workflows/cache-factory.yml
+++ b/.github/workflows/cache-factory.yml
@@ -75,6 +75,3 @@ jobs:
 
       - name: Render docs
         run: cargo doc --all-features --workspace
-
-      - name: Install tools
-        run: cargo install cargo-semver-checks --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Check public API for semver violations
         if: steps.check-released.outputs.code == 200 # Workaround until https://github.com/obi1kenobi/cargo-semver-check/issues/146 is shipped.
         run: |
-          cargo install cargo-semver-checks --locked
+          wget -q -O- https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v0.16.1/cargo-semver-checks-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C ~/.cargo/bin
           cargo semver-checks check-release -p ${{ matrix.crate }}
 
       - name: Enforce no dependency on meta crate


### PR DESCRIPTION
## Description

This is much quicker to execute. To keep our CI reproducible, I opted to link to a specific version instead of the "latest" release. Updating to a new version is as easy as switching out the version number in the URL.

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
