### PR TITLE
ci: reduce size of Rust interop-test image 

### DIFF
--- a/interop-tests/Dockerfile
+++ b/interop-tests/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.5-labs
-FROM rust:1.67.0
+FROM rust:1.67.0 as builder
 
 # Run with access to the target cache to speed up builds
 WORKDIR /workspace
@@ -11,5 +11,7 @@ RUN --mount=type=cache,target=./target \
 RUN --mount=type=cache,target=./target \
     mv ./target/debug/ping /usr/local/bin/testplan
 
+FROM gcr.io/distroless/cc
+COPY --from=builder /usr/local/bin/testplan /usr/local/bin/testplan
 ENV RUST_BACKTRACE=1
 ENTRYPOINT ["testplan"]

--- a/interop-tests/Dockerfile
+++ b/interop-tests/Dockerfile
@@ -6,10 +6,10 @@ WORKDIR /workspace
 ADD . .
 RUN --mount=type=cache,target=./target \
     --mount=type=cache,target=/usr/local/cargo/registry \
-    cargo build --package interop-tests
+    cargo build --release --package interop-tests
 
 RUN --mount=type=cache,target=./target \
-    mv ./target/debug/ping /usr/local/bin/testplan
+    mv ./target/release/ping /usr/local/bin/testplan
 
 FROM gcr.io/distroless/cc
 COPY --from=builder /usr/local/bin/testplan /usr/local/bin/testplan

--- a/interop-tests/Dockerfile
+++ b/interop-tests/Dockerfile
@@ -1,6 +1,12 @@
 # syntax=docker/dockerfile:1.5-labs
 FROM rust:1.67.0 as builder
 
+# Install zlib as long as libp2p-websocket requires it: https://github.com/paritytech/soketto/issues/72
+RUN apt-get update && \
+    apt-get download zlib1g && \
+    mkdir /dpkg && \
+    for deb in *.deb; do dpkg --extract $deb /dpkg || exit 10; done
+
 # Run with access to the target cache to speed up builds
 WORKDIR /workspace
 ADD . .
@@ -13,5 +19,6 @@ RUN --mount=type=cache,target=./target \
 
 FROM gcr.io/distroless/cc
 COPY --from=builder /usr/local/bin/testplan /usr/local/bin/testplan
+COPY --from=builder /dpkg /
 ENV RUST_BACKTRACE=1
 ENTRYPOINT ["testplan"]


### PR DESCRIPTION
## Description

By using a multi-stage docker build, a distroless base image and a release build, we can get the size of the Rust interop test down to 50MB. Previously, the image would be around 500MB. A debug build image would still have ~400MB. The release build slows down our interop build step by about 1min 20s. That however is only because we don't currently seem to utilize the caches that from what I understand should work on self-hosted runners. I opted https://github.com/libp2p/rust-libp2p/issues/3925 for that.

Resolves: #3881.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

Once this is merged, I'll backport it to the older releases and update the commit hashes that `libp2p/test-plans` points to.

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
