### PR TITLE
feat(tcp): make send & recv buffer sizes configurable

### DIFF
--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- Allow setting send and receive buffer sizes for the TCP socket. See [PR 3818]
+
+[PR 3818]: https://github.com/libp2p/rust-libp2p/pull/3818
+
 ## 0.39.0
 
 - Update to `libp2p-core` `v0.39.0`.


### PR DESCRIPTION
Rebase of #2019, but only the parts concerning the send/receive buffer settings.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
