### PR TITLE
fix(libp2p): export perf protocol

### DIFF
--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -11,9 +11,13 @@
 - Introduce `libp2p::allow_block_list` module and deprecate `libp2p::Swarm::ban_peer_id`.
   See [PR 3590].
 
+- Introduce `libp2p::perf` module.
+  See [PR XXX].
+
 [PR 3386]: https://github.com/libp2p/rust-libp2p/pull/3386
 [PR 3580]: https://github.com/libp2p/rust-libp2p/pull/3580
 [PR 3590]: https://github.com/libp2p/rust-libp2p/pull/3590
+[PR XXX]: https://github.com/libp2p/rust-libp2p/pull/XXX
 
 # 0.51.1
 

--- a/libp2p/src/lib.rs
+++ b/libp2p/src/lib.rs
@@ -89,6 +89,8 @@ pub use libp2p_mplex as mplex;
 #[doc(inline)]
 pub use libp2p_noise as noise;
 #[cfg(feature = "perf")]
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "perf")))]
 #[doc(inline)]
 pub use libp2p_perf as perf;
 #[cfg(feature = "ping")]

--- a/libp2p/src/lib.rs
+++ b/libp2p/src/lib.rs
@@ -88,6 +88,9 @@ pub use libp2p_mplex as mplex;
 #[cfg(feature = "noise")]
 #[doc(inline)]
 pub use libp2p_noise as noise;
+#[cfg(feature = "perf")]
+#[doc(inline)]
+pub use libp2p_perf as perf;
 #[cfg(feature = "ping")]
 #[doc(inline)]
 pub use libp2p_ping as ping;


### PR DESCRIPTION
## Description

As we do with all other protocols, make sure to expose `libp2p-perf` as well.

Related: https://github.com/libp2p/rust-libp2p/pull/3508#discussion_r1125546920.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
