### PR TITLE
 refactor(gossipsub): make subscription_filter module private

### DIFF
--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -164,6 +164,11 @@ pub use self::peer_score::{
     score_parameter_decay, score_parameter_decay_with_base, PeerScoreParams, PeerScoreThresholds,
     TopicScoreParams,
 };
+pub use self::subscription_filter::{
+    regex::RegexSubscriptionFilter, AllowAllSubscriptionFilter, CallbackSubscriptionFilter,
+    CombinedSubscriptionFilters, MaxCountSubscriptionFilter, TopicSubscriptionFilter,
+    WhitelistSubscriptionFilter,
+};
 pub use self::topic::{Hasher, Topic, TopicHash};
 pub use self::transform::{DataTransform, IdentityTransform};
 pub use self::types::{FastMessageId, Message, MessageAcceptance, MessageId, RawMessage, Rpc};


### PR DESCRIPTION
## Description

## Notes

Additionally to making subscription_filter available from root, should it be have a deprecation notice regarding the public usage? cc @thomaseizinger 

## Links to any relevant issues

Resolves https://github.com/libp2p/rust-libp2p/issues/3392

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
