### PR TITLE
fix(tcp): remove correct listener in`Transport::remove_listener`

### DIFF
--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 0.39.0 [unreleased]
 
 - Update to `libp2p-core` `v0.39.0`.
+- Fix a bug where we removed any other listener in `Transport::remove_listener` except for the one with the provided `ListenerId`. See [PR 3387].
+
+[PR 3387]: https://github.com/libp2p/rust-libp2p/pull/3387
 
 # 0.38.0
 


### PR DESCRIPTION

## Description

`libp2p_tcp::Transport::remove_listener` previously removed the first listener that *did not match* the provided `ListenerId`. This small fix brings it inline with other implementations.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
