### PR TITLE
fix: remove obsolete `event_process = false`

### DIFF
--- a/examples/dcutr/src/main.rs
+++ b/examples/dcutr/src/main.rs
@@ -104,7 +104,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     .boxed();
 
     #[derive(NetworkBehaviour)]
-    #[behaviour(to_swarm = "Event", event_process = false)]
+    #[behaviour(to_swarm = "Event")]
     struct Behaviour {
         relay_client: relay::client::Behaviour,
         ping: ping::Behaviour,

--- a/protocols/dcutr/tests/lib.rs
+++ b/protocols/dcutr/tests/lib.rs
@@ -136,11 +136,7 @@ fn build_client() -> Swarm<Client> {
 }
 
 #[derive(NetworkBehaviour)]
-#[behaviour(
-    to_swarm = "ClientEvent",
-    event_process = false,
-    prelude = "libp2p_swarm::derive_prelude"
-)]
+#[behaviour(to_swarm = "ClientEvent", prelude = "libp2p_swarm::derive_prelude")]
 struct Client {
     relay: relay::client::Behaviour,
     dcutr: dcutr::Behaviour,

--- a/transports/webrtc/examples/listen_ping.rs
+++ b/transports/webrtc/examples/listen_ping.rs
@@ -37,11 +37,7 @@ fn create_swarm() -> Result<Swarm<Behaviour>> {
 }
 
 #[derive(NetworkBehaviour, Default)]
-#[behaviour(
-    to_swarm = "Event",
-    event_process = false,
-    prelude = "libp2p_swarm::derive_prelude"
-)]
+#[behaviour(to_swarm = "Event", prelude = "libp2p_swarm::derive_prelude")]
 struct Behaviour {
     ping: ping::Behaviour,
     keep_alive: keep_alive::Behaviour,


### PR DESCRIPTION
## Description

The `libp2p-swarm-derive` `event_process` option was removed in https://github.com/libp2p/rust-libp2p/pull/2840.



<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
