### PR TITLE
chore(identity): Make Keypair and PublicKey enums opaque

### DIFF
--- a/identity/src/keypair_dummy.rs
+++ b/identity/src/keypair_dummy.rs
@@ -21,7 +21,7 @@
 use crate::error::{DecodingError, SigningError};
 
 #[derive(Debug, Clone)]
-pub enum Keypair {}
+pub struct Keypair;
 
 impl Keypair {
     pub fn sign(&self, _: &[u8]) -> Result<Vec<u8>, SigningError> {
@@ -44,7 +44,7 @@ impl Keypair {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum PublicKey {}
+pub struct PublicKey;
 
 impl PublicKey {
     #[must_use]

--- a/identity/src/lib.rs
+++ b/identity/src/lib.rs
@@ -98,25 +98,26 @@ impl zeroize::Zeroize for proto::PrivateKey {
 ))]
 impl From<&PublicKey> for proto::PublicKey {
     fn from(key: &PublicKey) -> Self {
+        use keypair::PublicKeyInner;
         #[allow(deprecated)]
-        match key {
+        match &key.0 {
             #[cfg(feature = "ed25519")]
-            PublicKey::Ed25519(key) => proto::PublicKey {
+            PublicKeyInner::Ed25519(key) => proto::PublicKey {
                 Type: proto::KeyType::Ed25519,
                 Data: key.encode().to_vec(),
             },
             #[cfg(all(feature = "rsa", not(target_arch = "wasm32")))]
-            PublicKey::Rsa(key) => proto::PublicKey {
+            PublicKeyInner::Rsa(key) => proto::PublicKey {
                 Type: proto::KeyType::RSA,
                 Data: key.encode_x509(),
             },
             #[cfg(feature = "secp256k1")]
-            PublicKey::Secp256k1(key) => proto::PublicKey {
+            PublicKeyInner::Secp256k1(key) => proto::PublicKey {
                 Type: proto::KeyType::Secp256k1,
                 Data: key.encode().to_vec(),
             },
             #[cfg(feature = "ecdsa")]
-            PublicKey::Ecdsa(key) => proto::PublicKey {
+            PublicKeyInner::Ecdsa(key) => proto::PublicKey {
                 Type: proto::KeyType::ECDSA,
                 Data: key.encode_der(),
             },
@@ -125,6 +126,7 @@ impl From<&PublicKey> for proto::PublicKey {
 }
 
 pub use error::{DecodingError, OtherVariantError, SigningError};
+
 pub use keypair::{Keypair, PublicKey};
 #[cfg(feature = "peerid")]
 pub use peer_id::{ParseError, PeerId};

--- a/transports/noise/src/protocol/x25519.rs
+++ b/transports/noise/src/protocol/x25519.rs
@@ -127,7 +127,7 @@ impl Protocol<X25519> for X25519 {
 
     #[allow(irrefutable_let_patterns)]
     fn linked(id_pk: &identity::PublicKey, dh_pk: &PublicKey<X25519>) -> bool {
-        if let identity::PublicKey::Ed25519(ref p) = id_pk {
+        if let Ok(ref p) = id_pk.clone().try_into_ed25519() {
             PublicKey::from_ed25519(p).as_ref() == dh_pk.as_ref()
         } else {
             false
@@ -161,20 +161,16 @@ impl Keypair<X25519> {
     /// >  * [Noise: Static Key Reuse](http://www.noiseprotocol.org/noise.html#security-considerations)
     #[allow(unreachable_patterns)]
     pub fn from_identity(id_keys: &identity::Keypair) -> Option<AuthenticKeypair<X25519>> {
-        match id_keys {
-            identity::Keypair::Ed25519(p) => {
-                let kp = Keypair::from(SecretKey::from_ed25519(&p.secret()));
-                let id = KeypairIdentity {
-                    public: id_keys.public(),
-                    signature: None,
-                };
-                Some(AuthenticKeypair {
-                    keypair: kp,
-                    identity: id,
-                })
-            }
-            _ => None,
-        }
+        let keypair = id_keys.clone().try_into_ed25519().ok()?;
+        let kp = Keypair::from(SecretKey::from_ed25519(&keypair.secret()));
+        let id = KeypairIdentity {
+            public: id_keys.public(),
+            signature: None,
+        };
+        Some(AuthenticKeypair {
+            keypair: kp,
+            identity: id,
+        })
     }
 }
 


### PR DESCRIPTION
## Description
This will make Keypair and PublicKey enums opaque.

Resolves #3860 
<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions
<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
