### PR TITLE
chore: prepare v0.51.3

### DIFF
--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.51.3 - unreleased
+## 0.51.3
 
 - Deprecate the `mplex` feature.
 The recommended baseline stream multiplexer is `yamux`.

--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.2 - unreleased
+## 0.10.2
 
 - Store server `PeerId`s in `HashSet` to avoid duplicates and lower memory consumption.
   See [PR 3736].

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.44.3 - unreleased
+## 0.44.3
 
 - Fix erroneously duplicate message IDs. See [PR 3716].
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.43.2 - unreleased
+## 0.43.2
 
 - Export pub enum `RoutingUpdate`. See [PR 3739].
 - Deprecate `handler`, `kbucket`, `protocol`, `record` modules to make them private. See [PR 3738].

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.15.2 - unreleased
+## 0.15.2
 
 - Send correct `PeerId` in outbound STOP message to client.
   See [PR 3767].


### PR DESCRIPTION
## Description

## Notes & open questions

Most pressing I would like to get https://github.com/libp2p/rust-libp2p/pull/3767, https://github.com/libp2p/rust-libp2p/pull/3765 and https://github.com/libp2p/rust-libp2p/pull/3716 out there.