### PR TITLE
fix(identity): handle warnings related to feature flags

### DIFF
--- a/identity/src/error.rs
+++ b/identity/src/error.rs
@@ -166,6 +166,7 @@ pub struct OtherVariantError {
 }
 
 impl OtherVariantError {
+    #[allow(dead_code)] // This is used but the cfg is too complicated to write ..
     pub(crate) fn new(actual: KeyType) -> OtherVariantError {
         OtherVariantError { actual }
     }

--- a/identity/src/keypair.rs
+++ b/identity/src/keypair.rs
@@ -20,7 +20,7 @@
 
 use crate::error::OtherVariantError;
 use crate::error::{DecodingError, SigningError};
-use crate::{proto, KeyType};
+use crate::proto;
 use quick_protobuf::{BytesReader, Writer};
 use std::convert::TryFrom;
 
@@ -322,11 +322,11 @@ impl TryInto<ed25519::Keypair> for Keypair {
         match self {
             Keypair::Ed25519(inner) => Ok(inner),
             #[cfg(all(feature = "rsa", not(target_arch = "wasm32")))]
-            Keypair::Rsa(_) => Err(OtherVariantError::new(KeyType::RSA)),
+            Keypair::Rsa(_) => Err(OtherVariantError::new(crate::KeyType::RSA)),
             #[cfg(feature = "secp256k1")]
-            Keypair::Secp256k1(_) => Err(OtherVariantError::new(KeyType::Secp256k1)),
+            Keypair::Secp256k1(_) => Err(OtherVariantError::new(crate::KeyType::Secp256k1)),
             #[cfg(feature = "ecdsa")]
-            Keypair::Ecdsa(_) => Err(OtherVariantError::new(KeyType::Ecdsa)),
+            Keypair::Ecdsa(_) => Err(OtherVariantError::new(crate::KeyType::Ecdsa)),
         }
     }
 }
@@ -340,11 +340,11 @@ impl TryInto<ecdsa::Keypair> for Keypair {
         match self {
             Keypair::Ecdsa(inner) => Ok(inner),
             #[cfg(feature = "ed25519")]
-            Keypair::Ed25519(_) => Err(OtherVariantError::new(KeyType::Ed25519)),
+            Keypair::Ed25519(_) => Err(OtherVariantError::new(crate::KeyType::Ed25519)),
             #[cfg(all(feature = "rsa", not(target_arch = "wasm32")))]
-            Keypair::Rsa(_) => Err(OtherVariantError::new(KeyType::RSA)),
+            Keypair::Rsa(_) => Err(OtherVariantError::new(crate::KeyType::RSA)),
             #[cfg(feature = "secp256k1")]
-            Keypair::Secp256k1(_) => Err(OtherVariantError::new(KeyType::Secp256k1)),
+            Keypair::Secp256k1(_) => Err(OtherVariantError::new(crate::KeyType::Secp256k1)),
         }
     }
 }
@@ -358,11 +358,11 @@ impl TryInto<secp256k1::Keypair> for Keypair {
         match self {
             Keypair::Secp256k1(inner) => Ok(inner),
             #[cfg(feature = "ed25519")]
-            Keypair::Ed25519(_) => Err(OtherVariantError::new(KeyType::Ed25519)),
+            Keypair::Ed25519(_) => Err(OtherVariantError::new(crate::KeyType::Ed25519)),
             #[cfg(all(feature = "rsa", not(target_arch = "wasm32")))]
-            Keypair::Rsa(_) => Err(OtherVariantError::new(KeyType::RSA)),
+            Keypair::Rsa(_) => Err(OtherVariantError::new(crate::KeyType::RSA)),
             #[cfg(feature = "ecdsa")]
-            Keypair::Ecdsa(_) => Err(OtherVariantError::new(KeyType::Ecdsa)),
+            Keypair::Ecdsa(_) => Err(OtherVariantError::new(crate::KeyType::Ecdsa)),
         }
     }
 }
@@ -376,11 +376,11 @@ impl TryInto<rsa::Keypair> for Keypair {
         match self {
             Keypair::Rsa(inner) => Ok(inner),
             #[cfg(feature = "ed25519")]
-            Keypair::Ed25519(_) => Err(OtherVariantError::new(KeyType::Ed25519)),
+            Keypair::Ed25519(_) => Err(OtherVariantError::new(crate::KeyType::Ed25519)),
             #[cfg(feature = "secp256k1")]
-            Keypair::Secp256k1(_) => Err(OtherVariantError::new(KeyType::Secp256k1)),
+            Keypair::Secp256k1(_) => Err(OtherVariantError::new(crate::KeyType::Secp256k1)),
             #[cfg(feature = "ecdsa")]
-            Keypair::Ecdsa(_) => Err(OtherVariantError::new(KeyType::Ecdsa)),
+            Keypair::Ecdsa(_) => Err(OtherVariantError::new(crate::KeyType::Ecdsa)),
         }
     }
 }

--- a/identity/src/keypair.rs
+++ b/identity/src/keypair.rs
@@ -597,11 +597,11 @@ impl TryInto<ed25519::PublicKey> for PublicKey {
         match self {
             PublicKey::Ed25519(inner) => Ok(inner),
             #[cfg(all(feature = "rsa", not(target_arch = "wasm32")))]
-            PublicKey::Rsa(_) => Err(OtherVariantError::new(KeyType::RSA)),
+            PublicKey::Rsa(_) => Err(OtherVariantError::new(crate::KeyType::RSA)),
             #[cfg(feature = "secp256k1")]
-            PublicKey::Secp256k1(_) => Err(OtherVariantError::new(KeyType::Secp256k1)),
+            PublicKey::Secp256k1(_) => Err(OtherVariantError::new(crate::KeyType::Secp256k1)),
             #[cfg(feature = "ecdsa")]
-            PublicKey::Ecdsa(_) => Err(OtherVariantError::new(KeyType::Ecdsa)),
+            PublicKey::Ecdsa(_) => Err(OtherVariantError::new(crate::KeyType::Ecdsa)),
         }
     }
 }
@@ -615,11 +615,11 @@ impl TryInto<ecdsa::PublicKey> for PublicKey {
         match self {
             PublicKey::Ecdsa(inner) => Ok(inner),
             #[cfg(feature = "ed25519")]
-            PublicKey::Ed25519(_) => Err(OtherVariantError::new(KeyType::Ed25519)),
+            PublicKey::Ed25519(_) => Err(OtherVariantError::new(crate::KeyType::Ed25519)),
             #[cfg(all(feature = "rsa", not(target_arch = "wasm32")))]
-            PublicKey::Rsa(_) => Err(OtherVariantError::new(KeyType::RSA)),
+            PublicKey::Rsa(_) => Err(OtherVariantError::new(crate::KeyType::RSA)),
             #[cfg(feature = "secp256k1")]
-            PublicKey::Secp256k1(_) => Err(OtherVariantError::new(KeyType::Secp256k1)),
+            PublicKey::Secp256k1(_) => Err(OtherVariantError::new(crate::KeyType::Secp256k1)),
         }
     }
 }
@@ -633,11 +633,11 @@ impl TryInto<secp256k1::PublicKey> for PublicKey {
         match self {
             PublicKey::Secp256k1(inner) => Ok(inner),
             #[cfg(feature = "ed25519")]
-            PublicKey::Ed25519(_) => Err(OtherVariantError::new(KeyType::Ed25519)),
+            PublicKey::Ed25519(_) => Err(OtherVariantError::new(crate::KeyType::Ed25519)),
             #[cfg(all(feature = "rsa", not(target_arch = "wasm32")))]
-            PublicKey::Rsa(_) => Err(OtherVariantError::new(KeyType::RSA)),
+            PublicKey::Rsa(_) => Err(OtherVariantError::new(crate::KeyType::RSA)),
             #[cfg(feature = "ecdsa")]
-            PublicKey::Ecdsa(_) => Err(OtherVariantError::new(KeyType::Ecdsa)),
+            PublicKey::Ecdsa(_) => Err(OtherVariantError::new(crate::KeyType::Ecdsa)),
         }
     }
 }
@@ -651,11 +651,11 @@ impl TryInto<rsa::PublicKey> for PublicKey {
         match self {
             PublicKey::Rsa(inner) => Ok(inner),
             #[cfg(feature = "ed25519")]
-            PublicKey::Ed25519(_) => Err(OtherVariantError::new(KeyType::Ed25519)),
+            PublicKey::Ed25519(_) => Err(OtherVariantError::new(crate::KeyType::Ed25519)),
             #[cfg(feature = "secp256k1")]
-            PublicKey::Secp256k1(_) => Err(OtherVariantError::new(KeyType::Secp256k1)),
+            PublicKey::Secp256k1(_) => Err(OtherVariantError::new(crate::KeyType::Secp256k1)),
             #[cfg(feature = "ecdsa")]
-            PublicKey::Ecdsa(_) => Err(OtherVariantError::new(KeyType::Ecdsa)),
+            PublicKey::Ecdsa(_) => Err(OtherVariantError::new(crate::KeyType::Ecdsa)),
         }
     }
 }


### PR DESCRIPTION
## Description

Some of the feature-flags weren't set correctly and thus produced warnings for unused code. We can fix this by using absolute paths instead of imports and allow `dead_code` for the error constructor. It might be possible to write a correct `cfg` for this as well but I think it will be very verbose, hence I didn't bother.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
