### PR TITLE
fix(relay): ensure stable `connect` test

### DIFF
--- a/protocols/relay/tests/lib.rs
+++ b/protocols/relay/tests/lib.rs
@@ -210,12 +210,16 @@ fn connect() {
     src.dial(dst_addr).unwrap();
 
     pool.run_until(futures::future::join(
-        connection_established_to(src, relay_peer_id, dst_peer_id),
-        connection_established_to(dst, relay_peer_id, src_peer_id),
+        connection_established_to(&mut src, relay_peer_id, dst_peer_id),
+        connection_established_to(&mut dst, relay_peer_id, src_peer_id),
     ));
 }
 
-async fn connection_established_to(mut swarm: Swarm<Client>, relay_peer_id: PeerId, other: PeerId) {
+async fn connection_established_to(
+    swarm: &mut Swarm<Client>,
+    relay_peer_id: PeerId,
+    other: PeerId,
+) {
     loop {
         match swarm.select_next_some().await {
             SwarmEvent::Dialing(peer_id) if peer_id == relay_peer_id => {}


### PR DESCRIPTION
## Description

With the changes from #3767, we made the `connect` test flaky because the `Swarm` was fully passed to the future and thus dropped as soon as the connection was established. We pass a mutable reference instead which keeps the `Swarm` alive.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
