### PR TITLE
feat(dependabot): revert `versioning-strategy` set to `widen`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
     commit-message:
       prefix: "deps"
     rebase-strategy: "disabled"
-    versioning-strategy: "widen"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Description

This is an invalid configuration parameter and does not work. Let's revert it.

Reverts libp2p/rust-libp2p#3434.