### PR TITLE
refactor(gossipsub): use dummy handler instead of calling `new_handler`

### DIFF
--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -265,15 +265,21 @@ where
             role_override: Endpoint::Dialer,
         }; // this is not relevant
            // peer_connections.connections should never be empty.
+
         let mut active_connections = peer_connections.connections.len();
         for connection_id in peer_connections.connections.clone() {
-            let handler = gs.new_handler();
             active_connections = active_connections.checked_sub(1).unwrap();
+
+            let dummy_handler = GossipsubHandler::new(
+                ProtocolConfig::new(&GossipsubConfig::default()),
+                Duration::ZERO,
+            );
+
             gs.on_swarm_event(FromSwarm::ConnectionClosed(ConnectionClosed {
                 peer_id: *peer_id,
                 connection_id,
                 endpoint: &fake_endpoint,
-                handler,
+                handler: dummy_handler,
                 remaining_established: active_connections,
             }));
         }

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -33,6 +33,7 @@ use async_std::net::Ipv4Addr;
 use byteorder::{BigEndian, ByteOrder};
 use libp2p_core::{ConnectedPoint, Endpoint};
 use rand::Rng;
+use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::thread::sleep;
@@ -271,7 +272,7 @@ where
             active_connections = active_connections.checked_sub(1).unwrap();
 
             let dummy_handler = GossipsubHandler::new(
-                ProtocolConfig::new(&GossipsubConfig::default()),
+                ProtocolConfig::new(Cow::from(""), None, 0, ValidationMode::None, false),
                 Duration::ZERO,
             );
 


### PR DESCRIPTION
## Description

The gossipsub tests are calling lifecycle functions of the `NetworkBehaviour` that aren't meant to be called outside of `Swarm`. This already surfaced as a problem in https://github.com/libp2p/rust-libp2p/pull/3327 and it is coming up again in https://github.com/libp2p/rust-libp2p/pull/3254 where `new_handler` gets deprecated.

Try to mitigate that by constructing a dummy handler instead. Functionally, there is no difference as in both cases, the given handler has never seen a connection.

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
