### PR TITLE
feat(inter-op): make `Dockerfile` generic over test binary

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# This Docker ignore file aims to optimise the build process of the interop tests.
+# The Dockerfile in ./interop-tests/Dockerfile copies a locally built binary into the container and
+# thus does not need anything else to be present in the working directory.
+*
+
+# CI will build and copy over the release binary.
+target/release/ping
+
+# Locally, we might want to build it as `debug` binary to accelerate the build process.
+target/debug/ping

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,7 @@
 *
 
 # CI will build and copy over the release binary.
-target/release/ping
+!target/release/ping
 
 # Locally, we might want to build it as `debug` binary to accelerate the build process.
-target/debug/ping
+!target/debug/ping

--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -24,13 +24,10 @@ jobs:
       - name: Install Protoc
         run: sudo apt-get install protobuf-compiler
       - name: Build image
-        working-directory: ./interop-tests
         run: |
           cargo build --release -p interop-tests
-          mkdir -p target/release/
-          cp ../target/release/ping target/release
-          docker build -t rust-libp2p-head .
-          docker image save -o ping-image.tar rust-libp2p-head
+          docker build -t rust-libp2p-head --build-arg=TEST_BINARY=target/release/ping . -f ./interop-tests/Dockerfile
+          docker image save -o ./interop-tests/ping-image.tar rust-libp2p-head
       - name: Upload ping versions info
         uses: actions/upload-artifact@v3
         with:

--- a/interop-tests/Dockerfile
+++ b/interop-tests/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:22.04
-COPY target/release/ping /usr/local/bin/testplan
+ARG TEST_BINARY
+COPY $TEST_BINARY /usr/local/bin/testplan
 ENV RUST_BACKTRACE=1
 ENTRYPOINT ["testplan"]


### PR DESCRIPTION
## Description

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

We make the binary that should be copied into the container configurable via a build time `ARG`. This will allow us to reuse the same `Dockerfile` once we write more tests.
Additionally, this allows us to remove some of the directory switching and creation code. In order to not send the entire repository over to the docker daemon as a build context, we introduce a `.dockerignore` file that only allows select binary to be sent over.

The downside of this is that we need to extend this ignore file every time we add a new test. This shouldn't happen very often though and is easily discovered because the building of the docker container will fail.

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
