### PR TITLE
feat(core): remove deprecated `identity` module and features

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -6,8 +6,13 @@
 - Remove deprecated symbols related to upgrades.
   See [PR 3867].
 
+- Remove deprecated `identity` module and features.
+  You should depend on `libp2p-identity` instead.
+  See [PR XXXX].
+
 [PR 3715]: https://github.com/libp2p/rust-libp2p/pull/3715
 [PR 3867]: https://github.com/libp2p/rust-libp2p/pull/3867
+[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
 
 - Enforce protocol names to be valid UTF8 strings as required by the [spec].
   We delete the `ProtocolName` trait and replace it with a requirement for `AsRef<str>`.

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -8,11 +8,11 @@
 
 - Remove deprecated `identity` module and features.
   You should depend on `libp2p-identity` instead.
-  See [PR XXXX].
+  See [PR 3898].
 
 [PR 3715]: https://github.com/libp2p/rust-libp2p/pull/3715
 [PR 3867]: https://github.com/libp2p/rust-libp2p/pull/3867
-[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
+[PR 3898]: https://github.com/libp2p/rust-libp2p/pull/3898
 
 - Enforce protocol names to be valid UTF8 strings as required by the [spec].
   We delete the `ProtocolName` trait and replace it with a requirement for `AsRef<str>`.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,7 @@ fnv = "1.0"
 futures = { version = "0.3.28", features = ["executor", "thread-pool"] }
 futures-timer = "3"
 instant = "0.1.11"
-libp2p-identity = { workspace = true }
+libp2p-identity = { workspace = true, features = ["peerid"] }
 log = "0.4"
 multiaddr = { version = "0.17.1" }
 multihash = { version = "0.17.0", default-features = false, features = ["std"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,7 @@ fnv = "1.0"
 futures = { version = "0.3.28", features = ["executor", "thread-pool"] }
 futures-timer = "3"
 instant = "0.1.11"
-libp2p-identity = { workspace = true, features = ["peerid", "ed25519"] }
+libp2p-identity = { workspace = true }
 log = "0.4"
 multiaddr = { version = "0.17.1" }
 multihash = { version = "0.17.0", default-features = false, features = ["std"] }
@@ -41,9 +41,6 @@ multihash = { version = "0.17.0", default-features = false, features = ["arb"] }
 quickcheck = { workspace = true }
 
 [features]
-secp256k1 = [ "libp2p-identity/secp256k1" ]
-ecdsa = [ "libp2p-identity/ecdsa" ]
-rsa = [ "libp2p-identity/rsa" ]
 serde = ["multihash/serde-codec", "dep:serde", "libp2p-identity/serde"]
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -51,55 +51,6 @@ use std::fmt;
 use std::fmt::Formatter;
 pub type Negotiated<T> = multistream_select::Negotiated<T>;
 
-#[deprecated(since = "0.39.0", note = "Depend on `libp2p-identity` instead.")]
-pub mod identity {
-    pub use libp2p_identity::Keypair;
-    pub use libp2p_identity::PublicKey;
-
-    pub mod ed25519 {
-        pub use libp2p_identity::ed25519::Keypair;
-        pub use libp2p_identity::ed25519::PublicKey;
-        pub use libp2p_identity::ed25519::SecretKey;
-    }
-
-    #[cfg(feature = "ecdsa")]
-    #[deprecated(
-        since = "0.39.0",
-        note = "The `ecdsa` feature-flag is deprecated and will be removed in favor of `libp2p-identity`."
-    )]
-    pub mod ecdsa {
-        pub use libp2p_identity::ecdsa::Keypair;
-        pub use libp2p_identity::ecdsa::PublicKey;
-        pub use libp2p_identity::ecdsa::SecretKey;
-    }
-
-    #[cfg(feature = "secp256k1")]
-    #[deprecated(
-        since = "0.39.0",
-        note = "The `secp256k1` feature-flag is deprecated and will be removed in favor of `libp2p-identity`."
-    )]
-    pub mod secp256k1 {
-        pub use libp2p_identity::secp256k1::Keypair;
-        pub use libp2p_identity::secp256k1::PublicKey;
-        pub use libp2p_identity::secp256k1::SecretKey;
-    }
-
-    #[cfg(feature = "rsa")]
-    #[deprecated(
-        since = "0.39.0",
-        note = "The `rsa` feature-flag is deprecated and will be removed in favor of `libp2p-identity`."
-    )]
-    pub mod rsa {
-        pub use libp2p_identity::rsa::Keypair;
-        pub use libp2p_identity::rsa::PublicKey;
-    }
-
-    pub mod error {
-        pub use libp2p_identity::DecodingError;
-        pub use libp2p_identity::SigningError;
-    }
-}
-
 mod translation;
 
 pub mod connection;
@@ -109,15 +60,6 @@ pub mod peer_record;
 pub mod signed_envelope;
 pub mod transport;
 pub mod upgrade;
-
-#[deprecated(since = "0.39.0", note = "Depend on `libp2p-identity` instead.")]
-pub type PublicKey = libp2p_identity::PublicKey;
-
-#[deprecated(since = "0.39.0", note = "Depend on `libp2p-identity` instead.")]
-pub type PeerId = libp2p_identity::PeerId;
-
-#[deprecated(since = "0.39.0", note = "Depend on `libp2p-identity` instead.")]
-pub type ParseError = libp2p_identity::ParseError;
 
 pub use connection::{ConnectedPoint, Endpoint};
 pub use multiaddr::Multiaddr;

--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -10,8 +10,13 @@
   We encourage users to use `StreamProtocol` when implementing `UpgradeInfo`.
   See [PR 3746].
 
+- Make the `ed25519` feature explicitly opt-in.
+  Previously, this would be active by default.
+  See [PR XXXX].
+
 [PR 3746]: https://github.com/libp2p/rust-libp2p/pull/3746
 [PR 3715]: https://github.com/libp2p/rust-libp2p/pull/3715
+[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
 
 ## 0.51.3
 

--- a/protocols/gossipsub/src/error.rs
+++ b/protocols/gossipsub/src/error.rs
@@ -20,7 +20,7 @@
 
 //! Error types that can result from gossipsub.
 
-use libp2p_core::identity::error::SigningError;
+use libp2p_identity::SigningError;
 
 /// Error associated with publishing a gossipsub message.
 #[derive(Debug)]

--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -48,7 +48,7 @@
 //! encoded) by setting the `hash_topics` configuration parameter to true.
 //!
 //! - **Sequence Numbers** - A message on the gossipsub network is identified by the source
-//! [`libp2p_core::PeerId`] and a nonce (sequence number) of the message. The sequence numbers in
+//! [`libp2p_identity::PeerId`] and a nonce (sequence number) of the message. The sequence numbers in
 //! this implementation are sent as raw bytes across the wire. They are 64-bit big-endian unsigned
 //! integers. When messages are signed, they are monotonically increasing integers starting from a
 //! random value and wrapping around u64::MAX. When messages are unsigned, they are chosen at random.
@@ -83,7 +83,7 @@
 //!
 //! The [`Behaviour`] struct implements the [`libp2p_swarm::NetworkBehaviour`] trait allowing it to
 //! act as the routing behaviour in a [`libp2p_swarm::Swarm`]. This struct requires an instance of
-//! [`libp2p_core::PeerId`] and [`Config`].
+//! [`libp2p_identity::PeerId`] and [`Config`].
 //!
 //! [`Behaviour`]: struct.Behaviour.html
 

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -515,7 +515,7 @@ mod tests {
     use crate::config::Config;
     use crate::{Behaviour, ConfigBuilder};
     use crate::{IdentTopic as Topic, Version};
-    use libp2p_core::identity::Keypair;
+    use libp2p_identity::Keypair;
     use quickcheck::*;
 
     #[derive(Clone, Debug)]

--- a/swarm-test/Cargo.toml
+++ b/swarm-test/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 async-trait = "0.1.68"
 libp2p-core = { workspace = true }
-libp2p-identity = { workspace = true }
+libp2p-identity = { workspace = true, features = ["ed25519"] }
 libp2p-plaintext = { workspace = true }
 libp2p-swarm = { workspace = true }
 libp2p-tcp = { workspace = true, features = ["async-io"] }

--- a/swarm-test/src/lib.rs
+++ b/swarm-test/src/lib.rs
@@ -22,10 +22,9 @@ use async_trait::async_trait;
 use futures::future::Either;
 use futures::StreamExt;
 use libp2p_core::{
-    identity::Keypair, multiaddr::Protocol, transport::MemoryTransport, upgrade::Version,
-    Multiaddr, Transport,
+    multiaddr::Protocol, transport::MemoryTransport, upgrade::Version, Multiaddr, Transport,
 };
-use libp2p_identity::PeerId;
+use libp2p_identity::{Keypair, PeerId};
 use libp2p_plaintext::PlainText2Config;
 use libp2p_swarm::dial_opts::PeerCondition;
 use libp2p_swarm::{

--- a/transports/plaintext/src/error.rs
+++ b/transports/plaintext/src/error.rs
@@ -31,7 +31,7 @@ pub enum PlainTextError {
     InvalidPayload(DecodeError),
 
     /// Failed to parse public key from bytes in protobuf message.
-    InvalidPublicKey(libp2p_core::identity::error::DecodingError),
+    InvalidPublicKey(libp2p_identity::DecodingError),
 
     /// Failed to parse the [`PeerId`](libp2p_core::PeerId) from bytes in the protobuf message.
     InvalidPeerId(libp2p_core::multihash::Error),
@@ -93,8 +93,8 @@ impl From<quick_protobuf::Error> for PlainTextError {
     }
 }
 
-impl From<libp2p_core::identity::error::DecodingError> for PlainTextError {
-    fn from(err: libp2p_core::identity::error::DecodingError) -> PlainTextError {
+impl From<libp2p_identity::DecodingError> for PlainTextError {
+    fn from(err: libp2p_identity::DecodingError) -> PlainTextError {
         PlainTextError::InvalidPublicKey(err)
     }
 }

--- a/transports/pnet/Cargo.toml
+++ b/transports/pnet/Cargo.toml
@@ -19,8 +19,8 @@ rand = "0.8"
 pin-project = "1.0.2"
 
 [dev-dependencies]
-libp2p-core = { workspace = true, features = ["rsa", "ecdsa", "secp256k1"] }
-libp2p-identity = { workspace = true, features = ["ed25519"] }
+libp2p-core = { workspace = true }
+libp2p-identity = { workspace = true, features = ["ed25519", "rsa", "ecdsa", "secp256k1"] }
 libp2p-noise = { workspace = true }
 libp2p-swarm = { workspace = true, features = ["tokio"] }
 libp2p-tcp = { workspace = true, features = ["tokio"] }

--- a/transports/webrtc/src/tokio/transport.rs
+++ b/transports/webrtc/src/tokio/transport.rs
@@ -59,7 +59,7 @@ impl Transport {
     /// # Example
     ///
     /// ```
-    /// use libp2p_core::identity;
+    /// use libp2p_identity as identity;
     /// use rand::thread_rng;
     /// use libp2p_webrtc::tokio::{Transport, Certificate};
     ///


### PR DESCRIPTION
## Description

This removes the deprecated `identity` module and features. This makes the `ed25519` feature of `libp2p` explicitly opt-in as announced in the `0.51.1` changelog entry.

Related #3647.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

Draft because I still need to set the feature flags correctly in all our crates.

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
