### PR TITLE
fix(gossipsub): always honor `support_floodsub` setting

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,8 +1,12 @@
 ## 0.44.4 - unreleased
 
 - Deprecate `metrics`, `protocol`, `subscription_filter`, `time_cache` modules to make them private. See [PR 3777].
+- Honor the `gossipsub::Config::support_floodsub` in all cases.
+  Previously, it was ignored when a custom protocol id was set via `gossipsub::Config::protocol_id`.
+  See [PR XXXX].
 
 [PR 3777]: https://github.com/libp2p/rust-libp2p/pull/3777
+[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
 
 ## 0.44.3
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -3,10 +3,10 @@
 - Deprecate `metrics`, `protocol`, `subscription_filter`, `time_cache` modules to make them private. See [PR 3777].
 - Honor the `gossipsub::Config::support_floodsub` in all cases.
   Previously, it was ignored when a custom protocol id was set via `gossipsub::Config::protocol_id`.
-  See [PR XXXX].
+  See [PR 3837].
 
 [PR 3777]: https://github.com/libp2p/rust-libp2p/pull/3777
-[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
+[PR 3837]: https://github.com/libp2p/rust-libp2p/pull/3837
 
 ## 0.44.3
 

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -892,29 +892,6 @@ mod test {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
-    fn get_gossipsub_message() -> Message {
-        Message {
-            source: None,
-            data: vec![12, 34, 56],
-            sequence_number: None,
-            topic: Topic::<IdentityHash>::new("test").hash(),
-        }
-    }
-
-    fn get_expected_message_id() -> MessageId {
-        MessageId::from([
-            49, 55, 56, 51, 56, 52, 49, 51, 52, 51, 52, 55, 51, 51, 53, 52, 54, 54, 52, 49, 101,
-        ])
-    }
-
-    fn message_id_plain_function(message: &Message) -> MessageId {
-        let mut s = DefaultHasher::new();
-        message.data.hash(&mut s);
-        let mut v = s.finish().to_string();
-        v.push('e');
-        MessageId::from(v)
-    }
-
     #[test]
     fn create_config_with_message_id_as_plain_function() {
         let builder: Config = ConfigBuilder::default()
@@ -1003,5 +980,29 @@ mod test {
 
         assert_eq!(protocol_ids[0].protocol_id, b"purple".to_vec());
         assert_eq!(protocol_ids[0].kind, PeerKind::Gossipsub);
+    }
+
+
+    fn get_gossipsub_message() -> Message {
+        Message {
+            source: None,
+            data: vec![12, 34, 56],
+            sequence_number: None,
+            topic: Topic::<IdentityHash>::new("test").hash(),
+        }
+    }
+
+    fn get_expected_message_id() -> MessageId {
+        MessageId::from([
+            49, 55, 56, 51, 56, 52, 49, 51, 52, 51, 52, 55, 51, 51, 53, 52, 54, 54, 52, 49, 101,
+        ])
+    }
+
+    fn message_id_plain_function(message: &Message) -> MessageId {
+        let mut s = DefaultHasher::new();
+        message.data.hash(&mut s);
+        let mut v = s.finish().to_string();
+        v.push('e');
+        MessageId::from(v)
     }
 }

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -892,16 +892,6 @@ mod test {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
-    #[test]
-    fn create_thing() {
-        let builder: Config = ConfigBuilder::default()
-            .protocol_id_prefix("purple")
-            .build()
-            .unwrap();
-
-        dbg!(builder);
-    }
-
     fn get_gossipsub_message() -> Message {
         Message {
             source: None,

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -894,54 +894,51 @@ mod test {
 
     #[test]
     fn create_config_with_message_id_as_plain_function() {
-        let builder: Config = ConfigBuilder::default()
-            .protocol_id_prefix("purple")
+        let config = ConfigBuilder::default()
             .message_id_fn(message_id_plain_function)
             .build()
             .unwrap();
 
-        let result = builder.message_id(&get_gossipsub_message());
+        let result = config.message_id(&get_gossipsub_message());
+
         assert_eq!(result, get_expected_message_id());
     }
 
     #[test]
     fn create_config_with_message_id_as_closure() {
-        let closure = |message: &Message| {
-            let mut s = DefaultHasher::new();
-            message.data.hash(&mut s);
-            let mut v = s.finish().to_string();
-            v.push('e');
-            MessageId::from(v)
-        };
-
-        let builder: Config = ConfigBuilder::default()
-            .protocol_id_prefix("purple")
-            .message_id_fn(closure)
+        let config = ConfigBuilder::default()
+            .message_id_fn(|message: &Message| {
+                let mut s = DefaultHasher::new();
+                message.data.hash(&mut s);
+                let mut v = s.finish().to_string();
+                v.push('e');
+                MessageId::from(v)
+            })
             .build()
             .unwrap();
 
-        let result = builder.message_id(&get_gossipsub_message());
+        let result = config.message_id(&get_gossipsub_message());
+
         assert_eq!(result, get_expected_message_id());
     }
 
     #[test]
     fn create_config_with_message_id_as_closure_with_variable_capture() {
         let captured: char = 'e';
-        let closure = move |message: &Message| {
-            let mut s = DefaultHasher::new();
-            message.data.hash(&mut s);
-            let mut v = s.finish().to_string();
-            v.push(captured);
-            MessageId::from(v)
-        };
 
-        let builder: Config = ConfigBuilder::default()
-            .protocol_id_prefix("purple")
-            .message_id_fn(closure)
+        let config = ConfigBuilder::default()
+            .message_id_fn(move |message: &Message| {
+                let mut s = DefaultHasher::new();
+                message.data.hash(&mut s);
+                let mut v = s.finish().to_string();
+                v.push(captured);
+                MessageId::from(v)
+            })
             .build()
             .unwrap();
 
-        let result = builder.message_id(&get_gossipsub_message());
+        let result = config.message_id(&get_gossipsub_message());
+
         assert_eq!(result, get_expected_message_id());
     }
 
@@ -981,7 +978,6 @@ mod test {
         assert_eq!(protocol_ids[0].protocol_id, b"purple".to_vec());
         assert_eq!(protocol_ids[0].kind, PeerKind::Gossipsub);
     }
-
 
     fn get_gossipsub_message() -> Message {
         Message {

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -980,17 +980,13 @@ mod test {
 
     #[test]
     fn create_config_with_protocol_id_prefix() {
-        let builder: Config = ConfigBuilder::default()
-            .protocol_id_prefix("purple")
-            .validation_mode(ValidationMode::Anonymous)
-            .message_id_fn(message_id_plain_function)
-            .build()
-            .unwrap();
+        let protocol_config = ProtocolConfig::new(
+            &ConfigBuilder::default()
+                .protocol_id_prefix("purple")
+                .build()
+                .unwrap(),
+        );
 
-        assert_eq!(builder.protocol_id(), "purple");
-        assert_eq!(builder.custom_id_version(), &None);
-
-        let protocol_config = ProtocolConfig::new(&builder);
         let protocol_ids = protocol_config.protocol_info();
 
         assert_eq!(protocol_ids.len(), 2);
@@ -1004,17 +1000,13 @@ mod test {
 
     #[test]
     fn create_config_with_custom_protocol_id() {
-        let builder: Config = ConfigBuilder::default()
-            .protocol_id("purple", Version::V1_0)
-            .validation_mode(ValidationMode::Anonymous)
-            .message_id_fn(message_id_plain_function)
-            .build()
-            .unwrap();
+        let protocol_config = ProtocolConfig::new(
+            &ConfigBuilder::default()
+                .protocol_id("purple", Version::V1_0)
+                .build()
+                .unwrap(),
+        );
 
-        assert_eq!(builder.protocol_id(), "purple");
-        assert_eq!(builder.custom_id_version(), &Some(Version::V1_0));
-
-        let protocol_config = ProtocolConfig::new(&builder);
         let protocol_ids = protocol_config.protocol_info();
 
         assert_eq!(protocol_ids.len(), 1);

--- a/protocols/gossipsub/src/protocol_priv.rs
+++ b/protocols/gossipsub/src/protocol_priv.rs
@@ -57,7 +57,7 @@ impl ProtocolConfig {
     ///
     /// Sets the maximum gossip transmission size.
     pub fn new(gossipsub_config: &Config) -> ProtocolConfig {
-        let protocol_ids = match gossipsub_config.custom_id_version() {
+        let mut protocol_ids = match gossipsub_config.custom_id_version() {
             Some(v) => match v {
                 Version::V1_0 => vec![ProtocolId::new(
                     gossipsub_config.protocol_id(),
@@ -71,23 +71,21 @@ impl ProtocolConfig {
                 )],
             },
             None => {
-                let mut protocol_ids = vec![
+                vec![
                     ProtocolId::new(
                         gossipsub_config.protocol_id(),
                         PeerKind::Gossipsubv1_1,
                         true,
                     ),
                     ProtocolId::new(gossipsub_config.protocol_id(), PeerKind::Gossipsub, true),
-                ];
-
-                // add floodsub support if enabled.
-                if gossipsub_config.support_floodsub() {
-                    protocol_ids.push(ProtocolId::new("", PeerKind::Floodsub, false));
-                }
-
-                protocol_ids
+                ]
             }
         };
+
+        // add floodsub support if enabled.
+        if gossipsub_config.support_floodsub() {
+            protocol_ids.push(ProtocolId::new("", PeerKind::Floodsub, false));
+        }
 
         ProtocolConfig {
             protocol_ids,

--- a/protocols/gossipsub/src/protocol_priv.rs
+++ b/protocols/gossipsub/src/protocol_priv.rs
@@ -556,8 +556,8 @@ impl Decoder for GossipsubCodec {
 mod tests {
     use super::*;
     use crate::config::Config;
-    use crate::Behaviour;
     use crate::IdentTopic as Topic;
+    use crate::{Behaviour, ConfigBuilder};
     use libp2p_core::identity::Keypair;
     use quickcheck_ext::*;
 
@@ -652,5 +652,25 @@ mod tests {
         }
 
         QuickCheck::new().quickcheck(prop as fn(_) -> _)
+    }
+
+    #[test]
+    fn support_floodsub_with_custom_protocol() {
+        let gossipsub_config = ConfigBuilder::default()
+            .protocol_id("/foosub", Version::V1_1)
+            .support_floodsub()
+            .build()
+            .unwrap();
+
+        let protocol_config = ProtocolConfig::new(&gossipsub_config);
+
+        assert_eq!(
+            String::from_utf8_lossy(&protocol_config.protocol_ids[0].protocol_id),
+            "/foosub"
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&protocol_config.protocol_ids[1].protocol_id),
+            "/floodsub/1.0.0"
+        );
     }
 }


### PR DESCRIPTION
## Description

Previously, we only honored the `support_floodsub` setting when the user did not specify a custom protocol for gossipsub. This patch fixes this and allows users to advertise floodsub even when they use a custom protocol.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

cc @AgeManning I believe this is an oversight. Let me know in case this was intentional. I don't see a reason why we should silently ignore this setting when using a custom protocol identifier.

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
