### PR TITLE
feat(interop-tests): build test binary inside container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,1 @@
-# This Docker ignore file aims to optimise the build process of the interop tests.
-# The Dockerfile in ./interop-tests/Dockerfile copies a locally built binary into the container and
-# thus does not need anything else to be present in the working directory.
-*
-
-# CI will build and copy over the release binary.
-!target/release/ping
-
-# Locally, we might want to build it as `debug` binary to accelerate the build process.
-!target/debug/ping
+target

--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -17,8 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
       - name: Build image
-        run: |
-          docker buildx build --load -t rust-libp2p-head . -f interop-tests/Dockerfile
+        run: docker buildx build --load -t rust-libp2p-head . -f interop-tests/Dockerfile
       - uses: libp2p/test-plans/.github/actions/run-interop-ping-test@482e8ac2e5d91c69d7f432d325337e2ddca39cf9
         with:
           test-filter: rust-libp2p-head

--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -15,17 +15,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
-        with:
-          shared-key: interop-tests
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-      - name: Install Protoc
-        run: sudo apt-get install protobuf-compiler
+      - uses: docker/setup-buildx-action@v2
       - name: Build image
         run: |
-          cargo build --release -p interop-tests
-          docker build -t rust-libp2p-head --build-arg=TEST_BINARY=target/release/ping . -f interop-tests/Dockerfile
-      - uses: libp2p/test-plans/.github/actions/run-interop-ping-test@c9130e425d266e5b222636d61348c0f8d6b978e4
+          docker buildx build --load -t rust-libp2p-head . -f interop-tests/Dockerfile
+      - uses: libp2p/test-plans/.github/actions/run-interop-ping-test@482e8ac2e5d91c69d7f432d325337e2ddca39cf9
         with:
           test-filter: rust-libp2p-head
           extra-versions: ${{ github.workspace }}/interop-tests/ping-version.json
+          s3-cache-bucket: libp2p-by-tf-aws-bootstrap
+          s3-access-key-id: ${{ vars.TEST_PLANS_BUILD_CACHE_KEY_ID }}
+          s3-secret-access-key: ${{ secrets.TEST_PLANS_BUILD_CACHE_KEY }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,8 @@ members = [
     "transports/uds",
     "transports/websocket",
     "transports/wasm-ext",
-    "transports/webrtc"
+    "transports/webrtc",
+    "interop-tests"
 ]
 
 [[example]]

--- a/interop-tests/Dockerfile
+++ b/interop-tests/Dockerfile
@@ -1,6 +1,20 @@
-FROM ubuntu:22.04
-ARG TEST_BINARY
-COPY $TEST_BINARY /usr/local/bin/testplan
-LABEL org.opencontainers.image.source https://github.com/libp2p/rust-libp2p
+# syntax=docker/dockerfile:1.5-labs
+FROM rust:1.67.0
+
+# Setup protoc. TODO this breaks reproducibility and uses an old version of protoc.
+# In the future protobuf generated files will be checked in, so we can remove this
+WORKDIR /protoc-setup
+RUN apt-get update && apt-get install -y cmake protobuf-compiler
+
+# Run with access to the target cache to speed up builds
+WORKDIR /workspace
+ADD . .
+RUN --mount=type=cache,target=./target \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo build --package interop-tests
+
+RUN --mount=type=cache,target=./target \
+    mv ./target/debug/ping /usr/local/bin/testplan
+
 ENV RUST_BACKTRACE=1
 ENTRYPOINT ["testplan"]

--- a/interop-tests/README.md
+++ b/interop-tests/README.md
@@ -25,8 +25,7 @@ To run this test against all released libp2p versions you'll need to have the
 (libp2p/test-plans)[https://github.com/libp2p/test-plans] checked out. Then do
 the following (from the root directory of this repository):
 
-1. Build the ping binary: `cargo build --release -p interop-tests`
-1. Build the image: `docker build -t rust-libp2p-head --build-arg=TEST_BINARY=target/release/ping . -f interop-tests/Dockerfile`.
+1. Build the image: `docker build -t rust-libp2p-head . -f interop-tests/Dockerfile`.
 1. Build the images for all released versions in `libp2p/test-plans`: `(cd <path to >/libp2p/test-plans/multidim-interop/ && make)`.
 1. Run the test:
 ```


### PR DESCRIPTION
## Description

Building inside the container allows Windows and MacOS users to also build this binary. Thanks to a new feature from docker, `--mount=type=cache`, rebuilding layers is fast without any additional hacks.

## Notes

continuation of #3439 for master. @thomaseizinger will backport these tests to older versions once we merge this.
