### PR TITLE
ci(mergify): automatically approve PRs from maintainers

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -41,6 +41,13 @@ pull_request_rules:
         message: Approvals have been dismissed because the PR was updated after the `send-it` label was applied.
         changes_requested: false
 
+  - name: Approve maintainer PRs
+    conditions:
+      - base=master
+      - author=@libp2p/rust-libp2p-maintainers
+    actions:
+      review:
+
 queue_rules:
   - name: default
     conditions: []

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -41,9 +41,10 @@ pull_request_rules:
         message: Approvals have been dismissed because the PR was updated after the `send-it` label was applied.
         changes_requested: false
 
-  - name: Approve maintainer PRs
+  - name: Approve trivial maintainer PRs
     conditions:
       - base=master
+      - label=trivial
       - author=@libp2p/rust-libp2p-maintainers
     actions:
       review:


### PR DESCRIPTION
## Description

We have a limit of 1 approval for each PR in order to go into the merge queue. To make life for us maintainers easier, we configure mergify to approve our and only our PRs. This allows a single maintainer to land small PRs without having to ping another maintainer.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
