### PR TITLE
ci: disable cache in semver-checks

### DIFF
--- a/.github/actions/cargo-semver-checks/action.yml
+++ b/.github/actions/cargo-semver-checks/action.yml
@@ -22,11 +22,6 @@ runs:
         rustc --version | tee .rustc-version
         cargo semver-checks --version | tee .semver-checks-version
 
-    - uses: actions/cache@v3
-      with:
-        path: ${{ github.workspace }}/target/semver-checks/cache
-        key: semver-checks-cache-${{ hashFiles('.rustc-version') }}-${{ hashFiles('.semver-checks-version') }}-${{ inputs.crate }}-${{ steps.get-released-version.outputs.version }}
-
     - run: cargo semver-checks check-release --package ${{ inputs.crate }} --verbose
       shell: bash
       env:


### PR DESCRIPTION
## Description

I noticed that `semver-checks` cache artifacts are tiny (hundreds of kilobytes tops) so it might worth maintaining them. Additionally, I hope it might help with the network issue reported here: https://github.com/libp2p/rust-libp2p/pull/3782#issuecomment-1523346255. It's a shot in the dark but some solutions to similar reported problems include [clearing directories](https://github.com/rust-lang/cargo/issues/7662#issuecomment-561917271) - my thinking is, maybe we're caching something that we shouldn't. 
<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
