### PR TITLE
deps: remove `sec1` from `libp2p-identity`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2566,7 +2566,6 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rmp-serde",
- "sec1",
  "serde",
  "serde_json",
  "sha2 0.10.6",

--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -22,7 +22,6 @@ multihash = { version = "0.17.0", default-features = false, features = ["std"], 
 p256 = { version = "0.12", default-features = false, features = ["ecdsa", "std"], optional = true }
 quick-protobuf = { version = "0.8.1", optional = true }
 rand = { version = "0.8", optional = true }
-sec1 = { version = "0.3.0", features = ["std"], optional = true } # Activate `std` feature until https://github.com/RustCrypto/traits/pull/1131 is released.
 serde = { version = "1", optional = true, features = ["derive"] }
 sha2 = { version = "0.10.0", optional = true }
 thiserror = { version = "1.0", optional = true }
@@ -34,7 +33,7 @@ ring = { version = "0.16.9", features = ["alloc", "std"], default-features = fal
 
 [features]
 secp256k1 = [ "dep:libsecp256k1", "dep:asn1_der", "dep:rand", "dep:sha2", "dep:zeroize", "dep:quick-protobuf" ]
-ecdsa = [ "dep:p256", "dep:rand", "dep:void", "dep:zeroize", "dep:sec1", "dep:quick-protobuf" ]
+ecdsa = [ "dep:p256", "dep:rand", "dep:void", "dep:zeroize", "dep:quick-protobuf" ]
 rsa = [ "dep:ring", "dep:asn1_der", "dep:rand", "dep:zeroize", "dep:quick-protobuf" ]
 ed25519 = [ "dep:ed25519-dalek", "dep:rand", "dep:zeroize", "dep:quick-protobuf" ]
 peerid = [ "dep:multihash", "dep:multiaddr", "dep:bs58", "dep:rand", "dep:thiserror", "dep:sha2" ]


### PR DESCRIPTION
## Description

Remove `sec1` because it's no longer needed.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
