### PR TITLE
feat(ci): move PR number to commit message body

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,9 +3,11 @@ defaults:
     queue:
       method: squash
       commit_message_template: |
-        {{ title }} (#{{ number }})
+        {{ title }}
         
-        {{ body | get_section("## Description", "") }}   
+        {{ body | get_section("## Description", "") }}
+        
+        Pull-Request: #{{ number }}.
 
 pull_request_rules:
   - name: Ask to resolve conflict


### PR DESCRIPTION
## Description

Commit message titles should at most be 72 characters long. Together with our semantic commit conventions, appending the pull request number to the title only allows for so many characters to be used for the actual message.

When exceeding the 72 char limit, GitHub inserts a newline into the title, see https://github.com/libp2p/rust-libp2p/commit/caed1fe2c717ba1688a4eb0549284cddba8c9ea6 as an example.

We enforce the 72 char limit in CI but this does not take into account the additional 8 characters taken up by ` (#XXXX)`. Instead of lowering the limit, this patch moves the PR number as a line to the body of the message, allowing the full 72 characters to be used for the commit message.

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
