### PR TITLE
fix(ci): ensure all examples compile with the specified feature-set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,28 @@ jobs:
       - name: Run ipfs-kad example
         run: cd ./examples/ipfs-kad/ && RUST_LOG=libp2p_swarm=debug,libp2p_kad=trace,libp2p_tcp=debug cargo run
 
+  examples:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: r7kamura/rust-problem-matchers@d58b70c4a13c4866d96436315da451d8106f8f08 #v1.3.0
+
+      - uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f # v2.2.1
+        with:
+          shared-key: stable-cache
+          save-if: false
+
+      - name: Compile all examples
+        run: |
+          set -e;
+
+          for toml in examples/**/Cargo.toml; do
+            cargo check --manifest-path "$toml";
+          done
+
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/examples/autonat/src/bin/autonat_client.rs
+++ b/examples/autonat/src/bin/autonat_client.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("Local peer id: {local_peer_id:?}");
 
     let transport = tcp::async_io::Transport::default()
-        .upgrade(Version::V1)
+        .upgrade(Version::V1Lazy)
         .authenticate(noise::NoiseAuthenticated::xx(&local_key)?)
         .multiplex(yamux::YamuxConfig::default())
         .boxed();

--- a/examples/autonat/src/bin/autonat_server.rs
+++ b/examples/autonat/src/bin/autonat_server.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("Local peer id: {local_peer_id:?}");
 
     let transport = tcp::async_io::Transport::default()
-        .upgrade(Version::V1)
+        .upgrade(Version::V1Lazy)
         .authenticate(noise::NoiseAuthenticated::xx(&local_key)?)
         .multiplex(yamux::YamuxConfig::default())
         .boxed();

--- a/examples/chat-example/src/main.rs
+++ b/examples/chat-example/src/main.rs
@@ -76,7 +76,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Set up an encrypted DNS-enabled TCP Transport over the Mplex protocol.
     let tcp_transport = tcp::async_io::Transport::new(tcp::Config::default().nodelay(true))
-        .upgrade(upgrade::Version::V1)
+        .upgrade(upgrade::Version::V1Lazy)
         .authenticate(
             noise::NoiseAuthenticated::xx(&id_keys).expect("signing libp2p-noise static keypair"),
         )

--- a/examples/dcutr/src/main.rs
+++ b/examples/dcutr/src/main.rs
@@ -96,7 +96,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         )))
         .unwrap(),
     )
-    .upgrade(upgrade::Version::V1)
+    .upgrade(upgrade::Version::V1Lazy)
     .authenticate(
         noise::NoiseAuthenticated::xx(&local_key)
             .expect("Signing libp2p-noise static DH keypair failed."),

--- a/examples/distributed-key-value-store/src/main.rs
+++ b/examples/distributed-key-value-store/src/main.rs
@@ -42,15 +42,16 @@
 
 use async_std::io;
 use futures::{prelude::*, select};
+use libp2p::core::upgrade::Version;
 use libp2p::kad::record::store::MemoryStore;
 use libp2p::kad::{
     record::Key, AddProviderOk, GetProvidersOk, GetRecordOk, Kademlia, KademliaEvent, PeerRecord,
     PutRecordOk, QueryResult, Quorum, Record,
 };
 use libp2p::{
-    development_transport, identity, mdns,
+    identity, mdns, noise,
     swarm::{NetworkBehaviour, SwarmBuilder, SwarmEvent},
-    PeerId,
+    tcp, yamux, PeerId, Transport,
 };
 use std::error::Error;
 
@@ -62,8 +63,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let local_key = identity::Keypair::generate_ed25519();
     let local_peer_id = PeerId::from(local_key.public());
 
-    // Set up a an encrypted DNS-enabled TCP Transport over the Mplex protocol.
-    let transport = development_transport(local_key).await?;
+    let transport = tcp::async_io::Transport::default()
+        .upgrade(Version::V1Lazy)
+        .authenticate(noise::NoiseAuthenticated::xx(&local_key)?)
+        .multiplex(yamux::YamuxConfig::default())
+        .boxed();
 
     // We create a custom network behaviour that combines Kademlia and mDNS.
     #[derive(NetworkBehaviour)]

--- a/examples/identify/src/main.rs
+++ b/examples/identify/src/main.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("Local peer id: {local_peer_id:?}");
 
     let transport = tcp::async_io::Transport::default()
-        .upgrade(Version::V1)
+        .upgrade(Version::V1Lazy)
         .authenticate(noise::NoiseAuthenticated::xx(&local_key).unwrap())
         .multiplex(yamux::YamuxConfig::default())
         .boxed();

--- a/examples/ipfs-private/src/main.rs
+++ b/examples/ipfs-private/src/main.rs
@@ -63,7 +63,7 @@ pub fn build_transport(
         None => Either::Right(base_transport),
     };
     maybe_encrypted
-        .upgrade(Version::V1)
+        .upgrade(Version::V1Lazy)
         .authenticate(noise_config)
         .multiplex(yamux_config)
         .timeout(Duration::from_secs(20))

--- a/examples/metrics/src/main.rs
+++ b/examples/metrics/src/main.rs
@@ -73,7 +73,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut swarm = SwarmBuilder::without_executor(
         tcp::async_io::Transport::default()
-            .upgrade(Version::V1)
+            .upgrade(Version::V1Lazy)
             .authenticate(noise::NoiseAuthenticated::xx(&local_key)?)
             .multiplex(yamux::YamuxConfig::default())
             .boxed(),

--- a/examples/ping-example/src/main.rs
+++ b/examples/ping-example/src/main.rs
@@ -41,10 +41,11 @@
 //! and begin pinging each other.
 
 use futures::prelude::*;
+use libp2p::core::upgrade::Version;
 use libp2p::{
-    identity, ping,
+    identity, noise, ping,
     swarm::{keep_alive, NetworkBehaviour, SwarmBuilder, SwarmEvent},
-    Multiaddr, PeerId,
+    tcp, yamux, Multiaddr, PeerId, Transport,
 };
 use std::error::Error;
 
@@ -54,7 +55,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let local_peer_id = PeerId::from(local_key.public());
     println!("Local peer id: {local_peer_id:?}");
 
-    let transport = libp2p::development_transport(local_key).await?;
+    let transport = tcp::async_io::Transport::default()
+        .upgrade(Version::V1Lazy)
+        .authenticate(noise::NoiseAuthenticated::xx(&local_key)?)
+        .multiplex(yamux::YamuxConfig::default())
+        .boxed();
 
     let mut swarm =
         SwarmBuilder::with_async_std_executor(transport, Behaviour::default(), local_peer_id)

--- a/examples/relay-server/src/main.rs
+++ b/examples/relay-server/src/main.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let tcp_transport = tcp::async_io::Transport::default();
 
     let transport = tcp_transport
-        .upgrade(upgrade::Version::V1)
+        .upgrade(upgrade::Version::V1Lazy)
         .authenticate(
             noise::NoiseAuthenticated::xx(&local_key)
                 .expect("Signing libp2p-noise static DH keypair failed."),

--- a/examples/rendezvous/src/bin/rzv-discover.rs
+++ b/examples/rendezvous/src/bin/rzv-discover.rs
@@ -43,7 +43,7 @@ async fn main() {
 
     let mut swarm = SwarmBuilder::with_tokio_executor(
         tcp::tokio::Transport::default()
-            .upgrade(Version::V1)
+            .upgrade(Version::V1Lazy)
             .authenticate(noise::NoiseAuthenticated::xx(&key_pair).unwrap())
             .multiplex(yamux::YamuxConfig::default())
             .boxed(),

--- a/examples/rendezvous/src/bin/rzv-identify.rs
+++ b/examples/rendezvous/src/bin/rzv-identify.rs
@@ -39,7 +39,7 @@ async fn main() {
 
     let mut swarm = SwarmBuilder::with_tokio_executor(
         tcp::tokio::Transport::default()
-            .upgrade(Version::V1)
+            .upgrade(Version::V1Lazy)
             .authenticate(noise::NoiseAuthenticated::xx(&key_pair).unwrap())
             .multiplex(yamux::YamuxConfig::default())
             .boxed(),

--- a/examples/rendezvous/src/bin/rzv-register.rs
+++ b/examples/rendezvous/src/bin/rzv-register.rs
@@ -39,7 +39,7 @@ async fn main() {
 
     let mut swarm = SwarmBuilder::with_tokio_executor(
         tcp::tokio::Transport::default()
-            .upgrade(Version::V1)
+            .upgrade(Version::V1Lazy)
             .authenticate(noise::NoiseAuthenticated::xx(&key_pair).unwrap())
             .multiplex(yamux::YamuxConfig::default())
             .boxed(),

--- a/examples/rendezvous/src/main.rs
+++ b/examples/rendezvous/src/main.rs
@@ -53,7 +53,7 @@ async fn main() {
 
     let mut swarm = SwarmBuilder::with_tokio_executor(
         tcp::tokio::Transport::default()
-            .upgrade(Version::V1)
+            .upgrade(Version::V1Lazy)
             .authenticate(noise::NoiseAuthenticated::xx(&key_pair).unwrap())
             .multiplex(yamux::YamuxConfig::default())
             .boxed(),


### PR DESCRIPTION
## Description

Due to cargo's feature unification, a full build of our workspace doesn't actually check whether the examples compile as standalone projects.

We add a new CI check that iterates through all crates in the `examples/` directory and runs a plain `cargo check` on them. Any failure is bubbled up via `set -e`, thus failing CI in case one of the `cargo check` commands fails.

To fix the current failures, we construct a simple TCP transport everywhere where we were previously using `development_transport`. That is because `development_transport` requires `mplex` which is now deprecated.

Related #3657.
Related #3809.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Open tasks

- [ ] Open a GitHub mgmt repository PR to make this mandatory once it is merged.

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
