### PR TITLE
fix(metrics/identify): remove newline in metric description

### DIFF
--- a/misc/metrics/src/identify.rs
+++ b/misc/metrics/src/identify.rs
@@ -36,8 +36,7 @@ use std::sync::{Arc, Mutex};
 static PROTOCOLS_DESCRIPTOR: Lazy<Descriptor> = Lazy::new(|| {
     Descriptor::new(
         "remote_protocols",
-        r#"Number of connected nodes supporting a specific protocol, with "unrecognized" for each
-        peer supporting one or more unrecognized protocols"#,
+        "Number of connected nodes supporting a specific protocol, with \"unrecognized\" for each peer supporting one or more unrecognized protocols",
         None,
         None,
         vec![],


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

Otherwise one gets the following invalid Prometheus output. Note the newline.
```
# HELP libp2p_libp2p_identify_remote_protocols Number of connected nodes supporting a specific protocol, with "unrecognized" for each
        peer supporting one or more unrecognized protocols...
# TYPE libp2p_libp2p_identify_remote_protocols gauge
libp2p_libp2p_identify_remote_protocols{protocol="unrecognized"} 1057
```

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
