### PR TITLE
fix(ping): remove debug_assert on protocol negotiation timeout

### DIFF
--- a/protocols/ping/src/handler.rs
+++ b/protocols/ping/src/handler.rs
@@ -196,10 +196,12 @@ impl Handler {
                 return;
             }
             // Note: This timeout only covers protocol negotiation.
-            StreamUpgradeError::Timeout => {
-                debug_assert!(false, "ReadyUpgrade cannot time out");
-                return;
-            }
+            StreamUpgradeError::Timeout => Failure::Other {
+                error: Box::new(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "ping protocol negotiation timed out",
+                )),
+            },
             StreamUpgradeError::Apply(e) => void::unreachable(e),
             StreamUpgradeError::Io(e) => Failure::Other { error: Box::new(e) },
         };


### PR DESCRIPTION
## Description

The negotiation of the ping protocol can timeout, thus a debug_assert is not correct. Return an `std::io::Error` instead.



<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

I ran into this issue with https://github.com/mxinden/kademlia-exporter/ using latest `master`.

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
