### PR TITLE
fix(yamux): don't register waker on success

### DIFF
--- a/muxers/yamux/src/lib.rs
+++ b/muxers/yamux/src/lib.rs
@@ -100,9 +100,12 @@ where
             return Poll::Ready(Ok(stream));
         }
 
-        self.inbound_stream_waker = Some(cx.waker().clone());
+        if let Poll::Ready(res) = self.poll_inner(cx) {
+            return Poll::Ready(res);
+        }
 
-        self.poll_inner(cx)
+        self.inbound_stream_waker = Some(cx.waker().clone());
+        Poll::Pending
     }
 
     fn poll_outbound(


### PR DESCRIPTION


## Description
In case `self.poll_inner` returns `Poll::Ready` there is no need to register `self.inbound_stream_waker`. With this commit, `self.inbound_stream_waker` is only registered in case `self.poll_inner` returned `Poll::Pending`.
<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
