### PR TITLE
feat: derive `Clone` for `mdns::Event`

### DIFF
--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.43.1 [unreleased]
 
-- Deriving `Clone` for `mdns::Event`. See [PR 3606].
+- Derive `Clone` for `mdns::Event`. See [PR 3606].
 
 [PR 3606]: https://github.com/libp2p/rust-libp2p/pull/3606
 # 0.43.0

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.43.1 [unreleased]
+
+- Deriving `Clone` for `mdns::Event`. See [PR 3606].
+
 # 0.43.0
 
 - Update to `libp2p-core` `v0.39.0`.

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Deriving `Clone` for `mdns::Event`. See [PR 3606].
 
+[PR 3606]: https://github.com/libp2p/rust-libp2p/pull/3606
 # 0.43.0
 
 - Update to `libp2p-core` `v0.39.0`.

--- a/protocols/mdns/src/behaviour.rs
+++ b/protocols/mdns/src/behaviour.rs
@@ -339,7 +339,7 @@ where
 }
 
 /// Event that can be produced by the `Mdns` behaviour.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Event {
     /// Discovered nodes through mDNS.
     Discovered(DiscoveredAddrsIter),
@@ -352,6 +352,7 @@ pub enum Event {
 }
 
 /// Iterator that produces the list of addresses that have been discovered.
+#[derive(Clone)]
 pub struct DiscoveredAddrsIter {
     inner: smallvec::IntoIter<[(PeerId, Multiaddr); 4]>,
 }
@@ -379,6 +380,7 @@ impl fmt::Debug for DiscoveredAddrsIter {
 }
 
 /// Iterator that produces the list of addresses that have expired.
+#[derive(Clone)]
 pub struct ExpiredAddrsIter {
     inner: smallvec::IntoIter<[(PeerId, Multiaddr); 4]>,
 }


### PR DESCRIPTION
## Description

Derive trait `Clone` for `mdns::Event`. This makes cloning its contents without destroying type information possible.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

Related #3593.

## Notes & open questions

CHANGELOG to be filled. Should we open a new minor version for the change?

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
