### PR TITLE
refactor(core): remove `InfoIterChain`

### DIFF
--- a/core/src/upgrade/select.rs
+++ b/core/src/upgrade/select.rs
@@ -25,6 +25,7 @@ use crate::{
 };
 use either::Either;
 use futures::future;
+use std::iter::{Chain, Map};
 
 /// Upgrade that combines two upgrades into one. Supports all the protocols supported by either
 /// sub-upgrade.
@@ -48,16 +49,24 @@ where
     B: UpgradeInfo,
 {
     type Info = EitherName<A::Info, B::Info>;
-    type InfoIter = InfoIterChain<
-        <A::InfoIter as IntoIterator>::IntoIter,
-        <B::InfoIter as IntoIterator>::IntoIter,
+    type InfoIter = Chain<
+        Map<<A::InfoIter as IntoIterator>::IntoIter, fn(A::Info) -> Self::Info>,
+        Map<<B::InfoIter as IntoIterator>::IntoIter, fn(B::Info) -> Self::Info>,
     >;
 
     fn protocol_info(&self) -> Self::InfoIter {
-        InfoIterChain(
-            self.0.protocol_info().into_iter(),
-            self.1.protocol_info().into_iter(),
-        )
+        let a = self
+            .0
+            .protocol_info()
+            .into_iter()
+            .map(EitherName::A as fn(A::Info) -> _);
+        let b = self
+            .1
+            .protocol_info()
+            .into_iter()
+            .map(EitherName::B as fn(B::Info) -> _);
+
+        a.chain(b)
     }
 }
 
@@ -92,34 +101,5 @@ where
             EitherName::A(info) => EitherFuture::First(self.0.upgrade_outbound(sock, info)),
             EitherName::B(info) => EitherFuture::Second(self.1.upgrade_outbound(sock, info)),
         }
-    }
-}
-
-/// Iterator that combines the protocol names of twp upgrades.
-#[derive(Debug, Clone)]
-pub struct InfoIterChain<A, B>(A, B);
-
-impl<A, B> Iterator for InfoIterChain<A, B>
-where
-    A: Iterator,
-    B: Iterator,
-{
-    type Item = EitherName<A::Item, B::Item>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(info) = self.0.next() {
-            return Some(EitherName::A(info));
-        }
-        if let Some(info) = self.1.next() {
-            return Some(EitherName::B(info));
-        }
-        None
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let (min1, max1) = self.0.size_hint();
-        let (min2, max2) = self.1.size_hint();
-        let max = max1.and_then(move |m1| max2.and_then(move |m2| m1.checked_add(m2)));
-        (min1.saturating_add(min2), max)
     }
 }


### PR DESCRIPTION
## Description

This type can be replaced with std-lib components.

Related: https://github.com/libp2p/rust-libp2p/pull/3746.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
