### PR TITLE
fix(libp2p): don't re-export libp2p-perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2408,7 +2408,6 @@ dependencies = [
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-noise",
- "libp2p-perf",
  "libp2p-ping",
  "libp2p-plaintext",
  "libp2p-pnet",

--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -18,13 +18,13 @@
   See [PR 3920].
 
 - Remove `libp2p-perf` protocol. To use `libp2p-perf` one needs to import it directly.
-  See [PR XXX].
+  See [PR 3990].
 
 [PR 3715]: https://github.com/libp2p/rust-libp2p/pull/3715
 [PR 3746]: https://github.com/libp2p/rust-libp2p/pull/3746
 [PR 3848]: https://github.com/libp2p/rust-libp2p/pull/3848
 [PR 3920]: https://github.com/libp2p/rust-libp2p/pull/3920
-[PR XXX]: https://github.com/libp2p/rust-libp2p/pull/XXX
+[PR 3990]: https://github.com/libp2p/rust-libp2p/pull/3990
 
 ## 0.51.3
 

--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -9,7 +9,7 @@
   This newtype enforces additional variants like a leading forward-slash.
   We encourage users to use `StreamProtocol` when implementing `UpgradeInfo`.
   See [PR 3746].
-  
+
 - Rename `NetworkBehaviour::OutEvent` to `NetworkBehaviour::ToSwarm`, `ConnectionHandler::InEvent` to `ConnectionHandler::FromBehaviour`, `ConnectionHandler::OutEvent` to `ConnectionHandler::ToBehaviour`. See [PR 3848].
 
 - Remove deprecated `mplex` module.
@@ -17,10 +17,14 @@
   This also removes `mplex` from the `development_transport` and `tokio_development_transport` functions.
   See [PR 3920].
 
+- Remove `libp2p-perf` protocol. To use `libp2p-perf` one needs to import it directly.
+  See [PR XXX].
+
 [PR 3715]: https://github.com/libp2p/rust-libp2p/pull/3715
 [PR 3746]: https://github.com/libp2p/rust-libp2p/pull/3746
 [PR 3848]: https://github.com/libp2p/rust-libp2p/pull/3848
 [PR 3920]: https://github.com/libp2p/rust-libp2p/pull/3920
+[PR XXX]: https://github.com/libp2p/rust-libp2p/pull/XXX
 
 ## 0.51.3
 

--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -27,7 +27,6 @@ full = [
     "mdns",
     "metrics",
     "noise",
-    "perf",
     "ping",
     "plaintext",
     "pnet",
@@ -65,7 +64,6 @@ macros = ["libp2p-swarm/macros"]
 mdns = ["dep:libp2p-mdns"]
 metrics = ["dep:libp2p-metrics"]
 noise = ["dep:libp2p-noise"]
-perf = ["dep:libp2p-perf"]
 ping = ["dep:libp2p-ping", "libp2p-metrics?/ping"]
 plaintext = ["dep:libp2p-plaintext"]
 pnet = ["dep:libp2p-pnet"]
@@ -123,7 +121,6 @@ pin-project = "1.0.0"
 libp2p-deflate = { workspace = true, optional = true }
 libp2p-dns = { workspace = true, optional = true }
 libp2p-mdns = { workspace = true, optional = true }
-libp2p-perf = { workspace = true, optional = true }
 libp2p-quic = { workspace = true, optional = true }
 libp2p-tcp = { workspace = true, optional = true }
 libp2p-tls = { workspace = true, optional = true }

--- a/libp2p/src/lib.rs
+++ b/libp2p/src/lib.rs
@@ -85,11 +85,6 @@ pub use libp2p_metrics as metrics;
 #[cfg(feature = "noise")]
 #[doc(inline)]
 pub use libp2p_noise as noise;
-#[cfg(feature = "perf")]
-#[cfg(not(target_arch = "wasm32"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "perf")))]
-#[doc(inline)]
-pub use libp2p_perf as perf;
 #[cfg(feature = "ping")]
 #[doc(inline)]
 pub use libp2p_ping as ping;


### PR DESCRIPTION
## Description

This commit removes the `libp2p-perf` protocol from `libp2p` crate. To use `libp2p-perf` one needs to import it directly. Rational beeing that `libp2p-perf`'s API is not yet stable enough and will most likely require breaking changes in the near future.



<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
