### PR TITLE
feat(yamux): increase max number of buffered inbound streams to 256

### DIFF
--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -3,7 +3,11 @@
 - Raise MSRV to 1.65.
   See [PR 3715].
 
+- Increase the amount of buffered inbound streams to 256.
+  See [PR XXXX].
+
 [PR 3715]: https://github.com/libp2p/rust-libp2p/pull/3715
+[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
 
 ## 0.43.1
 

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -4,10 +4,10 @@
   See [PR 3715].
 
 - Increase the amount of buffered inbound streams to 256.
-  See [PR XXXX].
+  See [PR 3872].
 
 [PR 3715]: https://github.com/libp2p/rust-libp2p/pull/3715
-[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
+[PR 3872]: https://github.com/libp2p/rust-libp2p/pull/3872
 
 ## 0.43.1
 

--- a/muxers/yamux/src/lib.rs
+++ b/muxers/yamux/src/lib.rs
@@ -63,7 +63,7 @@ pub struct Muxer<S> {
     inbound_stream_waker: Option<Waker>,
 }
 
-const MAX_BUFFERED_INBOUND_STREAMS: usize = 25;
+const MAX_BUFFERED_INBOUND_STREAMS: usize = 256;
 
 impl<S> fmt::Debug for Muxer<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/muxers/yamux/src/lib.rs
+++ b/muxers/yamux/src/lib.rs
@@ -63,6 +63,10 @@ pub struct Muxer<S> {
     inbound_stream_waker: Option<Waker>,
 }
 
+/// Yamux does not have any built-in backpressure mechanism.
+///
+/// Implementations are encouraged to not open more than 256 unacknowledged streams, see <https://github.com/libp2p/specs/tree/master/yamux#ack-backlog>.
+/// Thus, it makes sense to buffer up to 256 streams before dropping them for good interoperability.
 const MAX_BUFFERED_INBOUND_STREAMS: usize = 256;
 
 impl<S> fmt::Debug for Muxer<S> {


### PR DESCRIPTION
## Description

With the effort to implement a consistent ACK backlog across all yamux implementations, it makes sense to up this limit to 256 to avoid stream drops as much as possible.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

Related: https://github.com/paritytech/polkadot-sdk/issues/758.

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
