### PR TITLE
feat(kad): Implement ability to acknowledge `AddProvider` before reading further messages from substream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,6 +2422,7 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-yamux",
  "log",
+ "parking_lot 0.12.1",
  "prost",
  "prost-build",
  "quickcheck-ext",

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -10,8 +10,11 @@
 
 - Bump MSRV to 1.65.0.
 
+- Implement ability to acknowledge `AddProvider` before reading further messages from substream. See [PR 3468].
+
 [PR 3239]: https://github.com/libp2p/rust-libp2p/pull/3239
 [PR 3287]: https://github.com/libp2p/rust-libp2p/pull/3287
+[PR 3468]: https://github.com/libp2p/rust-libp2p/pull/3468
 
 # 0.42.1
 

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.3.26"
 log = "0.4"
 libp2p-core = { version = "0.39.0", path = "../../core" }
 libp2p-swarm = { version = "0.42.0", path = "../../swarm" }
+parking_lot = "0.12.0"
 prost = "0.11"
 rand = "0.8"
 sha2 = "0.10.0"

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -1745,7 +1745,7 @@ where
         &mut self,
         key: record::Key,
         provider: KadPeer,
-        guard: InboundStreamEventGuard,
+        guard: Arc<InboundStreamEventGuard>,
     ) {
         if &provider.node_id != self.kbuckets.local_key().preimage() {
             let record = ProviderRecord {
@@ -1777,7 +1777,7 @@ where
                             KademliaEvent::InboundRequest {
                                 request: InboundRequest::AddProvider {
                                     record: Some(record),
-                                    guard: Some(Arc::new(guard)),
+                                    guard: Some(guard),
                                 },
                             },
                         ));


### PR DESCRIPTION
## Description

The goal is to make it possible for `AddProvider` to be processed asynchronously. It is a special case in Kademlia because there is no response expected.

While it works fine with in-memory storage, disk-based and other kinds of storage present challenges here and it might be desirable to do it asynchronously, but this is a challenge because Kademlia implementation before this PR will simply move on and will accept ever growing announcements, which may result in DoS.

The approach here is to process `AddProvider` with events (`KademliaStoreInserts::FilterBoth`) and keep introduced event guard alive for corresponding event as long as necessary. As long as guard is not dropped, corresponding incoming stream will be in pending state and will not receive new incoming messages from sender. Once guard is dropped incoming stream will continue working normally.

## Notes

This could have been implemented with an additional message passing, but I find it more cumbersome to implement and to use, thus prefer RAII whenever possible for these things.

Opening as draft for now since due to lack of stream reuse this resurrects following error in my environment:
```
New inbound substream to PeerId("X") exceeds inbound substream limit. No older substream waiting to be reused. Dropping new substream.
```

It was partially mitigated in https://github.com/libp2p/rust-libp2p/pull/3287, but never resolved fully and we acknowledged back then that there is a small chance it might still happen. Here chance is 100% under right conditions because incoming streams will be in pending state indefinitely, while sender will assume stream is closed already because they did it already.

This is fixed by stream reuse implemented in https://github.com/libp2p/rust-libp2p/pull/3474.

Note that we don't HAVE TO expose `Arc<InboundStreamEventGuard>` publicly, we could make it anonymous with `Arc<dyn Any + Send + Sync + 'static>`, but it looked not as nice to me, so I decided to leave it exposed.

## Links to any relevant issues

Primarily https://github.com/libp2p/rust-libp2p/discussions/3411

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
