### PR TITLE
feat(kad): Remove `TUserData` and replace with `QueryId`

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -6,8 +6,11 @@
 - Remove deprecated public modules `handler`, `protocol` and `kbucket`.
   See [PR 3896].
 
+- Remove `TUserData` in `KademliaHandler`, `KademliaHandlerEvent`, `KademliaHandlerIn` and replace with `QueryId`. See [PR 3959].
+
 [PR 3715]: https://github.com/libp2p/rust-libp2p/pull/3715
 [PR 3896]: https://github.com/libp2p/rust-libp2p/pull/3896
+[PR 3959]: https://github.com/libp2p/rust-libp2p/pull/3959
 
 ## 0.43.3
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -6,11 +6,8 @@
 - Remove deprecated public modules `handler`, `protocol` and `kbucket`.
   See [PR 3896].
 
-- Remove `TUserData` in `KademliaHandler`, `KademliaHandlerEvent`, `KademliaHandlerIn`, `OutboundSubstreamState` and replace with `QueryId`. See [PR 3959].
-
 [PR 3715]: https://github.com/libp2p/rust-libp2p/pull/3715
 [PR 3896]: https://github.com/libp2p/rust-libp2p/pull/3896
-[PR 3959]: https://github.com/libp2p/rust-libp2p/pull/3959
 
 ## 0.43.3
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Remove deprecated public modules `handler`, `protocol` and `kbucket`.
   See [PR 3896].
 
-- Remove `TUserData` in `KademliaHandler`, `KademliaHandlerEvent`, `KademliaHandlerIn` and replace with `QueryId`. See [PR 3959].
+- Remove `TUserData` in `KademliaHandler`, `KademliaHandlerEvent`, `KademliaHandlerIn`, `OutboundSubstreamState` and replace with `QueryId`. See [PR 3959].
 
 [PR 3715]: https://github.com/libp2p/rust-libp2p/pull/3715
 [PR 3896]: https://github.com/libp2p/rust-libp2p/pull/3896

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -103,7 +103,7 @@ pub struct Kademlia<TStore> {
     connection_idle_timeout: Duration,
 
     /// Queued events to return when the behaviour is being polled.
-    queued_events: VecDeque<ToSwarm<KademliaEvent, KademliaHandlerIn<QueryId>>>,
+    queued_events: VecDeque<ToSwarm<KademliaEvent, KademliaHandlerIn>>,
 
     listen_addresses: ListenAddresses,
 
@@ -1959,7 +1959,7 @@ impl<TStore> NetworkBehaviour for Kademlia<TStore>
 where
     TStore: RecordStore + Send + 'static,
 {
-    type ConnectionHandler = KademliaHandler<QueryId>;
+    type ConnectionHandler = KademliaHandler;
     type ToSwarm = KademliaEvent;
 
     fn handle_established_inbound_connection(
@@ -2907,7 +2907,7 @@ struct QueryInner {
     ///
     /// A request is pending if the targeted peer is not currently connected
     /// and these requests are sent as soon as a connection to the peer is established.
-    pending_rpcs: SmallVec<[(PeerId, KademliaHandlerIn<QueryId>); K_VALUE.get()]>,
+    pending_rpcs: SmallVec<[(PeerId, KademliaHandlerIn); K_VALUE.get()]>,
 }
 
 impl QueryInner {
@@ -3019,7 +3019,7 @@ pub enum QueryInfo {
 impl QueryInfo {
     /// Creates an event for a handler to issue an outgoing request in the
     /// context of a query.
-    fn to_request(&self, query_id: QueryId) -> KademliaHandlerIn<QueryId> {
+    fn to_request(&self, query_id: QueryId) -> KademliaHandlerIn {
         match &self {
             QueryInfo::Bootstrap { peer, .. } => KademliaHandlerIn::FindNodeReq {
                 key: peer.to_bytes(),

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -3023,20 +3023,20 @@ impl QueryInfo {
         match &self {
             QueryInfo::Bootstrap { peer, .. } => KademliaHandlerIn::FindNodeReq {
                 key: peer.to_bytes(),
-                user_data: query_id,
+                query_id,
             },
             QueryInfo::GetClosestPeers { key, .. } => KademliaHandlerIn::FindNodeReq {
                 key: key.clone(),
-                user_data: query_id,
+                query_id,
             },
             QueryInfo::GetProviders { key, .. } => KademliaHandlerIn::GetProvidersReq {
                 key: key.clone(),
-                user_data: query_id,
+                query_id,
             },
             QueryInfo::AddProvider { key, phase, .. } => match phase {
                 AddProviderPhase::GetClosestPeers => KademliaHandlerIn::FindNodeReq {
                     key: key.to_vec(),
-                    user_data: query_id,
+                    query_id,
                 },
                 AddProviderPhase::AddProvider {
                     provider_id,
@@ -3053,16 +3053,16 @@ impl QueryInfo {
             },
             QueryInfo::GetRecord { key, .. } => KademliaHandlerIn::GetRecord {
                 key: key.clone(),
-                user_data: query_id,
+                query_id,
             },
             QueryInfo::PutRecord { record, phase, .. } => match phase {
                 PutRecordPhase::GetClosestPeers => KademliaHandlerIn::FindNodeReq {
                     key: record.key.to_vec(),
-                    user_data: query_id,
+                    query_id,
                 },
                 PutRecordPhase::PutRecord { .. } => KademliaHandlerIn::PutRecord {
                     record: record.clone(),
-                    user_data: query_id,
+                    query_id,
                 },
             },
         }

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -2081,9 +2081,9 @@ where
 
             KademliaHandlerEvent::FindNodeRes {
                 closer_peers,
-                user_data,
+                query_id,
             } => {
-                self.discovered(&user_data, &source, closer_peers.iter());
+                self.discovered(&query_id, &source, closer_peers.iter());
             }
 
             KademliaHandlerEvent::GetProvidersReq { key, request_id } => {
@@ -2113,11 +2113,11 @@ where
             KademliaHandlerEvent::GetProvidersRes {
                 closer_peers,
                 provider_peers,
-                user_data,
+                query_id,
             } => {
                 let peers = closer_peers.iter().chain(provider_peers.iter());
-                self.discovered(&user_data, &source, peers);
-                if let Some(query) = self.queries.get_mut(&user_data) {
+                self.discovered(&query_id, &source, peers);
+                if let Some(query) = self.queries.get_mut(&query_id) {
                     let stats = query.stats().clone();
                     if let QueryInfo::GetProviders {
                         ref key,
@@ -2131,7 +2131,7 @@ where
 
                         self.queued_events.push_back(ToSwarm::GenerateEvent(
                             KademliaEvent::OutboundQueryProgressed {
-                                id: user_data,
+                                id: query_id,
                                 result: QueryResult::GetProviders(Ok(
                                     GetProvidersOk::FoundProviders {
                                         key: key.clone(),
@@ -2147,16 +2147,16 @@ where
                 }
             }
 
-            KademliaHandlerEvent::QueryError { user_data, error } => {
+            KademliaHandlerEvent::QueryError { query_id, error } => {
                 log::debug!(
                     "Request to {:?} in query {:?} failed with {:?}",
                     source,
-                    user_data,
+                    query_id,
                     error
                 );
                 // If the query to which the error relates is still active,
                 // signal the failure w.r.t. `source`.
-                if let Some(query) = self.queries.get_mut(&user_data) {
+                if let Some(query) = self.queries.get_mut(&query_id) {
                     query.on_failure(&source)
                 }
             }
@@ -2209,9 +2209,9 @@ where
             KademliaHandlerEvent::GetRecordRes {
                 record,
                 closer_peers,
-                user_data,
+                query_id,
             } => {
-                if let Some(query) = self.queries.get_mut(&user_data) {
+                if let Some(query) = self.queries.get_mut(&query_id) {
                     let stats = query.stats().clone();
                     if let QueryInfo::GetRecord {
                         key,
@@ -2229,7 +2229,7 @@ where
 
                             self.queued_events.push_back(ToSwarm::GenerateEvent(
                                 KademliaEvent::OutboundQueryProgressed {
-                                    id: user_data,
+                                    id: query_id,
                                     result: QueryResult::GetRecord(Ok(GetRecordOk::FoundRecord(
                                         record,
                                     ))),
@@ -2258,15 +2258,15 @@ where
                     }
                 }
 
-                self.discovered(&user_data, &source, closer_peers.iter());
+                self.discovered(&query_id, &source, closer_peers.iter());
             }
 
             KademliaHandlerEvent::PutRecord { record, request_id } => {
                 self.record_received(source, connection, request_id, record);
             }
 
-            KademliaHandlerEvent::PutRecordRes { user_data, .. } => {
-                if let Some(query) = self.queries.get_mut(&user_data) {
+            KademliaHandlerEvent::PutRecordRes { query_id, .. } => {
+                if let Some(query) = self.queries.get_mut(&query_id) {
                     query.on_success(&source, vec![]);
                     if let QueryInfo::PutRecord {
                         phase: PutRecordPhase::PutRecord { success, .. },
@@ -2284,7 +2284,7 @@ where
                                 debug!(
                                     "PutRecord query ({:?}) reached quorum ({}/{}) with response \
                                      from peer {} but could not yet finish.",
-                                    user_data,
+                                    query_id,
                                     peers.len(),
                                     quorum,
                                     source,

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -71,7 +71,7 @@ pub struct KademliaHandler {
     pending_messages: VecDeque<(KadRequestMsg, Option<QueryId>)>,
 
     /// List of active inbound substreams with the state they are in.
-    inbound_substreams: SelectAll<InboundSubstreamState<QueryId>>,
+    inbound_substreams: SelectAll<InboundSubstreamState>,
 
     /// Until when to keep the connection alive.
     keep_alive: KeepAlive,
@@ -133,7 +133,7 @@ enum OutboundSubstreamState {
 }
 
 /// State of an active inbound substream.
-enum InboundSubstreamState<TUserData> {
+enum InboundSubstreamState {
     /// Waiting for a request from the remote.
     WaitingMessage {
         /// Whether it is the first message to be awaited on this stream.
@@ -153,11 +153,11 @@ enum InboundSubstreamState<TUserData> {
     Cancelled,
 
     Poisoned {
-        phantom: PhantomData<TUserData>,
+        phantom: PhantomData<QueryId>,
     },
 }
 
-impl<TUserData> InboundSubstreamState<TUserData> {
+impl InboundSubstreamState {
     fn try_answer_with(
         &mut self,
         id: KademliaRequestId,
@@ -931,10 +931,7 @@ impl futures::Stream for OutboundSubstreamState {
     }
 }
 
-impl<TUserData> futures::Stream for InboundSubstreamState<TUserData>
-where
-    TUserData: Unpin,
-{
+impl futures::Stream for InboundSubstreamState {
     type Item = ConnectionHandlerEvent<KademliaProtocolConfig, (), KademliaHandlerEvent, io::Error>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -1083,19 +1083,19 @@ impl futures::Stream for InboundSubstreamState {
 }
 
 /// Process a Kademlia message that's supposed to be a response to one of our requests.
-fn process_kad_response(event: KadResponseMsg, user_data: QueryId) -> KademliaHandlerEvent {
+fn process_kad_response(event: KadResponseMsg, query_id: QueryId) -> KademliaHandlerEvent {
     // TODO: must check that the response corresponds to the request
     match event {
         KadResponseMsg::Pong => {
             // We never send out pings.
             KademliaHandlerEvent::QueryError {
                 error: KademliaHandlerQueryErr::UnexpectedMessage,
-                user_data,
+                user_data: query_id,
             }
         }
         KadResponseMsg::FindNode { closer_peers } => KademliaHandlerEvent::FindNodeRes {
             closer_peers,
-            user_data,
+            user_data: query_id,
         },
         KadResponseMsg::GetProviders {
             closer_peers,
@@ -1103,7 +1103,7 @@ fn process_kad_response(event: KadResponseMsg, user_data: QueryId) -> KademliaHa
         } => KademliaHandlerEvent::GetProvidersRes {
             closer_peers,
             provider_peers,
-            user_data,
+            user_data: query_id,
         },
         KadResponseMsg::GetValue {
             record,
@@ -1111,12 +1111,12 @@ fn process_kad_response(event: KadResponseMsg, user_data: QueryId) -> KademliaHa
         } => KademliaHandlerEvent::GetRecordRes {
             record,
             closer_peers,
-            user_data,
+            user_data: query_id,
         },
         KadResponseMsg::PutValue { key, value, .. } => KademliaHandlerEvent::PutRecordRes {
             key,
             value,
-            user_data,
+            user_data: query_id,
         },
     }
 }

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -1090,12 +1090,12 @@ fn process_kad_response(event: KadResponseMsg, query_id: QueryId) -> KademliaHan
             // We never send out pings.
             KademliaHandlerEvent::QueryError {
                 error: KademliaHandlerQueryErr::UnexpectedMessage,
-                query_id: query_id,
+                query_id,
             }
         }
         KadResponseMsg::FindNode { closer_peers } => KademliaHandlerEvent::FindNodeRes {
             closer_peers,
-            query_id: query_id,
+            query_id,
         },
         KadResponseMsg::GetProviders {
             closer_peers,
@@ -1103,7 +1103,7 @@ fn process_kad_response(event: KadResponseMsg, query_id: QueryId) -> KademliaHan
         } => KademliaHandlerEvent::GetProvidersRes {
             closer_peers,
             provider_peers,
-            query_id: query_id,
+            query_id,
         },
         KadResponseMsg::GetValue {
             record,
@@ -1111,12 +1111,12 @@ fn process_kad_response(event: KadResponseMsg, query_id: QueryId) -> KademliaHan
         } => KademliaHandlerEvent::GetRecordRes {
             record,
             closer_peers,
-            query_id: query_id,
+            query_id,
         },
         KadResponseMsg::PutValue { key, value, .. } => KademliaHandlerEvent::PutRecordRes {
             key,
             value,
-            query_id: query_id,
+            query_id,
         },
     }
 }

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -43,6 +43,7 @@ use std::task::Waker;
 use std::{
     error, fmt, io, marker::PhantomData, pin::Pin, task::Context, task::Poll, time::Duration,
 };
+
 const MAX_NUM_SUBSTREAMS: usize = 32;
 
 /// Protocol handler that manages substreams for the Kademlia protocol


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

Kademlia `ConnectionHandler` used a generic `TUserData` that is replaced by `QueryId` always used in practice. 

Resolves #3607.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
