### PR TITLE
fix(examples): use absolute paths to link to examples

### DIFF
--- a/libp2p/examples/README.md
+++ b/libp2p/examples/README.md
@@ -7,21 +7,21 @@ A set of examples showcasing how to use rust-libp2p.
 
 ## Individual libp2p features
 
-- [Chat](./chat-example) A basic chat application demonstrating libp2p and the mDNS and Gossipsub protocols.
-- [Distributed key-value store](./distributed-key-value-store) A basic key value store demonstrating libp2p and the mDNS and Kademlia protocol.
+- [Chat](/examples/chat-example) A basic chat application demonstrating libp2p and the mDNS and Gossipsub protocols.
+- [Distributed key-value store](/examples/distributed-key-value-store) A basic key value store demonstrating libp2p and the mDNS and Kademlia protocol.
 
-- [File sharing application](./file-sharing) Basic file sharing application with peers either providing or locating and getting files by name.
+- [File sharing application](/examples/file-sharing) Basic file sharing application with peers either providing or locating and getting files by name.
 
   While obviously showcasing how to build a basic file sharing application with the Kademlia and
   Request-Response protocol, the actual goal of this example is **to show how to integrate
   rust-libp2p into a larger application**.
 
-- [IPFS Kademlia](./ipfs-kad) Demonstrates how to perform Kademlia queries on the IPFS network.
+- [IPFS Kademlia](/examples/ipfs-kad) Demonstrates how to perform Kademlia queries on the IPFS network.
 
-- [IPFS Private](./ipfs-private) Implementation using the gossipsub, ping and identify protocols to implement the ipfs private swarms feature.
+- [IPFS Private](/examples/ipfs-private) Implementation using the gossipsub, ping and identify protocols to implement the ipfs private swarms feature.
 
-- [Ping](./ping-example) Small `ping` clone, sending a ping to a peer, expecting a pong as a response. See [tutorial](../src/tutorials/ping.rs) for a step-by-step guide building the example.
+- [Ping](/examples/ping-example) Small `ping` clone, sending a ping to a peer, expecting a pong as a response. See [tutorial](../src/tutorials/ping.rs) for a step-by-step guide building the example.
 
 
-- [Rendezvous](./rendezvous) Rendezvous Protocol. See [specs](https://github.com/libp2p/specs/blob/master/rendezvous/README.md).
+- [Rendezvous](/examples/rendezvous) Rendezvous Protocol. See [specs](https://github.com/libp2p/specs/blob/master/rendezvous/README.md).
 

--- a/libp2p/examples/README.md
+++ b/libp2p/examples/README.md
@@ -7,7 +7,7 @@ A set of examples showcasing how to use rust-libp2p.
 
 ## Individual libp2p features
 
-- [Chat](./chat) A basic chat application demonstrating libp2p and the mDNS and Gossipsub protocols.
+- [Chat](./chat-example) A basic chat application demonstrating libp2p and the mDNS and Gossipsub protocols.
 - [Distributed key-value store](./distributed-key-value-store) A basic key value store demonstrating libp2p and the mDNS and Kademlia protocol.
 
 - [File sharing application](./file-sharing) Basic file sharing application with peers either providing or locating and getting files by name.
@@ -20,7 +20,7 @@ A set of examples showcasing how to use rust-libp2p.
 
 - [IPFS Private](./ipfs-private) Implementation using the gossipsub, ping and identify protocols to implement the ipfs private swarms feature.
 
-- [Ping](./ping) Small `ping` clone, sending a ping to a peer, expecting a pong as a response. See [tutorial](../src/tutorials/ping.rs) for a step-by-step guide building the example.
+- [Ping](./ping-example) Small `ping` clone, sending a ping to a peer, expecting a pong as a response. See [tutorial](../src/tutorials/ping.rs) for a step-by-step guide building the example.
 
 
 - [Rendezvous](./rendezvous) Rendezvous Protocol. See [specs](https://github.com/libp2p/specs/blob/master/rendezvous/README.md).


### PR DESCRIPTION
## Description

The examples have recently been moved to a new directory. Use absolute paths to link to them and fix two bad links from renamed crates.

## Notes

examples were moved in previous PR

## Links to any relevant issues

n/a

## Open Questions

n/a

## Change checklist

n/a

- [x ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [n/a] A changelog entry has been made in the appropriate crates
