### PR TITLE
feat(noise): add WebTransport certhashes extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2710,6 +2710,8 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "log",
+ "multiaddr",
+ "multihash",
  "once_cell",
  "quick-protobuf",
  "quickcheck-ext",

--- a/transports/noise/CHANGELOG.md
+++ b/transports/noise/CHANGELOG.md
@@ -5,8 +5,12 @@
 
 - Remove deprecated APIs. See [PR 3511].
 
+- Add `Config::with_webtransport_certhashes`. See [PR 3991].
+  This can be used by WebTransport implementers to send (responder) or verify (initiator) certhashes.
+
 [PR 3511]: https://github.com/libp2p/rust-libp2p/pull/3511
 [PR 3715]: https://github.com/libp2p/rust-libp2p/pull/3715
+[PR 3715]: https://github.com/libp2p/rust-libp2p/pull/3991
 
 ## 0.42.2
 

--- a/transports/noise/Cargo.toml
+++ b/transports/noise/Cargo.toml
@@ -15,8 +15,10 @@ futures = "0.3.28"
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true, features = ["ed25519"] }
 log = "0.4"
-quick-protobuf = "0.8"
+multiaddr = { workspace = true }
+multihash = { workspace = true }
 once_cell = "1.18.0"
+quick-protobuf = "0.8"
 rand = "0.8.3"
 sha2 = "0.10.0"
 static_assertions = "1"
@@ -35,7 +37,7 @@ env_logger = "0.10.0"
 futures_ringbuf = "0.4.0"
 quickcheck = { workspace = true }
 
-# Passing arguments to the docsrs builder in order to properly document cfg's. 
+# Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true

--- a/transports/noise/src/generated/payload.proto
+++ b/transports/noise/src/generated/payload.proto
@@ -1,11 +1,15 @@
 syntax = "proto3";
-
 package payload.proto;
 
 // Payloads for Noise handshake messages.
 
+message NoiseExtensions {
+    repeated bytes webtransport_certhashes = 1;
+    repeated string stream_muxers = 2;
+}
+
 message NoiseHandshakePayload {
     bytes identity_key = 1;
     bytes identity_sig = 2;
-    bytes data         = 3;
+    optional NoiseExtensions extensions = 4;
 }

--- a/transports/noise/src/generated/payload/proto.rs
+++ b/transports/noise/src/generated/payload/proto.rs
@@ -15,10 +15,46 @@ use super::super::*;
 
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Default, PartialEq, Clone)]
+pub struct NoiseExtensions {
+    pub webtransport_certhashes: Vec<Vec<u8>>,
+    pub stream_muxers: Vec<String>,
+}
+
+impl<'a> MessageRead<'a> for NoiseExtensions {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
+        let mut msg = Self::default();
+        while !r.is_eof() {
+            match r.next_tag(bytes) {
+                Ok(10) => msg.webtransport_certhashes.push(r.read_bytes(bytes)?.to_owned()),
+                Ok(18) => msg.stream_muxers.push(r.read_string(bytes)?.to_owned()),
+                Ok(t) => { r.read_unknown(bytes, t)?; }
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(msg)
+    }
+}
+
+impl MessageWrite for NoiseExtensions {
+    fn get_size(&self) -> usize {
+        0
+        + self.webtransport_certhashes.iter().map(|s| 1 + sizeof_len((s).len())).sum::<usize>()
+        + self.stream_muxers.iter().map(|s| 1 + sizeof_len((s).len())).sum::<usize>()
+    }
+
+    fn write_message<W: WriterBackend>(&self, w: &mut Writer<W>) -> Result<()> {
+        for s in &self.webtransport_certhashes { w.write_with_tag(10, |w| w.write_bytes(&**s))?; }
+        for s in &self.stream_muxers { w.write_with_tag(18, |w| w.write_string(&**s))?; }
+        Ok(())
+    }
+}
+
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Debug, Default, PartialEq, Clone)]
 pub struct NoiseHandshakePayload {
     pub identity_key: Vec<u8>,
     pub identity_sig: Vec<u8>,
-    pub data: Vec<u8>,
+    pub extensions: Option<payload::proto::NoiseExtensions>,
 }
 
 impl<'a> MessageRead<'a> for NoiseHandshakePayload {
@@ -28,7 +64,7 @@ impl<'a> MessageRead<'a> for NoiseHandshakePayload {
             match r.next_tag(bytes) {
                 Ok(10) => msg.identity_key = r.read_bytes(bytes)?.to_owned(),
                 Ok(18) => msg.identity_sig = r.read_bytes(bytes)?.to_owned(),
-                Ok(26) => msg.data = r.read_bytes(bytes)?.to_owned(),
+                Ok(34) => msg.extensions = Some(r.read_message::<payload::proto::NoiseExtensions>(bytes)?),
                 Ok(t) => { r.read_unknown(bytes, t)?; }
                 Err(e) => return Err(e),
             }
@@ -42,13 +78,13 @@ impl MessageWrite for NoiseHandshakePayload {
         0
         + if self.identity_key.is_empty() { 0 } else { 1 + sizeof_len((&self.identity_key).len()) }
         + if self.identity_sig.is_empty() { 0 } else { 1 + sizeof_len((&self.identity_sig).len()) }
-        + if self.data.is_empty() { 0 } else { 1 + sizeof_len((&self.data).len()) }
+        + self.extensions.as_ref().map_or(0, |m| 1 + sizeof_len((m).get_size()))
     }
 
     fn write_message<W: WriterBackend>(&self, w: &mut Writer<W>) -> Result<()> {
         if !self.identity_key.is_empty() { w.write_with_tag(10, |w| w.write_bytes(&**&self.identity_key))?; }
         if !self.identity_sig.is_empty() { w.write_with_tag(18, |w| w.write_bytes(&**&self.identity_sig))?; }
-        if !self.data.is_empty() { w.write_with_tag(26, |w| w.write_bytes(&**&self.data))?; }
+        if let Some(ref s) = self.extensions { w.write_with_tag(34, |w| w.write_message(s))?; }
         Ok(())
     }
 }

--- a/transports/noise/src/io/framed.rs
+++ b/transports/noise/src/io/framed.rs
@@ -81,6 +81,14 @@ impl<T> NoiseFramed<T, snow::HandshakeState> {
         }
     }
 
+    pub(crate) fn is_initiator(&self) -> bool {
+        self.session.is_initiator()
+    }
+
+    pub(crate) fn is_responder(&self) -> bool {
+        !self.session.is_initiator()
+    }
+
     /// Converts the `NoiseFramed` into a `NoiseOutput` encrypted data stream
     /// once the handshake is complete, including the static DH [`PublicKey`]
     /// of the remote, if received.

--- a/transports/noise/tests/smoke.rs
+++ b/transports/noise/tests/smoke.rs
@@ -50,8 +50,8 @@ fn xx() {
 
         futures::executor::block_on(async move {
             let (
-                (reported_client_id, mut client_session),
-                (reported_server_id, mut server_session),
+                (reported_client_id, mut server_session),
+                (reported_server_id, mut client_session),
             ) = futures::future::try_join(
                 noise::Config::new(&server_id)
                     .unwrap()

--- a/transports/noise/tests/webtransport_certhashes.rs
+++ b/transports/noise/tests/webtransport_certhashes.rs
@@ -1,0 +1,152 @@
+use libp2p_core::{InboundUpgrade, OutboundUpgrade};
+use libp2p_identity as identity;
+use libp2p_noise as noise;
+use multihash::Multihash;
+use std::collections::HashSet;
+
+const SHA_256_MH: u64 = 0x12;
+
+#[test]
+fn webtransport_same_set_of_certhashes() {
+    let (certhash1, certhash2, _) = certhashes();
+
+    handshake_with_certhashes(vec![certhash1, certhash2], vec![certhash1, certhash2]).unwrap();
+}
+
+#[test]
+fn webtransport_subset_of_certhashes() {
+    let (certhash1, certhash2, _) = certhashes();
+
+    handshake_with_certhashes(vec![certhash1], vec![certhash1, certhash2]).unwrap();
+}
+
+#[test]
+fn webtransport_client_without_certhashes() {
+    let (certhash1, certhash2, _) = certhashes();
+
+    // Valid when server uses CA-signed TLS certificate.
+    handshake_with_certhashes(vec![], vec![certhash1, certhash2]).unwrap();
+}
+
+#[test]
+fn webtransport_client_and_server_without_certhashes() {
+    // Valid when server uses CA-signed TLS certificate.
+    handshake_with_certhashes(vec![], vec![]).unwrap();
+}
+
+#[test]
+fn webtransport_server_empty_certhashes() {
+    let (certhash1, certhash2, _) = certhashes();
+
+    // Invalid case, because a MITM attacker may strip certificates of the server.
+    let Err(noise::Error::UnknownWebTransportCerthashes(expected, received)) =
+        handshake_with_certhashes(vec![certhash1, certhash2], vec![]) else {
+            panic!("unexpected result");
+        };
+
+    assert_eq!(expected, HashSet::from([certhash1, certhash2]));
+    assert_eq!(received, HashSet::new());
+}
+
+#[test]
+fn webtransport_client_uninit_certhashes() {
+    let (certhash1, certhash2, _) = certhashes();
+
+    // Valid when server uses CA-signed TLS certificate.
+    handshake_with_certhashes(None, vec![certhash1, certhash2]).unwrap();
+}
+
+#[test]
+fn webtransport_client_and_server_uninit_certhashes() {
+    // Valid when server uses CA-signed TLS certificate.
+    handshake_with_certhashes(None, None).unwrap();
+}
+
+#[test]
+fn webtransport_server_uninit_certhashes() {
+    let (certhash1, certhash2, _) = certhashes();
+
+    // Invalid case, because a MITM attacker may strip certificates of the server.
+    let Err(noise::Error::UnknownWebTransportCerthashes(expected, received)) =
+        handshake_with_certhashes(vec![certhash1, certhash2], None) else {
+            panic!("unexpected result");
+        };
+
+    assert_eq!(expected, HashSet::from([certhash1, certhash2]));
+    assert_eq!(received, HashSet::new());
+}
+
+#[test]
+fn webtransport_different_server_certhashes() {
+    let (certhash1, certhash2, certhash3) = certhashes();
+
+    let Err(noise::Error::UnknownWebTransportCerthashes(expected, received)) =
+        handshake_with_certhashes(vec![certhash1, certhash3], vec![certhash1, certhash2]) else {
+            panic!("unexpected result");
+        };
+
+    assert_eq!(expected, HashSet::from([certhash1, certhash3]));
+    assert_eq!(received, HashSet::from([certhash1, certhash2]));
+}
+
+#[test]
+fn webtransport_superset_of_certhashes() {
+    let (certhash1, certhash2, _) = certhashes();
+
+    let Err(noise::Error::UnknownWebTransportCerthashes(expected, received)) =
+        handshake_with_certhashes(vec![certhash1, certhash2], vec![certhash1]) else {
+            panic!("unexpected result");
+        };
+
+    assert_eq!(expected, HashSet::from([certhash1, certhash2]));
+    assert_eq!(received, HashSet::from([certhash1]));
+}
+
+fn certhashes() -> (Multihash<64>, Multihash<64>, Multihash<64>) {
+    (
+        Multihash::wrap(SHA_256_MH, b"1").unwrap(),
+        Multihash::wrap(SHA_256_MH, b"2").unwrap(),
+        Multihash::wrap(SHA_256_MH, b"3").unwrap(),
+    )
+}
+
+// `valid_certhases` must be a strict subset of `server_certhashes`.
+fn handshake_with_certhashes(
+    valid_certhases: impl Into<Option<Vec<Multihash<64>>>>,
+    server_certhashes: impl Into<Option<Vec<Multihash<64>>>>,
+) -> Result<(), noise::Error> {
+    let valid_certhases = valid_certhases.into();
+    let server_certhashes = server_certhashes.into();
+
+    let client_id = identity::Keypair::generate_ed25519();
+    let server_id = identity::Keypair::generate_ed25519();
+
+    let (client, server) = futures_ringbuf::Endpoint::pair(100, 100);
+
+    futures::executor::block_on(async move {
+        let mut client_config = noise::Config::new(&client_id)?;
+        let mut server_config = noise::Config::new(&server_id)?;
+
+        if let Some(valid_certhases) = valid_certhases {
+            client_config =
+                client_config.with_webtransport_certhashes(valid_certhases.into_iter().collect());
+        }
+
+        if let Some(server_certhashes) = server_certhashes {
+            server_config =
+                server_config.with_webtransport_certhashes(server_certhashes.into_iter().collect());
+        }
+
+        let ((reported_client_id, mut _server_session), (reported_server_id, mut _client_session)) =
+            futures::future::try_join(
+                server_config.upgrade_inbound(server, ""),
+                client_config.upgrade_outbound(client, ""),
+            )
+            .await?;
+
+        assert_eq!(reported_client_id, client_id.public().to_peer_id());
+        assert_eq!(reported_server_id, server_id.public().to_peer_id());
+
+        Ok(())
+    })
+}


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

The extension for WebTransport certhashes was added and can be configured via `Config::with_webtransport_certhashes`.

In case of initiator, these certhashes will be used to validate the ones reported by responder. In case of responder, these certhashes will be reported to initiator.

Resolves #3988.
## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

I had also implemented another way to resolve this issue, which was exposing certhashes via `Output<T>::webtransport_certhashes`. In that implementation the user (i.e. the WebTransport implementer) was responsible to check if the certhashes were valid, but I wasn't sure if I like it.

With the code of this PR, the user needs to only define certhashes in the `Config`, so I find it less error prone. However it might be less future proof.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
