### PR TITLE
refactor(gossipsub): make `error` module private

### DIFF
--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -48,7 +48,6 @@ use wasm_timer::Instant;
 
 use crate::backoff::BackoffStorage;
 use crate::config::{Config, ValidationMode};
-use crate::error_priv::{PublishError, SubscriptionError, ValidationError};
 use crate::gossip_promises::GossipPromises;
 use crate::handler::{Handler, HandlerEvent, HandlerIn};
 use crate::mcache::MessageCache;
@@ -65,6 +64,7 @@ use crate::types::{
 };
 use crate::types::{PeerConnections, PeerKind, Rpc};
 use crate::{rpc_proto, TopicScoreParams};
+use crate::{PublishError, SubscriptionError, ValidationError};
 use std::{cmp::Ordering::Equal, fmt::Debug};
 use wasm_timer::Interval;
 

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -48,7 +48,7 @@ use wasm_timer::Instant;
 
 use crate::backoff::BackoffStorage;
 use crate::config::{Config, ValidationMode};
-use crate::error::{PublishError, SubscriptionError, ValidationError};
+use crate::error_priv::{PublishError, SubscriptionError, ValidationError};
 use crate::gossip_promises::GossipPromises;
 use crate::handler::{Handler, HandlerEvent, HandlerIn};
 use crate::mcache::MessageCache;

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -21,10 +21,10 @@
 // Collection of tests for the gossipsub network behaviour
 
 use super::*;
-use crate::error_priv::ValidationError;
 use crate::subscription_filter::WhitelistSubscriptionFilter;
 use crate::transform::{DataTransform, IdentityTransform};
 use crate::types::FastMessageId;
+use crate::ValidationError;
 use crate::{
     config::Config, config::ConfigBuilder, IdentTopic as Topic, Message, TopicScoreParams,
 };

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -21,7 +21,7 @@
 // Collection of tests for the gossipsub network behaviour
 
 use super::*;
-use crate::error::ValidationError;
+use crate::error_priv::ValidationError;
 use crate::subscription_filter::WhitelistSubscriptionFilter;
 use crate::transform::{DataTransform, IdentityTransform};
 use crate::types::FastMessageId;

--- a/protocols/gossipsub/src/error.rs
+++ b/protocols/gossipsub/src/error.rs
@@ -20,13 +20,13 @@
 
 #[deprecated(
     since = "0.44.0",
-    note = "Use `libp2p::gossipsub::PublishError` instead, as the `error` will become crate-private in the future."
+    note = "Use `libp2p::gossipsub::PublishError` instead, as the `error` module will become crate-private in the future."
 )]
 pub type PublishError = crate::error_priv::PublishError;
 
 #[deprecated(
     since = "0.44.0",
-    note = "Use `libp2p::gossipsub::SubscriptionError` instead, as the `error` will become crate-private in the future."
+    note = "Use `libp2p::gossipsub::SubscriptionError` instead, as the `error` module will become crate-private in the future."
 )]
 pub type SubscriptionError = crate::error_priv::SubscriptionError;
 
@@ -38,12 +38,12 @@ pub type GossipsubHandlerError = crate::error_priv::HandlerError;
 
 #[deprecated(
     since = "0.44.0",
-    note = "Use `libp2p::gossipsub::HandlerError` instead, as the `error` will become crate-private in the future."
+    note = "Use `libp2p::gossipsub::HandlerError` instead, as the `error` module will become crate-private in the future."
 )]
 pub type HandlerError = crate::error_priv::HandlerError;
 
 #[deprecated(
     since = "0.44.0",
-    note = "Use `libp2p::gossipsub::ValidationError` instead, as the `error` will become crate-private in the future."
+    note = "Use `libp2p::gossipsub::ValidationError` instead, as the `error` module will become crate-private in the future."
 )]
 pub type ValidationError = crate::error_priv::ValidationError;

--- a/protocols/gossipsub/src/error.rs
+++ b/protocols/gossipsub/src/error.rs
@@ -22,7 +22,7 @@ pub type GossipsubHandlerError = crate::error_priv::HandlerError;
 
 #[deprecated(
     since = "0.44.0",
-    note = "Use `libp2p::gossipsub::HandlerError instead, as the `error` will become crate-private in the future."
+    note = "Use `libp2p::gossipsub::HandlerError` instead, as the `error` will become crate-private in the future."
 )]
 pub type HandlerError = crate::error_priv::HandlerError;
 

--- a/protocols/gossipsub/src/error.rs
+++ b/protocols/gossipsub/src/error.rs
@@ -1,6 +1,22 @@
-// TODO: which copyright here?
+// Copyright 2023 Protocol Labs.
 //
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
 //
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
 
 #[deprecated(
     since = "0.44.0",

--- a/protocols/gossipsub/src/error.rs
+++ b/protocols/gossipsub/src/error.rs
@@ -1,153 +1,33 @@
-// Copyright 2020 Sigma Prime Pty Ltd.
+// TODO: which copyright here?
 //
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the "Software"),
-// to deal in the Software without restriction, including without limitation
-// the rights to use, copy, modify, merge, publish, distribute, sublicense,
-// and/or sell copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following conditions:
 //
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-// DEALINGS IN THE SOFTWARE.
 
-//! Error types that can result from gossipsub.
+#[deprecated(
+    since = "0.44.0",
+    note = "Use `libp2p::gossipsub::PublishError` instead, as the `error` will become crate-private in the future."
+)]
+pub type PublishError = crate::error_priv::PublishError;
 
-use libp2p_core::identity::error::SigningError;
-use libp2p_core::upgrade::ProtocolError;
-use thiserror::Error;
-
-/// Error associated with publishing a gossipsub message.
-#[derive(Debug)]
-pub enum PublishError {
-    /// This message has already been published.
-    Duplicate,
-    /// An error occurred whilst signing the message.
-    SigningError(SigningError),
-    /// There were no peers to send this message to.
-    InsufficientPeers,
-    /// The overall message was too large. This could be due to excessive topics or an excessive
-    /// message size.
-    MessageTooLarge,
-    /// The compression algorithm failed.
-    TransformFailed(std::io::Error),
-}
-
-impl std::fmt::Display for PublishError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{self:?}")
-    }
-}
-
-impl std::error::Error for PublishError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::SigningError(err) => Some(err),
-            Self::TransformFailed(err) => Some(err),
-            _ => None,
-        }
-    }
-}
-
-/// Error associated with subscribing to a topic.
-#[derive(Debug)]
-pub enum SubscriptionError {
-    /// Couldn't publish our subscription
-    PublishError(PublishError),
-    /// We are not allowed to subscribe to this topic by the subscription filter
-    NotAllowed,
-}
-
-impl std::fmt::Display for SubscriptionError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{self:?}")
-    }
-}
-
-impl std::error::Error for SubscriptionError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::PublishError(err) => Some(err),
-            _ => None,
-        }
-    }
-}
-
-impl From<SigningError> for PublishError {
-    fn from(error: SigningError) -> Self {
-        PublishError::SigningError(error)
-    }
-}
+#[deprecated(
+    since = "0.44.0",
+    note = "Use `libp2p::gossipsub::SubscriptionError` instead, as the `error` will become crate-private in the future."
+)]
+pub type SubscriptionError = crate::error_priv::SubscriptionError;
 
 #[deprecated(
     since = "0.44.0",
     note = "Use re-exports that omit `Gossipsub` prefix, i.e. `libp2p::gossipsub::HandlerError"
 )]
-pub type GossipsubHandlerError = HandlerError;
+pub type GossipsubHandlerError = crate::error_priv::HandlerError;
 
-/// Errors that can occur in the protocols handler.
-#[derive(Debug, Error)]
-pub enum HandlerError {
-    #[error("The maximum number of inbound substreams created has been exceeded.")]
-    MaxInboundSubstreams,
-    #[error("The maximum number of outbound substreams created has been exceeded.")]
-    MaxOutboundSubstreams,
-    #[error("The message exceeds the maximum transmission size.")]
-    MaxTransmissionSize,
-    #[error("Protocol negotiation timeout.")]
-    NegotiationTimeout,
-    #[error("Protocol negotiation failed.")]
-    NegotiationProtocolError(ProtocolError),
-    #[error("Failed to encode or decode")]
-    Codec(#[from] prost_codec::Error),
-}
+#[deprecated(
+    since = "0.44.0",
+    note = "Use `libp2p::gossipsub::HandlerError instead, as the `error` will become crate-private in the future."
+)]
+pub type HandlerError = crate::error_priv::HandlerError;
 
-#[derive(Debug, Clone, Copy)]
-pub enum ValidationError {
-    /// The message has an invalid signature,
-    InvalidSignature,
-    /// The sequence number was empty, expected a value.
-    EmptySequenceNumber,
-    /// The sequence number was the incorrect size
-    InvalidSequenceNumber,
-    /// The PeerId was invalid
-    InvalidPeerId,
-    /// Signature existed when validation has been sent to
-    /// [`crate::behaviour::MessageAuthenticity::Anonymous`].
-    SignaturePresent,
-    /// Sequence number existed when validation has been sent to
-    /// [`crate::behaviour::MessageAuthenticity::Anonymous`].
-    SequenceNumberPresent,
-    /// Message source existed when validation has been sent to
-    /// [`crate::behaviour::MessageAuthenticity::Anonymous`].
-    MessageSourcePresent,
-    /// The data transformation failed.
-    TransformFailed,
-}
-
-impl std::fmt::Display for ValidationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{self:?}")
-    }
-}
-
-impl std::error::Error for ValidationError {}
-
-impl From<std::io::Error> for HandlerError {
-    fn from(error: std::io::Error) -> HandlerError {
-        HandlerError::Codec(prost_codec::Error::from(error))
-    }
-}
-
-impl From<std::io::Error> for PublishError {
-    fn from(error: std::io::Error) -> PublishError {
-        PublishError::TransformFailed(error)
-    }
-}
+#[deprecated(
+    since = "0.44.0",
+    note = "Use `libp2p::gossipsub::ValidationError` instead, as the `error` will become crate-private in the future."
+)]
+pub type ValidationError = crate::error_priv::ValidationError;

--- a/protocols/gossipsub/src/error_priv.rs
+++ b/protocols/gossipsub/src/error_priv.rs
@@ -1,0 +1,147 @@
+// Copyright 2020 Sigma Prime Pty Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Error types that can result from gossipsub.
+
+use libp2p_core::identity::error::SigningError;
+use libp2p_core::upgrade::ProtocolError;
+use thiserror::Error;
+
+/// Error associated with publishing a gossipsub message.
+#[derive(Debug)]
+pub enum PublishError {
+    /// This message has already been published.
+    Duplicate,
+    /// An error occurred whilst signing the message.
+    SigningError(SigningError),
+    /// There were no peers to send this message to.
+    InsufficientPeers,
+    /// The overall message was too large. This could be due to excessive topics or an excessive
+    /// message size.
+    MessageTooLarge,
+    /// The compression algorithm failed.
+    TransformFailed(std::io::Error),
+}
+
+impl std::fmt::Display for PublishError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for PublishError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::SigningError(err) => Some(err),
+            Self::TransformFailed(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+/// Error associated with subscribing to a topic.
+#[derive(Debug)]
+pub enum SubscriptionError {
+    /// Couldn't publish our subscription
+    PublishError(PublishError),
+    /// We are not allowed to subscribe to this topic by the subscription filter
+    NotAllowed,
+}
+
+impl std::fmt::Display for SubscriptionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for SubscriptionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::PublishError(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<SigningError> for PublishError {
+    fn from(error: SigningError) -> Self {
+        PublishError::SigningError(error)
+    }
+}
+
+/// Errors that can occur in the protocols handler.
+#[derive(Debug, Error)]
+pub enum HandlerError {
+    #[error("The maximum number of inbound substreams created has been exceeded.")]
+    MaxInboundSubstreams,
+    #[error("The maximum number of outbound substreams created has been exceeded.")]
+    MaxOutboundSubstreams,
+    #[error("The message exceeds the maximum transmission size.")]
+    MaxTransmissionSize,
+    #[error("Protocol negotiation timeout.")]
+    NegotiationTimeout,
+    #[error("Protocol negotiation failed.")]
+    NegotiationProtocolError(ProtocolError),
+    #[error("Failed to encode or decode")]
+    Codec(#[from] prost_codec::Error),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ValidationError {
+    /// The message has an invalid signature,
+    InvalidSignature,
+    /// The sequence number was empty, expected a value.
+    EmptySequenceNumber,
+    /// The sequence number was the incorrect size
+    InvalidSequenceNumber,
+    /// The PeerId was invalid
+    InvalidPeerId,
+    /// Signature existed when validation has been sent to
+    /// [`crate::behaviour::MessageAuthenticity::Anonymous`].
+    SignaturePresent,
+    /// Sequence number existed when validation has been sent to
+    /// [`crate::behaviour::MessageAuthenticity::Anonymous`].
+    SequenceNumberPresent,
+    /// Message source existed when validation has been sent to
+    /// [`crate::behaviour::MessageAuthenticity::Anonymous`].
+    MessageSourcePresent,
+    /// The data transformation failed.
+    TransformFailed,
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+impl From<std::io::Error> for HandlerError {
+    fn from(error: std::io::Error) -> HandlerError {
+        HandlerError::Codec(prost_codec::Error::from(error))
+    }
+}
+
+impl From<std::io::Error> for PublishError {
+    fn from(error: std::io::Error) -> PublishError {
+        PublishError::TransformFailed(error)
+    }
+}

--- a/protocols/gossipsub/src/gossip_promises.rs
+++ b/protocols/gossipsub/src/gossip_promises.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::error::ValidationError;
+use crate::error_priv::ValidationError;
 use crate::peer_score::RejectReason;
 use crate::MessageId;
 use libp2p_core::PeerId;

--- a/protocols/gossipsub/src/gossip_promises.rs
+++ b/protocols/gossipsub/src/gossip_promises.rs
@@ -18,9 +18,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::error_priv::ValidationError;
 use crate::peer_score::RejectReason;
 use crate::MessageId;
+use crate::ValidationError;
 use libp2p_core::PeerId;
 use log::debug;
 use std::collections::HashMap;

--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::error::{HandlerError, ValidationError};
+use crate::error_priv::{HandlerError, ValidationError};
 use crate::protocol::{GossipsubCodec, ProtocolConfig};
 use crate::types::{PeerKind, RawMessage, Rpc};
 use asynchronous_codec::Framed;

--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -18,9 +18,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::error_priv::{HandlerError, ValidationError};
 use crate::protocol::{GossipsubCodec, ProtocolConfig};
 use crate::types::{PeerKind, RawMessage, Rpc};
+use crate::{HandlerError, ValidationError};
 use asynchronous_codec::Framed;
 use futures::prelude::*;
 use futures::StreamExt;

--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -138,18 +138,19 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub mod error;
+pub mod metrics;
 pub mod protocol;
+pub mod subscription_filter;
+pub mod time_cache;
 
 mod backoff;
 mod behaviour;
 mod config;
+mod error_priv;
 mod gossip_promises;
 mod handler;
 mod mcache;
-pub mod metrics;
 mod peer_score;
-pub mod subscription_filter;
-pub mod time_cache;
 mod topic;
 mod transform;
 mod types;
@@ -158,7 +159,7 @@ mod rpc_proto;
 
 pub use self::behaviour::{Behaviour, Event, MessageAuthenticity};
 pub use self::config::{Config, ConfigBuilder, ValidationMode, Version};
-pub use self::error::{HandlerError, PublishError, SubscriptionError, ValidationError};
+pub use self::error_priv::{HandlerError, PublishError, SubscriptionError, ValidationError};
 pub use self::peer_score::{
     score_parameter_decay, score_parameter_decay_with_base, PeerScoreParams, PeerScoreThresholds,
     TopicScoreParams,

--- a/protocols/gossipsub/src/peer_score.rs
+++ b/protocols/gossipsub/src/peer_score.rs
@@ -32,7 +32,7 @@ use std::time::Duration;
 use wasm_timer::Instant;
 
 mod params;
-use crate::error_priv::ValidationError;
+use crate::ValidationError;
 pub use params::{
     score_parameter_decay, score_parameter_decay_with_base, PeerScoreParams, PeerScoreThresholds,
     TopicScoreParams,

--- a/protocols/gossipsub/src/peer_score.rs
+++ b/protocols/gossipsub/src/peer_score.rs
@@ -32,7 +32,7 @@ use std::time::Duration;
 use wasm_timer::Instant;
 
 mod params;
-use crate::error::ValidationError;
+use crate::error_priv::ValidationError;
 pub use params::{
     score_parameter_decay, score_parameter_decay_with_base, PeerScoreParams, PeerScoreThresholds,
     TopicScoreParams,

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -19,7 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use crate::config::{ValidationMode, Version};
-use crate::error::{HandlerError, ValidationError};
+use crate::error_priv::{HandlerError, ValidationError};
 use crate::handler::HandlerEvent;
 use crate::topic::TopicHash;
 use crate::types::{

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -19,13 +19,13 @@
 // DEALINGS IN THE SOFTWARE.
 
 use crate::config::{ValidationMode, Version};
-use crate::error_priv::{HandlerError, ValidationError};
 use crate::handler::HandlerEvent;
 use crate::topic::TopicHash;
 use crate::types::{
     ControlAction, MessageId, PeerInfo, PeerKind, RawMessage, Rpc, Subscription, SubscriptionAction,
 };
 use crate::{rpc_proto, Config};
+use crate::{HandlerError, ValidationError};
 use asynchronous_codec::{Decoder, Encoder, Framed};
 use byteorder::{BigEndian, ByteOrder};
 use bytes::BytesMut;


### PR DESCRIPTION
Add error_priv module; export error enums from new module; make error private

## Description

Resolves https://github.com/libp2p/rust-libp2p/issues/3392.

## Links to any relevant issues

As per this comment - https://github.com/libp2p/rust-libp2p/pull/3303#discussion_r1084698192

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
