### PR TITLE
feat(swarm): enforce creation of `Swarm` via `SwarmBuilder`

### DIFF
--- a/examples/chat-example/src/main.rs
+++ b/examples/chat-example/src/main.rs
@@ -48,7 +48,10 @@
 use async_std::io;
 use futures::{prelude::*, select};
 use libp2p::{
-    gossipsub, identity, mdns, swarm::NetworkBehaviour, swarm::SwarmEvent, PeerId, Swarm,
+    gossipsub, identity, mdns,
+    swarm::NetworkBehaviour,
+    swarm::{SwarmBuilder, SwarmEvent},
+    PeerId,
 };
 use std::collections::hash_map::DefaultHasher;
 use std::error::Error;
@@ -104,7 +107,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut swarm = {
         let mdns = mdns::async_io::Behaviour::new(mdns::Config::default(), local_peer_id)?;
         let behaviour = MyBehaviour { gossipsub, mdns };
-        Swarm::with_async_std_executor(transport, behaviour, local_peer_id)
+        SwarmBuilder::with_async_std_executor(transport, behaviour, local_peer_id).build()
     };
 
     // Read full lines from stdin

--- a/examples/distributed-key-value-store/src/main.rs
+++ b/examples/distributed-key-value-store/src/main.rs
@@ -49,8 +49,8 @@ use libp2p::kad::{
 };
 use libp2p::{
     development_transport, identity, mdns,
-    swarm::{NetworkBehaviour, SwarmEvent},
-    PeerId, Swarm,
+    swarm::{NetworkBehaviour, SwarmBuilder, SwarmEvent},
+    PeerId,
 };
 use std::error::Error;
 
@@ -98,7 +98,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let kademlia = Kademlia::new(local_peer_id, store);
         let mdns = mdns::async_io::Behaviour::new(mdns::Config::default(), local_peer_id)?;
         let behaviour = MyBehaviour { kademlia, mdns };
-        Swarm::with_async_std_executor(transport, behaviour, local_peer_id)
+        SwarmBuilder::with_async_std_executor(transport, behaviour, local_peer_id).build()
     };
 
     // Read full lines from stdin

--- a/examples/file-sharing/src/network.rs
+++ b/examples/file-sharing/src/network.rs
@@ -15,7 +15,7 @@ use libp2p::{
     },
     multiaddr::Protocol,
     request_response::{self, ProtocolSupport, RequestId, ResponseChannel},
-    swarm::{ConnectionHandlerUpgrErr, NetworkBehaviour, Swarm, SwarmEvent},
+    swarm::{ConnectionHandlerUpgrErr, NetworkBehaviour, Swarm, SwarmBuilder, SwarmEvent},
     PeerId,
 };
 
@@ -47,7 +47,7 @@ pub async fn new(
 
     // Build the Swarm, connecting the lower layer transport logic with the
     // higher layer network behaviour logic.
-    let swarm = Swarm::with_threadpool_executor(
+    let swarm = SwarmBuilder::with_threadpool_executor(
         libp2p::development_transport(id_keys).await?,
         ComposedBehaviour {
             kademlia: Kademlia::new(peer_id, MemoryStore::new(peer_id)),
@@ -58,7 +58,8 @@ pub async fn new(
             ),
         },
         peer_id,
-    );
+    )
+    .build();
 
     let (command_sender, command_receiver) = mpsc::channel(0);
     let (event_sender, event_receiver) = mpsc::channel(0);

--- a/examples/file-sharing/src/network.rs
+++ b/examples/file-sharing/src/network.rs
@@ -47,7 +47,7 @@ pub async fn new(
 
     // Build the Swarm, connecting the lower layer transport logic with the
     // higher layer network behaviour logic.
-    let swarm = SwarmBuilder::with_threadpool_executor(
+    let swarm = SwarmBuilder::with_async_std_executor(
         libp2p::development_transport(id_keys).await?,
         ComposedBehaviour {
             kademlia: Kademlia::new(peer_id, MemoryStore::new(peer_id)),

--- a/examples/identify/src/main.rs
+++ b/examples/identify/src/main.rs
@@ -40,7 +40,7 @@ use futures::prelude::*;
 use libp2p::{
     core::{multiaddr::Multiaddr, upgrade::Version},
     identify, identity, noise,
-    swarm::{Swarm, SwarmEvent},
+    swarm::{SwarmBuilder, SwarmEvent},
     tcp, yamux, PeerId, Transport,
 };
 use std::error::Error;
@@ -63,7 +63,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         local_key.public(),
     ));
 
-    let mut swarm = Swarm::with_async_std_executor(transport, behaviour, local_peer_id);
+    let mut swarm =
+        SwarmBuilder::with_async_std_executor(transport, behaviour, local_peer_id).build();
 
     // Tell the swarm to listen on all interfaces and a random, OS-assigned
     // port.

--- a/examples/ipfs-kad/src/main.rs
+++ b/examples/ipfs-kad/src/main.rs
@@ -28,7 +28,7 @@ use libp2p::kad::record::store::MemoryStore;
 use libp2p::kad::{GetClosestPeersError, Kademlia, KademliaConfig, KademliaEvent, QueryResult};
 use libp2p::{
     development_transport, identity,
-    swarm::{Swarm, SwarmEvent},
+    swarm::{SwarmBuilder, SwarmEvent},
     PeerId,
 };
 use std::{env, error::Error, time::Duration};
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             behaviour.add_address(&peer.parse()?, "/dnsaddr/bootstrap.libp2p.io".parse()?);
         }
 
-        Swarm::with_async_std_executor(transport, behaviour, local_peer_id)
+        SwarmBuilder::with_async_std_executor(transport, behaviour, local_peer_id).build()
     };
 
     // Order Kademlia to search for a peer.

--- a/examples/ipfs-private/src/main.rs
+++ b/examples/ipfs-private/src/main.rs
@@ -40,10 +40,10 @@ use libp2p::{
     multiaddr::Protocol,
     noise, ping,
     pnet::{PnetConfig, PreSharedKey},
-    swarm::{NetworkBehaviour, SwarmEvent},
+    swarm::{NetworkBehaviour, SwarmBuilder, SwarmEvent},
     tcp,
     yamux::YamuxConfig,
-    Multiaddr, PeerId, Swarm, Transport,
+    Multiaddr, PeerId, Transport,
 };
 use std::{env, error::Error, fs, path::Path, str::FromStr, time::Duration};
 
@@ -199,7 +199,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         println!("Subscribing to {gossipsub_topic:?}");
         behaviour.gossipsub.subscribe(&gossipsub_topic).unwrap();
-        Swarm::with_async_std_executor(transport, behaviour, local_peer_id)
+        SwarmBuilder::with_async_std_executor(transport, behaviour, local_peer_id).build()
     };
 
     // Reach out to other nodes if specified

--- a/examples/ping-example/src/main.rs
+++ b/examples/ping-example/src/main.rs
@@ -43,7 +43,7 @@
 use futures::prelude::*;
 use libp2p::{
     identity, ping,
-    swarm::{keep_alive, NetworkBehaviour, Swarm, SwarmEvent},
+    swarm::{keep_alive, NetworkBehaviour, SwarmBuilder, SwarmEvent},
     Multiaddr, PeerId,
 };
 use std::error::Error;
@@ -56,7 +56,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let transport = libp2p::development_transport(local_key).await?;
 
-    let mut swarm = Swarm::with_async_std_executor(transport, Behaviour::default(), local_peer_id);
+    let mut swarm =
+        SwarmBuilder::with_async_std_executor(transport, Behaviour::default(), local_peer_id)
+            .build();
 
     // Tell the swarm to listen on all interfaces and a random, OS-assigned
     // port.

--- a/examples/rendezvous/src/bin/rzv-discover.rs
+++ b/examples/rendezvous/src/bin/rzv-discover.rs
@@ -24,7 +24,7 @@ use libp2p::{
     identity,
     multiaddr::Protocol,
     noise, ping, rendezvous,
-    swarm::{keep_alive, NetworkBehaviour, Swarm, SwarmEvent},
+    swarm::{keep_alive, NetworkBehaviour, SwarmBuilder, SwarmEvent},
     tcp, yamux, Multiaddr, PeerId, Transport,
 };
 use std::time::Duration;
@@ -41,7 +41,7 @@ async fn main() {
         .parse()
         .unwrap();
 
-    let mut swarm = Swarm::with_tokio_executor(
+    let mut swarm = SwarmBuilder::with_tokio_executor(
         tcp::tokio::Transport::default()
             .upgrade(Version::V1)
             .authenticate(noise::NoiseAuthenticated::xx(&key_pair).unwrap())
@@ -53,7 +53,8 @@ async fn main() {
             keep_alive: keep_alive::Behaviour,
         },
         PeerId::from(key_pair.public()),
-    );
+    )
+    .build();
 
     log::info!("Local peer id: {}", swarm.local_peer_id());
 

--- a/examples/rendezvous/src/bin/rzv-identify.rs
+++ b/examples/rendezvous/src/bin/rzv-identify.rs
@@ -22,7 +22,7 @@ use futures::StreamExt;
 use libp2p::{
     core::transport::upgrade::Version,
     identify, identity, noise, ping, rendezvous,
-    swarm::{keep_alive, NetworkBehaviour, Swarm, SwarmEvent},
+    swarm::{keep_alive, NetworkBehaviour, SwarmBuilder, SwarmEvent},
     tcp, yamux, Multiaddr, PeerId, Transport,
 };
 use std::time::Duration;
@@ -37,7 +37,7 @@ async fn main() {
         .parse()
         .unwrap();
 
-    let mut swarm = Swarm::with_tokio_executor(
+    let mut swarm = SwarmBuilder::with_tokio_executor(
         tcp::tokio::Transport::default()
             .upgrade(Version::V1)
             .authenticate(noise::NoiseAuthenticated::xx(&key_pair).unwrap())
@@ -53,7 +53,8 @@ async fn main() {
             keep_alive: keep_alive::Behaviour,
         },
         PeerId::from(key_pair.public()),
-    );
+    )
+    .build();
 
     log::info!("Local peer id: {}", swarm.local_peer_id());
 

--- a/examples/rendezvous/src/bin/rzv-register.rs
+++ b/examples/rendezvous/src/bin/rzv-register.rs
@@ -22,7 +22,7 @@ use futures::StreamExt;
 use libp2p::{
     core::transport::upgrade::Version,
     identity, noise, ping, rendezvous,
-    swarm::{keep_alive, AddressScore, NetworkBehaviour, Swarm, SwarmEvent},
+    swarm::{keep_alive, AddressScore, NetworkBehaviour, SwarmBuilder, SwarmEvent},
     tcp, yamux, Multiaddr, PeerId, Transport,
 };
 use std::time::Duration;
@@ -37,7 +37,7 @@ async fn main() {
         .parse()
         .unwrap();
 
-    let mut swarm = Swarm::with_tokio_executor(
+    let mut swarm = SwarmBuilder::with_tokio_executor(
         tcp::tokio::Transport::default()
             .upgrade(Version::V1)
             .authenticate(noise::NoiseAuthenticated::xx(&key_pair).unwrap())
@@ -49,7 +49,8 @@ async fn main() {
             keep_alive: keep_alive::Behaviour,
         },
         PeerId::from(key_pair.public()),
-    );
+    )
+    .build();
 
     // In production the external address should be the publicly facing IP address of the rendezvous point.
     // This address is recorded in the registration entry by the rendezvous point.

--- a/examples/rendezvous/src/main.rs
+++ b/examples/rendezvous/src/main.rs
@@ -40,7 +40,7 @@ use futures::StreamExt;
 use libp2p::{
     core::transport::upgrade::Version,
     identify, identity, noise, ping, rendezvous,
-    swarm::{keep_alive, NetworkBehaviour, Swarm, SwarmEvent},
+    swarm::{keep_alive, NetworkBehaviour, SwarmBuilder, SwarmEvent},
     tcp, yamux, PeerId, Transport,
 };
 use std::time::Duration;
@@ -51,7 +51,7 @@ async fn main() {
 
     let key_pair = identity::Keypair::generate_ed25519();
 
-    let mut swarm = Swarm::with_tokio_executor(
+    let mut swarm = SwarmBuilder::with_tokio_executor(
         tcp::tokio::Transport::default()
             .upgrade(Version::V1)
             .authenticate(noise::NoiseAuthenticated::xx(&key_pair).unwrap())
@@ -67,7 +67,8 @@ async fn main() {
             keep_alive: keep_alive::Behaviour,
         },
         PeerId::from(key_pair.public()),
-    );
+    )
+    .build();
 
     log::info!("Local peer id: {}", swarm.local_peer_id());
 

--- a/interop-tests/src/bin/ping.rs
+++ b/interop-tests/src/bin/ping.rs
@@ -13,8 +13,8 @@ use libp2p::swarm::{keep_alive, NetworkBehaviour, SwarmEvent};
 use libp2p::tls::TlsStream;
 use libp2p::websocket::WsConfig;
 use libp2p::{
-    identity, mplex, noise, ping, quic, tcp, tls, webrtc, yamux, InboundUpgradeExt, Multiaddr,
-    OutboundUpgradeExt, PeerId, Swarm, Transport as _,
+    identity, mplex, noise, ping, quic, swarm::SwarmBuilder, tcp, tls, webrtc, yamux,
+    InboundUpgradeExt, Multiaddr, OutboundUpgradeExt, PeerId, Transport as _,
 };
 use redis::AsyncCommands;
 
@@ -78,14 +78,15 @@ async fn main() -> Result<()> {
         ),
     };
 
-    let mut swarm = Swarm::with_tokio_executor(
+    let mut swarm = SwarmBuilder::with_tokio_executor(
         boxed_transport,
         Behaviour {
             ping: ping::Behaviour::new(ping::Config::new().with_interval(Duration::from_secs(1))),
             keep_alive: keep_alive::Behaviour,
         },
         local_peer_id,
-    );
+    )
+    .build();
 
     let mut conn = client.get_async_connection().await?;
 

--- a/misc/metrics/examples/metrics/main.rs
+++ b/misc/metrics/examples/metrics/main.rs
@@ -58,10 +58,7 @@ use libp2p_identity::PeerId;
 use libp2p_metrics::{Metrics, Recorder};
 use libp2p_noise as noise;
 use libp2p_ping as ping;
-use libp2p_swarm::keep_alive;
-use libp2p_swarm::NetworkBehaviour;
-use libp2p_swarm::Swarm;
-use libp2p_swarm::SwarmEvent;
+use libp2p_swarm::{keep_alive, NetworkBehaviour, SwarmBuilder, SwarmEvent};
 use libp2p_tcp as tcp;
 use libp2p_yamux as yamux;
 use log::info;
@@ -79,7 +76,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let local_pub_key = local_key.public();
     info!("Local peer id: {local_peer_id:?}");
 
-    let mut swarm = Swarm::without_executor(
+    let mut swarm = SwarmBuilder::without_executor(
         tcp::async_io::Transport::default()
             .upgrade(Version::V1)
             .authenticate(noise::NoiseAuthenticated::xx(&local_key)?)
@@ -87,7 +84,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             .boxed(),
         Behaviour::new(local_pub_key),
         local_peer_id,
-    );
+    )
+    .build();
 
     swarm.listen_on("/ip4/0.0.0.0/tcp/0".parse()?)?;
 

--- a/misc/multistream-select/tests/transport.rs
+++ b/misc/multistream-select/tests/transport.rs
@@ -29,7 +29,7 @@ use libp2p_identity as identity;
 use libp2p_identity::PeerId;
 use libp2p_mplex::MplexConfig;
 use libp2p_plaintext::PlainText2Config;
-use libp2p_swarm::{dummy, Swarm, SwarmEvent};
+use libp2p_swarm::{dummy, SwarmBuilder, SwarmEvent};
 use rand::random;
 use std::task::Poll;
 
@@ -63,9 +63,14 @@ fn transport_upgrade() {
         let listen_addr = Multiaddr::from(Protocol::Memory(random::<u64>()));
 
         let mut dialer =
-            Swarm::with_async_std_executor(dialer_transport, dummy::Behaviour, dialer_id);
-        let mut listener =
-            Swarm::with_async_std_executor(listener_transport, dummy::Behaviour, listener_id);
+            SwarmBuilder::with_async_std_executor(dialer_transport, dummy::Behaviour, dialer_id)
+                .build();
+        let mut listener = SwarmBuilder::with_async_std_executor(
+            listener_transport,
+            dummy::Behaviour,
+            listener_id,
+        )
+        .build();
 
         listener.listen_on(listen_addr).unwrap();
         let (addr_sender, addr_receiver) = oneshot::channel();

--- a/protocols/autonat/examples/autonat_client.rs
+++ b/protocols/autonat/examples/autonat_client.rs
@@ -38,7 +38,7 @@ use libp2p_identify as identify;
 use libp2p_identity as identity;
 use libp2p_identity::PeerId;
 use libp2p_noise as noise;
-use libp2p_swarm::{NetworkBehaviour, Swarm, SwarmEvent};
+use libp2p_swarm::{NetworkBehaviour, SwarmBuilder, SwarmEvent};
 use libp2p_tcp as tcp;
 use libp2p_yamux as yamux;
 use std::error::Error;
@@ -76,7 +76,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let behaviour = Behaviour::new(local_key.public());
 
-    let mut swarm = Swarm::with_async_std_executor(transport, behaviour, local_peer_id);
+    let mut swarm =
+        SwarmBuilder::with_async_std_executor(transport, behaviour, local_peer_id).build();
     swarm.listen_on(
         Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::UNSPECIFIED))

--- a/protocols/autonat/examples/autonat_server.rs
+++ b/protocols/autonat/examples/autonat_server.rs
@@ -34,7 +34,7 @@ use libp2p_identify as identify;
 use libp2p_identity as identity;
 use libp2p_identity::PeerId;
 use libp2p_noise as noise;
-use libp2p_swarm::{NetworkBehaviour, Swarm, SwarmEvent};
+use libp2p_swarm::{NetworkBehaviour, SwarmBuilder, SwarmEvent};
 use libp2p_tcp as tcp;
 use libp2p_yamux as yamux;
 use std::error::Error;
@@ -65,7 +65,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let behaviour = Behaviour::new(local_key.public());
 
-    let mut swarm = Swarm::with_async_std_executor(transport, behaviour, local_peer_id);
+    let mut swarm =
+        SwarmBuilder::with_async_std_executor(transport, behaviour, local_peer_id).build();
     swarm.listen_on(
         Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::UNSPECIFIED))

--- a/protocols/dcutr/tests/lib.rs
+++ b/protocols/dcutr/tests/lib.rs
@@ -26,7 +26,7 @@ use libp2p_identity as identity;
 use libp2p_identity::PeerId;
 use libp2p_plaintext::PlainText2Config;
 use libp2p_relay as relay;
-use libp2p_swarm::{NetworkBehaviour, Swarm, SwarmEvent};
+use libp2p_swarm::{NetworkBehaviour, Swarm, SwarmBuilder, SwarmEvent};
 use libp2p_swarm_test::SwarmExt as _;
 use std::time::Duration;
 
@@ -124,7 +124,7 @@ fn build_client() -> Swarm<Client> {
         .multiplex(libp2p_yamux::YamuxConfig::default())
         .boxed();
 
-    Swarm::without_executor(
+    SwarmBuilder::without_executor(
         transport,
         Client {
             relay: behaviour,
@@ -132,6 +132,7 @@ fn build_client() -> Swarm<Client> {
         },
         local_peer_id,
     )
+    .build()
 }
 
 #[derive(NetworkBehaviour)]

--- a/protocols/identify/src/behaviour.rs
+++ b/protocols/identify/src/behaviour.rs
@@ -566,7 +566,7 @@ mod tests {
     use libp2p_identity::PeerId;
     use libp2p_mplex::MplexConfig;
     use libp2p_noise as noise;
-    use libp2p_swarm::{Swarm, SwarmEvent};
+    use libp2p_swarm::{Swarm, SwarmBuilder, SwarmEvent};
     use libp2p_tcp as tcp;
     use std::time::Duration;
 
@@ -594,7 +594,9 @@ mod tests {
             let protocol = Behaviour::new(
                 Config::new("a".to_string(), pubkey.clone()).with_agent_version("b".to_string()),
             );
-            let swarm = Swarm::with_async_std_executor(transport, protocol, pubkey.to_peer_id());
+            let swarm =
+                SwarmBuilder::with_async_std_executor(transport, protocol, pubkey.to_peer_id())
+                    .build();
             (swarm, pubkey)
         };
 
@@ -603,7 +605,9 @@ mod tests {
             let protocol = Behaviour::new(
                 Config::new("c".to_string(), pubkey.clone()).with_agent_version("d".to_string()),
             );
-            let swarm = Swarm::with_async_std_executor(transport, protocol, pubkey.to_peer_id());
+            let swarm =
+                SwarmBuilder::with_async_std_executor(transport, protocol, pubkey.to_peer_id())
+                    .build();
             (swarm, pubkey)
         };
 
@@ -671,7 +675,9 @@ mod tests {
         let (mut swarm1, pubkey1) = {
             let (pubkey, transport) = transport();
             let protocol = Behaviour::new(Config::new("a".to_string(), pubkey.clone()));
-            let swarm = Swarm::with_async_std_executor(transport, protocol, pubkey.to_peer_id());
+            let swarm =
+                SwarmBuilder::with_async_std_executor(transport, protocol, pubkey.to_peer_id())
+                    .build();
             (swarm, pubkey)
         };
 
@@ -680,7 +686,9 @@ mod tests {
             let protocol = Behaviour::new(
                 Config::new("a".to_string(), pubkey.clone()).with_agent_version("b".to_string()),
             );
-            let swarm = Swarm::with_async_std_executor(transport, protocol, pubkey.to_peer_id());
+            let swarm =
+                SwarmBuilder::with_async_std_executor(transport, protocol, pubkey.to_peer_id())
+                    .build();
             (swarm, pubkey)
         };
 
@@ -752,7 +760,7 @@ mod tests {
                     .with_initial_delay(Duration::from_secs(10)),
             );
 
-            Swarm::with_async_std_executor(transport, protocol, pubkey.to_peer_id())
+            SwarmBuilder::with_async_std_executor(transport, protocol, pubkey.to_peer_id()).build()
         };
 
         let mut swarm2 = {
@@ -761,7 +769,7 @@ mod tests {
                 Config::new("a".to_string(), pubkey.clone()).with_agent_version("b".to_string()),
             );
 
-            Swarm::with_async_std_executor(transport, protocol, pubkey.to_peer_id())
+            SwarmBuilder::with_async_std_executor(transport, protocol, pubkey.to_peer_id()).build()
         };
 
         let swarm1_peer_id = *swarm1.local_peer_id();

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -37,7 +37,7 @@ use libp2p_core::{
 use libp2p_identity as identity;
 use libp2p_identity::PeerId;
 use libp2p_noise as noise;
-use libp2p_swarm::{ConnectionId, Swarm, SwarmEvent};
+use libp2p_swarm::{ConnectionId, Swarm, SwarmBuilder, SwarmEvent};
 use libp2p_yamux as yamux;
 use quickcheck::*;
 use rand::{random, rngs::StdRng, thread_rng, Rng, SeedableRng};
@@ -67,7 +67,7 @@ fn build_node_with_config(cfg: KademliaConfig) -> (Multiaddr, TestSwarm) {
     let store = MemoryStore::new(local_id);
     let behaviour = Kademlia::with_config(local_id, store, cfg);
 
-    let mut swarm = Swarm::without_executor(transport, behaviour, local_id);
+    let mut swarm = SwarmBuilder::without_executor(transport, behaviour, local_id).build();
 
     let address: Multiaddr = Protocol::Memory(random::<u64>()).into();
     swarm.listen_on(address.clone()).unwrap();

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3.27"
 futures-timer = "3"
 instant = "0.1.11"
 libp2p-core = { version = "0.39.0", path = "../../core" }
-libp2p-swarm = { version = "0.42.0", path = "../../swarm" }
+libp2p-swarm = { version = "0.42.0", path = "../../swarm", features = ["async-std"] }
 libp2p-identity = { version = "0.1.0", path = "../../identity" }
 log = "0.4"
 quick-protobuf = "0.8"

--- a/protocols/relay/examples/relay.rs
+++ b/protocols/relay/examples/relay.rs
@@ -31,7 +31,7 @@ use libp2p_identity::PeerId;
 use libp2p_noise as noise;
 use libp2p_ping as ping;
 use libp2p_relay as relay;
-use libp2p_swarm::{NetworkBehaviour, Swarm, SwarmEvent};
+use libp2p_swarm::{NetworkBehaviour, SwarmBuilder, SwarmEvent};
 use libp2p_tcp as tcp;
 use std::error::Error;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -67,7 +67,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         )),
     };
 
-    let mut swarm = Swarm::without_executor(transport, behaviour, local_peer_id);
+    let mut swarm = SwarmBuilder::without_executor(transport, behaviour, local_peer_id).build();
 
     // Listen on all interfaces
     let listen_addr = Multiaddr::empty()

--- a/protocols/relay/tests/lib.rs
+++ b/protocols/relay/tests/lib.rs
@@ -34,7 +34,7 @@ use libp2p_identity::PublicKey;
 use libp2p_ping as ping;
 use libp2p_plaintext::PlainText2Config;
 use libp2p_relay as relay;
-use libp2p_swarm::{AddressScore, NetworkBehaviour, Swarm, SwarmEvent};
+use libp2p_swarm::{AddressScore, NetworkBehaviour, Swarm, SwarmBuilder, SwarmEvent};
 use std::time::Duration;
 
 #[test]
@@ -292,7 +292,7 @@ fn build_relay() -> Swarm<Relay> {
 
     let transport = upgrade_transport(MemoryTransport::default().boxed(), local_public_key);
 
-    Swarm::with_threadpool_executor(
+    SwarmBuilder::with_async_std_executor(
         transport,
         Relay {
             ping: ping::Behaviour::new(ping::Config::new()),
@@ -306,6 +306,7 @@ fn build_relay() -> Swarm<Relay> {
         },
         local_peer_id,
     )
+    .build()
 }
 
 fn build_client() -> Swarm<Client> {
@@ -319,7 +320,7 @@ fn build_client() -> Swarm<Client> {
         local_public_key,
     );
 
-    Swarm::with_threadpool_executor(
+    SwarmBuilder::with_async_std_executor(
         transport,
         Client {
             ping: ping::Behaviour::new(ping::Config::new()),
@@ -327,6 +328,7 @@ fn build_client() -> Swarm<Client> {
         },
         local_peer_id,
     )
+    .build()
 }
 
 fn upgrade_transport<StreamSink>(

--- a/swarm-test/src/lib.rs
+++ b/swarm-test/src/lib.rs
@@ -28,7 +28,8 @@ use libp2p_core::{
 use libp2p_identity::PeerId;
 use libp2p_plaintext::PlainText2Config;
 use libp2p_swarm::{
-    dial_opts::DialOpts, AddressScore, NetworkBehaviour, Swarm, SwarmEvent, THandlerErr,
+    dial_opts::DialOpts, AddressScore, NetworkBehaviour, Swarm, SwarmBuilder, SwarmEvent,
+    THandlerErr,
 };
 use libp2p_yamux::YamuxConfig;
 use std::fmt::Debug;
@@ -218,7 +219,7 @@ where
             .timeout(Duration::from_secs(20))
             .boxed();
 
-        Swarm::without_executor(transport, behaviour_fn(identity), peer_id)
+        SwarmBuilder::without_executor(transport, behaviour_fn(identity), peer_id).build()
     }
 
     async fn connect<T>(&mut self, other: &mut Swarm<T>)

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -87,6 +87,9 @@
 
 - Remove `ConnectionId::new`. Manually creating `ConnectionId`s is now unsupported. See [PR 3327].
 
+- Deprecate methods `Swarm::with_executor`, `Swarm::with_*_executor`, `Swarm::without_executor`.
+  Introduce similar methods in `SwarmBuilder`. See [PR 3588].
+
 [PR 3364]: https://github.com/libp2p/rust-libp2p/pull/3364
 [PR 3170]: https://github.com/libp2p/rust-libp2p/pull/3170
 [PR 3134]: https://github.com/libp2p/rust-libp2p/pull/3134
@@ -102,6 +105,7 @@
 [PR 3375]: https://github.com/libp2p/rust-libp2p/pull/3375
 [PR 3254]: https://github.com/libp2p/rust-libp2p/pull/3254
 [PR 3497]: https://github.com/libp2p/rust-libp2p/pull/3497
+[PR 3588]: https://github.com/libp2p/rust-libp2p/pull/3588
 
 # 0.41.1
 

--- a/transports/pnet/tests/smoke.rs
+++ b/transports/pnet/tests/smoke.rs
@@ -6,7 +6,7 @@ use libp2p_core::upgrade::Version;
 use libp2p_core::Transport;
 use libp2p_core::{multiaddr::Protocol, Multiaddr};
 use libp2p_pnet::{PnetConfig, PreSharedKey};
-use libp2p_swarm::{keep_alive, NetworkBehaviour, Swarm, SwarmEvent};
+use libp2p_swarm::{keep_alive, NetworkBehaviour, Swarm, SwarmBuilder, SwarmEvent};
 
 const TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -113,11 +113,12 @@ where
         .authenticate(libp2p_noise::NoiseAuthenticated::xx(&identity).unwrap())
         .multiplex(libp2p_yamux::YamuxConfig::default())
         .boxed();
-    Swarm::with_tokio_executor(
+    SwarmBuilder::with_tokio_executor(
         transport,
         keep_alive::Behaviour,
         identity.public().to_peer_id(),
     )
+    .build()
 }
 
 async fn listen_on<B: NetworkBehaviour>(swarm: &mut Swarm<B>, addr: Multiaddr) -> Multiaddr {

--- a/transports/tls/tests/smoke.rs
+++ b/transports/tls/tests/smoke.rs
@@ -3,7 +3,7 @@ use libp2p_core::multiaddr::Protocol;
 use libp2p_core::transport::MemoryTransport;
 use libp2p_core::upgrade::Version;
 use libp2p_core::Transport;
-use libp2p_swarm::{keep_alive, Swarm, SwarmEvent};
+use libp2p_swarm::{keep_alive, Swarm, SwarmBuilder, SwarmEvent};
 
 #[tokio::test]
 async fn can_establish_connection() {
@@ -64,9 +64,10 @@ fn make_swarm() -> Swarm<keep_alive::Behaviour> {
         .multiplex(libp2p_yamux::YamuxConfig::default())
         .boxed();
 
-    Swarm::without_executor(
+    SwarmBuilder::without_executor(
         transport,
         keep_alive::Behaviour,
         identity.public().to_peer_id(),
     )
+    .build()
 }

--- a/transports/webrtc/examples/listen_ping.rs
+++ b/transports/webrtc/examples/listen_ping.rs
@@ -4,7 +4,7 @@ use libp2p_core::muxing::StreamMuxerBox;
 use libp2p_core::Transport;
 use libp2p_identity as identity;
 use libp2p_ping as ping;
-use libp2p_swarm::{keep_alive, NetworkBehaviour, Swarm};
+use libp2p_swarm::{keep_alive, NetworkBehaviour, Swarm, SwarmBuilder};
 use rand::thread_rng;
 use void::Void;
 
@@ -33,11 +33,7 @@ fn create_swarm() -> Result<Swarm<Behaviour>> {
         .map(|(peer_id, conn), _| (peer_id, StreamMuxerBox::new(conn)))
         .boxed();
 
-    Ok(Swarm::with_tokio_executor(
-        transport,
-        Behaviour::default(),
-        peer_id,
-    ))
+    Ok(SwarmBuilder::with_tokio_executor(transport, Behaviour::default(), peer_id).build())
 }
 
 #[derive(NetworkBehaviour, Default)]


### PR DESCRIPTION
## Description

Mark constructors `Swarm::with_X_executor` as deprecated.
Move the deprecated functionality to `SwarmBuilder::with_X_executor`
Use `SwarmBuilder` throughout.

Resolves #3186.
Resolves #3107.

## Notes
The main file to audit is https://github.com/libp2p/rust-libp2p/pull/3588/files#diff-7d75430c06d5d5aeba4229b6535d2b56f4e67809ffdac99d2dec8eb8a81b3c5c.
The rest contain changes related to the API change.

## Change checklist

Changelog is to be updated after the tech side is settled.

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
