### PR TITLE
fix(dcutr): don't set dial concurrency factor in example

### DIFF
--- a/protocols/dcutr/examples/dcutr.rs
+++ b/protocols/dcutr/examples/dcutr.rs
@@ -164,7 +164,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         Ok(tp) => SwarmBuilder::with_executor(transport, behaviour, local_peer_id, tp),
         Err(_) => SwarmBuilder::without_executor(transport, behaviour, local_peer_id),
     }
-    .dial_concurrency_factor(10_u8.try_into().unwrap())
     .build();
 
     swarm

--- a/protocols/dcutr/examples/dcutr.rs
+++ b/protocols/dcutr/examples/dcutr.rs
@@ -36,7 +36,6 @@ use libp2p_relay as relay;
 use libp2p_swarm::{NetworkBehaviour, SwarmBuilder, SwarmEvent};
 use libp2p_tcp as tcp;
 use log::info;
-use std::convert::TryInto;
 use std::error::Error;
 use std::net::Ipv4Addr;
 use std::str::FromStr;


### PR DESCRIPTION
## Description

Since https://github.com/libp2p/rust-libp2p/pull/2741 the default dial concurrency factor is > 1, more specifically 8. Thus there is no need to explicitly set it anylonger.


