### PR TITLE
chore: prepare patch releases on top of v0.51.3

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.39.2 - unreleased
+## 0.39.2
 
 - Deprecate `upgrade::from_fn` without replacement as it is not used within `rust-libp2p`.
   If you depend on it, we suggest you vendor it.

--- a/identity/CHANGELOG.md
+++ b/identity/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.2 - unreleased
+## 0.1.2
 
 - Add `impl From<ed25519::PublicKey> for PublicKey` so that `PublicKey::from(ed25519::PublicKey)` works.
   See [PR 3805].

--- a/misc/allow-block-list/CHANGELOG.md
+++ b/misc/allow-block-list/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.1 - unreleased
+## 0.1.1
 
 - Correctly unblock and disallow peer in `unblock_peer` and `disallow_peer` functions.
   See [PR 3789].

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.43.1 - unreleased
+## 0.43.1
 
 - Drop `Yamux` prefix from all types.
   Users are encouraged to import the `yamux` module and refer to types via `yamux::Muxer`, `yamux::Config` etc.

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.44.4 - unreleased
+## 0.44.4
 
 - Deprecate `metrics`, `protocol`, `subscription_filter`, `time_cache` modules to make them private. See [PR 3777].
 - Honor the `gossipsub::Config::support_floodsub` in all cases.

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.42.2 - unreleased
+## 0.42.2
 
 - Do not implicitly dial a peer upon `identify::Behaviour::push`.
   Previously, we would dial each peer in the provided list.

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.43.3 - unreleased
+## 0.43.3
 
 - Preserve existing `KeepAlive::Until` timeout instead of continuously setting new `KeepAlive::Until(Instant::now() + self.config.idle_timeout)`.
   See [PR 3801].

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.24.1 - unreleased
+## 0.24.1
 
 - Deprecate `handler`, `codec` modules to make them private. See [PR 3847].
 

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.42.2 - unreleased
+## 0.42.2
 
 - Add `ConnectionEvent::{is_outbound,is_inbound}`. See [PR 3625].
 

--- a/transports/noise/CHANGELOG.md
+++ b/transports/noise/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.42.2 - unreleased
+## 0.42.2
 
 - Deprecate all noise handshakes apart from XX.
   This deprecates `NoiseConfig` and `NoiseAuthenticated` in favor of a new `libp2p_noise::Config` struct.


### PR DESCRIPTION
## Description

Note that this does not release v0.51.4, i.e. there is no patch release of the meta crate `libp2p`.



<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
