### PR TITLE
feat(ci): remove actions-rs/cargo and use r7kamura/rust-problem-matchers

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-[alias]
-# Temporary solution to have clippy config in a single place until https://github.com/rust-lang/rust-clippy/blob/master/doc/roadmap-2021.md#lintstoml-configuration is shipped.
-custom-clippy = "clippy --workspace --all-features --all-targets -- -A clippy::type_complexity -A clippy::pedantic -W clippy::used_underscore_binding -D warnings"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[alias]
+# Temporary solution to have clippy config in a single place until https://github.com/rust-lang/rust-clippy/blob/master/doc/roadmap-2021.md#lintstoml-configuration is shipped.
+custom-clippy = "clippy --workspace --all-features --all-targets -- -A clippy::type_complexity -A clippy::pedantic -W clippy::used_underscore_binding -D warnings"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,10 +190,10 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
+      - uses: r7kamura/rust-problem-matchers@v1
+
       - name: Run cargo clippy
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: custom-clippy # cargo alias to allow reuse of config locally
+        run: cargo clippy --workspace --all-features --all-targets -- -A clippy::type_complexity -A clippy::pedantic -W clippy::used_underscore_binding -D warnings 
 
   ipfs-integration-test:
     name: IPFS Integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           toolchain: ${{ steps.parse-msrv.outputs.version }}
 
+      - uses: r7kamura/rust-problem-matchers@v1
+
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
         with:
           shared-key: msrv-cache
@@ -114,6 +116,8 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
 
+      - uses: r7kamura/rust-problem-matchers@v1
+
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
         with:
           key: ${{ matrix.target }}
@@ -139,6 +143,8 @@ jobs:
         with:
           toolchain: stable
 
+      - uses: r7kamura/rust-problem-matchers@v1
+
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
         with:
           key: ${{ matrix.features }}
@@ -158,6 +164,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@9cd00a88a73addc8617065438eff914dd08d0955 # v1
         with:
           toolchain: stable
+
+      - uses: r7kamura/rust-problem-matchers@v1
 
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
         with:
@@ -186,11 +194,11 @@ jobs:
           toolchain: ${{ matrix.rust-version }}
           components: clippy
 
+      - uses: r7kamura/rust-problem-matchers@v1
+
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
         with:
           save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      - uses: r7kamura/rust-problem-matchers@v1
 
       - name: Run cargo clippy
         run: cargo clippy --workspace --all-features --all-targets -- -A clippy::type_complexity -A clippy::pedantic -W clippy::used_underscore_binding -D warnings 
@@ -207,6 +215,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@9cd00a88a73addc8617065438eff914dd08d0955 # v1
         with:
           toolchain: stable
+
+      - uses: r7kamura/rust-problem-matchers@v1
 
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
         with:
@@ -225,6 +235,8 @@ jobs:
           toolchain: stable
           components: rustfmt
 
+      - uses: r7kamura/rust-problem-matchers@v1
+
       - name: Check formatting
         run: cargo fmt -- --check
 
@@ -236,6 +248,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@9cd00a88a73addc8617065438eff914dd08d0955 # v1
         with:          
           toolchain: stable
+
+      - uses: r7kamura/rust-problem-matchers@v1
 
       - name: Ensure `full` feature contains all features
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           toolchain: ${{ steps.parse-msrv.outputs.version }}
 
-      - uses: r7kamura/rust-problem-matchers@v1
+      - uses: r7kamura/rust-problem-matchers@d58b70c4a13c4866d96436315da451d8106f8f08 #v1.3.0
 
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
         with:
@@ -116,7 +116,7 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
 
-      - uses: r7kamura/rust-problem-matchers@v1
+      - uses: r7kamura/rust-problem-matchers@d58b70c4a13c4866d96436315da451d8106f8f08 #v1.3.0
 
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
         with:
@@ -143,7 +143,7 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: r7kamura/rust-problem-matchers@v1
+      - uses: r7kamura/rust-problem-matchers@d58b70c4a13c4866d96436315da451d8106f8f08 #v1.3.0
 
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
         with:
@@ -165,7 +165,7 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: r7kamura/rust-problem-matchers@v1
+      - uses: r7kamura/rust-problem-matchers@d58b70c4a13c4866d96436315da451d8106f8f08 #v1.3.0
 
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
         with:
@@ -194,14 +194,14 @@ jobs:
           toolchain: ${{ matrix.rust-version }}
           components: clippy
 
-      - uses: r7kamura/rust-problem-matchers@v1
+      - uses: r7kamura/rust-problem-matchers@d58b70c4a13c4866d96436315da451d8106f8f08 #v1.3.0
 
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
         with:
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Run cargo clippy
-        run: cargo clippy --workspace --all-features --all-targets -- -A clippy::type_complexity -A clippy::pedantic -W clippy::used_underscore_binding -D warnings 
+        run: cargo custom-clippy # cargo alias to allow reuse of config locally
 
   ipfs-integration-test:
     name: IPFS Integration tests
@@ -216,7 +216,7 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: r7kamura/rust-problem-matchers@v1
+      - uses: r7kamura/rust-problem-matchers@d58b70c4a13c4866d96436315da451d8106f8f08 #v1.3.0
 
       - uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
         with:
@@ -235,7 +235,7 @@ jobs:
           toolchain: stable
           components: rustfmt
 
-      - uses: r7kamura/rust-problem-matchers@v1
+      - uses: r7kamura/rust-problem-matchers@d58b70c4a13c4866d96436315da451d8106f8f08 #v1.3.0
 
       - name: Check formatting
         run: cargo fmt -- --check
@@ -249,7 +249,7 @@ jobs:
         with:          
           toolchain: stable
 
-      - uses: r7kamura/rust-problem-matchers@v1
+      - uses: r7kamura/rust-problem-matchers@d58b70c4a13c4866d96436315da451d8106f8f08 #v1.3.0
 
       - name: Ensure `full` feature contains all features
         run: |


### PR DESCRIPTION
## Description

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

Resolves https://github.com/libp2p/rust-libp2p/issues/3398.

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->

Removed also the `.cargo` folder with just the `.confing.toml` file since it was used just to run the command in `actions-rs/cargo`

## Links to any relevant issues

<!-- Reference any related issues.-->

Related issue #3398 

## Open Questions

<!-- Unresolved questions, if any. -->

1. I am not sure if the `cargo clippy` command should check also the dependencies, because on this pull request it seems that does not check the dependencies, instead on the pull request I did on my own fork it seems that it does the checks on the dependencies.
Which should be the correct behavior?
(If you know the reason for the different behavior on the two repos could you explain it to me?)

2. I think there are no docs or tests on the workflows, do I need to check something else?

I am just starting to contribute to open source code thus any comments are welcome :) 

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
