### PR TITLE
feat(plaintext): remove `Plaintext1Config`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,7 +2856,6 @@ dependencies = [
  "quickcheck-ext",
  "rand 0.8.5",
  "unsigned-varint",
- "void",
 ]
 
 [[package]]

--- a/misc/metrics/src/identify.rs
+++ b/misc/metrics/src/identify.rs
@@ -203,7 +203,7 @@ impl Collector for Peers {
                     .protocols
                     .iter()
                     .map(|p| {
-                        if ALLOWED_PROTOCOLS.contains(&p) {
+                        if ALLOWED_PROTOCOLS.contains(p) {
                             p.to_string()
                         } else {
                             "unrecognized".to_string()

--- a/transports/plaintext/CHANGELOG.md
+++ b/transports/plaintext/CHANGELOG.md
@@ -3,7 +3,12 @@
 - Raise MSRV to 1.65.
   See [PR 3715].
 
+- Remove `Plaintext1Config`.
+  Use `Plaintext2Config` instead.
+  See [PR XXXX.
+
 [PR 3715]: https://github.com/libp2p/rust-libp2p/pull/3715
+[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
 
 ## 0.39.1
 

--- a/transports/plaintext/CHANGELOG.md
+++ b/transports/plaintext/CHANGELOG.md
@@ -5,10 +5,10 @@
 
 - Remove `Plaintext1Config`.
   Use `Plaintext2Config` instead.
-  See [PR XXXX.
+  See [PR 3915].
 
 [PR 3715]: https://github.com/libp2p/rust-libp2p/pull/3715
-[PR XXXX]: https://github.com/libp2p/rust-libp2p/pull/XXXX
+[PR 3915]: https://github.com/libp2p/rust-libp2p/pull/3915
 
 ## 0.39.1
 

--- a/transports/plaintext/Cargo.toml
+++ b/transports/plaintext/Cargo.toml
@@ -19,7 +19,6 @@ libp2p-identity = { workspace = true }
 log = "0.4.8"
 quick-protobuf = "0.8"
 unsigned-varint = { version = "0.7", features = ["asynchronous_codec"] }
-void = "1.0.2"
 
 [dev-dependencies]
 env_logger = "0.10.0"

--- a/transports/plaintext/src/lib.rs
+++ b/transports/plaintext/src/lib.rs
@@ -26,7 +26,6 @@ use crate::error::PlainTextError;
 
 use bytes::Bytes;
 use futures::future::BoxFuture;
-use futures::future::{self, Ready};
 use futures::prelude::*;
 use libp2p_core::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use libp2p_identity as identity;
@@ -38,7 +37,6 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use void::Void;
 
 mod error;
 mod handshake;
@@ -46,64 +44,6 @@ mod proto {
     #![allow(unreachable_pub)]
     include!("generated/mod.rs");
     pub(crate) use self::structs::Exchange;
-}
-
-/// `PlainText1Config` is an insecure connection handshake for testing purposes only.
-///
-/// > **Note**: Given that `PlainText1Config` has no notion of exchanging peer identity information it is not compatible
-/// > with the `libp2p_core::transport::upgrade::Builder` pattern. See
-/// > [`PlainText2Config`](struct.PlainText2Config.html) if compatibility is needed. Even though not compatible with the
-/// > Builder pattern one can still do an upgrade *manually*:
-///
-/// ```
-/// # use libp2p_core::transport::{ Transport, memory::MemoryTransport };
-/// # use libp2p_plaintext::PlainText1Config;
-/// #
-/// MemoryTransport::default()
-///   .and_then(move |io, endpoint| {
-///     libp2p_core::upgrade::apply(
-///       io,
-///       PlainText1Config{},
-///       endpoint,
-///       libp2p_core::transport::upgrade::Version::V1,
-///     )
-///   })
-///   .map(|plaintext, _endpoint| {
-///     unimplemented!();
-///     // let peer_id = somehow_derive_peer_id();
-///     // return (peer_id, plaintext);
-///   });
-/// ```
-#[derive(Debug, Copy, Clone)]
-pub struct PlainText1Config;
-
-impl UpgradeInfo for PlainText1Config {
-    type Info = &'static str;
-    type InfoIter = iter::Once<Self::Info>;
-
-    fn protocol_info(&self) -> Self::InfoIter {
-        iter::once("/plaintext/1.0.0")
-    }
-}
-
-impl<C> InboundUpgrade<C> for PlainText1Config {
-    type Output = C;
-    type Error = Void;
-    type Future = Ready<Result<C, Self::Error>>;
-
-    fn upgrade_inbound(self, i: C, _: Self::Info) -> Self::Future {
-        future::ready(Ok(i))
-    }
-}
-
-impl<C> OutboundUpgrade<C> for PlainText1Config {
-    type Output = C;
-    type Error = Void;
-    type Future = Ready<Result<C, Self::Error>>;
-
-    fn upgrade_outbound(self, i: C, _: Self::Info) -> Self::Future {
-        future::ready(Ok(i))
-    }
 }
 
 /// `PlainText2Config` is an insecure connection handshake for testing purposes only, implementing


### PR DESCRIPTION
## Description

`Plaintext2Config` works with the upgrade infrastructure and is thus preferable.

Related: #3915.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
