### PR TITLE
refactor(gossipsub)!: initialize `ProtocolConfig` from `GossipsubConfig`

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -6,10 +6,10 @@
 
 - Update to `libp2p-swarm` `v0.42.0`.
 
-- Initialize `ProtocolConfig` via `GossipsubConfig`. See [PR XXXX].
+- Initialize `ProtocolConfig` via `GossipsubConfig`. See [PR 3381].
 
 [PR 3207]: https://github.com/libp2p/rust-libp2p/pull/3207/
-[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX/
+[PR 3381]: https://github.com/libp2p/rust-libp2p/pull/3381/
 
 # 0.43.0
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 - Update to `libp2p-swarm` `v0.42.0`.
 
+- Initialize `ProtocolConfig` via `GossipsubConfig`. See [PR XXXX].
+
 [PR 3207]: https://github.com/libp2p/rust-libp2p/pull/3207/
+[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX/
 
 # 0.43.0
 

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -3298,15 +3298,10 @@ where
     type OutEvent = GossipsubEvent;
 
     fn new_handler(&mut self) -> Self::ConnectionHandler {
-        let protocol_config = ProtocolConfig::new(
-            self.config.protocol_id().clone(),
-            self.config.custom_id_version().clone(),
-            self.config.max_transmit_size(),
-            self.config.validation_mode().clone(),
-            self.config.support_floodsub(),
-        );
-
-        GossipsubHandler::new(protocol_config, self.config.idle_timeout())
+        GossipsubHandler::new(
+            ProtocolConfig::new(&self.config),
+            self.config.idle_timeout(),
+        )
     }
 
     fn on_connection_handler_event(

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -33,7 +33,6 @@ use async_std::net::Ipv4Addr;
 use byteorder::{BigEndian, ByteOrder};
 use libp2p_core::{ConnectedPoint, Endpoint};
 use rand::Rng;
-use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::thread::sleep;
@@ -272,7 +271,7 @@ where
             active_connections = active_connections.checked_sub(1).unwrap();
 
             let dummy_handler = GossipsubHandler::new(
-                ProtocolConfig::new(Cow::from(""), None, 0, ValidationMode::None, false),
+                ProtocolConfig::new(&GossipsubConfig::default()),
                 Duration::ZERO,
             );
 

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -885,12 +885,11 @@ impl std::fmt::Debug for GossipsubConfig {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::protocol::ProtocolConfig;
     use crate::topic::IdentityHash;
     use crate::types::PeerKind;
     use crate::Topic;
-    use crate::{Gossipsub, MessageAuthenticity};
     use libp2p_core::UpgradeInfo;
-    use libp2p_swarm::{ConnectionHandler, NetworkBehaviour};
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
@@ -992,11 +991,7 @@ mod test {
         assert_eq!(builder.protocol_id(), "purple");
         assert_eq!(builder.custom_id_version(), &None);
 
-        let mut gossipsub: Gossipsub =
-            Gossipsub::new(MessageAuthenticity::Anonymous, builder).expect("Correct configuration");
-
-        let handler = gossipsub.new_handler();
-        let (protocol_config, _) = handler.listen_protocol().into_upgrade();
+        let protocol_config = ProtocolConfig::new(&builder);
         let protocol_ids = protocol_config.protocol_info();
 
         assert_eq!(protocol_ids.len(), 2);
@@ -1020,11 +1015,7 @@ mod test {
         assert_eq!(builder.protocol_id(), "purple");
         assert_eq!(builder.custom_id_version(), &Some(GossipsubVersion::V1_0));
 
-        let mut gossipsub: Gossipsub =
-            Gossipsub::new(MessageAuthenticity::Anonymous, builder).expect("Correct configuration");
-
-        let handler = gossipsub.new_handler();
-        let (protocol_config, _) = handler.listen_protocol().into_upgrade();
+        let protocol_config = ProtocolConfig::new(&builder);
         let protocol_ids = protocol_config.protocol_info();
 
         assert_eq!(protocol_ids.len(), 1);


### PR DESCRIPTION
## Description

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

This simplifies the tests as we don't have to go through the `new_handler` abstraction.

## Notes

Extracted out of https://github.com/libp2p/rust-libp2p/pull/3254.
Unfortunately, this is a breaking change because the `protocol` module is public. See https://github.com/libp2p/rust-libp2p/pull/3303#discussion_r1084698192 for more discussion.

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
