### PR TITLE
docs(release): Skip unused `cargo release` steps

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -27,8 +27,11 @@ documentation will refer to `X.Y.Z` as _major_, _minor_ and _patch_ version.
    `CHANGELOG.md`. Create a pull request with the changes against the
    rust-libp2p `master` branch.
 
-2. Once merged, run `cargo release publish --execute` and `cargo release tag --sign-tag --execute`
-   on the (squash-) merged commit on the `master` branch.
+2. Once merged, run the two commands below on the (squash-) merged commit on the `master` branch.
+
+    1. `cargo release publish --execute`
+
+    2. `cargo release tag --sign-tag --execute`
 
 3. Confirm that `cargo release` tagged the commit correctly via `git push
    $YOUR_ORIGIN --tag --dry-run` and then push the new tags via `git push

--- a/docs/release.md
+++ b/docs/release.md
@@ -27,7 +27,7 @@ documentation will refer to `X.Y.Z` as _major_, _minor_ and _patch_ version.
    `CHANGELOG.md`. Create a pull request with the changes against the
    rust-libp2p `master` branch.
 
-2. Once merged, run `cargo release --workspace --sign-tag --no-push --execute`
+2. Once merged, run `cargo release publish --execute` and `cargo release tag --sign-tag --execute`
    on the (squash-) merged commit on the `master` branch.
 
 3. Confirm that `cargo release` tagged the commit correctly via `git push


### PR DESCRIPTION
## Description

`cargo release` provides multiple steps:
- changes
- version
- replace
- hook
- commit
- publish
- owner
- tag
- push
- config
- help

We only make use of `publish` and `tag`. We explicitly don't want `cargo release` to do `version` or `commit`.

Update the release docs accordingly, namely replace the generic `cargo release` with a two step process `cargo release publish` and `cargo release tag`.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
