### PR TITLE
fix(swarm): gracefully disable oneshot handler on dial upgrade errors

### DIFF
--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -90,6 +90,8 @@
 - Deprecate methods `Swarm::with_executor`, `Swarm::with_*_executor`, `Swarm::without_executor`.
   Introduce similar methods in `SwarmBuilder`. See [PR 3588].
 
+- Gracefully disable oneshot handler on dial upgrade errors. See [PR 3577].
+
 [PR 3364]: https://github.com/libp2p/rust-libp2p/pull/3364
 [PR 3170]: https://github.com/libp2p/rust-libp2p/pull/3170
 [PR 3134]: https://github.com/libp2p/rust-libp2p/pull/3134
@@ -106,6 +108,7 @@
 [PR 3254]: https://github.com/libp2p/rust-libp2p/pull/3254
 [PR 3497]: https://github.com/libp2p/rust-libp2p/pull/3497
 [PR 3588]: https://github.com/libp2p/rust-libp2p/pull/3588
+[PR 3577]: https://github.com/libp2p/rust-libp2p/pull/3577
 
 # 0.41.1
 

--- a/swarm/src/handler.rs
+++ b/swarm/src/handler.rs
@@ -458,7 +458,7 @@ impl<TUpgrErr> ConnectionHandlerUpgrErr<TUpgrErr> {
 
 impl<TUpgrErr> fmt::Display for ConnectionHandlerUpgrErr<TUpgrErr>
 where
-    TUpgrErr: fmt::Display,
+    TUpgrErr: error::Error + 'static,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -468,7 +468,10 @@ where
             ConnectionHandlerUpgrErr::Timer => {
                 write!(f, "Timer error while opening a substream")
             }
-            ConnectionHandlerUpgrErr::Upgrade(err) => write!(f, "{err}"),
+            ConnectionHandlerUpgrErr::Upgrade(err) => {
+                write!(f, "Upgrade: ")?;
+                crate::print_error_chain(f, err)
+            }
         }
     }
 }
@@ -481,7 +484,7 @@ where
         match self {
             ConnectionHandlerUpgrErr::Timeout => None,
             ConnectionHandlerUpgrErr::Timer => None,
-            ConnectionHandlerUpgrErr::Upgrade(err) => Some(err),
+            ConnectionHandlerUpgrErr::Upgrade(_) => None,
         }
     }
 }

--- a/swarm/src/handler/one_shot.rs
+++ b/swarm/src/handler/one_shot.rs
@@ -213,7 +213,8 @@ where
             }
             ConnectionEvent::DialUpgradeError(DialUpgradeError { error, .. }) => {
                 if self.pending_error.is_none() {
-                    self.pending_error = Some(error);
+                    log::debug!("DialUpgradeError: {error}");
+                    self.keep_alive = KeepAlive::No;
                 }
             }
             ConnectionEvent::AddressChange(_) | ConnectionEvent::ListenUpgradeError(_) => {}


### PR DESCRIPTION
## Description

Resolves https://github.com/libp2p/rust-libp2p/issues/3269.

## Notes

This PR implement changes discussed in #3269 

> > I’d propose to log inbound upgrade errors on debug level in the above spot.
> 
> Sounds good to me.
> 
> > In the above code snippet, outbound upgrade errors lead to closing the connection. I’m not sure whether that is the best possible response given that many protocols may be composed and thus the escalation’s scope seems too large.
> 
> Agreed. Setting its `keep_alive` to `False` should be enough.

## Links to any relevant issues

#3269 

## Change checklist

The changes are trivial. Not sure whether the usual checklist applies.
