### PR TITLE
fix: 0.50 pin libp2p-quic prerelease deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2138,7 +2138,7 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "libp2p"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.7.0-alpha"
+version = "0.7.0-alpha.0"
 dependencies = [
  "async-std",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p"
 edition = "2021"
 rust-version = "1.62.0"
 description = "Peer-to-peer networking library"
-version = "0.50.1"
+version = "0.50.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -120,7 +120,7 @@ smallvec = "1.6.1"
 libp2p-deflate = { version = "0.38.0", path = "transports/deflate", optional = true }
 libp2p-dns = { version = "0.38.0", path = "transports/dns", optional = true }
 libp2p-mdns = { version = "0.42.0", path = "protocols/mdns", optional = true }
-libp2p-quic = { version = "=0.7.0-alpha", path = "transports/quic", optional = true }
+libp2p-quic = { version = "=0.7.0-alpha.0", path = "transports/quic", optional = true }
 libp2p-tcp = { version = "0.38.0", path = "transports/tcp", optional = true }
 libp2p-tls = { version = "=0.1.0-alpha", path = "transports/tls", optional = true }
 libp2p-webrtc = { version = "=0.4.0-alpha", path = "transports/webrtc", optional = true }

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-quic"
-version = "0.7.0-alpha"
+version = "0.7.0-alpha.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 rust-version = "1.62.0"
@@ -15,7 +15,7 @@ futures = "0.3.15"
 futures-timer = "3.0.2"
 if-watch = "3.0.0"
 libp2p-core = { version = "0.38.0", path = "../../core" }
-libp2p-tls = { version = "0.1.0-alpha", path = "../tls" }
+libp2p-tls = { version = "=0.1.0-alpha", path = "../tls" }
 log = "0.4"
 parking_lot = "0.12.0"
 quinn-proto = { version = "0.9.0", default-features = false, features = ["tls-rustls"] }


### PR DESCRIPTION
## Description

backport of #3548, and should fully resolve #3537

## Notes

- libp2p-quic bumped to `-alpha.0`
  - pinned libp2p-tls `-alpha`
- bumped libp2p to 0.50.2
  - bumped to new libp2p-quic version

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
