### PR TITLE
fix(docs): correct link to chat-example in examples readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ A set of examples showcasing how to use rust-libp2p.
 
 ## Individual libp2p features
 
-- [Chat](./autonat) A basic chat application demonstrating libp2p and the mDNS and Gossipsub protocols.
+- [Chat](./chat-example) A basic chat application demonstrating libp2p and the mDNS and Gossipsub protocols.
 - [Distributed key-value store](./distributed-key-value-store) A basic key value store demonstrating libp2p and the mDNS and Kademlia protocol.
 
 - [File sharing application](./file-sharing) Basic file sharing application with peers either providing or locating and getting files by name.


### PR DESCRIPTION
## Description

Resolves #3830.

## Notes & open questions

Should the examples also point to the others and perhaps detail them?

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
