### PR TITLE
feat(ci): only send (and refresh) dependabot PRs weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 9999
     commit-message:
       prefix: "deps"


### PR DESCRIPTION
## Description

Despite `rebase-strategy: "disabled"`, dependabot will refresh (i.e. rebase) PRs on the specified schedule interval. With the addition of `Cargo.lock` to our repository, dependabot is opening a lot more PRs which consumes unnecessary CI resources.

We change the interval to "weekly" to reduce the noise and resource consumption.

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
