### PR TITLE
fix(interop): use `webrtc-direct` as browser-to-server identifier

### DIFF
--- a/interop-tests/ping-version.json
+++ b/interop-tests/ping-version.json
@@ -5,7 +5,7 @@
     "ws",
     "tcp",
     "quic-v1",
-    "webrtc"
+    "webrtc-direct"
   ],
   "secureChannels": [
     "tls",

--- a/interop-tests/src/bin/ping.rs
+++ b/interop-tests/src/bin/ping.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<()> {
                 .boxed(),
             format!("/ip4/{ip}/tcp/0/ws"),
         ),
-        Transport::Webrtc => (
+        Transport::WebRtcDirect => (
             webrtc::tokio::Transport::new(
                 local_key,
                 webrtc::tokio::Certificate::generate(&mut rand::thread_rng())?,
@@ -213,7 +213,7 @@ fn muxer_protocol_from_env() -> Result<Either<yamux::YamuxConfig, mplex::MplexCo
 pub enum Transport {
     Tcp,
     QuicV1,
-    Webrtc,
+    WebRtcDirect,
     Ws,
 }
 
@@ -224,7 +224,7 @@ impl FromStr for Transport {
         Ok(match s {
             "tcp" => Self::Tcp,
             "quic-v1" => Self::QuicV1,
-            "webrtc" => Self::Webrtc,
+            "webrtc-direct" => Self::WebRtcDirect,
             "ws" => Self::Ws,
             other => bail!("unknown transport {other}"),
         })


### PR DESCRIPTION
## Description

See https://github.com/multiformats/multiaddr/pull/150#issuecomment-1468791586 for context on the rename.

## Notes & open questions

I need to do the corresponding changes in https://github.com/libp2p/test-plans/. Draft here for now.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
