### PR TITLE
feat(gossipsub): use signed peer records on handle prune

### DIFF
--- a/core/src/signed_envelope.rs
+++ b/core/src/signed_envelope.rs
@@ -8,7 +8,7 @@ use unsigned_varint::encode::usize_buffer;
 /// A signed envelope contains an arbitrary byte string payload, a signature of the payload, and the public key that can be used to verify the signature.
 ///
 /// For more details see libp2p RFC0002: <https://github.com/libp2p/specs/blob/master/RFC/0002-signed-envelopes.md>
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SignedEnvelope {
     key: PublicKey,
     payload_type: Vec<u8>,

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -1865,8 +1865,8 @@ fn test_connect_to_px_peers_with_peer_record_on_handle_prune() {
 
     let mut px_peer_ids = Vec::new();
     let mut px = Vec::new();
-    // propose more px peers than config.prune_peers()
-    for i in 0..config.prune_peers() + 5 {
+    // propose more px peers than config.mesh_n_high()
+    for i in 0..config.mesh_n_high() + 5 {
         let key = Keypair::generate_ed25519();
         let address: Multiaddr = format!("/ip4/1.2.3.4/tcp/{i}").try_into().unwrap();
         let peer_record = PeerRecord::new(&key, vec![address]).unwrap();
@@ -1893,7 +1893,7 @@ fn test_connect_to_px_peers_with_peer_record_on_handle_prune() {
         .iter()
         .filter_map(|e| match e {
             // TODO: How to extract addresses from DialOpts to assert them in the test?
-            NetworkBehaviourAction::Dial { opts } => opts.get_peer_id(),
+            ToSwarm::Dial { opts } => opts.get_peer_id(),
             _ => None,
         })
         .collect();
@@ -3100,7 +3100,11 @@ fn test_ignore_rpc_from_peers_below_graylist_threshold() {
 
 #[test]
 fn test_ignore_px_from_peers_below_accept_px_threshold() {
-    let config = ConfigBuilder::default().prune_peers(16).build().unwrap();
+    let config = ConfigBuilder::default()
+        .prune_peers(16)
+        .do_px()
+        .build()
+        .unwrap();
     let peer_score_params = PeerScoreParams::default();
     let peer_score_thresholds = PeerScoreThresholds {
         accept_px_threshold: peer_score_params.app_specific_weight,

--- a/protocols/gossipsub/src/types.rs
+++ b/protocols/gossipsub/src/types.rs
@@ -20,6 +20,7 @@
 
 //! A collection of types using the Gossipsub system.
 use crate::TopicHash;
+use libp2p_core::SignedEnvelope;
 use libp2p_identity::PeerId;
 use libp2p_swarm::ConnectionId;
 use prometheus_client::encoding::EncodeLabelValue;
@@ -200,9 +201,7 @@ pub enum SubscriptionAction {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PeerInfo {
     pub peer_id: Option<PeerId>,
-    //TODO add this when RFC: Signed Address Records got added to the spec (see pull request
-    // https://github.com/libp2p/specs/pull/217)
-    //pub signed_peer_record: ?,
+    pub signed_peer_record: Option<SignedEnvelope>,
 }
 
 /// A Control message received by the gossipsub system.
@@ -330,8 +329,9 @@ impl From<Rpc> for proto::RPC {
                             .into_iter()
                             .map(|info| proto::PeerInfo {
                                 peer_id: info.peer_id.map(|id| id.to_bytes()),
-                                /// TODO, see https://github.com/libp2p/specs/pull/217
-                                signed_peer_record: None,
+                                signed_peer_record: info
+                                    .signed_peer_record
+                                    .map(|spr| spr.into_protobuf_encoding()),
                             })
                             .collect(),
                         backoff,


### PR DESCRIPTION
## Description

<!-- Please write a summary of your changes and why you made them.-->
<!-- This section will appear as the commit message after merging. Please craft it accordingly. -->

Gossipsub's PeerExchange functionality suggests peers to connect to upon pruning a node from the mesh. Currently, we cannot import _sending_ signed peer records to other nodes because we don't have a peer store (yet). This patch implements handling incoming signed peer records from other nodes in case we get pruned from the mesh.

Related https://github.com/libp2p/rust-libp2p/issues/2398.

## Notes

<!-- Any notes or remarks you'd like to make about the PR. -->
N/A

## Links to any relevant issues

<!-- Reference any related issues.-->
- https://github.com/libp2p/rust-libp2p/issues/2398

## Open Questions

<!-- Unresolved questions, if any. -->
N/A

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
  - Could not find any docs affected, please indicate otherwise 
- [x] I have added tests that prove my fix is effective or that my feature works
  - A test covers dialing peers from signed_peer_records, but does not assert that addresses is correct, see

https://github.com/libp2p/rust-libp2p/blob/d1d468c13c8df04ef8b52566c58961b24652515c/protocols/gossipsub/src/behaviour/tests.rs#L1896-L1897

- [ ] A changelog entry has been made in the appropriate crates
  - Where should I append the entry? Add a new `# 0.45.0` section?
