### PR TITLE
chore: prepare `libp2p` `v0.51.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,7 +2492,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "async-io",
  "async-std",

--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.52.2 - unreleased
+# 0.52.2
 
 - Introduce `libp2p::connection_limits` module.
   See [PR 3386].

--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -12,12 +12,12 @@
   See [PR 3590].
 
 - Introduce `libp2p::perf` module.
-  See [PR XXX].
+  See [PR 3693].
 
 [PR 3386]: https://github.com/libp2p/rust-libp2p/pull/3386
 [PR 3580]: https://github.com/libp2p/rust-libp2p/pull/3580
 [PR 3590]: https://github.com/libp2p/rust-libp2p/pull/3590
-[PR XXX]: https://github.com/libp2p/rust-libp2p/pull/XXX
+[PR 3693]: https://github.com/libp2p/rust-libp2p/pull/3693
 
 # 0.51.1
 

--- a/misc/allow-block-list/CHANGELOG.md
+++ b/misc/allow-block-list/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 0.1.0 - unreleased
+# 0.1.0
 
 - Initial release.

--- a/misc/connection-limits/CHANGELOG.md
+++ b/misc/connection-limits/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 0.1.0 - unreleased
+# 0.1.0
 
 - Initial release.

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.44.2 - unreleased
+# 0.44.2
 
 - Signed messages now use sequential integers in the sequence number field.
   See [PR 3551].

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.43.1 [unreleased]
+# 0.43.1
 
 - Derive `Clone` for `mdns::Event`. See [PR 3606].
 

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-mdns"
 edition = "2021"
 rust-version = "1.62.0"
-version = "0.43.0"
+version = "0.43.1"
 description = "Implementation of the libp2p mDNS discovery method"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"

--- a/protocols/perf/CHANGELOG.md
+++ b/protocols/perf/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 0.1.0 - unreleased
+# 0.1.0
 
 - Initial release.

--- a/swarm-test/CHANGELOG.md
+++ b/swarm-test/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 0.1.0 - unreleased
+# 0.1.0
 
 - Initial release.

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.42.1 - unreleased
+# 0.42.1
 
 - Deprecate `ConnectionLimits` in favor of `libp2p::connection_limits`.
   See [PR 3386].
@@ -12,12 +12,12 @@
 - Rename `NetworkBehaviourAction` to `ToSwarm`.
   A deprecated type-alias is provided to ease the transition.
   The new name is meant to better indicate the message-passing relationship between `Swarm` and `NetworkBehaviour`.
-  See [PR XXXX].
+  See [PR 3658].
 
 [PR 3386]: https://github.com/libp2p/rust-libp2p/pull/3386
 [PR 3652]: https://github.com/libp2p/rust-libp2p/pull/3652
 [PR 3590]: https://github.com/libp2p/rust-libp2p/pull/3590
-[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
+[PR 3658]: https://github.com/libp2p/rust-libp2p/pull/3658
 
 # 0.42.0
 

--- a/transports/webrtc/CHANGELOG.md
+++ b/transports/webrtc/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.4.0-alpha.4 - unreleased
+# 0.4.0-alpha.4
 
 - Make `Fingerprint` type public. See [PR 3648].
 


### PR DESCRIPTION
## Description

Depends-On: #3693.

## Notes & open questions

Unblocks @melekes. See https://github.com/libp2p/rust-libp2p/pull/3652#issuecomment-1485414961

Targets `master`. I will fast forward `v0.51` branch once this pull request is merged and release from `v0.51`.

I would like to include https://github.com/libp2p/rust-libp2p/pull/3693 first.

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
