### PR TITLE
refactor(gossipsub): use `pop` instead of `remove`

### DIFF
--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -450,16 +450,16 @@ impl ConnectionHandler for Handler {
             ) {
                 // outbound idle state
                 Some(OutboundSubstreamState::WaitingOutput(substream)) => {
-                    if !self.send_queue.is_empty() {
-                        let message = self.send_queue.remove(0);
+                    if let Some(message) = self.send_queue.pop() {
                         self.send_queue.shrink_to_fit();
                         self.outbound_substream =
                             Some(OutboundSubstreamState::PendingSend(substream, message));
-                    } else {
-                        self.outbound_substream =
-                            Some(OutboundSubstreamState::WaitingOutput(substream));
-                        break;
+                        continue;
                     }
+
+                    self.outbound_substream =
+                        Some(OutboundSubstreamState::WaitingOutput(substream));
+                    break;
                 }
                 Some(OutboundSubstreamState::PendingSend(mut substream, message)) => {
                     match Sink::poll_ready(Pin::new(&mut substream), cx) {


### PR DESCRIPTION
## Description

Doesn't change any functionality but `pop` returns an `Option` whereas `remove` will panic on out-of-bounds. I am more comfortable with `pop` and a pattern match. Also, usage of `continue` allows us to not use an `else`.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
