### PR TITLE
fix(quic): Downgrade driver shutdown log line from info to debug

### DIFF
--- a/transports/quic/src/endpoint.rs
+++ b/transports/quic/src/endpoint.rs
@@ -471,7 +471,7 @@ impl<P: Provider> Driver<P> {
                 if is_drained_event {
                     self.alive_connections.remove(&connection_id);
                     if self.is_decoupled && self.alive_connections.is_empty() {
-                        log::info!(
+                        log::debug!(
                             "Driver is decoupled and no active connections remain. Shutting down."
                         );
                         return ControlFlow::Break(());


### PR DESCRIPTION
## Description

No need to inform the user each time the quic socket driver is shutting down.


## Notes & open questions

@thomaseizinger let me know in case you would like to see a changelog entry.

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
