### PR TITLE
fix(libp2p): do not pin alpha versions

### DIFF
--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -117,11 +117,11 @@ pin-project = "1.0.0"
 libp2p-deflate = { version = "0.39.0", path = "../transports/deflate", optional = true }
 libp2p-dns = { version = "0.39.0", path = "../transports/dns", optional = true }
 libp2p-mdns = { version = "0.43.0", path = "../protocols/mdns", optional = true }
-libp2p-quic = { version = "=0.7.0-alpha.2", path = "../transports/quic", optional = true }
+libp2p-quic = { version = "0.7.0-alpha.2", path = "../transports/quic", optional = true }
 libp2p-tcp = { version = "0.39.0", path = "../transports/tcp", optional = true }
-libp2p-tls = { version = "=0.1.0-alpha.2", path = "../transports/tls", optional = true }
+libp2p-tls = { version = "0.1.0-alpha.2", path = "../transports/tls", optional = true }
 libp2p-uds = { version = "0.38.0", path = "../transports/uds", optional = true }
-libp2p-webrtc = { version = "=0.4.0-alpha.3", path = "../transports/webrtc", optional = true }
+libp2p-webrtc = { version = "0.4.0-alpha.3", path = "../transports/webrtc", optional = true }
 libp2p-websocket = { version = "0.41.0", path = "../transports/websocket", optional = true }
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]


### PR DESCRIPTION
## Description

We will embrace the fact that cargo auto updates to new alpha versions. We can prevent auto updates on breaking alpha versions by bumping their minor version.

Reverts https://github.com/libp2p/rust-libp2p/pull/3538/



<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
  - https://github.com/libp2p/rust-libp2p/pull/3538/ has never been released 
