### PR TITLE
ci(semver-checks): upgrade to cargo semver-checks v0.19.0

### DIFF
--- a/.github/actions/cargo-semver-checks/action.yml
+++ b/.github/actions/cargo-semver-checks/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: wget -q -O- https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v0.18.3/cargo-semver-checks-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C ~/.cargo/bin
+    - run: wget -q -O- https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v0.19.0/cargo-semver-checks-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C ~/.cargo/bin
       shell: bash
 
     - name: Get released version


### PR DESCRIPTION
## Description

cargo-semver-checks v0.19.0 contains two new lints and a bugfix for the stale caches issue.
https://github.com/obi1kenobi/cargo-semver-checks/releases/v0.19.0/

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
