### PR TITLE
fix(examples): enable mplex feature for libp2p dep

### DIFF
--- a/examples/distributed-key-value-store/Cargo.toml
+++ b/examples/distributed-key-value-store/Cargo.toml
@@ -10,5 +10,5 @@ async-std = { version = "1.12", features = ["attributes"] }
 async-trait = "0.1"
 env_logger = "0.10"
 futures = "0.3.28"
-libp2p = { path = "../../libp2p", features = ["async-std", "dns", "kad", "mdns", "noise", "macros", "tcp", "websocket", "yamux"] }
+libp2p = { path = "../../libp2p", features = ["async-std", "dns", "kad", "mdns", "noise", "macros", "tcp", "websocket", "yamux", "mplex"] }
 multiaddr = { version = "0.17.1" }

--- a/examples/file-sharing/Cargo.toml
+++ b/examples/file-sharing/Cargo.toml
@@ -12,5 +12,5 @@ clap = { version = "4.2.1", features = ["derive"] }
 either = "1.8"
 env_logger = "0.10"
 futures = "0.3.28"
-libp2p = { path = "../../libp2p", features = ["async-std", "dns", "kad", "noise", "macros", "request-response", "tcp", "websocket", "yamux"] }
+libp2p = { path = "../../libp2p", features = ["async-std", "dns", "kad", "noise", "macros", "request-response", "tcp", "websocket", "yamux", "mplex"] }
 multiaddr = { version = "0.17.1" }

--- a/examples/ipfs-kad/Cargo.toml
+++ b/examples/ipfs-kad/Cargo.toml
@@ -10,4 +10,4 @@ async-std = { version = "1.12", features = ["attributes"] }
 async-trait = "0.1"
 env_logger = "0.10"
 futures = "0.3.28"
-libp2p = { path = "../../libp2p", features = ["async-std", "dns", "kad", "mplex", "noise", "tcp", "websocket", "yamux"] }
+libp2p = { path = "../../libp2p", features = ["async-std", "dns", "kad", "mplex", "noise", "tcp", "websocket", "yamux", "mpex"] }

--- a/examples/ipfs-kad/Cargo.toml
+++ b/examples/ipfs-kad/Cargo.toml
@@ -10,4 +10,4 @@ async-std = { version = "1.12", features = ["attributes"] }
 async-trait = "0.1"
 env_logger = "0.10"
 futures = "0.3.28"
-libp2p = { path = "../../libp2p", features = ["async-std", "dns", "kad", "mplex", "noise", "tcp", "websocket", "yamux", "mpex"] }
+libp2p = { path = "../../libp2p", features = ["async-std", "dns", "kad", "mplex", "noise", "tcp", "websocket", "yamux", "mplex"] }

--- a/examples/ping-example/Cargo.toml
+++ b/examples/ping-example/Cargo.toml
@@ -9,5 +9,5 @@ license = "MIT"
 async-std = { version = "1.12", features = ["attributes"] }
 async-trait = "0.1"
 futures = "0.3.28"
-libp2p = { path = "../../libp2p", features = ["async-std", "dns", "macros", "noise", "ping", "tcp", "websocket", "yamux"] }
+libp2p = { path = "../../libp2p", features = ["async-std", "dns", "macros", "noise", "ping", "tcp", "websocket", "yamux", "mplex"] }
 multiaddr = { version = "0.17.1" }


### PR DESCRIPTION
## Description

Some rust-libp2p examples uses `development_transport(...)` that requires the `mplex` feature enabled. But, the `Cargo.toml`s of those examples don't enable the `mplex`.
This isn't an issue in this repo because those examples refer to the `libp2p` using `path = "../../libp2p"`, but if you try to rewrite those examples from scratch by referring to `libp2p = { version = "...", ...}`, the following error will occur:
```
error[E0432]: unresolved import `libp2p::development_transport`
```

## Notes & open questions 

I just enable the `mplex` feature for those examples.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
