### PR TITLE
refactor(identify): use `ReadyUpgrade` for {In,Out}boundUpgrade

### DIFF
--- a/protocols/identify/src/handler.rs
+++ b/protocols/identify/src/handler.rs
@@ -18,8 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::protocol::{self, InboundPush, Info, OutboundPush, Protocol, Push, UpgradeError};
-use crate::PROTOCOL_NAME;
+use crate::protocol::{self, Info, Protocol, UpgradeError};
+use crate::{PROTOCOL_NAME, PUSH_PROTOCOL_NAME};
 use either::Either;
 use futures::future::BoxFuture;
 use futures::prelude::*;
@@ -27,15 +27,12 @@ use futures::stream::FuturesUnordered;
 use futures_timer::Delay;
 use libp2p_core::upgrade::{ReadyUpgrade, SelectUpgrade};
 use libp2p_core::{ConnectedPoint, Multiaddr, PeerId, PublicKey};
-use libp2p_swarm::handler::{
-    ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
-};
+use libp2p_swarm::handler::{ConnectionEvent, FullyNegotiatedInbound, FullyNegotiatedOutbound};
 use libp2p_swarm::{
     ConnectionHandler, ConnectionHandlerEvent, ConnectionHandlerUpgrErr, IntoConnectionHandler,
     KeepAlive, NegotiatedSubstream, SubstreamProtocol,
 };
 use log::warn;
-use smallvec::SmallVec;
 use std::collections::VecDeque;
 use std::{io, pin::Pin, task::Context, task::Poll, time::Duration};
 
@@ -86,7 +83,10 @@ impl IntoConnectionHandler for Proto {
     }
 
     fn inbound_protocol(&self) -> <Self::Handler as ConnectionHandler>::InboundProtocol {
-        SelectUpgrade::new(ReadyUpgrade::new(PROTOCOL_NAME), Push::inbound())
+        SelectUpgrade::new(
+            ReadyUpgrade::new(PROTOCOL_NAME),
+            ReadyUpgrade::new(PUSH_PROTOCOL_NAME),
+        )
     }
 }
 
@@ -99,21 +99,23 @@ pub struct Handler {
     remote_peer_id: PeerId,
     inbound_identify_push: Option<BoxFuture<'static, Result<Info, UpgradeError>>>,
     /// Pending events to yield.
-    events: SmallVec<
-        [ConnectionHandlerEvent<
-            Either<ReadyUpgrade<&'static [u8]>, Push<OutboundPush>>,
-            (),
-            Event,
-            io::Error,
-        >; 4],
+    pending_events: FuturesUnordered<
+        BoxFuture<
+            'static,
+            Result<
+                ConnectionHandlerEvent<
+                    Either<ReadyUpgrade<&'static [u8]>, ReadyUpgrade<&'static [u8]>>,
+                    Option<Info>,
+                    Event,
+                    io::Error,
+                >,
+                UpgradeError,
+            >,
+        >,
     >,
 
     /// Streams awaiting `BehaviourInfo` to then send identify requests.
     reply_streams: VecDeque<NegotiatedSubstream>,
-
-    /// Pending identification replies, awaiting being sent and received.
-    pending_replies:
-        FuturesUnordered<BoxFuture<'static, Result<Either<PeerId, Info>, UpgradeError>>>,
 
     /// Future that fires when we need to identify the node again.
     trigger_next_identify: Delay,
@@ -182,9 +184,8 @@ impl Handler {
         Self {
             remote_peer_id,
             inbound_identify_push: Default::default(),
-            events: SmallVec::new(),
+            pending_events: FuturesUnordered::new(),
             reply_streams: VecDeque::new(),
-            pending_replies: FuturesUnordered::new(),
             trigger_next_identify: Delay::new(initial_delay),
             keep_alive: KeepAlive::Yes,
             interval,
@@ -206,8 +207,10 @@ impl Handler {
     ) {
         match output {
             future::Either::Left(substream) => {
-                self.events
-                    .push(ConnectionHandlerEvent::Custom(Event::Identify));
+                self.pending_events
+                    .push(Box::pin(future::ok(ConnectionHandlerEvent::Custom(
+                        Event::Identify,
+                    ))));
                 if !self.reply_streams.is_empty() {
                     warn!(
                         "New inbound identify request from {} while a previous one \
@@ -217,8 +220,12 @@ impl Handler {
                 }
                 self.reply_streams.push_back(substream);
             }
-            future::Either::Right(fut) => {
-                if self.inbound_identify_push.replace(fut).is_some() {
+            future::Either::Right(substream) => {
+                if self
+                    .inbound_identify_push
+                    .replace(Box::pin(protocol::recv(substream)))
+                    .is_some()
+                {
                     warn!(
                         "New inbound identify push stream from {} while still \
                          upgrading previous one. Replacing previous with new.",
@@ -232,46 +239,33 @@ impl Handler {
     fn on_fully_negotiated_outbound(
         &mut self,
         FullyNegotiatedOutbound {
-            protocol: output, ..
+            protocol: output,
+            info,
         }: FullyNegotiatedOutbound<
             <Self as ConnectionHandler>::OutboundProtocol,
             <Self as ConnectionHandler>::OutboundOpenInfo,
         >,
     ) {
         match output {
-            future::Either::Left(remote_info) => {
+            future::Either::Left(substream) => {
                 let fut = Box::pin(async move {
-                    let info = protocol::recv(remote_info).await?;
-                    Ok(Either::Right(info))
+                    let info = protocol::recv(substream).await?;
+                    Ok(ConnectionHandlerEvent::Custom(Event::Identified(info)))
                 });
-                self.pending_replies.push(fut);
+                self.pending_events.push(fut);
             }
-            future::Either::Right(()) => self
-                .events
-                .push(ConnectionHandlerEvent::Custom(Event::IdentificationPushed)),
+            future::Either::Right(substream) => {
+                let fut = Box::pin(async move {
+                    protocol::send(
+                        substream,
+                        info.expect("Info should be available on a Push substream request"),
+                    )
+                    .await?;
+                    Ok(ConnectionHandlerEvent::Custom(Event::IdentificationPushed))
+                });
+                self.pending_events.push(fut);
+            }
         }
-    }
-
-    fn on_dial_upgrade_error(
-        &mut self,
-        DialUpgradeError { error: err, .. }: DialUpgradeError<
-            <Self as ConnectionHandler>::OutboundOpenInfo,
-            <Self as ConnectionHandler>::OutboundProtocol,
-        >,
-    ) {
-        use libp2p_core::upgrade::UpgradeError;
-
-        let err = err.map_upgrade_err(|e| match e {
-            UpgradeError::Select(e) => UpgradeError::Select(e),
-            UpgradeError::Apply(Either::Left(_ioe)) => unreachable!(),
-            UpgradeError::Apply(Either::Right(ioe)) => UpgradeError::Apply(ioe),
-        });
-        self.events
-            .push(ConnectionHandlerEvent::Custom(Event::IdentificationError(
-                err,
-            )));
-        self.keep_alive = KeepAlive::No;
-        self.trigger_next_identify.reset(self.interval);
     }
 }
 
@@ -279,14 +273,17 @@ impl ConnectionHandler for Handler {
     type InEvent = InEvent;
     type OutEvent = Event;
     type Error = io::Error;
-    type InboundProtocol = SelectUpgrade<ReadyUpgrade<&'static [u8]>, Push<InboundPush>>;
-    type OutboundProtocol = Either<ReadyUpgrade<&'static [u8]>, Push<OutboundPush>>;
-    type OutboundOpenInfo = ();
+    type InboundProtocol = SelectUpgrade<ReadyUpgrade<&'static [u8]>, ReadyUpgrade<&'static [u8]>>;
+    type OutboundProtocol = Either<ReadyUpgrade<&'static [u8]>, ReadyUpgrade<&'static [u8]>>;
+    type OutboundOpenInfo = Option<Info>;
     type InboundOpenInfo = ();
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
         SubstreamProtocol::new(
-            SelectUpgrade::new(ReadyUpgrade::new(PROTOCOL_NAME), Push::inbound()),
+            SelectUpgrade::new(
+                ReadyUpgrade::new(PROTOCOL_NAME),
+                ReadyUpgrade::new(PUSH_PROTOCOL_NAME),
+            ),
             (),
         )
     }
@@ -310,10 +307,14 @@ impl ConnectionHandler for Handler {
 
         match protocol {
             Protocol::Push => {
-                self.events
-                    .push(ConnectionHandlerEvent::OutboundSubstreamRequest {
-                        protocol: SubstreamProtocol::new(Either::Right(Push::outbound(info)), ()),
-                    });
+                self.pending_events.push(Box::pin(future::ok(
+                    ConnectionHandlerEvent::OutboundSubstreamRequest {
+                        protocol: SubstreamProtocol::new(
+                            Either::Right(ReadyUpgrade::new(PUSH_PROTOCOL_NAME)),
+                            Some(info),
+                        ),
+                    },
+                )));
             }
             Protocol::Identify(_) => {
                 let substream = self
@@ -323,9 +324,9 @@ impl ConnectionHandler for Handler {
                 let peer = self.remote_peer_id;
                 let fut = Box::pin(async move {
                     protocol::send(substream, info).await?;
-                    Ok(Either::Left(peer))
+                    Ok(ConnectionHandlerEvent::Custom(Event::Identification(peer)))
                 });
-                self.pending_replies.push(fut);
+                self.pending_events.push(fut);
             }
         }
     }
@@ -340,8 +341,17 @@ impl ConnectionHandler for Handler {
     ) -> Poll<
         ConnectionHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Event, Self::Error>,
     > {
-        if !self.events.is_empty() {
-            return Poll::Ready(self.events.remove(0));
+        // Check for pending events to yield.
+        match self.pending_events.poll_next_unpin(cx) {
+            Poll::Ready(Some(Ok(event))) => return Poll::Ready(event),
+            Poll::Ready(Some(Err(err))) => {
+                return Poll::Ready(ConnectionHandlerEvent::Custom(Event::IdentificationError(
+                    ConnectionHandlerUpgrErr::Upgrade(libp2p_core::upgrade::UpgradeError::Apply(
+                        err,
+                    )),
+                )));
+            }
+            Poll::Ready(None) | Poll::Pending => {}
         }
 
         // Poll the future that fires when we need to identify the node again.
@@ -352,7 +362,7 @@ impl ConnectionHandler for Handler {
                 let ev = ConnectionHandlerEvent::OutboundSubstreamRequest {
                     protocol: SubstreamProtocol::new(
                         Either::Left(ReadyUpgrade::new(PROTOCOL_NAME)),
-                        (),
+                        None,
                     ),
                 };
                 return Poll::Ready(ev);
@@ -371,21 +381,7 @@ impl ConnectionHandler for Handler {
             }
         }
 
-        // Check for pending replies to send.
-        match self.pending_replies.poll_next_unpin(cx) {
-            Poll::Ready(Some(Ok(Either::Left(peer_id)))) => Poll::Ready(
-                ConnectionHandlerEvent::Custom(Event::Identification(peer_id)),
-            ),
-            Poll::Ready(Some(Ok(Either::Right(info)))) => {
-                Poll::Ready(ConnectionHandlerEvent::Custom(Event::Identified(info)))
-            }
-            Poll::Ready(Some(Err(err))) => Poll::Ready(ConnectionHandlerEvent::Custom(
-                Event::IdentificationError(ConnectionHandlerUpgrErr::Upgrade(
-                    libp2p_core::upgrade::UpgradeError::Apply(err),
-                )),
-            )),
-            Poll::Ready(None) | Poll::Pending => Poll::Pending,
-        }
+        Poll::Pending
     }
 
     fn on_connection_event(
@@ -404,10 +400,9 @@ impl ConnectionHandler for Handler {
             ConnectionEvent::FullyNegotiatedOutbound(fully_negotiated_outbound) => {
                 self.on_fully_negotiated_outbound(fully_negotiated_outbound)
             }
-            ConnectionEvent::DialUpgradeError(dial_upgrade_error) => {
-                self.on_dial_upgrade_error(dial_upgrade_error)
-            }
-            ConnectionEvent::AddressChange(_) | ConnectionEvent::ListenUpgradeError(_) => {}
+            ConnectionEvent::DialUpgradeError(_)
+            | ConnectionEvent::AddressChange(_)
+            | ConnectionEvent::ListenUpgradeError(_) => {}
         }
     }
 }

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -20,18 +20,13 @@
 
 use crate::structs_proto;
 use asynchronous_codec::{FramedRead, FramedWrite};
-use futures::{future::BoxFuture, prelude::*};
-use libp2p_core::{
-    identity, multiaddr,
-    upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo},
-    Multiaddr, PublicKey,
-};
+use futures::prelude::*;
+use libp2p_core::{identity, multiaddr, Multiaddr, PublicKey};
 use libp2p_swarm::ConnectionId;
 use log::{debug, trace};
 use std::convert::TryFrom;
-use std::{io, iter, pin::Pin};
+use std::io;
 use thiserror::Error;
-use void::Void;
 
 const MAX_MESSAGE_SIZE_BYTES: usize = 4096;
 
@@ -44,24 +39,6 @@ pub const PUSH_PROTOCOL_NAME: &[u8] = b"/ipfs/id/push/1.0.0";
 pub enum Protocol {
     Identify(ConnectionId),
     Push,
-}
-
-/// Substream upgrade protocol for `/ipfs/id/push/1.0.0`.
-#[derive(Debug, Clone)]
-pub struct Push<T>(T);
-pub struct InboundPush();
-pub struct OutboundPush(Info);
-
-impl Push<InboundPush> {
-    pub fn inbound() -> Self {
-        Push(InboundPush())
-    }
-}
-
-impl Push<OutboundPush> {
-    pub fn outbound(info: Info) -> Self {
-        Push(OutboundPush(info))
-    }
 }
 
 /// Information of a peer sent in protocol messages.
@@ -81,42 +58,6 @@ pub struct Info {
     pub protocols: Vec<String>,
     /// Address observed by or for the remote.
     pub observed_addr: Multiaddr,
-}
-
-impl<T> UpgradeInfo for Push<T> {
-    type Info = &'static [u8];
-    type InfoIter = iter::Once<Self::Info>;
-
-    fn protocol_info(&self) -> Self::InfoIter {
-        iter::once(PUSH_PROTOCOL_NAME)
-    }
-}
-
-impl<C> InboundUpgrade<C> for Push<InboundPush>
-where
-    C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-{
-    type Output = BoxFuture<'static, Result<Info, UpgradeError>>;
-    type Error = Void;
-    type Future = future::Ready<Result<Self::Output, Self::Error>>;
-
-    fn upgrade_inbound(self, socket: C, _: Self::Info) -> Self::Future {
-        // Lazily upgrade stream, thus allowing upgrade to happen within identify's handler.
-        future::ok(recv(socket).boxed())
-    }
-}
-
-impl<C> OutboundUpgrade<C> for Push<OutboundPush>
-where
-    C: AsyncWrite + Unpin + Send + 'static,
-{
-    type Output = ();
-    type Error = UpgradeError;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
-
-    fn upgrade_outbound(self, socket: C, _: Self::Info) -> Self::Future {
-        send(socket, self.0 .0).boxed()
-    }
 }
 
 pub(crate) async fn send<T>(io: T, info: Info) -> Result<(), UpgradeError>

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -35,9 +35,9 @@ use void::Void;
 
 const MAX_MESSAGE_SIZE_BYTES: usize = 4096;
 
-pub const PROTOCOL_NAME: &[u8; 14] = b"/ipfs/id/1.0.0";
+pub const PROTOCOL_NAME: &[u8] = b"/ipfs/id/1.0.0";
 
-pub const PUSH_PROTOCOL_NAME: &[u8; 19] = b"/ipfs/id/push/1.0.0";
+pub const PUSH_PROTOCOL_NAME: &[u8] = b"/ipfs/id/push/1.0.0";
 
 /// The type of the Substream protocol.
 #[derive(Debug, PartialEq, Eq)]
@@ -45,10 +45,6 @@ pub enum Protocol {
     Identify(ConnectionId),
     Push,
 }
-
-/// Substream upgrade protocol for `/ipfs/id/1.0.0`.
-#[derive(Debug, Clone)]
-pub struct Identify;
 
 /// Substream upgrade protocol for `/ipfs/id/push/1.0.0`.
 #[derive(Debug, Clone)]
@@ -85,38 +81,6 @@ pub struct Info {
     pub protocols: Vec<String>,
     /// Address observed by or for the remote.
     pub observed_addr: Multiaddr,
-}
-
-impl UpgradeInfo for Identify {
-    type Info = &'static [u8];
-    type InfoIter = iter::Once<Self::Info>;
-
-    fn protocol_info(&self) -> Self::InfoIter {
-        iter::once(PROTOCOL_NAME)
-    }
-}
-
-impl<C> InboundUpgrade<C> for Identify {
-    type Output = C;
-    type Error = UpgradeError;
-    type Future = future::Ready<Result<Self::Output, UpgradeError>>;
-
-    fn upgrade_inbound(self, socket: C, _: Self::Info) -> Self::Future {
-        future::ok(socket)
-    }
-}
-
-impl<C> OutboundUpgrade<C> for Identify
-where
-    C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-{
-    type Output = Info;
-    type Error = UpgradeError;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
-
-    fn upgrade_outbound(self, socket: C, _: Self::Info) -> Self::Future {
-        recv(socket).boxed()
-    }
 }
 
 impl<T> UpgradeInfo for Push<T> {
@@ -189,7 +153,7 @@ where
     Ok(())
 }
 
-async fn recv<T>(mut socket: T) -> Result<Info, UpgradeError>
+pub async fn recv<T>(mut socket: T) -> Result<Info, UpgradeError>
 where
     T: AsyncRead + AsyncWrite + Unpin,
 {
@@ -272,7 +236,7 @@ mod tests {
     use futures::channel::oneshot;
     use libp2p_core::{
         identity,
-        upgrade::{self, apply_inbound, apply_outbound},
+        upgrade::{self, apply_inbound, apply_outbound, ReadyUpgrade},
         Transport,
     };
     use libp2p_tcp as tcp;
@@ -311,7 +275,9 @@ mod tests {
                 .await
                 .unwrap();
 
-            let sender = apply_inbound(socket, Identify).await.unwrap();
+            let sender = apply_inbound(socket, ReadyUpgrade::new(PROTOCOL_NAME))
+                .await
+                .unwrap();
 
             send(
                 sender,
@@ -335,9 +301,14 @@ mod tests {
             let mut transport = tcp::async_io::Transport::default();
 
             let socket = transport.dial(rx.await.unwrap()).unwrap().await.unwrap();
-            let info = apply_outbound(socket, Identify, upgrade::Version::V1)
-                .await
-                .unwrap();
+            let upgrade = apply_outbound(
+                socket,
+                ReadyUpgrade::new(PROTOCOL_NAME),
+                upgrade::Version::V1,
+            )
+            .await
+            .unwrap();
+            let info = recv(upgrade).await.unwrap();
             assert_eq!(
                 info.observed_addr,
                 "/ip4/100.101.102.103/tcp/5000".parse().unwrap()


### PR DESCRIPTION
## Description
Starts addressing https://github.com/libp2p/rust-libp2p/issues/2863
## Notes

I read the discussion Thomas, namely [your comment](https://github.com/libp2p/rust-libp2p/issues/2863#issuecomment-1377330094) to start with the `TimedFutures` implementation. But as I wasn't completely familiar with everything you wrote I started experimenting with `identify` and was able to use `ReadyUpgrade` for `{In,Out}boundUpgrade` therefore removing most of the `protocol` code.

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

- I am not familiar with all the protocols yet, but wdyt of following the same approach hereby presented for `identify` and first replace all custom `{In,Out}boundUpgrade`'s with `ReadyUpgrade`'s then creating the `TimedFutures` and then introducing the breaking changes on the `ConnectionHandler`?
The reason I ask this, is because with `identify` for example this PR AFAICT maintains the same timeouts and backpressure right? Nonetheless if you prefer we can add `TimedFutures` now and introduce it already to `identify` no strong opinion.

- What do you think of joining all the `events` on the same `FuturesUnordered`? I feel it makes sense as they are all events, it's just some haven't been resolved but if prefered I can rollback to the `events` and `pending_replies` approach, though that will probably mean the need for another enum with the identify variants.  

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
