### PR TITLE
feat(swarm): close connections on `multistream-select` protocol violations

### DIFF
--- a/protocols/dcutr/src/handler/relayed.rs
+++ b/protocols/dcutr/src/handler/relayed.rs
@@ -26,7 +26,7 @@ use futures::future;
 use futures::future::{BoxFuture, FutureExt};
 use instant::Instant;
 use libp2p_core::multiaddr::Multiaddr;
-use libp2p_core::upgrade::{DeniedUpgrade, NegotiationError, UpgradeError};
+use libp2p_core::upgrade::DeniedUpgrade;
 use libp2p_core::ConnectedPoint;
 use libp2p_swarm::handler::{
     ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
@@ -229,27 +229,23 @@ impl Handler {
                     },
                 ));
             }
-            ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(NegotiationError::Failed)) => {
+            ConnectionHandlerUpgrErr::NegotiationFailed => {
                 // The remote merely doesn't support the DCUtR protocol.
                 // This is no reason to close the connection, which may
                 // successfully communicate with other protocols already.
                 self.keep_alive = KeepAlive::No;
                 self.queued_events.push_back(ConnectionHandlerEvent::Custom(
                     Event::InboundNegotiationFailed {
-                        error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(
-                            NegotiationError::Failed,
-                        )),
+                        error: ConnectionHandlerUpgrErr::NegotiationFailed,
                     },
                 ));
             }
             _ => {
                 // Anything else is considered a fatal error or misbehaviour of
                 // the remote peer and results in closing the connection.
-                self.pending_error = Some(error.map_upgrade_err(|e| {
-                    e.map_err(|e| match e {
-                        Either::Left(e) => Either::Left(e),
-                        Either::Right(v) => void::unreachable(v),
-                    })
+                self.pending_error = Some(error.map_upgrade_err(|e| match e {
+                    Either::Left(e) => Either::Left(e),
+                    Either::Right(v) => void::unreachable(v),
                 }));
             }
         }
@@ -272,22 +268,20 @@ impl Handler {
                     },
                 ));
             }
-            ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(NegotiationError::Failed)) => {
+            ConnectionHandlerUpgrErr::NegotiationFailed => {
                 // The remote merely doesn't support the DCUtR protocol.
                 // This is no reason to close the connection, which may
                 // successfully communicate with other protocols already.
                 self.queued_events.push_back(ConnectionHandlerEvent::Custom(
                     Event::OutboundNegotiationFailed {
-                        error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(
-                            NegotiationError::Failed,
-                        )),
+                        error: ConnectionHandlerUpgrErr::NegotiationFailed,
                     },
                 ));
             }
             _ => {
                 // Anything else is considered a fatal error or misbehaviour of
                 // the remote peer and results in closing the connection.
-                self.pending_error = Some(error.map_upgrade_err(|e| e.map_err(Either::Right)));
+                self.pending_error = Some(error.map_upgrade_err(Either::Right));
             }
         }
     }
@@ -388,7 +382,7 @@ impl ConnectionHandler for Handler {
                 }
                 Err(e) => {
                     return Poll::Ready(ConnectionHandlerEvent::Close(
-                        ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(Either::Left(e))),
+                        ConnectionHandlerUpgrErr::Upgrade(Either::Left(e)),
                     ))
                 }
             }

--- a/protocols/identify/src/handler.rs
+++ b/protocols/identify/src/handler.rs
@@ -254,12 +254,9 @@ impl Handler {
             <Self as ConnectionHandler>::OutboundProtocol,
         >,
     ) {
-        use libp2p_core::upgrade::UpgradeError;
-
         let err = err.map_upgrade_err(|e| match e {
-            UpgradeError::Select(e) => UpgradeError::Select(e),
-            UpgradeError::Apply(Either::Left(ioe)) => UpgradeError::Apply(ioe),
-            UpgradeError::Apply(Either::Right(ioe)) => UpgradeError::Apply(ioe),
+            Either::Left(ioe) => ioe,
+            Either::Right(ioe) => ioe,
         });
         self.events
             .push(ConnectionHandlerEvent::Custom(Event::IdentificationError(
@@ -366,9 +363,7 @@ impl ConnectionHandler for Handler {
                 Event::Identification(peer_id),
             )),
             Poll::Ready(Some(Err(err))) => Poll::Ready(ConnectionHandlerEvent::Custom(
-                Event::IdentificationError(ConnectionHandlerUpgrErr::Upgrade(
-                    libp2p_core::upgrade::UpgradeError::Apply(err),
-                )),
+                Event::IdentificationError(ConnectionHandlerUpgrErr::Upgrade(err)),
             )),
             Poll::Ready(None) | Poll::Pending => Poll::Pending,
         }

--- a/protocols/ping/src/handler.rs
+++ b/protocols/ping/src/handler.rs
@@ -23,7 +23,6 @@ use futures::future::BoxFuture;
 use futures::prelude::*;
 use futures_timer::Delay;
 use libp2p_core::upgrade::ReadyUpgrade;
-use libp2p_core::{upgrade::NegotiationError, UpgradeError};
 use libp2p_swarm::handler::{
     ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
 };
@@ -238,7 +237,7 @@ impl Handler {
         self.outbound = None; // Request a new substream on the next `poll`.
 
         let error = match error {
-            ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(NegotiationError::Failed)) => {
+            ConnectionHandlerUpgrErr::NegotiationFailed => {
                 debug_assert_eq!(self.state, State::Active);
 
                 self.state = State::Inactive { reported: false };

--- a/protocols/request-response/src/handler.rs
+++ b/protocols/request-response/src/handler.rs
@@ -31,7 +31,6 @@ pub use protocol::{ProtocolSupport, RequestProtocol, ResponseProtocol};
 
 use futures::{channel::oneshot, future::BoxFuture, prelude::*, stream::FuturesUnordered};
 use instant::Instant;
-use libp2p_core::upgrade::{NegotiationError, UpgradeError};
 use libp2p_swarm::{
     handler::{ConnectionHandler, ConnectionHandlerEvent, ConnectionHandlerUpgrErr, KeepAlive},
     SubstreamProtocol,
@@ -148,7 +147,7 @@ where
             ConnectionHandlerUpgrErr::Timeout => {
                 self.pending_events.push_back(Event::OutboundTimeout(info));
             }
-            ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(NegotiationError::Failed)) => {
+            ConnectionHandlerUpgrErr::NegotiationFailed => {
                 // The remote merely doesn't support the protocol(s) we requested.
                 // This is no reason to close the connection, which may
                 // successfully communicate with other protocols already.
@@ -175,7 +174,7 @@ where
             ConnectionHandlerUpgrErr::Timeout => {
                 self.pending_events.push_back(Event::InboundTimeout(info))
             }
-            ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(NegotiationError::Failed)) => {
+            ConnectionHandlerUpgrErr::NegotiationFailed => {
                 // The local peer merely doesn't support the protocol(s) requested.
                 // This is no reason to close the connection, which may
                 // successfully communicate with other protocols already.

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -71,6 +71,11 @@
 
 - Remove `ConnectionId::new`. Manually creating `ConnectionId`s is now unsupported. See [PR 3327].
 
+- Close connections on `multistream-select` protocol violations.
+  As a consequence, `ConnectionHandlerUpgrErr::Upgrade` directly contains the upgrade error now.
+  Additionally, `ConnectionHandlerUpgrErr::NegotiationFailed` is introduced to represent nodes failing to agree on a protocol for a stream.
+  See [PR XXXX].
+
 [PR 3364]: https://github.com/libp2p/rust-libp2p/pull/3364
 [PR 3170]: https://github.com/libp2p/rust-libp2p/pull/3170
 [PR 3134]: https://github.com/libp2p/rust-libp2p/pull/3134
@@ -84,6 +89,7 @@
 [PR 3373]: https://github.com/libp2p/rust-libp2p/pull/3373
 [PR 3374]: https://github.com/libp2p/rust-libp2p/pull/3374
 [PR 3375]: https://github.com/libp2p/rust-libp2p/pull/3375
+[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
 
 # 0.41.1
 

--- a/swarm/src/behaviour/toggle.rs
+++ b/swarm/src/behaviour/toggle.rs
@@ -211,12 +211,11 @@ where
         let err = match err {
             ConnectionHandlerUpgrErr::Timeout => ConnectionHandlerUpgrErr::Timeout,
             ConnectionHandlerUpgrErr::Timer => ConnectionHandlerUpgrErr::Timer,
-            ConnectionHandlerUpgrErr::Upgrade(err) => {
-                ConnectionHandlerUpgrErr::Upgrade(err.map_err(|err| match err {
-                    Either::Left(e) => e,
-                    Either::Right(v) => void::unreachable(v),
-                }))
+            ConnectionHandlerUpgrErr::Upgrade(Either::Left(e)) => {
+                ConnectionHandlerUpgrErr::Upgrade(e)
             }
+            ConnectionHandlerUpgrErr::Upgrade(Either::Right(never)) => void::unreachable(never),
+            ConnectionHandlerUpgrErr::NegotiationFailed => ConnectionHandlerUpgrErr::NegotiationFailed,
         };
 
         inner.on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {

--- a/swarm/src/connection/error.rs
+++ b/swarm/src/connection/error.rs
@@ -21,6 +21,7 @@
 use crate::transport::TransportError;
 use crate::Multiaddr;
 use crate::{connection::ConnectionLimit, ConnectedPoint, PeerId};
+use libp2p_core::upgrade::ProtocolError;
 use std::{fmt, io};
 
 /// Errors that can occur in the context of an established `Connection`.
@@ -35,6 +36,11 @@ pub enum ConnectionError<THandlerErr> {
 
     /// The connection handler produced an error.
     Handler(THandlerErr),
+
+    /// A unrecoverable [`ProtocolError`] occurred on one of the streams of this connection.
+    ///
+    /// A protocol violation results in the entire connection being closed.
+    Protocol(ProtocolError),
 }
 
 impl<THandlerErr> fmt::Display for ConnectionError<THandlerErr>
@@ -48,6 +54,7 @@ where
                 write!(f, "Connection closed due to expired keep-alive timeout.")
             }
             ConnectionError::Handler(err) => write!(f, "Connection error: Handler error: {err}"),
+            ConnectionError::Protocol(_) => write!(f, "Unrecoverable protocol error occurred"),
         }
     }
 }
@@ -61,6 +68,7 @@ where
             ConnectionError::IO(err) => Some(err),
             ConnectionError::KeepAliveTimeout => None,
             ConnectionError::Handler(err) => Some(err),
+            ConnectionError::Protocol(err) => Some(err),
         }
     }
 }

--- a/swarm/src/dummy.rs
+++ b/swarm/src/dummy.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 use libp2p_core::upgrade::DeniedUpgrade;
 use libp2p_core::PeerId;
-use libp2p_core::UpgradeError;
 use std::task::{Context, Poll};
 use void::Void;
 
@@ -117,10 +116,8 @@ impl crate::handler::ConnectionHandler for ConnectionHandler {
             ConnectionEvent::DialUpgradeError(DialUpgradeError { info: _, error }) => match error {
                 ConnectionHandlerUpgrErr::Timeout => unreachable!(),
                 ConnectionHandlerUpgrErr::Timer => unreachable!(),
-                ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(e)) => void::unreachable(e),
-                ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(_)) => {
-                    unreachable!("Denied upgrade does not support any protocols")
-                }
+                ConnectionHandlerUpgrErr::Upgrade(e) => void::unreachable(e),
+                ConnectionHandlerUpgrErr::NegotiationFailed => unreachable!(),
             },
             ConnectionEvent::AddressChange(_) | ConnectionEvent::ListenUpgradeError(_) => {}
         }

--- a/swarm/src/handler/either.rs
+++ b/swarm/src/handler/either.rs
@@ -26,7 +26,6 @@ use crate::handler::{
 use crate::upgrade::SendWrapper;
 use either::Either;
 use futures::future;
-use libp2p_core::upgrade::UpgradeError;
 use libp2p_core::{ConnectedPoint, PeerId};
 use std::task::{Context, Poll};
 
@@ -122,31 +121,17 @@ where
     fn transpose(self) -> Either<ListenUpgradeError<LIOI, LIP>, ListenUpgradeError<RIOI, RIP>> {
         match self {
             ListenUpgradeError {
-                error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(Either::Left(error))),
+                error: ConnectionHandlerUpgrErr::Upgrade(Either::Left(error)),
                 info: Either::Left(info),
             } => Either::Left(ListenUpgradeError {
-                error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(error)),
+                error: ConnectionHandlerUpgrErr::Upgrade(error),
                 info,
             }),
             ListenUpgradeError {
-                error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(Either::Right(error))),
+                error: ConnectionHandlerUpgrErr::Upgrade(Either::Right(error)),
                 info: Either::Right(info),
             } => Either::Right(ListenUpgradeError {
-                error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Apply(error)),
-                info,
-            }),
-            ListenUpgradeError {
-                error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(error)),
-                info: Either::Left(info),
-            } => Either::Left(ListenUpgradeError {
-                error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(error)),
-                info,
-            }),
-            ListenUpgradeError {
-                error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(error)),
-                info: Either::Right(info),
-            } => Either::Right(ListenUpgradeError {
-                error: ConnectionHandlerUpgrErr::Upgrade(UpgradeError::Select(error)),
+                error: ConnectionHandlerUpgrErr::Upgrade(error),
                 info,
             }),
             ListenUpgradeError {


### PR DESCRIPTION
## Description

As per discussion in https://github.com/libp2p/rust-libp2p/discussions/3353, this patch proposes to not report what I deem to be fatal errors during protocol negotiation to a `ConnectionHandler` but instead close the entire connection.

The error is returned to the `Swarm` as the reason for why the connection is being closed.

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes

I consider this a medium-risk PR because it introduces a potentially drastic change in behaviour. Previously, a `ConnectionHandler` could simply ignore these errors and a peer that only happened to f.e. send a bad protocol name for one stream but was otherwise well-behaved worked fine. With this patch, such a connection would get closed by the `Swarm`.

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

- Is closing the connection the right thing to do? We could differentiate between the various kinds of `ProtocolError` and only "close" the connection on IO errors but still report protocol violations back to the `ConnectionHandler`?

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
