### PR TITLE
ci(mergify): only report conflicts on draft PRs with a milestone

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -36,7 +36,6 @@ pull_request_rules:
       - label=send-it
       - author!=@libp2p/rust-libp2p-maintainers
       - author!=dependabot[bot]
-
     actions:
       dismiss_reviews:
         message: Approvals have been dismissed because the PR was updated after the `send-it` label was applied.

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,8 +15,8 @@ pull_request_rules:
       - conflict
       - -author=dependabot[bot]
       - or:
-        - -draft
-        - and:
+        - -draft # Don't report conflicts on regular draft.
+        - and: # Do report conflicts on draft that are scheduled for the next major release.
           - draft
           - milestone~=v[0-9]\.[0-9]{2}
     actions:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -14,6 +14,11 @@ pull_request_rules:
     conditions:
       - conflict
       - -author=dependabot[bot]
+      - or:
+        - -draft
+        - and:
+          - draft
+          - milestone~=v[0-9]\.[0-9]{2}
     actions:
       comment:
         message: This pull request has merge conflicts. Could you please resolve them @{{author}}? 🙏
@@ -31,6 +36,7 @@ pull_request_rules:
       - label=send-it
       - author!=@libp2p/rust-libp2p-maintainers
       - author!=dependabot[bot]
+
     actions:
       dismiss_reviews:
         message: Approvals have been dismissed because the PR was updated after the `send-it` label was applied.


### PR DESCRIPTION
## Description

This is an evolution of the idea in https://github.com/libp2p/rust-libp2p/pull/3614 that should be closer to what we want. Not sure why I didn't think of this in the first place.