### PR TITLE
fix(changelog): Make release heading levels consistent

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,17 +1,17 @@
-# 0.39.1
+## 0.39.1
 
 - Migrate from `prost` to `quick-protobuf`. This removes `protoc` dependency. See [PR 3312].
 
 [PR 3221]: https://github.com/libp2p/rust-libp2p/pull/3221
 
-# 0.39.0
+## 0.39.0
 
 - Move `ConnectionId` to `libp2p-swarm`. See [PR 3221].
 - Move `PendingPoint` to `libp2p-swarm` and make it crate-private. See [PR 3221].
 
 [PR 3312]: https://github.com/libp2p/rust-libp2p/pull/3312
 
-# 0.38.0
+## 0.38.0
 
 - Remove deprecated functions `StreamMuxerExt::next_{inbound,outbound}`. See [PR 3031].
 
@@ -46,7 +46,7 @@
 [PR 3340]: https://github.com/libp2p/rust-libp2p/pull/3340
 [PR 3341]: https://github.com/libp2p/rust-libp2p/pull/3341
 
-# 0.37.0
+## 0.37.0
 
 - Implement `Hash` and `Ord` for `PublicKey`. See [PR 2915].
 
@@ -59,7 +59,7 @@
 [PR 2918]: https://github.com/libp2p/rust-libp2p/pull/2918
 [PR 3002]: https://github.com/libp2p/rust-libp2p/pull/3002
 
-# 0.36.0
+## 0.36.0
 
 - Make RSA keypair support optional. To enable RSA support, `rsa` feature should be enabled.
   See [PR 2860].
@@ -69,13 +69,13 @@
 [PR 2855]: https://github.com/libp2p/rust-libp2p/pull/2855
 [PR 2860]: https://github.com/libp2p/rust-libp2p/pull/2860/
 
-# 0.35.1
+## 0.35.1
 
 - Update to `p256` `v0.11.0`. See [PR 2636].
 
 [PR 2636]: https://github.com/libp2p/rust-libp2p/pull/2636/
 
-# 0.35.0
+## 0.35.0
 
 - Update prost requirement from 0.10 to 0.11 which no longer installs the protoc Protobuf compiler.
   Thus you will need protoc installed locally. See [PR 2788].
@@ -94,7 +94,7 @@
 [PR 2797]: https://github.com/libp2p/rust-libp2p/pull/2797
 [PR 2788]: https://github.com/libp2p/rust-libp2p/pull/2788
 
-# 0.34.0
+## 0.34.0
 
 - Remove `{read,write,flush,shutdown,destroy}_substream` functions from `StreamMuxer` trait
   in favor of forcing `StreamMuxer::Substream` to implement `AsyncRead + AsyncWrite`. See [PR 2707].
@@ -109,7 +109,7 @@
 [PR 2710]: https://github.com/libp2p/rust-libp2p/pull/2710
 [PR 2652]: https://github.com/libp2p/rust-libp2p/pull/2652
 
-# 0.33.0
+## 0.33.0
 
 - Have methods on `Transport` take `&mut self` instead of `self`. See [PR 2529].
 - Remove `StreamMuxer::flush_all`. See [PR 2669].
@@ -122,11 +122,11 @@
 [PR 2669]: https://github.com/libp2p/rust-libp2p/pull/2669
 
 
-# 0.32.1
+## 0.32.1
 
 - Add `PeerId::try_from_multiaddr` to extract a `PeerId` from a `Multiaddr` that ends in `/p2p/<peer-id>`.
 
-# 0.32.0 [2022-02-22]
+## 0.32.0 [2022-02-22]
 
 - Remove `Network`. `libp2p-core` is from now on an auxiliary crate only. Users
   that have previously used `Network` only, will need to use `Swarm` instead. See
@@ -155,7 +155,7 @@
 [PR 2463]: https://github.com/libp2p/rust-libp2p/pull/2463/
 [PR 2522]: https://github.com/libp2p/rust-libp2p/pull/2522
 
-# 0.31.0 [2022-01-27]
+## 0.31.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -202,13 +202,13 @@
 [PR 2428]: https://github.com/libp2p/rust-libp2p/pull/2428
 [PR 2363]: https://github.com/libp2p/rust-libp2p/pull/2363
 
-# 0.30.1 [2021-11-16]
+## 0.30.1 [2021-11-16]
 
 - Use `instant` instead of `wasm-timer` (see [PR 2245]).
 
 [PR 2245]: https://github.com/libp2p/rust-libp2p/pull/2245
 
-# 0.30.0 [2021-11-01]
+## 0.30.0 [2021-11-01]
 
 - Add `ConnectionLimit::with_max_established` (see [PR 2137]).
 
@@ -270,7 +270,7 @@
 [RFC0002]: https://github.com/libp2p/specs/blob/master/RFC/0002-signed-envelopes.md
 [RFC0003]: https://github.com/libp2p/specs/blob/master/RFC/0003-routing-records.md
 
-# 0.29.0 [2021-07-12]
+## 0.29.0 [2021-07-12]
 
 - Switch from `parity-multiaddr` to upstream `multiaddr`.
 
@@ -286,19 +286,19 @@
 
 [PR 2090]: https://github.com/libp2p/rust-libp2p/pull/2090
 
-# 0.28.3 [2021-04-26]
+## 0.28.3 [2021-04-26]
 
 - Fix build with secp256k1 disabled [PR 2057](https://github.com/libp2p/rust-libp2p/pull/2057).
 
-# 0.28.2 [2021-04-13]
+## 0.28.2 [2021-04-13]
 
 - Update dependencies.
 
-# 0.28.1 [2021-03-17]
+## 0.28.1 [2021-03-17]
 
 - Update `paritytech-multiaddr` to `>=v0.11.2`.
 
-# 0.28.0 [2021-03-17]
+## 0.28.0 [2021-03-17]
 
 - `Network::dial()` understands `/p2p` addresses and `Transport::dial`
   gets a "fully qualified" `/p2p` address when dialing a specific peer,
@@ -310,11 +310,11 @@
 
 - Shorten and unify `Debug` impls of public keys.
 
-# 0.27.1 [2021-02-15]
+## 0.27.1 [2021-02-15]
 
 - Update dependencies.
 
-# 0.27.0 [2021-01-12]
+## 0.27.0 [2021-01-12]
 
 - (Re)add `Transport::address_translation` to permit transport-specific
   translations of observed addresses onto listening addresses.
@@ -322,20 +322,20 @@
 
 - Update dependencies.
 
-# 0.26.0 [2020-12-17]
+## 0.26.0 [2020-12-17]
 
 - Make `PeerId` be `Copy`, including small `PeerId` API changes.
   [PR 1874](https://github.com/libp2p/rust-libp2p/pull/1874/).
 
-# 0.25.2 [2020-12-02]
+## 0.25.2 [2020-12-02]
 
 - Require `multistream-select-0.9.1`.
 
-# 0.25.1 [2020-11-25]
+## 0.25.1 [2020-11-25]
 
 - Add missing multiaddr upgrade.
 
-# 0.25.0 [2020-11-25]
+## 0.25.0 [2020-11-25]
 
 - The `NetworkConfig` API is now a builder that moves `self`.
   [PR 1848](https://github.com/libp2p/rust-libp2p/pull/1848/).
@@ -350,17 +350,17 @@
 
 - Update `multistream-select`.
 
-# 0.24.0 [2020-11-09]
+## 0.24.0 [2020-11-09]
 
 - Remove `ConnectionInfo` trait and replace it with `PeerId`
   everywhere. This was already effectively the case because
   `ConnectionInfo` was implemented on `PeerId`.
 
-# 0.23.1 [2020-10-20]
+## 0.23.1 [2020-10-20]
 
 - Update dependencies.
 
-# 0.23.0 [2020-10-16]
+## 0.23.0 [2020-10-16]
 
 - Rework transport boxing and move timeout configuration
   to the transport builder.
@@ -368,12 +368,12 @@
 
 - Update dependencies.
 
-# 0.22.1 [2020-09-10]
+## 0.22.1 [2020-09-10]
 
 - Require at least parity-multiaddr v0.9.2 in order to fulfill `Ord` bound on
   `Multiaddr`. [PR 1742](https://github.com/libp2p/rust-libp2p/pull/1742).
 
-# 0.22.0 [2020-09-09]
+## 0.22.0 [2020-09-09]
 
 - Simplify incoming connection handling. The `IncomingConnectionEvent`
   has been removed. Instead, pass the `IncomingConnection` obtained
@@ -400,7 +400,7 @@
   `MemoryTransport` `Listener` `ListenerEvent::Upgrade`
   [PR 1724](https://github.com/libp2p/rust-libp2p/pull/1724).
 
-# 0.21.0 [2020-08-18]
+## 0.21.0 [2020-08-18]
 
 - Remove duplicates when performing address translation
   [PR 1697](https://github.com/libp2p/rust-libp2p/pull/1697).
@@ -422,11 +422,11 @@
 - Add `ConnectedPoint::get_remote_address`
   ([PR 1649](https://github.com/libp2p/rust-libp2p/pull/1649)).
 
-# 0.20.1 [2020-07-17]
+## 0.20.1 [2020-07-17]
 
 - Update ed25519-dalek dependency.
 
-# 0.20.0 [2020-07-01]
+## 0.20.0 [2020-07-01]
 
 - Conditional compilation fixes for the `wasm32-wasi` target
   ([PR 1633](https://github.com/libp2p/rust-libp2p/pull/1633)).
@@ -438,7 +438,7 @@ a change in the address of the underlying connection.
 
 - Add `ConnectionHandler::inject_address_change`.
 
-# 0.19.2 [2020-06-22]
+## 0.19.2 [2020-06-22]
 
 - Add PartialOrd and Ord for PeerId
   ([PR 1594](https://github.com/libp2p/rust-libp2p/pull/1594)).

--- a/identity/CHANGELOG.md
+++ b/identity/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.1.1
+## 0.1.1
 
 - Add `From` impl for specific keypairs.
   See [PR 3626].

--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.52.2
+## 0.52.2
 
 - Introduce `libp2p::connection_limits` module.
   See [PR 3386].
@@ -19,7 +19,7 @@
 [PR 3590]: https://github.com/libp2p/rust-libp2p/pull/3590
 [PR 3693]: https://github.com/libp2p/rust-libp2p/pull/3693
 
-# 0.51.1
+## 0.51.1
 
 - Depend on `libp2p-tls` `v0.1.0`.
 
@@ -30,7 +30,7 @@
 
 [PR 3350]: https://github.com/libp2p/rust-libp2p/pull/3350
 
-# 0.51.0
+## 0.51.0
 
 - Enable `NetworkBehaviour`s to manage connections.
   This deprecates `NetworkBehaviour::new_handler` and `NetworkBehaviour::addresses_of_peer`.
@@ -86,7 +86,7 @@
 
 [PR 3191]: https://github.com/libp2p/rust-libp2p/pull/3191
 
-# 0.50.0
+## 0.50.0
 
 This is a large release. After > 4 years, rust-libp2p ships with an [(alpha) QUIC
 implementation](transports/quic/CHANGELOG.md#070-alpha). The [necessary TLS logic is extracted into
@@ -136,7 +136,7 @@ definitely not it. See below for the many other changes packed into this release
 [PR 2289]: https://github.com/libp2p/rust-libp2p/pull/2289
 [PR 3055]: https://github.com/libp2p/rust-libp2p/pull/3055
 
-# 0.49.0
+## 0.49.0
 
 - Remove default features. You need to enable required features explicitly now. As a quick workaround, you may want to use the
   new `full` feature which activates all features. See [PR 2918].
@@ -181,7 +181,7 @@ definitely not it. See below for the many other changes packed into this release
 [PR 2918]: https://github.com/libp2p/rust-libp2p/pull/2918
 [PR 2962]: https://github.com/libp2p/rust-libp2p/pull/2962
 
-# 0.48.0
+## 0.48.0
 
 - Update to [`libp2p-core` `v0.36.0`](core/CHANGELOG.md#0360).
 
@@ -207,7 +207,7 @@ definitely not it. See below for the many other changes packed into this release
 
 - Update to [`libp2p-request-response` `v0.21.0`](protocols/request-response/CHANGELOG.md#0210).
 
-# 0.47.0
+## 0.47.0
 
 - Update to [`libp2p-dcutr` `v0.5.0`](protocols/dcutr/CHANGELOG.md#050).
 
@@ -233,11 +233,11 @@ definitely not it. See below for the many other changes packed into this release
 
 - Update to [`libp2p-swarm` `v0.38.0`](swarm/CHANGELOG.md#0380).
 
-# 0.46.1
+## 0.46.1
 
 - Update to `libp2p-derive` [`v0.28.0`](swarm-derive/CHANGELOG.md#0280).
 
-# 0.46.0
+## 0.46.0
 
 - Semver bump Rust from `1.56.1` to `1.60.0` . See [PR 2646].
 - Added weak dependencies for features. See [PR 2646].
@@ -263,7 +263,7 @@ definitely not it. See below for the many other changes packed into this release
 
 [PR 2646]: https://github.com/libp2p/rust-libp2p/pull/2646
 
-# 0.45.1
+## 0.45.1
 
 - Update individual crates.
     - Update to [`libp2p-dcutr` `v0.3.1`](protocols/dcutr/CHANGELOG.md).
@@ -272,7 +272,7 @@ definitely not it. See below for the many other changes packed into this release
     - Update to [`libp2p-relay` `v0.9.1`](protocols/relay/CHANGELOG.md).
     - Update to [`libp2p-swarm` `v0.36.1`](swarm/CHANGELOG.md).
 
-# 0.45.0
+## 0.45.0
 - Update individual crates.
     - Update to [`libp2p-plaintext` `v0.33.0`](transports/plaintext/CHANGELOG.md).
     - Update to [`libp2p-noise` `v0.36.0`](transports/noise/CHANGELOG.md).

--- a/misc/allow-block-list/CHANGELOG.md
+++ b/misc/allow-block-list/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 0.1.0
+## 0.1.0
 
 - Initial release.

--- a/misc/connection-limits/CHANGELOG.md
+++ b/misc/connection-limits/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 0.1.0
+## 0.1.0
 
 - Initial release.

--- a/misc/metrics/CHANGELOG.md
+++ b/misc/metrics/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.12.0
+## 0.12.0
 
 - Update to `prometheus-client` `v0.19.0`. See [PR 3207].
 
@@ -23,7 +23,7 @@
 [PR 3134]: https://github.com/libp2p/rust-libp2p/pull/3134/
 [PR 3207]: https://github.com/libp2p/rust-libp2p/pull/3207/
 
-# 0.11.0
+## 0.11.0
 
 - Update to `libp2p-dcutr` `v0.8.0`.
 
@@ -52,7 +52,7 @@
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 [PR 2712]: https://github.com/libp2p/rust-libp2p/pull/2712
 
-# 0.10.0
+## 0.10.0
 
 - Update to `libp2p-swarm` `v0.40.0`.
 
@@ -70,7 +70,7 @@
 
 - Update to `libp2p-gossipsub` `v0.42.0`.
 
-# 0.9.0
+## 0.9.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 
@@ -86,7 +86,7 @@
 
 - Update to `libp2p-core` `v0.36.0`.
 
-# 0.8.0
+## 0.8.0
 
 - Update to `libp2p-swarm` `v0.38.0`.
 
@@ -110,7 +110,7 @@
 
 [PR 2734]: https://github.com/libp2p/rust-libp2p/pull/2734/
 
-# 0.7.0
+## 0.7.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
@@ -126,11 +126,11 @@
 
 - Update to `libp2p-kad` `v0.38.0`.
 
-# 0.6.1
+## 0.6.1
 
 - Update `dcutr` events from `libp2p_relay_events` to `libp2p_dcutr_events`, to avoid conflict with `relay` events.
 
-# 0.6.0
+## 0.6.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
@@ -150,7 +150,7 @@
 
 [PR 2631]: https://github.com/libp2p/rust-libp2p/pull/2631
 
-# 0.5.0
+## 0.5.0
 
 - Update to `libp2p-swarm` `v0.35.0`.
 
@@ -164,7 +164,7 @@
 
 - Update to `libp2p-kad` `v0.36.0`.
 
-# 0.4.0 [2022-02-22]
+## 0.4.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
@@ -186,7 +186,7 @@
 
 [PR 2506]: https://github.com/libp2p/rust-libp2p/pull/2506
 
-# 0.3.0 [2022-01-27]
+## 0.3.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -194,7 +194,7 @@
 
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 
-# 0.2.0 [2021-11-16]
+## 0.2.0 [2021-11-16]
 
 - Include gossipsub metrics (see [PR 2316]).
 
@@ -202,6 +202,6 @@
 
 [PR 2316]: https://github.com/libp2p/rust-libp2p/pull/2316
 
-# 0.1.0 [2021-11-01]
+## 0.1.0 [2021-11-01]
 
 - Add initial version.

--- a/misc/multistream-select/CHANGELOG.md
+++ b/misc/multistream-select/CHANGELOG.md
@@ -1,51 +1,51 @@
-# 0.12.1
+## 0.12.1
 
 - Update `rust-version` to reflect the actual MSRV: 1.60.0. See [PR 3090].
 
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.12.0
+## 0.12.0
 
 - Remove parallel dialing optimization, to avoid requiring the use of the `ls` command. See [PR 2934].
 
 [PR 2934]: https://github.com/libp2p/rust-libp2p/pull/2934
 
-# 0.11.0 [2022-01-27]
+## 0.11.0 [2022-01-27]
 
 - Migrate to Rust edition 2021 (see [PR 2339]).
 
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 
-# 0.10.4 [2021-11-01]
+## 0.10.4 [2021-11-01]
 
 - Implement `From<io::Error> for ProtocolError` instead of `Into`.
   [PR 2169](https://github.com/libp2p/rust-libp2p/pull/2169)
 
-# 0.10.3 [2021-03-17]
+## 0.10.3 [2021-03-17]
 
 - Update dependencies.
 
-# 0.10.2 [2021-03-01]
+## 0.10.2 [2021-03-01]
 
 - Re-enable "parallel negotiation" if the dialer has 3 or more
   alternative protocols.
   [PR 1934](https://github.com/libp2p/rust-libp2p/pull/1934)
 
-# 0.10.1 [2021-02-15]
+## 0.10.1 [2021-02-15]
 
 - Update dependencies.
 
-# 0.10.0 [2021-01-12]
+## 0.10.0 [2021-01-12]
 
 - Update dependencies.
 
-# 0.9.1 [2020-12-02]
+## 0.9.1 [2020-12-02]
 
 - Ensure uniform outcomes for failed negotiations with both
   `V1` and `V1Lazy`.
   [PR 1871](https://github.com/libp2p/rust-libp2p/pull/1871)
 
-# 0.9.0 [2020-11-25]
+## 0.9.0 [2020-11-25]
 
 - Make the `V1Lazy` upgrade strategy more interoperable with `V1`. Specifically,
   the listener now behaves identically with `V1` and `V1Lazy`. Furthermore, the
@@ -61,18 +61,18 @@
   be spec-compliant and interoperable with other implementations.
   For a clean upgrade, `0.8.4` must already be deployed.
 
-# 0.8.5 [2020-11-09]
+## 0.8.5 [2020-11-09]
 
 - During negotiation do not interpret EOF error as an IO error, but instead as a
   negotiation error. See https://github.com/libp2p/rust-libp2p/pull/1823.
 
-# 0.8.4 [2020-10-20]
+## 0.8.4 [2020-10-20]
 
 - Temporarily disable the internal selection of "parallel" protocol
   negotiation for the dialer to later change the response format of the "ls"
   message for spec compliance. See https://github.com/libp2p/rust-libp2p/issues/1795.
 
-# 0.8.3 [2020-10-16]
+## 0.8.3 [2020-10-16]
 
 - Fix a regression resulting in a panic with the `V1Lazy` protocol.
   [PR 1783](https://github.com/libp2p/rust-libp2p/pull/1783).
@@ -84,6 +84,6 @@
 
 - Update dependencies.
 
-# 0.8.2 [2020-06-22]
+## 0.8.2 [2020-06-22]
 
 - Updated dependencies.

--- a/misc/quick-protobuf-codec/CHANGELOG.md
+++ b/misc/quick-protobuf-codec/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.1.0
+## 0.1.0
 
 - Migrate from `prost` to `quick-protobuf`. This removes `protoc` dependency. See [PR 3312].
 

--- a/misc/rw-stream-sink/CHANGELOG.md
+++ b/misc/rw-stream-sink/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.3.0
+## 0.3.0
 
 - Move from https://github.com/paritytech/rw-stream-sink/ to https://github.com/libp2p/rust-libp2p. See [Issue 2504].
 

--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 0.39.0
+## 0.39.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
-# 0.38.0
+## 0.38.0
 
 - Update to `libp2p-core` `v0.38.0`.
 
@@ -10,32 +10,32 @@
 
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.37.0
+## 0.37.0
 
 - Bump rand to 0.8 and quickcheck to 1. See [PR 2857].
 
 [PR 2857]: https://github.com/libp2p/rust-libp2p/pull/2857
 
-# 0.36.0
+## 0.36.0
 
 - Update to `libp2p-core` `v0.36.0`
 
-# 0.35.0
+## 0.35.0
 
 - Update to `libp2p-core` `v0.35.0`
 
-# 0.34.0
+## 0.34.0
 
 - `Substream` now implements `AsyncRead` and `AsyncWrite`. See [PR 2706].
 - Update to `libp2p-core` `v0.34.0`
 
 [PR 2706]: https://github.com/libp2p/rust-libp2p/pull/2706/
 
-# 0.33.0
+## 0.33.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
-# 0.32.0 [2022-02-22]
+## 0.32.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
@@ -43,7 +43,7 @@
 
 [PR 2463]: https://github.com/libp2p/rust-libp2p/pull/2463/
 
-# 0.31.0 [2022-01-27]
+## 0.31.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -53,13 +53,13 @@
 
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 
-# 0.30.0 [2021-11-01]
+## 0.30.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
 - Update dependencies.
 
-# 0.29.0 [2021-07-12]
+## 0.29.0 [2021-07-12]
 
 - Update dependencies.
 
@@ -67,30 +67,30 @@
 
 [PR 2094]: https://github.com/libp2p/rust-libp2p/pull/2094
 
-# 0.28.0 [2021-03-17]
+## 0.28.0 [2021-03-17]
 
 - Update dependencies.
 
-# 0.27.1 [2021-02-15]
+## 0.27.1 [2021-02-15]
 
 - Update dependencies.
 
-# 0.27.0 [2021-01-12]
+## 0.27.0 [2021-01-12]
 
 - Update dependencies.
 
-# 0.26.0 [2020-12-17]
+## 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.
 
-# 0.25.0 [2020-11-25]
+## 0.25.0 [2020-11-25]
 
 - Update `libp2p-core`.
 
 - Change the default `split_send_size` from 1KiB to 8KiB.
   [PR 1834](https://github.com/libp2p/rust-libp2p/pull/1834).
 
-# 0.24.0 [2020-11-09]
+## 0.24.0 [2020-11-09]
 
 - Change the default configuration to use `MaxBufferBehaviour::Block`
   and yield from waiting for the next substream or reading from a
@@ -107,7 +107,7 @@
 
 - Update dependencies.
 
-# 0.23.1 [2020-10-28]
+## 0.23.1 [2020-10-28]
 
 - Be lenient with duplicate `Close` frames received. Version
   `0.23.0` started treating duplicate `Close` frames for a
@@ -116,7 +116,7 @@
   redundancy, this releases reverts back to the pre-0.23 behaviour
   of ignoring duplicate `Close` frames.
 
-# 0.23.0 [2020-10-16]
+## 0.23.0 [2020-10-16]
 
 - More granular execution of pending flushes, better logging and
   avoiding unnecessary hashing.
@@ -143,20 +143,20 @@
 
 - Update dependencies.
 
-# 0.22.0 [2020-09-09]
+## 0.22.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.
 
-# 0.21.0 [2020-08-18]
+## 0.21.0 [2020-08-18]
 
 - Bump `libp2p-core` dependency.
 
-# 0.20.0 [2020-07-01]
+## 0.20.0 [2020-07-01]
 
 - Update `libp2p-core`, i.e. `StreamMuxer::poll_inbound` has been renamed
   to `poll_event` and returns a `StreamMuxerEvent`.
 
-# 0.19.2 [2020-06-22]
+## 0.19.2 [2020-06-22]
 
 - Deprecated method `Multiplex::is_remote_acknowledged` has been removed
   as part of [PR 1616](https://github.com/libp2p/rust-libp2p/pull/1616).

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 0.43.0
+## 0.43.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
-# 0.42.0
+## 0.42.0
 
 - Update to `libp2p-core` `v0.38.0`.
 
@@ -10,7 +10,7 @@
 
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.41.1
+## 0.41.1
 
 - Yield from `StreamMuxer::poll` as soon as we receive a single substream.
   This fixes [issue 3041].
@@ -19,11 +19,11 @@
 [PR 3071]: https://github.com/libp2p/rust-libp2p/pull/3071/
 [issue 3041]: https://github.com/libp2p/rust-libp2p/issues/3041/
 
-# 0.41.0
+## 0.41.0
 
 - Update to `libp2p-core` `v0.37.0`.
 
-# 0.40.0
+## 0.40.0
 
 - Update to `libp2p-core` `v0.36.0`
 
@@ -35,19 +35,19 @@
 [PR 2873]: https://github.com/libp2p/rust-libp2p/pull/2873/
 [PR 2861]: https://github.com/libp2p/rust-libp2p/pull/2861/
 
-# 0.39.0
+## 0.39.0
 
 - Update to `libp2p-core` `v0.35.0`
 
-# 0.38.0
+## 0.38.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
-# 0.37.0
+## 0.37.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
-# 0.36.0 [2022-02-22]
+## 0.36.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
@@ -55,7 +55,7 @@
 
 [PR 2463]: https://github.com/libp2p/rust-libp2p/pull/2463/
 
-# 0.35.0 [2022-01-27]
+## 0.35.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -67,7 +67,7 @@
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 [PR 2435]: https://github.com/libp2p/rust-libp2p/pull/2435
 
-# 0.34.0 [2021-11-01]
+## 0.34.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
@@ -77,36 +77,36 @@
 - Implement `From<io::Error> for YamuxError` instead of `Into`.
   [PR 2169](https://github.com/libp2p/rust-libp2p/pull/2169)
 
-# 0.33.0 [2021-07-12]
+## 0.33.0 [2021-07-12]
 
 - Update dependencies.
 
-# 0.32.0 [2021-04-13]
+## 0.32.0 [2021-04-13]
 
 - Update to `yamux` `v0.9.0` [PR
   1960](https://github.com/libp2p/rust-libp2p/pull/1960).
 
-# 0.31.0 [2021-03-17]
+## 0.31.0 [2021-03-17]
 
 - Update `libp2p-core`.
 
-# 0.30.1 [2021-02-17]
+## 0.30.1 [2021-02-17]
 
 - Update `yamux` to `0.8.1`.
 
-# 0.30.0 [2021-01-12]
+## 0.30.0 [2021-01-12]
 
 - Update dependencies.
 
-# 0.29.0 [2020-12-17]
+## 0.29.0 [2020-12-17]
 
 - Update `libp2p-core`.
 
-# 0.28.0 [2020-11-25]
+## 0.28.0 [2020-11-25]
 
 - Update `libp2p-core`.
 
-# 0.27.0 [2020-11-09]
+## 0.27.0 [2020-11-09]
 
 - Tweak the naming in the `MplexConfig` API for better
   consistency with `libp2p-mplex`.
@@ -114,29 +114,29 @@
 
 - Update dependencies.
 
-# 0.26.0 [2020-10-16]
+## 0.26.0 [2020-10-16]
 
 - Update `libp2p-core`.
 
-# 0.25.0 [2020-09-09]
+## 0.25.0 [2020-09-09]
 
 - Update to `yamux-0.8.0`. Upgrade step 4 of 4. This version always implements
   the additive meaning w.r.t. initial window updates. The configuration option
   `lazy_open` is removed. Yamux will automatically send an initial window update
   if the receive window is configured to be larger than the default.
 
-# 0.24.0 [2020-09-09]
+## 0.24.0 [2020-09-09]
 
 - Update to `yamux-0.7.0`. Upgrade step 3 of 4. This version sets the flag but will
   always interpret initial window updates as additive.
 
-# 0.23.0 [2020-09-09]
+## 0.23.0 [2020-09-09]
 
 - Update to `yamux-0.6.0`. As explain below, this is step 2 of 4 in a multi-release
   upgrade. This version recognises and sets the flag that causes the new semantics
   for the initial window update.
 
-# 0.22.0 [2020-09-09]
+## 0.22.0 [2020-09-09]
 
 - Update to `yamux-0.5.0`. *This is the start of a multi-release transition* to a
   different behaviour w.r.t. the initial window update frame. Tracked in [[1]],
@@ -156,19 +156,19 @@
 
 [1]: https://github.com/paritytech/yamux/issues/92
 
-# 0.21.0 [2020-08-18]
+## 0.21.0 [2020-08-18]
 
 - Bump `libp2p-core` dependency.
 
 - Allow overriding the mode (client/server), e.g. in the context
 of TCP hole punching. [PR 1691](https://github.com/libp2p/rust-libp2p/pull/1691).
 
-# 0.20.0 [2020-07-01]
+## 0.20.0 [2020-07-01]
 
 - Update `libp2p-core`, i.e. `StreamMuxer::poll_inbound` has been renamed
   to `poll_event` and returns a `StreamMuxerEvent`.
 
-# 0.19.1 [2020-06-22]
+## 0.19.1 [2020-06-22]
 
 - Deprecated method `Yamux::is_remote_acknowledged` has been removed
   as part of [PR 1616](https://github.com/libp2p/rust-libp2p/pull/1616).

--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -1,10 +1,10 @@
-# 0.10.1
+## 0.10.1
 
 - Migrate from `prost` to `quick-protobuf`. This removes `protoc` dependency. See [PR 3312].
 
 [PR 3153]: https://github.com/libp2p/rust-libp2p/pull/3153
 
-# 0.10.0
+## 0.10.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
@@ -16,14 +16,14 @@
 
 [PR 3312]: https://github.com/libp2p/rust-libp2p/pull/3312
 
-# 0.9.1
+## 0.9.1
 
 - Skip unparsable multiaddr in `DialRequest::from_bytes`. See [PR 3351].
 
 [PR 3351]: https://github.com/libp2p/rust-libp2p/pull/3351
 
 
-# 0.9.0
+## 0.9.0
 
 - Update to `libp2p-core` `v0.38.0`.
 
@@ -39,7 +39,7 @@
 [PR 3011]: https://github.com/libp2p/rust-libp2p/pull/3011
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.8.0
+## 0.8.0
 
 - Update to `libp2p-core` `v0.37.0`.
 
@@ -47,7 +47,7 @@
 
 - Update to `libp2p-request-response` `v0.22.0`.
 
-# 0.7.0
+## 0.7.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 
@@ -55,7 +55,7 @@
 
 - Update to `libp2p-core` `v0.36.0`.
 
-# 0.6.0
+## 0.6.0
 
 - Update prost requirement from 0.10 to 0.11 which no longer installs the protoc Protobuf compiler.
   Thus you will need protoc installed locally. See [PR 2788].
@@ -68,7 +68,7 @@
 
 [PR 2788]: https://github.com/libp2p/rust-libp2p/pull/2788
 
-# 0.5.0
+## 0.5.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
@@ -76,11 +76,11 @@
 
 - Update to `libp2p-request-response` `v0.19.0`.
 
-# 0.4.1
+## 0.4.1
 
 - Export `DEFAULT_PROTOCOL_NAME`.
 
-# 0.4.0
+## 0.4.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
@@ -93,13 +93,13 @@
 
 [PR 2618]: https://github.com/libp2p/rust-libp2p/pull/2618
 
-# 0.3.0
+## 0.3.0
 
 - Update to `libp2p-swarm` `v0.35.0`.
 
 - Update to `libp2p-request-response` `v0.17.0`.
 
-# 0.2.0 [2022-02-22]
+## 0.2.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
@@ -111,6 +111,6 @@
 
 [PR 2445]: https://github.com/libp2p/rust-libp2p/pull/2445
 
-# 0.1.0 [2022-01-27]
+## 0.1.0 [2022-01-27]
 
 - Initial release.

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -1,10 +1,10 @@
-# 0.9.1
+## 0.9.1
 
 - Migrate from `prost` to `quick-protobuf`. This removes `protoc` dependency. See [PR 3312].
 
 [PR 3312]: https://github.com/libp2p/rust-libp2p/pull/3312
 
-# 0.9.0
+## 0.9.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
@@ -22,14 +22,14 @@
 [issue 2217]: https://github.com/libp2p/rust-libp2p/issues/2217
 [PR 3214]: https://github.com/libp2p/rust-libp2p/pull/3214
 
-# 0.8.1
+## 0.8.1
 
 - Skip unparsable multiaddr in `InboundUpgrade::upgrade_inbound` and
   `OutboundUpgrade::upgrade_outbound`. See [PR 3300].
 
 [PR 3300]: https://github.com/libp2p/rust-libp2p/pull/3300
 
-# 0.8.0
+## 0.8.0
 
 - Update to `prost-codec` `v0.3.0`.
 
@@ -49,7 +49,7 @@
 [PR 3011]: https://github.com/libp2p/rust-libp2p/pull/3011
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.7.0
+## 0.7.0
 
 - Update to `libp2p-core` `v0.37.0`.
 
@@ -59,19 +59,19 @@
 
 [PR 2991]: https://github.com/libp2p/rust-libp2p/pull/2991/
 
-# 0.6.0
+## 0.6.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 
 - Update to `libp2p-core` `v0.36.0`.
 
-# 0.5.1
+## 0.5.1
 
 - Make default features of `libp2p-core` optional. See [PR 2836].
 
 [PR 2836]: https://github.com/libp2p/rust-libp2p/pull/2836/
 
-# 0.5.0
+## 0.5.0
 
 - Update prost requirement from 0.10 to 0.11 which no longer installs the protoc Protobuf compiler.
   Thus you will need protoc installed locally. See [PR 2788].
@@ -85,23 +85,23 @@
 [PR 2734]: https://github.com/libp2p/rust-libp2p/pull/2734/
 [PR 2788]: https://github.com/libp2p/rust-libp2p/pull/2788
 
-# 0.4.0
+## 0.4.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
 - Update to `libp2p-swarm` `v0.37.0`.
 
-# 0.3.1
+## 0.3.1
 
 - Upgrade at most one inbound connect request.
 
-# 0.3.0
+## 0.3.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
 - Update to `libp2p-swarm` `v0.36.0`.
 
-# 0.2.0
+## 0.2.0
 
 - Expose `InboundUpgradeError` and `OutboundUpgradeError`. See [PR, 2586].
 
@@ -109,6 +109,6 @@
 
 [PR 2586]: https://github.com/libp2p/rust-libp2p/pull/2586
 
-# 0.1.0 [2022-02-22]
+## 0.1.0 [2022-02-22]
 
 - Initial release.

--- a/protocols/floodsub/CHANGELOG.md
+++ b/protocols/floodsub/CHANGELOG.md
@@ -1,16 +1,16 @@
-# 0.42.1
+## 0.42.1
 
 - Migrate from `prost` to `quick-protobuf`. This removes `protoc` dependency. See [PR 3312].
 
 [PR 3312]: https://github.com/libp2p/rust-libp2p/pull/3312
 
-# 0.42.0
+## 0.42.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
 - Update to `libp2p-swarm` `v0.42.0`.
 
-# 0.41.0
+## 0.41.0
 
 - Update to `libp2p-core` `v0.38.0`.
 
@@ -24,7 +24,7 @@
 [PR 3011]: https://github.com/libp2p/rust-libp2p/pull/3011
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.40.0
+## 0.40.0
 
 - Bump rand to 0.8 and quickcheck to 1. See [PR 2857].
 
@@ -34,13 +34,13 @@
 
 [PR 2857]: https://github.com/libp2p/rust-libp2p/pull/2857
 
-# 0.39.0
+## 0.39.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 
 - Update to `libp2p-core` `v0.36.0`.
 
-# 0.38.0
+## 0.38.0
 
 - Update prost requirement from 0.10 to 0.11 which no longer installs the protoc Protobuf compiler.
   Thus you will need protoc installed locally. See [PR 2788].
@@ -51,23 +51,23 @@
 
 [PR 2788]: https://github.com/libp2p/rust-libp2p/pull/2788
 
-# 0.37.0
+## 0.37.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
 - Update to `libp2p-swarm` `v0.37.0`.
 
-# 0.36.0
+## 0.36.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
 - Update to `libp2p-swarm` `v0.36.0`.
 
-# 0.35.0
+## 0.35.0
 
 - Update to `libp2p-swarm` `v0.35.0`.
 
-# 0.34.0 [2022-02-22]
+## 0.34.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
@@ -77,7 +77,7 @@
 
 [PR 2445]: https://github.com/libp2p/rust-libp2p/pull/2445
 
-# 0.33.0 [2022-01-27]
+## 0.33.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -89,18 +89,18 @@
 
 [PR 2360]: https://github.com/libp2p/rust-libp2p/pull/2360/
 
-# 0.32.0 [2021-11-16]
+## 0.32.0 [2021-11-16]
 
 - Update dependencies.
 
-# 0.31.0 [2021-11-01]
+## 0.31.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
 
 - Update dependencies.
 
-# 0.30.0 [2021-07-12]
+## 0.30.0 [2021-07-12]
 
 - Update dependencies.
 
@@ -109,48 +109,48 @@
 
 [PR 2111]: https://github.com/libp2p/rust-libp2p/pull/2111
 
-# 0.29.0 [2021-04-13]
+## 0.29.0 [2021-04-13]
 
 - Update `libp2p-swarm`.
 
-# 0.28.0 [2021-03-17]
+## 0.28.0 [2021-03-17]
 
 - Update `libp2p-swarm`.
 
 - Update dependencies.
 
-# 0.27.0 [2021-01-12]
+## 0.27.0 [2021-01-12]
 
 - Update dependencies.
 
-# 0.26.0 [2020-12-17]
+## 0.26.0 [2020-12-17]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.25.0 [2020-11-25]
+## 0.25.0 [2020-11-25]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.24.0 [2020-11-09]
+## 0.24.0 [2020-11-09]
 
 - Update dependencies.
 
-# 0.23.0 [2020-10-16]
+## 0.23.0 [2020-10-16]
 
 - Update dependencies.
 
-# 0.22.0 [2020-09-09]
+## 0.22.0 [2020-09-09]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.21.0 [2020-08-18]
+## 0.21.0 [2020-08-18]
 
 - Bump `libp2p-core` and `libp2p-swarm` dependency.
 
-# 0.20.0 [2020-07-01]
+## 0.20.0 [2020-07-01]
 
 - Updated dependencies.
 
-# 0.19.1 [2020-06-22]
+## 0.19.1 [2020-06-22]
 
 - Updated dependencies.

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,17 +1,17 @@
-# 0.44.2
+## 0.44.2
 
 - Signed messages now use sequential integers in the sequence number field.
   See [PR 3551].
 
 [PR 3551]: https://github.com/libp2p/rust-libp2p/pull/3551
 
-# 0.44.1
+## 0.44.1
 
 - Migrate from `prost` to `quick-protobuf`. This removes `protoc` dependency. See [PR 3312].
 
 [PR 3312]: https://github.com/libp2p/rust-libp2p/pull/3312
 
-# 0.44.0
+## 0.44.0
 
 - Update to `prometheus-client` `v0.19.0`. See [PR 3207].
 
@@ -32,7 +32,7 @@
 [PR 3381]: https://github.com/libp2p/rust-libp2p/pull/3381/
 [discussion 2174]: https://github.com/libp2p/rust-libp2p/discussions/2174
 
-# 0.43.0
+## 0.43.0
 
 - Update to `libp2p-core` `v0.38.0`.
 
@@ -55,7 +55,7 @@
 [PR 3011]: https://github.com/libp2p/rust-libp2p/pull/3011
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.42.0
+## 0.42.0
 
 - Bump rand to 0.8 and quickcheck to 1. See [PR 2857].
 
@@ -65,7 +65,7 @@
 
 [PR 2857]: https://github.com/libp2p/rust-libp2p/pull/2857
 
-# 0.41.0
+## 0.41.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 
@@ -75,7 +75,7 @@
 
 [PR 2862]: https://github.com/libp2p/rust-libp2p/pull/2862
 
-# 0.40.0
+## 0.40.0
 
 - Update prost requirement from 0.10 to 0.11 which no longer installs the protoc Protobuf compiler.
   Thus you will need protoc installed locally. See [PR 2788].
@@ -89,7 +89,7 @@
 [PR 2822]: https://github.com/libp2p/rust-libp2p/pull/2761/
 [PR 2788]: https://github.com/libp2p/rust-libp2p/pull/2788
 
-# 0.39.0
+## 0.39.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
@@ -99,13 +99,13 @@
 
 [PR 2718]: https://github.com/libp2p/rust-libp2p/pull/2718/
 
-# 0.38.1
+## 0.38.1
 
 - Fix duplicate connection id. See [PR 2702].
 
 [PR 2702]: https://github.com/libp2p/rust-libp2p/pull/2702
 
-# 0.38.0
+## 0.38.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
@@ -118,7 +118,7 @@
 [PR 2620]: https://github.com/libp2p/rust-libp2p/pull/2620
 [PR 2631]: https://github.com/libp2p/rust-libp2p/pull/2631
 
-# 0.37.0
+## 0.37.0
 
 - Update to `libp2p-swarm` `v0.35.0`.
 
@@ -129,7 +129,7 @@
 [PR 2558]: https://github.com/libp2p/rust-libp2p/pull/2558
 [PR 2595]: https://github.com/libp2p/rust-libp2p/pull/2595
 
-# 0.36.0 [2022-02-22]
+## 0.36.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
@@ -151,7 +151,7 @@
 [PR 2506]: https://github.com/libp2p/rust-libp2p/pull/2506
 [PR 2493]: https://github.com/libp2p/rust-libp2p/pull/2493
 
-# 0.35.0 [2022-01-27]
+## 0.35.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -176,7 +176,7 @@
 [PR 2403]: https://github.com/libp2p/rust-libp2p/pull/2403
 [libp2p specs PR 383]: https://github.com/libp2p/specs/pull/383
 
-# 0.34.0 [2021-11-16]
+## 0.34.0 [2021-11-16]
 
 - Add topic and mesh metrics (see [PR 2316]).
 
@@ -190,7 +190,7 @@
 [PR 2325]: https://github.com/libp2p/rust-libp2p/pull/2325
 [PR 2316]: https://github.com/libp2p/rust-libp2p/pull/2316
 
-# 0.33.0 [2021-11-01]
+## 0.33.0 [2021-11-01]
 
 - Add an event to register peers that do not support the gossipsub protocol
   [PR 2241](https://github.com/libp2p/rust-libp2p/pull/2241)
@@ -209,7 +209,7 @@
 - Implement std::error::Error for error types.
   [PR 2254](https://github.com/libp2p/rust-libp2p/pull/2254)
 
-# 0.32.0 [2021-07-12]
+## 0.32.0 [2021-07-12]
 
 - Update dependencies.
 
@@ -217,65 +217,65 @@
 
 [PR 2101]: https://github.com/libp2p/rust-libp2p/pull/2101
 
-# 0.31.0 [2021-05-17]
+## 0.31.0 [2021-05-17]
 
 - Keep connections to peers in a mesh alive. Allow closing idle connections to peers not in a mesh
   [PR-2043].
 
 [PR-2043]: https://github.com/libp2p/rust-libp2p/pull/2043https://github.com/libp2p/rust-libp2p/pull/2043
 
-# 0.30.1 [2021-04-27]
+## 0.30.1 [2021-04-27]
 
 - Remove `regex-filter` feature flag thus always enabling `regex::RegexSubscriptionFilter` [PR
   2056](https://github.com/libp2p/rust-libp2p/pull/2056).
 
-# 0.30.0 [2021-04-13]
+## 0.30.0 [2021-04-13]
 
 - Update `libp2p-swarm`.
 
 - Update dependencies.
 
-# 0.29.0 [2021-03-17]
+## 0.29.0 [2021-03-17]
 
 - Update `libp2p-swarm`.
 
 - Update dependencies.
 
-# 0.28.0 [2021-02-15]
+## 0.28.0 [2021-02-15]
 
 - Prevent non-published messages being added to caches.
   [PR 1930](https://github.com/libp2p/rust-libp2p/pull/1930)
 
 - Update dependencies.
 
-# 0.27.0 [2021-01-12]
+## 0.27.0 [2021-01-12]
 
 - Update dependencies.
 
 - Implement Gossipsub v1.1 specification.
   [PR 1720](https://github.com/libp2p/rust-libp2p/pull/1720)
 
-# 0.26.0 [2020-12-17]
+## 0.26.0 [2020-12-17]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.25.0 [2020-11-25]
+## 0.25.0 [2020-11-25]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.24.0 [2020-11-09]
+## 0.24.0 [2020-11-09]
 
 - Update dependencies.
 
-# 0.23.0 [2020-10-16]
+## 0.23.0 [2020-10-16]
 
 - Update dependencies.
 
-# 0.22.0 [2020-09-09]
+## 0.22.0 [2020-09-09]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.21.0 [2020-08-18]
+## 0.21.0 [2020-08-18]
 
 - Add public API to list topics and peers. [PR 1677](https://github.com/libp2p/rust-libp2p/pull/1677).
 
@@ -285,14 +285,14 @@
 
 - Bump `libp2p-core` and `libp2p-swarm` dependency.
 
-# 0.20.0 [2020-07-01]
+## 0.20.0 [2020-07-01]
 
 - Updated dependencies.
 
-# 0.19.3 [2020-06-23]
+## 0.19.3 [2020-06-23]
 
 - Maintenance release fixing linter warnings.
 
-# 0.19.2 [2020-06-22]
+## 0.19.2 [2020-06-22]
 
 - Updated dependencies.

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,10 +1,10 @@
-# 0.42.1
+## 0.42.1
 
 - Migrate from `prost` to `quick-protobuf`. This removes `protoc` dependency. See [PR 3312].
 
 [PR 3312]: https://github.com/libp2p/rust-libp2p/pull/3312
 
-# 0.42.0
+## 0.42.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
@@ -18,13 +18,13 @@
 [PR 3208]: https://github.com/libp2p/rust-libp2p/pull/3208
 [PR 3344]: https://github.com/libp2p/rust-libp2p/pull/3344
 
-# 0.41.1
+## 0.41.1
 
 - Skip invalid multiaddr in `listen_addrs`. See [PR 3246].
 
 [PR 3246]: https://github.com/libp2p/rust-libp2p/pull/3246
 
-# 0.41.0
+## 0.41.0
 
 - Change default `cache_size` of `Config` to 100. See [PR 2995].
 
@@ -47,7 +47,7 @@
 [PR 2995]: https://github.com/libp2p/rust-libp2p/pull/2995
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.40.0
+## 0.40.0
 
 - Update dependencies.
 
@@ -63,13 +63,13 @@
 
 - Update to `libp2p-swarm` `v0.40.0`.
 
-# 0.39.0
+## 0.39.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 
 - Update to `libp2p-core` `v0.36.0`.
 
-# 0.38.0
+## 0.38.0
 
 - Update prost requirement from 0.10 to 0.11 which no longer installs the protoc Protobuf compiler.
   Thus you will need protoc installed locally. See [PR 2788].
@@ -83,7 +83,7 @@
 [PR 2788]: https://github.com/libp2p/rust-libp2p/pull/2788
 [PR 2734]: https://github.com/libp2p/rust-libp2p/pull/2734/
 
-# 0.37.0
+## 0.37.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
@@ -91,11 +91,11 @@
 
 - Extend log message on second identify push stream with peer ID.
 
-# 0.36.1
+## 0.36.1
 
 - Allow at most one inbound identify push stream.
 
-# 0.36.0
+## 0.36.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
@@ -104,11 +104,11 @@
 - Expose explicits errors via `UpgradeError` instead of generic `io::Error`. See [PR 2630].
 
 [PR 2630]: https://github.com/libp2p/rust-libp2p/pull/2630
-# 0.35.0
+## 0.35.0
 
 - Update to `libp2p-swarm` `v0.35.0`.
 
-# 0.34.0 [2022-02-22]
+## 0.34.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
@@ -118,7 +118,7 @@
 
 [PR 2445]: https://github.com/libp2p/rust-libp2p/pull/2445
 
-# 0.33.0 [2022-01-27]
+## 0.33.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -126,7 +126,7 @@
 
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 
-# 0.32.0 [2021-11-16]
+## 0.32.0 [2021-11-16]
 
 - Use `futures-timer` instead of `wasm-timer` (see [PR 2245]).
 - Filter invalid peers from cache used in `addresses_of_peer` – [PR 2338].
@@ -136,7 +136,7 @@
 [PR 2245]: https://github.com/libp2p/rust-libp2p/pull/2245
 [PR 2338]: https://github.com/libp2p/rust-libp2p/pull/2338
 
-# 0.31.0 [2021-11-01]
+## 0.31.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
@@ -147,11 +147,11 @@
   of other peers from `addresses_of_peer` (see [PR
   2232](https://github.com/libp2p/rust-libp2p/pull/2232)), disabled by default.
 
-# 0.30.0 [2021-07-12]
+## 0.30.0 [2021-07-12]
 
 - Update dependencies.
 
-# 0.29.0 [2021-04-13]
+## 0.29.0 [2021-04-13]
 
 - Add support for configurable automatic push to connected peers
   on listen addr changes. Disabled by default.
@@ -165,44 +165,44 @@
   information to peer [PR
   2030](https://github.com/libp2p/rust-libp2p/pull/2030).
 
-# 0.28.0 [2021-03-17]
+## 0.28.0 [2021-03-17]
 
 - Update `libp2p-swarm`.
 
 - Update dependencies.
 
-# 0.27.0 [2021-01-12]
+## 0.27.0 [2021-01-12]
 
 - Update dependencies.
 
-# 0.26.0 [2020-12-17]
+## 0.26.0 [2020-12-17]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.25.0 [2020-11-25]
+## 0.25.0 [2020-11-25]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.24.0 [2020-11-09]
+## 0.24.0 [2020-11-09]
 
 - Update dependencies.
 
-# 0.23.0 [2020-10-16]
+## 0.23.0 [2020-10-16]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.22.0 [2020-09-09]
+## 0.22.0 [2020-09-09]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.21.0 [2020-08-18]
+## 0.21.0 [2020-08-18]
 
 - Bump `libp2p-core` and `libp2p-swarm` dependencies.
 
-# 0.20.0 [2020-07-01]
+## 0.20.0 [2020-07-01]
 
 - Updated dependencies.
 
-# 0.19.2 [2020-06-22]
+## 0.19.2 [2020-06-22]
 
 - Updated dependencies.

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,10 +1,10 @@
-# 0.43.1
+## 0.43.1
 
 - Migrate from `prost` to `quick-protobuf`. This removes `protoc` dependency. See [PR 3312].
 
 [PR 3312]: https://github.com/libp2p/rust-libp2p/pull/3312
 
-# 0.43.0
+## 0.43.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
@@ -19,13 +19,13 @@
 [PR 3239]: https://github.com/libp2p/rust-libp2p/pull/3239
 [PR 3287]: https://github.com/libp2p/rust-libp2p/pull/3287
 
-# 0.42.1
+## 0.42.1
 
 - Skip unparsable multiaddr in `Peer::addrs`. See [PR 3280].
 
 [PR 3280]: https://github.com/libp2p/rust-libp2p/pull/3280
 
-# 0.42.0
+## 0.42.0
 
 - Update to `libp2p-core` `v0.38.0`.
 
@@ -56,7 +56,7 @@
 [PR 3152]: https://github.com/libp2p/rust-libp2p/pull/3152
 [PR 2712]: https://github.com/libp2p/rust-libp2p/pull/2712
 
-# 0.41.0
+## 0.41.0
 
 - Remove deprecated `set_protocol_name()` from `KademliaConfig` & `KademliaProtocolConfig`.
   Use `set_protocol_names()` instead. See [PR 2866].
@@ -70,7 +70,7 @@
 [PR 2866]: https://github.com/libp2p/rust-libp2p/pull/2866
 [PR 2857]: https://github.com/libp2p/rust-libp2p/pull/2857
 
-# 0.40.0
+## 0.40.0
 
 - Add support for multiple protocol names. Update `Kademlia`, `KademliaConfig`,
   and `KademliaProtocolConfig` accordingly. See [Issue 2837]. See [PR 2846].
@@ -82,7 +82,7 @@
 [Issue 2837]: https://github.com/libp2p/rust-libp2p/issues/2837
 [PR 2846]: https://github.com/libp2p/rust-libp2p/pull/2846
 
-# 0.39.0
+## 0.39.0
 
 - Update prost requirement from 0.10 to 0.11 which no longer installs the protoc Protobuf compiler.
   Thus you will need protoc installed locally. See [PR 2788].
@@ -93,19 +93,19 @@
 
 [PR 2788]: https://github.com/libp2p/rust-libp2p/pull/2788
 
-# 0.38.0
+## 0.38.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
 - Update to `libp2p-swarm` `v0.37.0`.
 
-# 0.37.1
+## 0.37.1
 
 - Limit # of inbound streams to 32. [See PR 2699].
 
 [PR 2699]: https://github.com/libp2p/rust-libp2p/pull/2699
 
-# 0.37.0
+## 0.37.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
@@ -115,11 +115,11 @@
 
 [PR 2614]: https://github.com/libp2p/rust-libp2p/pull/2614
 
-# 0.36.0
+## 0.36.0
 
 - Update to `libp2p-swarm` `v0.35.0`.
 
-# 0.35.0 [2022-02-22]
+## 0.35.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
@@ -132,7 +132,7 @@
 [PR 2477]: https://github.com/libp2p/rust-libp2p/pull/2477
 [PR 2445]: https://github.com/libp2p/rust-libp2p/pull/2445
 
-# 0.34.0 [2022-01-27]
+## 0.34.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -149,7 +149,7 @@
 [PR 2408]: https://github.com/libp2p/rust-libp2p/pull/2408
 [PR 2436]: https://github.com/libp2p/rust-libp2p/pull/2436
 
-# 0.33.0 [2021-11-16]
+## 0.33.0 [2021-11-16]
 
 - Use `instant` and `futures-timer` instead of `wasm-timer` (see [PR 2245]).
 
@@ -165,7 +165,7 @@
 [PR 2297]: https://github.com/libp2p/rust-libp2p/pull/2297
 [PR 2309]: https://github.com/libp2p/rust-libp2p/pull/2309
 
-# 0.32.0 [2021-11-01]
+## 0.32.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
@@ -180,7 +180,7 @@
 [PR 2163]: https://github.com/libp2p/rust-libp2p/pull/2163
 [PR 2221]: https://github.com/libp2p/rust-libp2p/pull/2163
 
-# 0.31.0 [2021-07-12]
+## 0.31.0 [2021-07-12]
 
 - Update dependencies.
 
@@ -201,11 +201,11 @@
 [PR 2120]: https://github.com/libp2p/rust-libp2p/pull/2120
 [PR 2125]: https://github.com/libp2p/rust-libp2p/pull/2125
 
-# 0.30.0 [2021-04-13]
+## 0.30.0 [2021-04-13]
 
 - Update `libp2p-swarm`.
 
-# 0.29.0 [2021-03-17]
+## 0.29.0 [2021-03-17]
 
 - Add `KademliaCaching` and `KademliaConfig::set_caching` to configure
   whether Kademlia should track, in lookups, the closest nodes to a key
@@ -224,31 +224,31 @@
 
 - Update dependencies.
 
-# 0.28.1 [2021-02-15]
+## 0.28.1 [2021-02-15]
 
 - Update dependencies.
 
-# 0.28.0 [2021-01-12]
+## 0.28.0 [2021-01-12]
 
 - Update dependencies.
 
-# 0.27.1 [2021-01-11]
+## 0.27.1 [2021-01-11]
 
 - Add From impls for `kbucket::Key`.
   [PR 1909](https://github.com/libp2p/rust-libp2p/pull/1909).
 
-# 0.27.0 [2020-12-17]
+## 0.27.0 [2020-12-17]
 
 - Update `libp2p-core` and `libp2p-swarm`.
 
-# 0.26.0 [2020-11-25]
+## 0.26.0 [2020-11-25]
 
 - Update `libp2p-core` and `libp2p-swarm`.
 
 - Have two `ProviderRecord`s be equal iff their `key` and `provider` fields are
   equal. [PR 1850](https://github.com/libp2p/rust-libp2p/pull/1850/).
 
-# 0.25.0 [2020-11-09]
+## 0.25.0 [2020-11-09]
 
 - Upon newly established connections, delay routing table
   updates until after the configured protocol name has
@@ -261,13 +261,13 @@
 
 - Update dependencies.
 
-# 0.24.0 [2020-10-16]
+## 0.24.0 [2020-10-16]
 
 - Update `libp2p-core` and `libp2p-swarm`.
 
 - Update `sha2` dependency.
 
-# 0.23.0 [2020-09-09]
+## 0.23.0 [2020-09-09]
 
 - Increase default max packet size from 4KiB to 16KiB.
   See [issue 1622](https://github.com/libp2p/rust-libp2p/issues/1622).
@@ -276,12 +276,12 @@
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.22.1 [2020-08-19]
+## 0.22.1 [2020-08-19]
 
 - Explicitly convert from u8 to usize in `BucketIndex::range` to prevent type
   inference issues ([PR 1716](https://github.com/libp2p/rust-libp2p/pull/1716)).
 
-# 0.22.0 [2020-08-18]
+## 0.22.0 [2020-08-18]
 
 - Store addresses in provider records.
   See [PR 1708](https://github.com/libp2p/rust-libp2p/pull/1708).
@@ -295,7 +295,7 @@
 - Add `NetworkBehaviour::inject_address_change` implementation
   ([PR 1649](https://github.com/libp2p/rust-libp2p/pull/1649)).
 
-# 0.21.0 [2020-07-01]
+## 0.21.0 [2020-07-01]
 
 - Remove `KademliaEvent::Discovered`
   ([PR 1632](https://github.com/libp2p/rust-libp2p/pull/1632))
@@ -310,11 +310,11 @@
   required to be acted upon in order to retain existing behaviour).
   For more details, see the PR description.
 
-# 0.20.1 [2020-06-23]
+## 0.20.1 [2020-06-23]
 
 - Maintenance release ([PR 1623](https://github.com/libp2p/rust-libp2p/pull/1623)).
 
-# 0.20.0 [2020-06-22]
+## 0.20.0 [2020-06-22]
 
 - Optionally require iterative queries to use disjoint paths based
   on S/Kademlia for increased resiliency in the presence of potentially

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,9 +1,9 @@
-# 0.43.1
+## 0.43.1
 
 - Derive `Clone` for `mdns::Event`. See [PR 3606].
 
 [PR 3606]: https://github.com/libp2p/rust-libp2p/pull/3606
-# 0.43.0
+## 0.43.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
@@ -18,7 +18,7 @@
 [PR 3153]: https://github.com/libp2p/rust-libp2p/pull/3153
 [PR 3367]: https://github.com/libp2p/rust-libp2p/pull/3367
 
-# 0.42.0
+## 0.42.0
 
 - Update to `libp2p-core` `v0.38.0`.
 
@@ -45,7 +45,7 @@ and move and rename `Mdns` to `async_io::Behaviour`. See [PR 3096].
 [PR 3102]: https://github.com/libp2p/rust-libp2p/pull/3102
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.41.0
+## 0.41.0
 
 - Remove default features. If you previously depended on `async-io` you need to enable this explicitly now. See [PR 2918].
 
@@ -64,7 +64,7 @@ and move and rename `Mdns` to `async_io::Behaviour`. See [PR 3096].
 [PR 2977]: https://github.com/libp2p/rust-libp2p/pull/2977
 [PR 2978]: https://github.com/libp2p/rust-libp2p/pull/2978
 
-# 0.40.0
+## 0.40.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 
@@ -78,30 +78,30 @@ and move and rename `Mdns` to `async_io::Behaviour`. See [PR 3096].
 
 [PR 2748]: https://github.com/libp2p/rust-libp2p/pull/2748
 
-# 0.39.0
+## 0.39.0
 
 - Update to `libp2p-swarm` `v0.38.0`.
 - Update to `if-watch` `v1.1.1`.
 
 - Update to `libp2p-core` `v0.35.0`.
 
-# 0.38.0
+## 0.38.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
 - Update to `libp2p-swarm` `v0.37.0`.
 
-# 0.37.0
+## 0.37.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
 - Update to `libp2p-swarm` `v0.36.0`.
 
-# 0.36.0
+## 0.36.0
 
 - Update to `libp2p-swarm` `v0.35.0`.
 
-# 0.35.0 [2022-02-22]
+## 0.35.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
@@ -111,7 +111,7 @@ and move and rename `Mdns` to `async_io::Behaviour`. See [PR 3096].
 
 [PR 2445]: https://github.com/libp2p/rust-libp2p/pull/2445
 
-# 0.34.0 [2022-01-27]
+## 0.34.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -136,11 +136,11 @@ and move and rename `Mdns` to `async_io::Behaviour`. See [PR 3096].
 
 [PR 2383]: https://github.com/libp2p/rust-libp2p/pull/2383
 
-# 0.33.0 [2021-11-16]
+## 0.33.0 [2021-11-16]
 
 - Update dependencies.
 
-# 0.32.0 [2021-11-01]
+## 0.32.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
@@ -156,27 +156,27 @@ and move and rename `Mdns` to `async_io::Behaviour`. See [PR 3096].
 [PR 2161]: https://github.com/libp2p/rust-libp2p/pull/2161/
 [PR 2212]: https://github.com/libp2p/rust-libp2p/pull/2212/
 
-# 0.31.0 [2021-07-12]
+## 0.31.0 [2021-07-12]
 
 - Update dependencies.
 
-# 0.30.2 [2021-05-06]
+## 0.30.2 [2021-05-06]
 
 - Fix discovered event emission.
   [PR 2065](https://github.com/libp2p/rust-libp2p/pull/2065)
 
-# 0.30.1 [2021-04-21]
+## 0.30.1 [2021-04-21]
 
 - Fix timely discovery of peers after listening on a new address.
   [PR 2053](https://github.com/libp2p/rust-libp2p/pull/2053/)
 
-# 0.30.0 [2021-04-13]
+## 0.30.0 [2021-04-13]
 
 - Derive `Debug` and `Clone` for `MdnsConfig`.
 
 - Update `libp2p-swarm`.
 
-# 0.29.0 [2021-03-17]
+## 0.29.0 [2021-03-17]
 
 - Introduce `MdnsConfig` with configurable TTL of discovered peer
   records and configurable multicast query interval. The default
@@ -193,19 +193,19 @@ and move and rename `Mdns` to `async_io::Behaviour`. See [PR 3096].
 
 - Update `libp2p-swarm`.
 
-# 0.28.1 [2021-02-15]
+## 0.28.1 [2021-02-15]
 
 - Update dependencies.
 
-# 0.28.0 [2021-01-12]
+## 0.28.0 [2021-01-12]
 
 - Update dependencies.
 
-# 0.27.0 [2020-12-17]
+## 0.27.0 [2020-12-17]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.26.0 [2020-12-08]
+## 0.26.0 [2020-12-08]
 
 - Create multiple multicast response packets as required to avoid
   hitting the limit of 9000 bytes per MDNS packet.
@@ -222,35 +222,35 @@ and move and rename `Mdns` to `async_io::Behaviour`. See [PR 3096].
   still being polled by the `tokio` runtime.
   [PR 1830](https://github.com/libp2p/rust-libp2p/pull/1830).
 
-# 0.25.0 [2020-11-25]
+## 0.25.0 [2020-11-25]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.24.0 [2020-11-09]
+## 0.24.0 [2020-11-09]
 
 - Update dependencies.
 
-# 0.23.0 [2020-10-16]
+## 0.23.0 [2020-10-16]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
 - Double receive buffer to 4KiB. [PR 1779](https://github.com/libp2p/rust-libp2p/pull/1779/files).
 
-# 0.22.0 [2020-09-09]
+## 0.22.0 [2020-09-09]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.21.0 [2020-08-18]
+## 0.21.0 [2020-08-18]
 
 - Bump `libp2p-core` and `libp2p-swarm` dependencies.
 
 - Allow libp2p-mdns to use either async-std or tokio to drive required UDP
   socket ([PR 1699](https://github.com/libp2p/rust-libp2p/pull/1699)).
 
-# 0.20.0 [2020-07-01]
+## 0.20.0 [2020-07-01]
 
 - Updated dependencies.
 
-# 0.19.2 [2020-06-22]
+## 0.19.2 [2020-06-22]
 
 - Updated dependencies.

--- a/protocols/perf/CHANGELOG.md
+++ b/protocols/perf/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 0.1.0
+## 0.1.0
 
 - Initial release.

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,10 +1,10 @@
-# 0.42.0
+## 0.42.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
 - Update to `libp2p-swarm` `v0.42.0`.
 
-# 0.41.0
+## 0.41.0
 
 - Update to `libp2p-core` `v0.38.0`.
 
@@ -22,7 +22,7 @@
 [PR 3011]: https://github.com/libp2p/rust-libp2p/pull/3011
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.40.0
+## 0.40.0
 
 - Bump rand to 0.8 and quickcheck to 1. See [PR 2857].
 - Deprecate types with `Ping` prefix. Prefer importing them via the `ping` namespace, i.e. `libp2p::ping::Event` instead
@@ -38,13 +38,13 @@
 [PR 2937]: https://github.com/libp2p/rust-libp2p/pull/2937
 [PR 2859]: https://github.com/libp2p/rust-libp2p/pull/2859/
 
-# 0.39.0
+## 0.39.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 
 - Update to `libp2p-core` `v0.36.0`.
 
-# 0.38.0
+## 0.38.0
 
 - Update to `libp2p-swarm` `v0.38.0`.
 
@@ -54,23 +54,23 @@
 
 [PR 2734]: https://github.com/libp2p/rust-libp2p/pull/2734/
 
-# 0.37.0
+## 0.37.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
 - Update to `libp2p-swarm` `v0.37.0`.
 
-# 0.36.0
+## 0.36.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
 - Update to `libp2p-swarm` `v0.36.0`.
 
-# 0.35.0
+## 0.35.0
 
 - Update to `libp2p-swarm` `v0.35.0`.
 
-# 0.34.0 [2022-02-22]
+## 0.34.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
@@ -80,7 +80,7 @@
 
 [PR 2445]: https://github.com/libp2p/rust-libp2p/pull/2445
 
-# 0.33.0 [2022-01-27]
+## 0.33.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -88,7 +88,7 @@
 
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 
-# 0.32.0 [2021-11-16]
+## 0.32.0 [2021-11-16]
 
 - Use `instant` and `futures-timer` instead of `wasm-timer` (see [PR 2245]).
 
@@ -96,7 +96,7 @@
 
 [PR 2245]: https://github.com/libp2p/rust-libp2p/pull/2245
 
-# 0.31.0 [2021-11-01]
+## 0.31.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
@@ -124,35 +124,35 @@
 
   [discussion 2174]: https://github.com/libp2p/rust-libp2p/discussions/2174
 
-# 0.30.0 [2021-07-12]
+## 0.30.0 [2021-07-12]
 
 - Update dependencies.
 
-# 0.29.0 [2021-04-13]
+## 0.29.0 [2021-04-13]
 
 - Update `libp2p-swarm`.
 
-# 0.28.0 [2021-03-17]
+## 0.28.0 [2021-03-17]
 
 - Update `libp2p-swarm`.
 
-# 0.27.0 [2021-01-12]
+## 0.27.0 [2021-01-12]
 
 - Update dependencies.
 
-# 0.26.0 [2020-12-17]
+## 0.26.0 [2020-12-17]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.25.0 [2020-11-25]
+## 0.25.0 [2020-11-25]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.24.0 [2020-11-09]
+## 0.24.0 [2020-11-09]
 
 - Update dependencies.
 
-# 0.23.0 [2020-10-16]
+## 0.23.0 [2020-10-16]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
@@ -161,11 +161,11 @@
   implementation details of the stream muxer used.
   The current behaviour resulted in stalls with Mplex.
 
-# 0.22.0 [2020-09-09]
+## 0.22.0 [2020-09-09]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.21.0 [2020-08-18]
+## 0.21.0 [2020-08-18]
 
 - Refactor the ping protocol for conformity by (re)using
 a single substream for outbound pings, addressing
@@ -173,15 +173,15 @@ a single substream for outbound pings, addressing
 
 - Bump `libp2p-core` and `libp2p-swarm` dependencies.
 
-# 0.20.0 [2020-07-01]
+## 0.20.0 [2020-07-01]
 
 - Updated dependencies.
 
-# 0.19.3 [2020-06-22]
+## 0.19.3 [2020-06-22]
 
 - Updated dependencies.
 
-# 0.19.2 [2020-06-18]
+## 0.19.2 [2020-06-18]
 
 - Close substream in inbound upgrade
   [PR 1606](https://github.com/libp2p/rust-libp2p/pull/1606).

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,10 +1,10 @@
-# 0.15.1
+## 0.15.1
 
 - Migrate from `prost` to `quick-protobuf`. This removes `protoc` dependency. See [PR 3312].
 
 [PR 3312]: https://github.com/libp2p/rust-libp2p/pull/3312
 
-# 0.15.0
+## 0.15.0
 
 - Rename types as per [discussion 2174].
   `Relay` has been renamed to `Behaviour`.
@@ -20,7 +20,7 @@
 [PR 3238]: https://github.com/libp2p/rust-libp2p/pull/3238
 [discussion 2174]: https://github.com/libp2p/rust-libp2p/issues/2174
 
-# 0.14.0
+## 0.14.0
 
 - Update to `prost-codec` `v0.3.0`.
 
@@ -40,7 +40,7 @@
 [PR 3011]: https://github.com/libp2p/rust-libp2p/pull/3011
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.13.0
+## 0.13.0
 
 - Update to `libp2p-core` `v0.37.0`.
 
@@ -50,13 +50,13 @@
 
 [PR 2991]: https://github.com/libp2p/rust-libp2p/pull/2991/
 
-# 0.12.0
+## 0.12.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 
 - Update to `libp2p-core` `v0.36.0`.
 
-# 0.11.0
+## 0.11.0
 
 - Update prost requirement from 0.10 to 0.11 which no longer installs the protoc Protobuf compiler.
   Thus you will need protoc installed locally. See [PR 2788].
@@ -70,7 +70,7 @@
 [PR 2734]: https://github.com/libp2p/rust-libp2p/pull/2734/
 [PR 2788]: https://github.com/libp2p/rust-libp2p/pull/2788
 
-# 0.10.0
+## 0.10.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
@@ -84,7 +84,7 @@
 [PR 2701]: https://github.com/libp2p/rust-libp2p/pull/2701/
 [PR 2652]: https://github.com/libp2p/rust-libp2p/pull/2652
 
-# 0.9.1
+## 0.9.1
 
 - Respond to at most one incoming reservation request. Deny <= 8 incoming
   circuit requests with one per peer. And deny new circuits before accepting new
@@ -95,13 +95,13 @@
 
 [PR 2698]: https://github.com/libp2p/rust-libp2p/pull/2698/
 
-# 0.9.0
+## 0.9.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
 - Update to `libp2p-swarm` `v0.36.0`.
 
-# 0.8.0
+## 0.8.0
 
 - Expose `{Inbound,Outbound}{Hop,Stop}UpgradeError`. See [PR 2586].
 
@@ -112,7 +112,7 @@
 [PR 2549]: https://github.com/libp2p/rust-libp2p/pull/2549
 [PR 2586]: https://github.com/libp2p/rust-libp2p/pull/2586
 
-# 0.7.0 [2022-02-22]
+## 0.7.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
@@ -122,13 +122,13 @@
 
 [PR 2445]: https://github.com/libp2p/rust-libp2p/pull/2445
 
-# 0.6.1 [2022-02-02]
+## 0.6.1 [2022-02-02]
 
 - Remove empty peer entries in `reservations` `HashMap`. See [PR 2464].
 
 [PR 2464]: https://github.com/libp2p/rust-libp2p/pull/2464
 
-# 0.6.0 [2022-01-27]
+## 0.6.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -136,7 +136,7 @@
 
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 
-# 0.5.0 [2021-11-16]
+## 0.5.0 [2021-11-16]
 
 - Use `instant` instead of `wasm-timer` (see [PR 2245]).
 
@@ -144,7 +144,7 @@
 
 [PR 2245]: https://github.com/libp2p/rust-libp2p/pull/2245
 
-# 0.4.0 [2021-11-01]
+## 0.4.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
@@ -155,15 +155,15 @@
 
 [PR 2183]: https://github.com/libp2p/rust-libp2p/pull/2183
 
-# 0.3.0 [2021-07-12]
+## 0.3.0 [2021-07-12]
 
 - Update dependencies.
 
-# 0.2.0 [2021-04-13]
+## 0.2.0 [2021-04-13]
 
 - Update `libp2p-swarm`.
 
-# 0.1.0 [2021-03-17]
+## 0.1.0 [2021-03-17]
 
 - First release supporting all major features of the circuit relay v1
   specification. [PR 1838](https://github.com/libp2p/rust-libp2p/pull/1838).

--- a/protocols/rendezvous/CHANGELOG.md
+++ b/protocols/rendezvous/CHANGELOG.md
@@ -1,16 +1,16 @@
-# 0.12.1
+## 0.12.1
 
 - Migrate from `prost` to `quick-protobuf`. This removes `protoc` dependency. See [PR 3312].
 
 [PR 3312]: https://github.com/libp2p/rust-libp2p/pull/3312
 
-# 0.12.0
+## 0.12.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
 - Update to `libp2p-swarm` `v0.42.0`.
 
-# 0.11.0
+## 0.11.0
 
 - De- and encode protobuf messages using `prost-codec`. See [PR 3058].
 
@@ -27,19 +27,19 @@
 [PR 3058]: https://github.com/libp2p/rust-libp2p/pull/3058
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.10.0
+## 0.10.0
 
 - Update to `libp2p-core` `v0.37.0`.
 
 - Update to `libp2p-swarm` `v0.40.0`.
 
-# 0.9.0
+## 0.9.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 
 - Update to `libp2p-core` `v0.36.0`.
 
-# 0.8.0
+## 0.8.0
 
 - Update prost requirement from 0.10 to 0.11 which no longer installs the protoc Protobuf compiler.
   Thus you will need protoc installed locally. See [PR 2788].
@@ -50,13 +50,13 @@
 
 [PR 2788]: https://github.com/libp2p/rust-libp2p/pull/2788
 
-# 0.7.0
+## 0.7.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
 - Update to `libp2p-swarm` `v0.37.0`.
 
-# 0.6.0
+## 0.6.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
@@ -66,11 +66,11 @@
 
 [PR 2620]: https://github.com/libp2p/rust-libp2p/pull/2620
 
-# 0.5.0
+## 0.5.0
 
 - Update to `libp2p-swarm` `v0.35.0`.
 
-# 0.4.0 [2022-02-22]
+## 0.4.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
@@ -80,7 +80,7 @@
 
 [PR 2445]: https://github.com/libp2p/rust-libp2p/pull/2445
 
-# 0.3.0 [2022-01-27]
+## 0.3.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -88,7 +88,7 @@
 
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 
-# 0.2.0 [2021-11-16]
+## 0.2.0 [2021-11-16]
 
 - Use `instant` and `futures-timer` instead of `wasm-timer` (see [PR 2245]).
 
@@ -96,6 +96,6 @@
 
 [PR 2245]: https://github.com/libp2p/rust-libp2p/pull/2245
 
-# 0.1.0 [2021-11-01]
+## 0.1.0 [2021-11-01]
 
 - Initial release.

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.24.0
+## 0.24.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
@@ -14,7 +14,7 @@
 [discussion 2174]: https://github.com/libp2p/rust-libp2p/discussions/2174
 [PR 3159]: https://github.com/libp2p/rust-libp2p/pull/3159
 
-# 0.23.0
+## 0.23.0
 
 - Update to `libp2p-core` `v0.38.0`.
 
@@ -32,7 +32,7 @@
 [PR 3011]: https://github.com/libp2p/rust-libp2p/pull/3011
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.22.0
+## 0.22.0
 
 - Bump rand to 0.8 and quickcheck to 1. See [PR 2857].
 
@@ -42,35 +42,35 @@
 
 [PR 2857]: https://github.com/libp2p/rust-libp2p/pull/2857
 
-# 0.21.0
+## 0.21.0
 
 - Update to `libp2p-swarm` `v0.39.0`.
 
 - Update to `libp2p-core` `v0.36.0`.
 
-# 0.20.0
+## 0.20.0
 
 - Update to `libp2p-swarm` `v0.38.0`.
 
 - Update to `libp2p-core` `v0.35.0`.
 
-# 0.19.0
+## 0.19.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
 - Update to `libp2p-swarm` `v0.37.0`.
 
-# 0.18.0
+## 0.18.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
 - Update to `libp2p-swarm` `v0.36.0`.
 
-# 0.17.0
+## 0.17.0
 
 - Update to `libp2p-swarm` `v0.35.0`.
 
-# 0.16.0 [2022-02-22]
+## 0.16.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
@@ -80,7 +80,7 @@
 
 [PR 2445]: https://github.com/libp2p/rust-libp2p/pull/2445
 
-# 0.15.0 [2022-01-27]
+## 0.15.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -91,7 +91,7 @@
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 [PR 2358]: https://github.com/libp2p/rust-libp2p/pull/2358
 
-# 0.14.0 [2021-11-16]
+## 0.14.0 [2021-11-16]
 
 - Use `instant` instead of `wasm-timer` (see [PR 2245]).
 
@@ -99,7 +99,7 @@
 
 [PR 2245]: https://github.com/libp2p/rust-libp2p/pull/2245
 
-# 0.13.0 [2021-11-01]
+## 0.13.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
@@ -115,17 +115,17 @@
 [PR 2183]: https://github.com/libp2p/rust-libp2p/pull/2183
 [PR 2236]: https://github.com/libp2p/rust-libp2p/pull/2236
 
-# 0.12.0 [2021-07-12]
+## 0.12.0 [2021-07-12]
 
 - Update dependencies.
 
-# 0.11.0 [2021-04-13]
+## 0.11.0 [2021-04-13]
 
 - Update `libp2p-swarm`.
 - Implement `std::error::Error` for `InboundFailure` and `OutboundFailure` [PR
   2033](https://github.com/libp2p/rust-libp2p/pull/2033).
 
-# 0.10.0 [2021-03-17]
+## 0.10.0 [2021-03-17]
 
 - Update `libp2p-swarm`.
 
@@ -134,21 +134,21 @@
 
 - Update dependencies.
 
-# 0.9.1 [2021-02-15]
+## 0.9.1 [2021-02-15]
 
 - Make `is_pending_outbound` return true on pending connection.
   [PR 1928](https://github.com/libp2p/rust-libp2p/pull/1928).
 
 - Update dependencies.
 
-# 0.9.0 [2021-01-12]
+## 0.9.0 [2021-01-12]
 
 - Update dependencies.
 
 - Re-export `throttled`-specific response channel. [PR
   1902](https://github.com/libp2p/rust-libp2p/pull/1902).
 
-# 0.8.0 [2020-12-17]
+## 0.8.0 [2020-12-17]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
@@ -159,7 +159,7 @@
 - Derive Clone for `InboundFailure` and `Outbound}Failure`.
   [PR 1891](https://github.com/libp2p/rust-libp2p/pull/1891)
 
-# 0.7.0 [2020-12-08]
+## 0.7.0 [2020-12-08]
 
 - Refine emitted events for inbound requests, introducing
   the `ResponseSent` event and the `ResponseOmission`
@@ -167,19 +167,19 @@
   support for one-way protocols without responses.
   [PR 1867](https://github.com/libp2p/rust-libp2p/pull/1867).
 
-# 0.6.0 [2020-11-25]
+## 0.6.0 [2020-11-25]
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.5.0 [2020-11-09]
+## 0.5.0 [2020-11-09]
 
 - Update dependencies.
 
-# 0.4.0 [2020-10-16]
+## 0.4.0 [2020-10-16]
 
 - Update dependencies.
 
-# 0.3.0 [2020-09-09]
+## 0.3.0 [2020-09-09]
 
 - Add support for opt-in request-based flow-control to any
   request-response protocol via `RequestResponse::throttled()`.
@@ -187,13 +187,13 @@
 
 - Update `libp2p-swarm` and `libp2p-core`.
 
-# 0.2.0 [2020-08-18]
+## 0.2.0 [2020-08-18]
 
 - Fixed connection keep-alive, permitting connections to close due
   to inactivity.
 - Bump `libp2p-core` and `libp2p-swarm` dependencies.
 
-# 0.1.1
+## 0.1.1
 
 - Always properly `close()` the substream after sending requests and
 responses in the `InboundUpgrade` and `OutboundUpgrade`. Otherwise this is
@@ -201,6 +201,6 @@ left to `RequestResponseCodec::write_request` and `RequestResponseCodec::write_r
 which can be a pitfall and lead to subtle problems (see e.g.
 https://github.com/libp2p/rust-libp2p/pull/1606).
 
-# 0.1.0
+## 0.1.0
 
 - Initial release.

--- a/swarm-derive/CHANGELOG.md
+++ b/swarm-derive/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.32.0
+## 0.32.0
 
 - Fix `NetworkBehaviour` Derive macro for generic types when `out_event` was not provided. Previously the enum generated
   didn't have the `NetworkBehaviour` impl constraints whilst using the generics for `<Generic>::OutEvent`.
@@ -12,7 +12,7 @@
 [PR 3011]: https://github.com/libp2p/rust-libp2p/pull/3011
 [PR 3264]: https://github.com/libp2p/rust-libp2p/pull/3264
 
-# 0.31.0
+## 0.31.0
 
 - Add `prelude` configuration option.
   The derive-macro generates code that needs to refer to various symbols. See [PR 3055].
@@ -22,7 +22,7 @@
 [PR 3055]: https://github.com/libp2p/rust-libp2p/pull/3055
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.30.1
+## 0.30.1
 
 - Fix an issue where the derive would generate bad code if the type parameters between the behaviour and a custom
   out event differed. See [PR 2907].
@@ -31,7 +31,7 @@
 [PR 2907]: https://github.com/libp2p/rust-libp2p/pull/2907
 [PR 2921]: https://github.com/libp2p/rust-libp2p/pull/2921
 
-# 0.30.0
+## 0.30.0
 
 - Remove support for removed `NetworkBehaviourEventProcess`. See [PR 2840].
 
@@ -46,34 +46,34 @@
 
 [PR 2842]: https://github.com/libp2p/rust-libp2p/pull/2842
 
-# 0.29.0
+## 0.29.0
 
 - Generate `NetworkBehaviour::OutEvent` if not provided through `#[behaviour(out_event =
   "MyOutEvent")]` and event processing is disabled (default).
 
-# 0.28.0
+## 0.28.0
 
 - Import `ListenerId` from `libp2p::core::transport`. See [PR 2652].
 
 [PR 2652]: https://github.com/libp2p/rust-libp2p/pull/2652
 
-# 0.27.2
+## 0.27.2
 
 - Replace references of Protocol Handler with Connection Handler. See [PR 2640].
 
 [PR 2640]: https://github.com/libp2p/rust-libp2p/pull/2640
 
-# 0.27.1
+## 0.27.1
 
 - Allow mixing of ignored fields. See [PR 2570].
 
 [PR 2570]: https://github.com/libp2p/rust-libp2p/pull/2570
 
-# 0.27.0 [2022-02-22]
+## 0.27.0 [2022-02-22]
 
 - Adjust to latest changes in `libp2p-swarm`.
 
-# 0.26.1 [2022-01-27]
+## 0.26.1 [2022-01-27]
 
 - Remove unnecessary clone of error in `inject_dial_failure` (see [PR 2349]).
 
@@ -82,13 +82,13 @@
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 [PR 2349]: https://github.com/libp2p/rust-libp2p/pull/2349
 
-# 0.26.0 [2021-11-16]
+## 0.26.0 [2021-11-16]
 
 - Adjust to advanced dialing requests API changes (see [PR 2317]).
 
 [PR 2317]: https://github.com/libp2p/rust-libp2p/pull/2317
 
-# 0.25.0 [2021-11-01]
+## 0.25.0 [2021-11-01]
 
 - Update to latest `libp2p-swarm` changes (see [PR 2191]).
 
@@ -96,33 +96,33 @@
 
 [PR 2191]: https://github.com/libp2p/rust-libp2p/pull/2191
 
-# 0.24.0 [2021-07-12]
+## 0.24.0 [2021-07-12]
 
 - Handle `NetworkBehaviourAction::CloseConnection`. See [PR 2110] for details.
 
 [PR 2110]: https://github.com/libp2p/rust-libp2p/pull/2110/
 
-# 0.23.0 [2021-04-14]
+## 0.23.0 [2021-04-14]
 
 - Extend `NetworkBehaviour` callbacks, more concretely introducing new `fn
   inject_new_listener` and `fn inject_expired_external_addr` and have `fn
   inject_{new,expired}_listen_addr` provide a `ListenerId` [PR
   2011](https://github.com/libp2p/rust-libp2p/pull/2011).
 
-# 0.22.0 [2021-02-15]
+## 0.22.0 [2021-02-15]
 
 - Rename the crate to `libp2p-swarm-derive`.
 
-# 0.21.0 [2020-11-25]
+## 0.21.0 [2020-11-25]
 
 - Update for compatibility with `libp2p-swarm-0.25`.
 
-# 0.20.2 [2020-07-28]
+## 0.20.2 [2020-07-28]
 
 - Generate fully-qualified method name for `poll` to avoid
 ambiguity. [PR 1681](https://github.com/libp2p/rust-libp2p/pull/1681).
 
-# 0.20.1 [2020-07-08]
+## 0.20.1 [2020-07-08]
 
 - Allow users to opt out of the `NetworkBehaviourEventProcess`
 mechanism through `#[behaviour(event_process = false)]`. This is

--- a/swarm-test/CHANGELOG.md
+++ b/swarm-test/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 0.1.0
+## 0.1.0
 
 - Initial release.

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.42.1
+## 0.42.1
 
 - Deprecate `ConnectionLimits` in favor of `libp2p::connection_limits`.
   See [PR 3386].
@@ -19,7 +19,7 @@
 [PR 3590]: https://github.com/libp2p/rust-libp2p/pull/3590
 [PR 3658]: https://github.com/libp2p/rust-libp2p/pull/3658
 
-# 0.42.0
+## 0.42.0
 
 - Allow `NetworkBehaviour`s to manage connections.
   We deprecate `NetworkBehaviour::new_handler` and `NetworkBehaviour::addresses_of_peer` in favor of four new callbacks:
@@ -131,11 +131,11 @@
 [PR 3588]: https://github.com/libp2p/rust-libp2p/pull/3588
 [PR 3577]: https://github.com/libp2p/rust-libp2p/pull/3577
 
-# 0.41.1
+## 0.41.1
 
 - Update to `libp2p-swarm-derive` `v0.31.0`.
 
-# 0.41.0
+## 0.41.0
 
 - Update to `libp2p-core` `v0.38.0`.
 
@@ -240,7 +240,7 @@
 [Issue 3107]: https://github.com/libp2p/rust-libp2p/issues/3107
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.40.1
+## 0.40.1
 
 - Bump rand to 0.8 and quickcheck to 1. See [PR 2857].
 
@@ -258,7 +258,7 @@
 [PR 2928]: https://github.com/libp2p/rust-libp2p/pull/2928
 
 
-# 0.39.0
+## 0.39.0
 
 - Remove deprecated `NetworkBehaviourEventProcess`. See [libp2p-swarm v0.38.0 changelog entry] for
   migration path.
@@ -272,7 +272,7 @@
 [libp2p-swarm v0.38.0 changelog entry]: https://github.com/libp2p/rust-libp2p/blob/master/swarm/CHANGELOG.md#0380
 [PR 2861]: https://github.com/libp2p/rust-libp2p/pull/2861/
 
-# 0.38.0
+## 0.38.0
 
 - Deprecate `NetworkBehaviourEventProcess`. When deriving `NetworkBehaviour` on a custom `struct` users
   should either bring their own `OutEvent` via `#[behaviour(out_event = "MyBehaviourEvent")]` or,
@@ -359,7 +359,7 @@
 [PR 2784]: https://github.com/libp2p/rust-libp2p/pull/2784
 [PR 2792]: https://github.com/libp2p/rust-libp2p/pull/2792
 
-# 0.37.0
+## 0.37.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
@@ -370,13 +370,13 @@
 [PR 2716]: https://github.com/libp2p/rust-libp2p/pull/2716/
 [PR 2652]: https://github.com/libp2p/rust-libp2p/pull/2652
 
-# 0.36.1
+## 0.36.1
 
 - Limit negotiating inbound substreams per connection. See [PR 2697].
 
 [PR 2697]: https://github.com/libp2p/rust-libp2p/pull/2697
 
-# 0.36.0
+## 0.36.0
 
 - Don't require `Transport` to be `Clone`. See [PR 2529].
 
@@ -393,7 +393,7 @@
 [PR 2620]: https://github.com/libp2p/rust-libp2p/pull/2620
 [PR 2640]: https://github.com/libp2p/rust-libp2p/pull/2640
 
-# 0.35.0
+## 0.35.0
 
 - Add impl `IntoIterator` for `MultiHandler`. See [PR 2572].
 - Remove `Send` bound from `NetworkBehaviour`. See [PR 2535].
@@ -401,7 +401,7 @@
 [PR 2572]: https://github.com/libp2p/rust-libp2p/pull/2572/
 [PR 2535]: https://github.com/libp2p/rust-libp2p/pull/2535/
 
-# 0.34.0 [2022-02-22]
+## 0.34.0 [2022-02-22]
 
 - Rename `ProtocolsHandler` to `ConnectionHandler`. Upgrade should be as simple as renaming all
   occurences of `ProtocolsHandler` to `ConnectionHandler` with your favorite text manipulation tool
@@ -419,7 +419,7 @@
 [PR 2517]: https://github.com/libp2p/rust-libp2p/pull/2517
 [PR 2527]: https://github.com/libp2p/rust-libp2p/pull/2527
 
-# 0.33.0 [2022-01-27]
+## 0.33.0 [2022-01-27]
 
 - Patch reporting on banned peers and their non-banned and banned connections (see [PR 2350]).
 
@@ -458,7 +458,7 @@
 [PR 2363]: https://github.com/libp2p/rust-libp2p/pull/2363
 [PR 2445]: https://github.com/libp2p/rust-libp2p/pull/2445
 
-# 0.32.0 [2021-11-16]
+## 0.32.0 [2021-11-16]
 
 - Use `instant` and `futures-timer` instead of `wasm-timer` (see [PR 2245]).
 
@@ -506,7 +506,7 @@
 [PR 2245]: https://github.com/libp2p/rust-libp2p/pull/2245
 [PR 2317]: https://github.com/libp2p/rust-libp2p/pull/2317
 
-# 0.31.0 [2021-11-01]
+## 0.31.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
@@ -578,7 +578,7 @@
 [PR 2248]: https://github.com/libp2p/rust-libp2p/pull/2248
 [PR 2261]: https://github.com/libp2p/rust-libp2p/pull/2261
 
-# 0.30.0 [2021-07-12]
+## 0.30.0 [2021-07-12]
 
 - Update dependencies.
 
@@ -607,7 +607,7 @@
 [PR 2110]: https://github.com/libp2p/rust-libp2p/pull/2110/
 [PR 2123]: https://github.com/libp2p/rust-libp2p/pull/2123
 
-# 0.29.0 [2021-04-13]
+## 0.29.0 [2021-04-13]
 
 - Remove `Deref` and `DerefMut` implementations previously dereferencing to the
   `NetworkBehaviour` on `Swarm`. Instead one can access the `NetworkBehaviour`
@@ -626,7 +626,7 @@
   inject_{new,expired}_listen_addr` provide a `ListenerId` [PR
   2011](https://github.com/libp2p/rust-libp2p/pull/2011).
 
-# 0.28.0 [2021-03-17]
+## 0.28.0 [2021-03-17]
 
 - New error variant `DialError::InvalidAddress`
 
@@ -638,12 +638,12 @@
   There is a `Swarm`-scoped configuration for this version available since
   [1858](https://github.com/libp2p/rust-libp2p/pull/1858).
 
-# 0.27.2 [2021-02-04]
+## 0.27.2 [2021-02-04]
 
 - Have `ToggleProtoHandler` ignore listen upgrade errors when disabled.
   [PR 1945](https://github.com/libp2p/rust-libp2p/pull/1945/files).
 
-# 0.27.1 [2021-01-27]
+## 0.27.1 [2021-01-27]
 
 - Make `OneShotHandler`s `max_dial_negotiate` limit configurable.
   [PR 1936](https://github.com/libp2p/rust-libp2p/pull/1936).
@@ -651,11 +651,11 @@
 - Fix handling of DialPeerCondition::Always.
   [PR 1937](https://github.com/libp2p/rust-libp2p/pull/1937).
 
-# 0.27.0 [2021-01-12]
+## 0.27.0 [2021-01-12]
 
 - Update dependencies.
 
-# 0.26.0 [2020-12-17]
+## 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.
 
@@ -663,12 +663,12 @@
   a `NetworkBehaviour` to a `ProtocolsHandler` to be `Clone`.
   [PR 1880](https://github.com/libp2p/rust-libp2p/pull/1880).
 
-# 0.25.1 [2020-11-26]
+## 0.25.1 [2020-11-26]
 
 - Add `ExpandedSwarm::is_connected`.
   [PR 1862](https://github.com/libp2p/rust-libp2p/pull/1862).
 
-# 0.25.0 [2020-11-25]
+## 0.25.0 [2020-11-25]
 
 - Permit a configuration override for the substream upgrade protocol
   to use for all (outbound) substreams.
@@ -684,11 +684,11 @@
   retained "forever" (or until explicitly removed).
   [PR 1842](https://github.com/libp2p/rust-libp2p/pull/1842).
 
-# 0.24.0 [2020-11-09]
+## 0.24.0 [2020-11-09]
 
 - Update dependencies.
 
-# 0.23.0 [2020-10-16]
+## 0.23.0 [2020-10-16]
 
 - Require a `Boxed` transport to be given to the `Swarm`
   or `SwarmBuilder` to avoid unnecessary double-boxing of
@@ -709,7 +709,7 @@
 
   [PR 1775](https://github.com/libp2p/rust-libp2p/pull/1775)
 
-# 0.22.0 [2020-09-09]
+## 0.22.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.
 
@@ -723,7 +723,7 @@
   now. Consequently `ProtocolsHandlerEvent::OutboundSubstreamRequest` no longer
   has a separate `info` field.
 
-# 0.21.0 [2020-08-18]
+## 0.21.0 [2020-08-18]
 
 - Add missing delegation calls in some `ProtocolsHandler` wrappers.
 See [PR 1710](https://github.com/libp2p/rust-libp2p/pull/1710).
@@ -744,7 +744,7 @@ callback.
 - Fix connections being kept alive by `OneShotHandler` when not handling any
   requests [PR 1698](https://github.com/libp2p/rust-libp2p/pull/1698).
 
-# 0.20.1 [2020-07-08]
+## 0.20.1 [2020-07-08]
 
 - Documentation updates.
 
@@ -755,7 +755,7 @@ even happen in genuine situations, e.g. after the local node changed
 its network identity and a behaviour makes a dialing attempt to a
 former identity using the same addresses.
 
-# 0.20.0 [2020-07-01]
+## 0.20.0 [2020-07-01]
 
 - Updated the `libp2p-core` dependency.
 
@@ -768,7 +768,7 @@ retain existing behaviour.
 `NetworkBehaviour::inject_address_change` to notify of a change in
 the address of an existing connection.
 
-# 0.19.1 [2020-06-18]
+## 0.19.1 [2020-06-18]
 
 - Bugfix: Fix MultiHandler panicking when empty
   ([PR 1598](https://github.com/libp2p/rust-libp2p/pull/1598)).

--- a/transports/deflate/CHANGELOG.md
+++ b/transports/deflate/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 0.39.0
+## 0.39.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
-# 0.38.0
+## 0.38.0
 
 - Update to `libp2p-core` `v0.38.0`.
 
@@ -10,31 +10,31 @@
 
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.37.0
+## 0.37.0
 
 - Update to `libp2p-core` `v0.37.0`.
 
-# 0.36.0
+## 0.36.0
 
 - Update to `libp2p-core` `v0.36.0`.
 
-# 0.35.0
+## 0.35.0
 
 - Update to `libp2p-core` `v0.35.0`.
 
-# 0.34.0
+## 0.34.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
-# 0.33.0
+## 0.33.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
-# 0.32.0 [2022-02-22]
+## 0.32.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
-# 0.31.0 [2022-01-27]
+## 0.31.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -42,58 +42,58 @@
 
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 
-# 0.30.0 [2021-11-01]
+## 0.30.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
 
 - Update dependencies.
 
-# 0.29.0 [2021-07-12]
+## 0.29.0 [2021-07-12]
 
 - Update dependencies.
 
-# 0.28.0 [2021-03-17]
+## 0.28.0 [2021-03-17]
 
 - Update `libp2p-core`.
 
-# 0.27.1 [2021-01-27]
+## 0.27.1 [2021-01-27]
 
 - Ensure read buffers are initialised.
   [PR 1933](https://github.com/libp2p/rust-libp2p/pull/1933).
 
-# 0.27.0 [2021-01-12]
+## 0.27.0 [2021-01-12]
 
 - Update dependencies.
 
-# 0.26.0 [2020-12-17]
+## 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.
 
-# 0.25.0 [2020-11-25]
+## 0.25.0 [2020-11-25]
 
 - Update `libp2p-core`.
 
-# 0.24.0 [2020-11-09]
+## 0.24.0 [2020-11-09]
 
 - Update dependencies.
 
-# 0.23.0 [2020-10-16]
+## 0.23.0 [2020-10-16]
 
 - Bump `libp2p-core` dependency.
 
-# 0.22.0 [2020-09-09]
+## 0.22.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.
 
-# 0.21.0 [2020-08-18]
+## 0.21.0 [2020-08-18]
 
 - Bump `libp2p-core` dependency.
 
-# 0.20.0 [2020-07-01]
+## 0.20.0 [2020-07-01]
 
 - Updated dependencies.
 
-# 0.19.2 [2020-06-22]
+## 0.19.2 [2020-06-22]
 
 - Updated dependencies.

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 0.39.0
+## 0.39.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
-# 0.38.0
+## 0.38.0
 
 - Update to `libp2p-core` `v0.38.0`.
 
@@ -10,7 +10,7 @@
 
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.37.0
+## 0.37.0
 
 - Remove default features. If you previously depended on `async-std` you need to enable this explicitly now. See [PR 2918].
 
@@ -18,19 +18,19 @@
 
 [PR 2918]: https://github.com/libp2p/rust-libp2p/pull/2918
 
-# 0.36.0
+## 0.36.0
 
 - Update to `libp2p-core` `v0.36.0`.
 
-# 0.35.0
+## 0.35.0
 
 - Update to `libp2p-core` `v0.35.0`.
 
-# 0.34.0
+## 0.34.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
-# 0.33.0
+## 0.33.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
@@ -38,17 +38,17 @@
 
 [PR 2682]: https://github.com/libp2p/rust-libp2p/pull/2682
 
-# 0.32.1
+## 0.32.1
 
 - Update to `trust-dns` `v0.21`. See [PR 2543].
 
 [PR 2543]: https://github.com/libp2p/rust-libp2p/pull/2543
 
-# 0.32.0 [2022-02-22]
+## 0.32.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
-# 0.31.0 [2022-01-27]
+## 0.31.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -56,18 +56,18 @@
 
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 
-# 0.30.0 [2021-11-01]
+## 0.30.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
 
 - Update dependencies.
 
-# 0.29.0 [2021-07-12]
+## 0.29.0 [2021-07-12]
 
 - Update dependencies.
 
-# 0.28.1 [2021-04-01]
+## 0.28.1 [2021-04-01]
 
 - Update dependencies.
 
@@ -75,7 +75,7 @@
   domain name resolution [PR
   2027](https://github.com/libp2p/rust-libp2p/pull/2027).
 
-# 0.28.0 [2021-03-17]
+## 0.28.0 [2021-03-17]
 
 - Update `libp2p-core`.
 
@@ -86,34 +86,34 @@
   configuration of `trust-dns-resolver`.
   [PR 1927](https://github.com/libp2p/rust-libp2p/pull/1927)
 
-# 0.27.0 [2021-01-12]
+## 0.27.0 [2021-01-12]
 
 - Update dependencies.
 
-# 0.26.0 [2020-12-17]
+## 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.
 
-# 0.25.0 [2020-11-25]
+## 0.25.0 [2020-11-25]
 
 - Update `libp2p-core`.
 
-# 0.24.0 [2020-11-09]
+## 0.24.0 [2020-11-09]
 
 - Update dependencies.
 
-# 0.23.0 [2020-10-16]
+## 0.23.0 [2020-10-16]
 
 - Bump `libp2p-core` dependency.
 
-# 0.22.0 [2020-09-09]
+## 0.22.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.
 
-# 0.21.0 [2020-08-18]
+## 0.21.0 [2020-08-18]
 
 - Bump `libp2p-core` dependency.
 
-# 0.20.0 [2020-07-01]
+## 0.20.0 [2020-07-01]
 
 - Dependency and documentation updates.

--- a/transports/noise/CHANGELOG.md
+++ b/transports/noise/CHANGELOG.md
@@ -1,10 +1,10 @@
-# 0.42.1
+## 0.42.1
 
 - Migrate from `prost` to `quick-protobuf`. This removes `protoc` dependency. See [PR 3312].
 
 [PR 3312]: https://github.com/libp2p/rust-libp2p/pull/3312
 
-# 0.42.0
+## 0.42.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
@@ -15,7 +15,7 @@
 [PR 3227]: https://github.com/libp2p/rust-libp2p/pull/3227
 [PR 3265]: https://github.com/libp2p/rust-libp2p/pull/3265
 
-# 0.41.0
+## 0.41.0
 
 - Remove `prost::Error` from public API. See [PR 3058].
 
@@ -29,7 +29,7 @@
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 [PR 2972]: https://github.com/libp2p/rust-libp2p/pull/2972
 
-# 0.40.0
+## 0.40.0
 
 - Update to `libp2p-core` `v0.37.0`.
 
@@ -44,11 +44,11 @@
 [PR 2903]: https://github.com/libp2p/rust-libp2p/pull/2903
 [PR 2909]: https://github.com/libp2p/rust-libp2p/pull/2909
 
-# 0.39.0
+## 0.39.0
 
 - Update to `libp2p-core` `v0.36.0`.
 
-# 0.38.0
+## 0.38.0
 
 - Update prost requirement from 0.10 to 0.11 which no longer installs the protoc Protobuf compiler.
   Thus you will need protoc installed locally. See [PR 2788].
@@ -57,15 +57,15 @@
 
 [PR 2788]: https://github.com/libp2p/rust-libp2p/pull/2788
 
-# 0.37.0
+## 0.37.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
-# 0.36.0
+## 0.36.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
-# 0.35.0 [2022-02-22]
+## 0.35.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
@@ -73,7 +73,7 @@
 
 [PR 2472]: https://github.com/libp2p/rust-libp2p/pull/2472
 
-# 0.34.0 [2022-01-27]
+## 0.34.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -81,48 +81,48 @@
 
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 
-# 0.33.0 [2021-11-01]
+## 0.33.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
 
 - Update dependencies.
 
-# 0.32.0 [2021-07-12]
+## 0.32.0 [2021-07-12]
 
 - Update dependencies.
 
-# 0.31.0 [2021-05-17]
+## 0.31.0 [2021-05-17]
 
 - Update to `snow` `v0.8.0` ([PR-2068]).
 
 [PR-2068]: https://github.com/libp2p/rust-libp2p/pull/2068
 
-# 0.30.0 [2021-03-17]
+## 0.30.0 [2021-03-17]
 
 - Update `libp2p-core`.
 
-# 0.29.0 [2021-01-12]
+## 0.29.0 [2021-01-12]
 
 - Update dependencies.
 
-# 0.28.0 [2020-12-17]
+## 0.28.0 [2020-12-17]
 
 - Update `libp2p-core`.
 
-# 0.27.0 [2020-11-25]
+## 0.27.0 [2020-11-25]
 
 - Update `libp2p-core`.
 
-# 0.26.0 [2020-11-09]
+## 0.26.0 [2020-11-09]
 
 - Update dependencies.
 
-# 0.25.0 [2020-10-16]
+## 0.25.0 [2020-10-16]
 
 - Update dependencies.
 
-# 0.24.0 [2020-09-09]
+## 0.24.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.
 
@@ -130,11 +130,11 @@
 To continue supporting inbound legacy handshake payloads,
 `recv_legacy_handshake` must be configured on the `LegacyConfig`.
 
-# 0.23.0 [2020-08-18]
+## 0.23.0 [2020-08-18]
 
 - Bump `libp2p-core` dependency.
 
-# 0.22.0 [2020-08-03]
+## 0.22.0 [2020-08-03]
 
 **NOTE**: For a smooth upgrade path from `0.20` to `> 0.21`
 on an existing deployment, this version must not be skipped
@@ -152,7 +152,7 @@ delaying the handshake upgrade or keeping compatibility with a network
 whose peers are slow to upgrade, without having to freeze the
 version of `libp2p-noise` altogether in these projects.
 
-# 0.21.0 [2020-07-17]
+## 0.21.0 [2020-07-17]
 
 **NOTE**: For a smooth upgrade path from `0.20` to `> 0.21`
 on an existing deployment, this version must not be skipped!
@@ -163,13 +163,13 @@ See [issue 1631](https://github.com/libp2p/rust-libp2p/issues/1631).
 
 - Update the `snow` dependency to the latest patch version.
 
-# 0.20.0 [2020-07-01]
+## 0.20.0 [2020-07-01]
 
 - Updated dependencies.
 - Conditional compilation fixes for the `wasm32-wasi` target
   ([PR 1633](https://github.com/libp2p/rust-libp2p/pull/1633)).
 
-# 0.19.1 [2020-06-22]
+## 0.19.1 [2020-06-22]
 
 - Re-add noise upgrades for IK and IX
   ([PR 1580](https://github.com/libp2p/rust-libp2p/pull/1580)).

--- a/transports/plaintext/CHANGELOG.md
+++ b/transports/plaintext/CHANGELOG.md
@@ -1,14 +1,14 @@
-# 0.39.1
+## 0.39.1
 
 - Migrate from `prost` to `quick-protobuf`. This removes `protoc` dependency. See [PR 3312].
 
 [PR 3312]: https://github.com/libp2p/rust-libp2p/pull/3312
 
-# 0.39.0
+## 0.39.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
-# 0.38.0
+## 0.38.0
 
 - Add more specific error reporting and remove `prost::Error` from public API. See [PR 3058].
 
@@ -19,15 +19,15 @@
 [PR 3058]: https://github.com/libp2p/rust-libp2p/pull/3058
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.37.0
+## 0.37.0
 
 - Update to `libp2p-core` `v0.37.0`.
 
-# 0.36.0
+## 0.36.0
 
 - Update to `libp2p-core` `v0.36.0`.
 
-# 0.35.0
+## 0.35.0
 
 - Update prost requirement from 0.10 to 0.11 which no longer installs the protoc Protobuf compiler.
   Thus you will need protoc installed locally. See [PR 2788].
@@ -36,19 +36,19 @@
 
 [PR 2788]: https://github.com/libp2p/rust-libp2p/pull/2788
 
-# 0.34.0
+## 0.34.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
-# 0.33.0
+## 0.33.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
-# 0.32.0 [2022-02-22]
+## 0.32.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
-# 0.31.0 [2022-01-27]
+## 0.31.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -56,48 +56,48 @@
 
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 
-# 0.30.0 [2021-11-01]
+## 0.30.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
 
 - Update dependencies.
 
-# 0.29.0 [2021-07-12]
+## 0.29.0 [2021-07-12]
 
 - Update dependencies.
 
-# 0.28.0 [2021-03-17]
+## 0.28.0 [2021-03-17]
 
 - Update `libp2p-core`.
 
-# 0.27.1 [2021-02-15]
+## 0.27.1 [2021-02-15]
 
 - Update dependencies.
 
-# 0.27.0 [2021-01-12]
+## 0.27.0 [2021-01-12]
 
 - Update dependencies.
 
-# 0.26.0 [2020-12-17]
+## 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.
 
-# 0.25.0 [2020-11-25]
+## 0.25.0 [2020-11-25]
 
 - Update `libp2p-core`.
 
-# 0.24.1 [2020-11-11]
+## 0.24.1 [2020-11-11]
 
 - Ensure that no follow-up protocol data is dropped at the end of the
   plaintext protocol handshake.
   [PR 1831](https://github.com/libp2p/rust-libp2p/pull/1831).
 
-# 0.24.0 [2020-11-09]
+## 0.24.0 [2020-11-09]
 
 - Update dependencies.
 
-# 0.23.0 [2020-10-16]
+## 0.23.0 [2020-10-16]
 
 - Improve error logging
   [PR 1759](https://github.com/libp2p/rust-libp2p/pull/1759).
@@ -108,18 +108,18 @@
   varint. Return a plain socket once handshaking succeeded. See [issue
   1760](https://github.com/libp2p/rust-libp2p/issues/1760) for details.
 
-# 0.22.0 [2020-09-09]
+## 0.22.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.
 
-# 0.21.0 [2020-08-18]
+## 0.21.0 [2020-08-18]
 
 - Bump `libp2p-core` dependency.
 
-# 0.20.0 [2020-07-01]
+## 0.20.0 [2020-07-01]
 
 - Updated dependencies.
 
-# 0.19.1 [2020-06-22]
+## 0.19.1 [2020-06-22]
 
 - Updated dependencies.

--- a/transports/pnet/CHANGELOG.md
+++ b/transports/pnet/CHANGELOG.md
@@ -1,16 +1,16 @@
-# 0.22.3
+## 0.22.3
 
 - Fix handshake over websocket. See [PR 3476]
 
 [PR 3476]: https://github.com/libp2p/rust-libp2p/pull/3476
 
-# 0.22.2
+## 0.22.2
 
 - Update `rust-version` to reflect the actual MSRV: 1.60.0. See [PR 3090].
 
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.22.1
+## 0.22.1
 
 - Bump rand to 0.8 and quickcheck to 1. See [PR 2857].
 
@@ -22,7 +22,7 @@
 [PR 2988]: https://github.com/libp2p/rust-libp2p/pull/2988
 [PR 2989]: https://github.com/libp2p/rust-libp2p/pull/2989
 
-# 0.22.0 [2021-11-01]
+## 0.22.0 [2021-11-01]
 
 - Update dependencies.
 
@@ -30,18 +30,18 @@
 
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 
-# 0.21.0 [2021-05-17]
+## 0.21.0 [2021-05-17]
 
 - Update dependencies.
 
-# 0.20.0 [2020-12-17]
+## 0.20.0 [2020-12-17]
 
 - Update dependencies.
 
-# 0.19.2 [2020-10-16]
+## 0.19.2 [2020-10-16]
 
 - Update dependencies.
 
-# 0.19.1 [2020-06-22]
+## 0.19.1 [2020-06-22]
 
 - Updated dependencies.

--- a/transports/quic/CHANGELOG.md
+++ b/transports/quic/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 0.7.0-alpha.3
+## 0.7.0-alpha.3
 
 - Depend `libp2p-tls` `v0.1.0`.
 
-# 0.7.0-alpha.2
+## 0.7.0-alpha.2
 
 - Update to `libp2p-tls` `v0.1.0-alpha.2`.
 
@@ -19,6 +19,6 @@
 [PR 3342]: https://github.com/libp2p/rust-libp2p/pull/3342
 [PR 3420]: https://github.com/libp2p/rust-libp2p/pull/3420
 
-# 0.7.0-alpha
+## 0.7.0-alpha
 
 - Initial alpha release.

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,11 +1,11 @@
-# 0.39.0
+## 0.39.0
 
 - Update to `libp2p-core` `v0.39.0`.
 - Fix a bug where we removed any other listener in `Transport::remove_listener` except for the one with the provided `ListenerId`. See [PR 3387].
 
 [PR 3387]: https://github.com/libp2p/rust-libp2p/pull/3387
 
-# 0.38.0
+## 0.38.0
 
 - Update to `if-watch`  `v3.0.0` and pass through `tokio` and `async-io` features. See [PR 3101].
 
@@ -21,7 +21,7 @@
 [PR 2961]: https://github.com/libp2p/rust-libp2p/pull/2961
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.37.0
+## 0.37.0
 
 - Update to `if-watch` `v2.0.0`. Simplify `IfWatcher` integration.
   Use `if_watch::IfWatcher` for all runtimes. See [PR 2813].
@@ -37,17 +37,17 @@
 [PR 2918]: https://github.com/libp2p/rust-libp2p/pull/2918
 [PR 2970]: https://github.com/libp2p/rust-libp2p/pull/2970
 
-# 0.36.0
+## 0.36.0
 
 - Update to `libp2p-core` `v0.36.0`.
 
-# 0.35.0
+## 0.35.0
 
 - Update to `libp2p-core` `v0.35.0`.
 
 - Update to `if-watch` `v1.1.1`.
 
-# 0.34.0
+## 0.34.0
 
 - Update to `libp2p-core` `v0.34.0`.
 
@@ -61,7 +61,7 @@
 
 [PR 2652]: https://github.com/libp2p/rust-libp2p/pull/2652
 
-# 0.33.0
+## 0.33.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
@@ -69,17 +69,17 @@
 
 [PR 2682]: https://github.com/libp2p/rust-libp2p/pull/2682
 
-# 0.32.0 [2022-02-22]
+## 0.32.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
-# 0.31.1 [2022-02-02]
+## 0.31.1 [2022-02-02]
 
 - Call `TcpSocket::take_error` to report connection establishment errors early. See [PR 2458].
 
 [PR 2458]: https://github.com/libp2p/rust-libp2p/pull/2458
 
-# 0.31.0 [2022-01-27]
+## 0.31.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -90,18 +90,18 @@
 [PR 2382]: https://github.com/libp2p/rust-libp2p/pull/2382
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 
-# 0.30.0 [2021-11-01]
+## 0.30.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
 
 - Update dependencies.
 
-# 0.29.0 [2021-07-12]
+## 0.29.0 [2021-07-12]
 
 - Update dependencies.
 
-# 0.28.0 [2021-03-17]
+## 0.28.0 [2021-03-17]
 
 - Update `libp2p-core`.
 
@@ -109,11 +109,11 @@
 
 - Update to `if-watch-0.2`.
 
-# 0.27.1 [2021-02-15]
+## 0.27.1 [2021-02-15]
 
 - Update dependencies.
 
-# 0.27.0 [2021-01-12]
+## 0.27.0 [2021-01-12]
 
 - Add support for port reuse and (re)add transport-specific
   address translation. Thereby use only `async-io` instead of
@@ -124,41 +124,41 @@
 
 - Update dependencies.
 
-# 0.26.0 [2020-12-17]
+## 0.26.0 [2020-12-17]
 
 - Update `async-io`.
 
-# 0.25.1 [2020-11-26]
+## 0.25.1 [2020-11-26]
 
 - Lower `async-std` version to `1.6`, for compatibility
   with other libp2p crates.
 
-# 0.25.0 [2020-11-25]
+## 0.25.0 [2020-11-25]
 
 - Update `libp2p-core`.
 
-# 0.24.0 [2020-11-09]
+## 0.24.0 [2020-11-09]
 
 - Update dependencies.
 
-# 0.23.0 [2020-10-16]
+## 0.23.0 [2020-10-16]
 
 - Update `libp2p-core`.
 
 - Replace `get_if_addrs` with `if-addrs`.
 
-# 0.22.0 [2020-09-09]
+## 0.22.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.
 
-# 0.21.0 [2020-08-18]
+## 0.21.0 [2020-08-18]
 
 - Bump `libp2p-core` dependency.
 
-# 0.20.0 [2020-07-01]
+## 0.20.0 [2020-07-01]
 
 - Updated dependencies.
 
-# 0.19.2 [2020-06-22]
+## 0.19.2 [2020-06-22]
 
 - Updated dependencies.

--- a/transports/tls/CHANGELOG.md
+++ b/transports/tls/CHANGELOG.md
@@ -1,11 +1,11 @@
-# 0.1.0
+## 0.1.0
 
 - Promote to `v0.1.0`.
 
-# 0.1.0-alpha.2
+## 0.1.0-alpha.2
 
 - Update to `libp2p-core` `v0.39.0`.
 
-# 0.1.0-alpha
+## 0.1.0-alpha
 
 Initial release.

--- a/transports/uds/CHANGELOG.md
+++ b/transports/uds/CHANGELOG.md
@@ -1,14 +1,14 @@
-# 0.38.0
+## 0.38.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
-# 0.37.0
+## 0.37.0
 
 - Update `rust-version` to reflect the actual MSRV: 1.60.0. See [PR 3090].
 
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.36.0
+## 0.36.0
 
 - Remove default features. If you previously depended on `async-std` you need to enable this explicitly now. See [PR 2918].
 
@@ -16,15 +16,15 @@
 
 [PR 2918]: https://github.com/libp2p/rust-libp2p/pull/2918
 
-# 0.35.0
+## 0.35.0
 
 - Update to `libp2p-core` `v0.36.0`.
 
-# 0.34.0
+## 0.34.0
 
 - Update to `libp2p-core` `v0.35.0`.
 
-# 0.33.0
+## 0.33.0
 
 - Update dependencies.
 - Update to `libp2p-core` `v0.34.0`.
@@ -33,11 +33,11 @@
 
 [PR 2652]: https://github.com/libp2p/rust-libp2p/pull/2652
 
-# 0.32.0 [2022-01-27]
+## 0.32.0 [2022-01-27]
 
 - Update to `libp2p-core` `v0.32.0`.
 
-# 0.31.0 [2022-01-27]
+## 0.31.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -45,55 +45,55 @@
 
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 
-# 0.30.0 [2021-11-01]
+## 0.30.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
 
-# 0.29.0 [2021-07-12]
+## 0.29.0 [2021-07-12]
 
 - Update dependencies.
 
-# 0.28.0 [2021-03-17]
+## 0.28.0 [2021-03-17]
 
 - Update `libp2p-core`.
 
 - Permit `/p2p` addresses.
 
-# 0.27.0 [2021-01-12]
+## 0.27.0 [2021-01-12]
 
 - Update dependencies.
 
-# 0.26.0 [2020-12-17]
+## 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.
 
-# 0.25.0 [2020-11-25]
+## 0.25.0 [2020-11-25]
 
 - Update `libp2p-core`.
 
-# 0.24.0 [2020-11-09]
+## 0.24.0 [2020-11-09]
 
 - Update dependencies.
 
-# 0.23.0 [2020-10-16]
+## 0.23.0 [2020-10-16]
 
 - Update `libp2p-core` dependency.
 
-# 0.22.0 [2020-09-09]
+## 0.22.0 [2020-09-09]
 
 - Update `libp2p-core` dependency.
 
-# 0.21.0 [2020-08-18]
+## 0.21.0 [2020-08-18]
 
 - Update `libp2p-core` dependency.
 
-# 0.20.0 [2020-07-01]
+## 0.20.0 [2020-07-01]
 
 - Updated dependencies.
 - Conditional compilation fixes for the `wasm32-wasi` target
   ([PR 1633](https://github.com/libp2p/rust-libp2p/pull/1633)).
 
-# 0.19.2 [2020-06-22]
+## 0.19.2 [2020-06-22]
 
 - Updated dependencies.

--- a/transports/wasm-ext/CHANGELOG.md
+++ b/transports/wasm-ext/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 0.39.0
+## 0.39.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
-# 0.38.0
+## 0.38.0
 
 - Update to `libp2p-core` `v0.38.0`.
 
@@ -10,19 +10,19 @@
 
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.37.0
+## 0.37.0
 
 - Update to `libp2p-core` `v0.37.0`.
 
-# 0.36.0
+## 0.36.0
 
 - Update to `libp2p-core` `v0.36.0`.
 
-# 0.35.0
+## 0.35.0
 
 - Update to `libp2p-core` `v0.35.0`.
 
-# 0.34.0
+## 0.34.0
 
 - Update to `libp2p-core` `v0.34.0`.
 - Add `Transport::poll` and `Transport::remove_listener` and remove `Transport::Listener`
@@ -30,15 +30,15 @@
 
 [PR 2652]: https://github.com/libp2p/rust-libp2p/pull/2652
 
-# 0.33.0
+## 0.33.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
-# 0.32.0 [2022-02-22]
+## 0.32.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
-# 0.31.0 [2022-01-27]
+## 0.31.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -46,65 +46,65 @@
 
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 
-# 0.30.0 [2021-11-01]
+## 0.30.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
 
 - Update dependencies.
 
-# 0.29.0 [2021-07-12]
+## 0.29.0 [2021-07-12]
 
 - Update dependencies.
 
-# 0.28.2 [2021-04-27]
+## 0.28.2 [2021-04-27]
 
 - Support dialing `Multiaddr` with `/p2p` protocol [PR
   2058](https://github.com/libp2p/rust-libp2p/pull/2058).
 
-# 0.28.1 [2021-04-01]
+## 0.28.1 [2021-04-01]
 
 - Require at least js-sys v0.3.50 [PR
   2023](https://github.com/libp2p/rust-libp2p/pull/2023).
 
-# 0.28.0 [2021-03-17]
+## 0.28.0 [2021-03-17]
 
 - Update `libp2p-core`.
 
-# 0.27.0 [2021-01-12]
+## 0.27.0 [2021-01-12]
 
 - Update dependencies.
 
-# 0.26.0 [2020-12-17]
+## 0.26.0 [2020-12-17]
 
 - Update `libp2p-core`.
 
-# 0.25.0 [2020-11-25]
+## 0.25.0 [2020-11-25]
 
 - Update `libp2p-core`.
 
-# 0.24.0 [2020-11-09]
+## 0.24.0 [2020-11-09]
 
 - Fix the WebSocket implementation parsing `x-parity-ws` multiaddresses as `x-parity-wss`.
 - Update dependencies.
 
-# 0.23.0 [2020-10-16]
+## 0.23.0 [2020-10-16]
 
 - Update `libp2p-core` dependency.
 
-# 0.22.0 [2020-09-09]
+## 0.22.0 [2020-09-09]
 
 - Update `libp2p-core` dependency.
 
-# 0.21.0 [2020-08-18]
+## 0.21.0 [2020-08-18]
 
 - Update `libp2p-core` dependency.
 
-# 0.20.1 [2020-07-06]
+## 0.20.1 [2020-07-06]
 
 - Improve the code quality of the `websockets.js` binding with the browser's `WebSocket` API.
 
-# 0.20.0 [2020-07-01]
+## 0.20.0 [2020-07-01]
 
 - Updated dependencies.
 - Support `/dns` in the websocket implementation

--- a/transports/webrtc/CHANGELOG.md
+++ b/transports/webrtc/CHANGELOG.md
@@ -1,10 +1,10 @@
-# 0.4.0-alpha.4
+## 0.4.0-alpha.4
 
 - Make `Fingerprint` type public. See [PR 3648].
 
 [PR 3648]: https://github.com/libp2p/rust-libp2p/pull/3648
 
-# 0.4.0-alpha.3
+## 0.4.0-alpha.3
 
 - Gracefully handle `ConnectionReset` error on individual connections, avoiding shutdown of the entire listener upon disconnect of a single client.
   See [PR 3575].
@@ -14,12 +14,12 @@
 [PR 3575]: https://github.com/libp2p/rust-libp2p/pull/3575
 [PR 3312]: https://github.com/libp2p/rust-libp2p/pull/3312
 
-# 0.4.0-alpha.2
+## 0.4.0-alpha.2
 
 - Update to `libp2p-noise` `v0.42.0`.
 
 - Update to `libp2p-core` `v0.39.0`.
 
-# 0.4.0-alpha
+## 0.4.0-alpha
 
 - Initial alpha release.

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 0.41.0
+## 0.41.0
 
 - Update to `libp2p-core` `v0.39.0`.
 
-# 0.40.0
+## 0.40.0
 
 - Update to `libp2p-core` `v0.38.0`.
 
@@ -10,19 +10,19 @@
 
 [PR 3090]: https://github.com/libp2p/rust-libp2p/pull/3090
 
-# 0.39.0
+## 0.39.0
 
 - Update to `libp2p-core` `v0.37.0`.
 
-# 0.38.0
+## 0.38.0
 
 - Update to `libp2p-core` `v0.36.0`.
 
-# 0.37.0
+## 0.37.0
 
 - Update to `libp2p-core` `v0.35.0`.
 
-# 0.36.0
+## 0.36.0
 
 - Update to `libp2p-core` `v0.34.0`.
 - Add `Transport::poll` and `Transport::remove_listener` and remove `Transport::Listener`
@@ -30,7 +30,7 @@
 
 [PR 2652]: https://github.com/libp2p/rust-libp2p/pull/2652
 
-# 0.35.0
+## 0.35.0
 
 - Update to `libp2p-core` `v0.33.0`.
 
@@ -38,11 +38,11 @@
 
 [PR 2682]: https://github.com/libp2p/rust-libp2p/pull/2682
 
-# 0.34.0 [2022-02-22]
+## 0.34.0 [2022-02-22]
 
 - Update to `libp2p-core` `v0.32.0`.
 
-# 0.33.0 [2022-01-27]
+## 0.33.0 [2022-01-27]
 
 - Update dependencies.
 
@@ -50,78 +50,78 @@
 
 [PR 2339]: https://github.com/libp2p/rust-libp2p/pull/2339
 
-# v0.32.0 [2021-11-16]
+## v0.32.0 [2021-11-16]
 
 - Handle websocket CLOSE with reason code (see [PR 2085]).
 
 [PR 2085]: https://github.com/libp2p/rust-libp2p/pull/2085
 
-# 0.31.0 [2021-11-01]
+## 0.31.0 [2021-11-01]
 
 - Make default features of `libp2p-core` optional.
   [PR 2181](https://github.com/libp2p/rust-libp2p/pull/2181)
 
 - Update dependencies.
 
-# 0.30.0 [2021-07-12]
+## 0.30.0 [2021-07-12]
 
 - Update dependencies.
 
-# 0.29.0 [2021-03-17]
+## 0.29.0 [2021-03-17]
 
 - Update `libp2p-core`.
 
 - Permit dialing `/p2p` addresses.
 
-# 0.28.0 [2021-01-12]
+## 0.28.0 [2021-01-12]
 
 - Update dependencies.
 
-# 0.27.0 [2020-12-17]
+## 0.27.0 [2020-12-17]
 
 - Update `libp2p-core`.
 
-# 0.26.3 [2020-12-10]
+## 0.26.3 [2020-12-10]
 
 - Update `async-tls`.
 
-# 0.26.2 [2020-12-09]
+## 0.26.2 [2020-12-09]
 
 - Update minimum patch version for `async-tls`.
 
-# 0.26.1 [2020-12-07]
+## 0.26.1 [2020-12-07]
 
 - Update `rustls`.
 
-# 0.26.0 [2020-11-25]
+## 0.26.0 [2020-11-25]
 
 - Update dependencies.
 
-# 0.25.0 [2020-11-09]
+## 0.25.0 [2020-11-09]
 
 - Update dependencies.
 
-# 0.24.0 [2020-10-16]
+## 0.24.0 [2020-10-16]
 
 - Update dependencies.
 
-# 0.23.0 [2020-09-09]
+## 0.23.0 [2020-09-09]
 
 - Bump `libp2p-core` dependency.
 
-# 0.22.0 [2020-08-18]
+## 0.22.0 [2020-08-18]
 
 - Bump `libp2p-core` dependency.
 
-# 0.21.1 [2020-07-09]
+## 0.21.1 [2020-07-09]
 
 - Update `async-tls` and `rustls` dependency.
 
-# 0.21.0 [2020-07-02]
+## 0.21.0 [2020-07-02]
 
 - Update `libp2p-core`.
 
-# 0.20.0 [2020-06-22]
+## 0.20.0 [2020-06-22]
 
 - Updated `soketto` dependency which caused some smaller
   API changes ([PR 1603](https://github.com/libp2p/rust-libp2p/pull/1603)).


### PR DESCRIPTION
## Description

See `##` for release headings everywhere. This is consistent with markdown conventions of one `#` per document and in line with https://keepachangelog.com/.

See report in https://github.com/libp2p/rust-libp2p/issues/3531.

