### PR TITLE
feat(transport): Implement dial_with_new_port to prevent port reuse

### DIFF
--- a/core/src/either.rs
+++ b/core/src/either.rs
@@ -206,6 +206,25 @@ where
         }
     }
 
+    fn dial_with_new_port(
+        &mut self,
+        addr: Multiaddr,
+    ) -> Result<Self::Dial, TransportError<Self::Error>> {
+        use TransportError::*;
+        match self {
+            Either::Left(a) => match a.dial_with_new_port(addr) {
+                Ok(connec) => Ok(EitherFuture::First(connec)),
+                Err(MultiaddrNotSupported(addr)) => Err(MultiaddrNotSupported(addr)),
+                Err(Other(err)) => Err(Other(Either::Left(err))),
+            },
+            Either::Right(b) => match b.dial_with_new_port(addr) {
+                Ok(connec) => Ok(EitherFuture::Second(connec)),
+                Err(MultiaddrNotSupported(addr)) => Err(MultiaddrNotSupported(addr)),
+                Err(Other(err)) => Err(Other(Either::Right(err))),
+            },
+        }
+    }
+
     fn address_translation(&self, server: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
         match self {
             Either::Left(a) => a.address_translation(server, observed),

--- a/core/src/transport.rs
+++ b/core/src/transport.rs
@@ -134,6 +134,14 @@ pub trait Transport {
         addr: Multiaddr,
     ) -> Result<Self::Dial, TransportError<Self::Error>>;
 
+    ///
+    fn dial_with_new_port(
+        &mut self,
+        _addr: Multiaddr,
+    ) -> Result<Self::Dial, TransportError<Self::Error>> {
+        unimplemented!()
+    }
+
     /// Poll for [`TransportEvent`]s.
     ///
     /// A [`TransportEvent::Incoming`] should be produced whenever a connection is received at the lowest

--- a/core/src/transport/and_then.rs
+++ b/core/src/transport/and_then.rs
@@ -105,6 +105,28 @@ where
         Ok(future)
     }
 
+    fn dial_with_new_port(
+        &mut self,
+        addr: Multiaddr,
+    ) -> Result<Self::Dial, TransportError<Self::Error>> {
+        let dialed_fut = self
+            .transport
+            .dial_with_new_port(addr.clone())
+            .map_err(|err| err.map(Either::Left))?;
+        let future = AndThenFuture {
+            inner: Either::Left(Box::pin(dialed_fut)),
+            args: Some((
+                self.fun.clone(),
+                ConnectedPoint::Dialer {
+                    address: addr,
+                    role_override: Endpoint::Dialer,
+                },
+            )),
+            _marker: PhantomPinned,
+        };
+        Ok(future)
+    }
+
     fn address_translation(&self, server: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
         self.transport.address_translation(server, observed)
     }

--- a/core/src/transport/map.rs
+++ b/core/src/transport/map.rs
@@ -96,6 +96,21 @@ where
         })
     }
 
+    fn dial_with_new_port(
+        &mut self,
+        addr: Multiaddr,
+    ) -> Result<Self::Dial, TransportError<Self::Error>> {
+        let future = self.transport.dial_with_new_port(addr.clone())?;
+        let p = ConnectedPoint::Dialer {
+            address: addr,
+            role_override: Endpoint::Dialer,
+        };
+        Ok(MapFuture {
+            inner: future,
+            args: Some((self.fun.clone(), p)),
+        })
+    }
+
     fn address_translation(&self, server: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
         self.transport.address_translation(server, observed)
     }

--- a/core/src/transport/map_err.rs
+++ b/core/src/transport/map_err.rs
@@ -84,6 +84,20 @@ where
         }
     }
 
+    fn dial_with_new_port(
+        &mut self,
+        addr: Multiaddr,
+    ) -> Result<Self::Dial, TransportError<Self::Error>> {
+        let map = self.map.clone();
+        match self.transport.dial_with_new_port(addr) {
+            Ok(future) => Ok(MapErrDial {
+                inner: future,
+                map: Some(map),
+            }),
+            Err(err) => Err(err.map(map)),
+        }
+    }
+
     fn address_translation(&self, server: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
         self.transport.address_translation(server, observed)
     }

--- a/core/src/transport/memory.rs
+++ b/core/src/transport/memory.rs
@@ -237,6 +237,13 @@ impl Transport for MemoryTransport {
         self.dial(addr)
     }
 
+    fn dial_with_new_port(
+        &mut self,
+        addr: Multiaddr,
+    ) -> Result<DialFuture, TransportError<Self::Error>> {
+        self.dial(addr)
+    }
+
     fn address_translation(&self, _server: &Multiaddr, _observed: &Multiaddr) -> Option<Multiaddr> {
         None
     }

--- a/core/src/transport/optional.rs
+++ b/core/src/transport/optional.rs
@@ -95,6 +95,17 @@ where
         }
     }
 
+    fn dial_with_new_port(
+        &mut self,
+        addr: Multiaddr,
+    ) -> Result<Self::Dial, TransportError<Self::Error>> {
+        if let Some(inner) = self.0.as_mut() {
+            inner.dial_with_new_port(addr)
+        } else {
+            Err(TransportError::MultiaddrNotSupported(addr))
+        }
+    }
+
     fn address_translation(&self, server: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
         if let Some(inner) = &self.0 {
             inner.address_translation(server, observed)

--- a/core/src/transport/timeout.rs
+++ b/core/src/transport/timeout.rs
@@ -120,6 +120,20 @@ where
         })
     }
 
+    fn dial_with_new_port(
+        &mut self,
+        addr: Multiaddr,
+    ) -> Result<Self::Dial, TransportError<Self::Error>> {
+        let dial = self
+            .inner
+            .dial_with_new_port(addr)
+            .map_err(|err| err.map(TransportTimeoutError::Other))?;
+        Ok(Timeout {
+            inner: dial,
+            timer: Delay::new(self.outgoing_timeout),
+        })
+    }
+
     fn address_translation(&self, server: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
         self.inner.address_translation(server, observed)
     }

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -350,6 +350,13 @@ where
         self.0.dial_as_listener(addr)
     }
 
+    fn dial_with_new_port(
+        &mut self,
+        addr: Multiaddr,
+    ) -> Result<Self::Dial, TransportError<Self::Error>> {
+        self.0.dial_with_new_port(addr)
+    }
+
     fn listen_on(&mut self, addr: Multiaddr) -> Result<ListenerId, TransportError<Self::Error>> {
         self.0.listen_on(addr)
     }
@@ -422,6 +429,20 @@ where
         let future = self
             .inner
             .dial_as_listener(addr)
+            .map_err(|err| err.map(TransportUpgradeError::Transport))?;
+        Ok(DialUpgradeFuture {
+            future: Box::pin(future),
+            upgrade: future::Either::Left(Some(self.upgrade.clone())),
+        })
+    }
+
+    fn dial_with_new_port(
+        &mut self,
+        addr: Multiaddr,
+    ) -> Result<Self::Dial, TransportError<Self::Error>> {
+        let future = self
+            .inner
+            .dial_with_new_port(addr)
             .map_err(|err| err.map(TransportUpgradeError::Transport))?;
         Ok(DialUpgradeFuture {
             future: Box::pin(future),

--- a/protocols/autonat/src/behaviour/as_client.rs
+++ b/protocols/autonat/src/behaviour/as_client.rs
@@ -300,7 +300,7 @@ impl<'a> AsClient<'a> {
                 return Err(OutboundProbeError::NoServer);
             }
         };
-        let request_id = self.inner.send_request(
+        let request_id = self.inner.send_request_with_new_port(
             &server,
             DialRequest {
                 peer_id: self.local_peer_id,

--- a/protocols/autonat/src/behaviour/as_server.rs
+++ b/protocols/autonat/src/behaviour/as_server.rs
@@ -135,6 +135,7 @@ impl<'a> HandleInnerEvent for AsServer<'a> {
                                     .override_dial_concurrency_factor(
                                         NonZeroU8::new(1).expect("1 > 0"),
                                     )
+                                    .use_new_port()
                                     .addresses(addrs)
                                     .build(),
                             },

--- a/swarm/src/dial_opts.rs
+++ b/swarm/src/dial_opts.rs
@@ -46,6 +46,7 @@ pub struct DialOpts {
     role_override: Endpoint,
     dial_concurrency_factor_override: Option<NonZeroU8>,
     connection_id: ConnectionId,
+    use_new_port: bool,
 }
 
 impl DialOpts {
@@ -66,6 +67,7 @@ impl DialOpts {
             condition: Default::default(),
             role_override: Endpoint::Dialer,
             dial_concurrency_factor_override: Default::default(),
+            use_new_port: false,
         }
     }
 
@@ -147,6 +149,10 @@ impl DialOpts {
     pub(crate) fn role_override(&self) -> Endpoint {
         self.role_override
     }
+
+    pub(crate) fn use_new_port(&self) -> bool {
+        self.use_new_port
+    }
 }
 
 impl From<Multiaddr> for DialOpts {
@@ -167,6 +173,7 @@ pub struct WithPeerId {
     condition: PeerCondition,
     role_override: Endpoint,
     dial_concurrency_factor_override: Option<NonZeroU8>,
+    use_new_port: bool,
 }
 
 impl WithPeerId {
@@ -192,6 +199,7 @@ impl WithPeerId {
             extend_addresses_through_behaviour: false,
             role_override: self.role_override,
             dial_concurrency_factor_override: self.dial_concurrency_factor_override,
+            use_new_port: self.use_new_port,
         }
     }
 
@@ -206,6 +214,12 @@ impl WithPeerId {
         self
     }
 
+    /// TODO: Document
+    pub fn use_new_port(mut self) -> Self {
+        self.use_new_port = true;
+        self
+    }
+
     /// Build the final [`DialOpts`].
     pub fn build(self) -> DialOpts {
         DialOpts {
@@ -216,6 +230,7 @@ impl WithPeerId {
             role_override: self.role_override,
             dial_concurrency_factor_override: self.dial_concurrency_factor_override,
             connection_id: ConnectionId::next(),
+            use_new_port: self.use_new_port,
         }
     }
 }
@@ -228,6 +243,7 @@ pub struct WithPeerIdWithAddresses {
     extend_addresses_through_behaviour: bool,
     role_override: Endpoint,
     dial_concurrency_factor_override: Option<NonZeroU8>,
+    use_new_port: bool,
 }
 
 impl WithPeerIdWithAddresses {
@@ -262,6 +278,12 @@ impl WithPeerIdWithAddresses {
         self
     }
 
+    ///
+    pub fn use_new_port(mut self) -> Self {
+        self.use_new_port = true;
+        self
+    }
+
     /// Build the final [`DialOpts`].
     pub fn build(self) -> DialOpts {
         DialOpts {
@@ -272,6 +294,7 @@ impl WithPeerIdWithAddresses {
             role_override: self.role_override,
             dial_concurrency_factor_override: self.dial_concurrency_factor_override,
             connection_id: ConnectionId::next(),
+            use_new_port: self.use_new_port,
         }
     }
 }
@@ -316,6 +339,7 @@ impl WithoutPeerIdWithAddress {
             role_override: self.role_override,
             dial_concurrency_factor_override: None,
             connection_id: ConnectionId::next(),
+            use_new_port: false,
         }
     }
 }

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -599,10 +599,15 @@ where
             .into_iter()
             .map(|a| match p2p_addr(peer_id, a) {
                 Ok(address) => {
-                    let dial = match dial_opts.role_override() {
-                        Endpoint::Dialer => self.transport.dial(address.clone()),
-                        Endpoint::Listener => self.transport.dial_as_listener(address.clone()),
+                    let dial = if dial_opts.use_new_port() {
+                        self.transport.dial_with_new_port(address.clone())
+                    } else {
+                        match dial_opts.role_override() {
+                            Endpoint::Dialer => self.transport.dial(address.clone()),
+                            Endpoint::Listener => self.transport.dial_as_listener(address.clone()),
+                        }
                     };
+
                     match dial {
                         Ok(fut) => fut
                             .map(|r| (address, r.map_err(TransportError::Other)))

--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -214,6 +214,13 @@ where
         self.transport.dial_as_listener(addr)
     }
 
+    fn dial_with_new_port(
+        &mut self,
+        addr: Multiaddr,
+    ) -> Result<Self::Dial, TransportError<Self::Error>> {
+        self.transport.dial_with_new_port(addr)
+    }
+
     fn address_translation(&self, server: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
         self.transport.address_translation(server, observed)
     }


### PR DESCRIPTION
This is useful in case of AutoNAT, whereby we do not want to reuse the same port when probing.

A new `dial_with_new_port` is added, that TCP and QUIC can use to create a new source socket (port). This is called when `DialOpts` has the option enabled to use a new port, which can be used by AutoNAT.

## Description

This is a draft to see what options there are to implement a fix for both #3889 and #3900. Please bear with me as I try to figure out the right way to maneuver the APIs and concepts here.

The AutoNAT client uses `request_response` to send a request, so that has to have an option added for using a new port too. For the AutoNAT server, I observed that secondary probes will still cause a dial to error with `AddrNotAvailable` if not using the new `with_new_port`. For this reason the AutoNAT server also has to create a new socket (TCP). However, this is probably because I am not getting rid of the sockets after AutoNAT is done. I am not sure how to do that.

For TCP the 'fix' is to ignore port reuse if enabled. And for QUIC we should create a new dialer. What I am trying to understand is how these sockets/dialers are handled and can be managed properly.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
