### PR TITLE
refactor(interop-test): remove easy to replace `strum` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,7 +2003,6 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "redis",
- "strum",
  "tokio",
 ]
 
@@ -4237,12 +4236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
-
-[[package]]
 name = "rw-stream-sink"
 version = "0.3.0"
 dependencies = [
@@ -4596,28 +4589,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
 
 [[package]]
 name = "stun"

--- a/interop-tests/Cargo.toml
+++ b/interop-tests/Cargo.toml
@@ -14,5 +14,4 @@ libp2p = { path = "../", features = ["websocket", "quic",  "mplex", "yamux", "tc
 log = "0.4"
 rand = "0.8.5"
 redis = { version = "0.22.1", features = ["tokio-native-tls-comp", "tokio-comp"] }
-strum = { version = "0.24.1", features = ["derive"] }
 tokio = { version = "1.24.1", features = ["full"] }


### PR DESCRIPTION
## Description

We only use `strum` for the interop-tests but we add 3 dependencies to a full build of the repository for it, including a proc-macro which needs to be pipelined in front of other crates which makes them hard to parallelize. Remove it in favor of fairly trivial reimplementation of `FromStr`.

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

## Links to any relevant issues

<!-- Reference any related issues.-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
