### PR TITLE
feat(swarm): downgrade connection limits warning from warn to debug

### DIFF
--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1107,7 +1107,7 @@ where
                                 error: &error,
                                 connection_id,
                             }));
-                        log::warn!("Incoming connection rejected: {:?}", connection_limit);
+                        log::debug!("Incoming connection rejected: {:?}", connection_limit);
                     }
                 };
             }


### PR DESCRIPTION
## Description

This tiny PR contains a proposed change for the warning related to the exceeded pending incoming connections limit. This warning can't be controlled and causes user confusion. It contains useful technical info but IMHO should be downgraded from `warn` to `debug`.

## Tasks

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
