### PR TITLE
fix(swarm): poll handler after injecting `LocalProtocolsChange` event

### DIFF
--- a/swarm/src/connection.rs
+++ b/swarm/src/connection.rs
@@ -425,12 +425,17 @@ where
             }
 
             let new_protocols = gather_supported_protocols(handler);
+            let changes = ProtocolsChange::from_full_sets(supported_protocols, &new_protocols);
 
-            for change in ProtocolsChange::from_full_sets(supported_protocols, &new_protocols) {
-                handler.on_connection_event(ConnectionEvent::LocalProtocolsChange(change));
+            if !changes.is_empty() {
+                for change in changes {
+                    handler.on_connection_event(ConnectionEvent::LocalProtocolsChange(change));
+                }
+
+                *supported_protocols = new_protocols;
+
+                continue; // Go back to the top, handler can potentially make progress again.
             }
-
-            *supported_protocols = new_protocols;
 
             return Poll::Pending; // Nothing can make progress, return `Pending`.
         }


### PR DESCRIPTION
## Description

Previously, we would not call the handler upon injecting `ConnectionEvent::LocalProtocolsChange`. This would prevent protocols from being able to react to this change and e.g. issue events or open streams.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

I decided to not add a changelog entry because this is a bug-fix for a yet-to-be-released feature.

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
