### PR TITLE
refactor(dcutr): fix typo in `observed_addreses`

### DIFF
--- a/protocols/dcutr/src/behaviour_impl.rs
+++ b/protocols/dcutr/src/behaviour_impl.rs
@@ -98,7 +98,7 @@ impl Behaviour {
         }
     }
 
-    fn observed_addreses(&self) -> Vec<Multiaddr> {
+    fn observed_addresses(&self) -> Vec<Multiaddr> {
         self.external_addresses
             .iter()
             .cloned()
@@ -132,7 +132,7 @@ impl Behaviour {
                         peer_id,
                         handler: NotifyHandler::One(connection_id),
                         event: Either::Left(handler::relayed::Command::Connect {
-                            obs_addrs: self.observed_addreses(),
+                            obs_addrs: self.observed_addresses(),
                         }),
                     },
                     ToSwarm::GenerateEvent(Event::InitiatedDirectConnectionUpgrade {
@@ -189,7 +189,7 @@ impl Behaviour {
                 handler: NotifyHandler::One(relayed_connection_id),
                 peer_id,
                 event: Either::Left(handler::relayed::Command::Connect {
-                    obs_addrs: self.observed_addreses(),
+                    obs_addrs: self.observed_addresses(),
                 }),
             })
         } else {
@@ -339,7 +339,7 @@ impl NetworkBehaviour for Behaviour {
                         peer_id: event_source,
                         event: Either::Left(handler::relayed::Command::AcceptInboundConnect {
                             inbound_connect,
-                            obs_addrs: self.observed_addreses(),
+                            obs_addrs: self.observed_addresses(),
                         }),
                     },
                     ToSwarm::GenerateEvent(Event::RemoteInitiatedDirectConnectionUpgrade {


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->



## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

Rename `observed_addreses` to `observed_addresses`.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
