### PR TITLE
fix(multistream-select): don't wait for negotiation in poll_close

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,7 +1748,19 @@ dependencies = [
  "futures",
  "log",
  "log-derive",
- "ringbuf",
+ "ringbuf 0.2.8",
+ "rustc_version",
+]
+
+[[package]]
+name = "futures_ringbuf"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6628abb6eb1fc74beaeb20cd0670c43d158b0150f7689b38c3eaf663f99bdec7"
+dependencies = [
+ "futures",
+ "log",
+ "ringbuf 0.3.3",
  "rustc_version",
 ]
 
@@ -2500,7 +2512,7 @@ dependencies = [
  "async-std",
  "flate2",
  "futures",
- "futures_ringbuf",
+ "futures_ringbuf 0.3.1",
  "libp2p-core",
  "libp2p-tcp",
  "quickcheck-ext",
@@ -2741,7 +2753,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "futures-timer",
- "futures_ringbuf",
+ "futures_ringbuf 0.3.1",
  "libp2p-core",
  "log",
 ]
@@ -2754,7 +2766,7 @@ dependencies = [
  "curve25519-dalek 3.2.0",
  "env_logger 0.10.0",
  "futures",
- "futures_ringbuf",
+ "futures_ringbuf 0.3.1",
  "libp2p-core",
  "libp2p-identity",
  "log",
@@ -2827,7 +2839,7 @@ dependencies = [
  "bytes",
  "env_logger 0.10.0",
  "futures",
- "futures_ringbuf",
+ "futures_ringbuf 0.3.1",
  "libp2p-core",
  "libp2p-identity",
  "log",
@@ -2950,7 +2962,7 @@ dependencies = [
  "async-trait",
  "env_logger 0.10.0",
  "futures",
- "futures_ringbuf",
+ "futures_ringbuf 0.3.1",
  "instant",
  "libp2p-core",
  "libp2p-identity",
@@ -3428,6 +3440,7 @@ dependencies = [
  "bytes",
  "env_logger 0.10.0",
  "futures",
+ "futures_ringbuf 0.4.0",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-mplex",
@@ -4306,6 +4319,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f65af18d50f789e74aaf23bbb3f65dcd22a3cb6e029b5bced149f6bd57c5c2a2"
 dependencies = [
  "cache-padded",
+]
+
+[[package]]
+name = "ringbuf"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79abed428d1fd2a128201cec72c5f6938e2da607c6f3745f769fabea399d950a"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/misc/multistream-select/CHANGELOG.md
+++ b/misc/multistream-select/CHANGELOG.md
@@ -1,8 +1,13 @@
 ## 0.13.0 - unreleased
 
+- Don't wait for negotiation on `<Negotiated as AsyncWrite>::poll_close`.
+  This can save one round-trip for protocols that use stream closing as an operation in ones protocol, e.g. using stream closing to signal the end of a request.
+  See [PR 4019] for details.
+
 - Raise MSRV to 1.65.
   See [PR 3715].
 
+[PR 4019]: https://github.com/libp2p/rust-libp2p/pull/4019
 [PR 3715]: https://github.com/libp2p/rust-libp2p/pull/3715
 
 ## 0.12.1

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -21,6 +21,7 @@ unsigned-varint = "0.7"
 [dev-dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }
 env_logger = "0.10"
+futures_ringbuf = "0.4.0"
 libp2p-core = { workspace = true }
 libp2p-mplex = { workspace = true }
 libp2p-plaintext = { workspace = true }

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -19,7 +19,7 @@ smallvec = "1.6.1"
 unsigned-varint = "0.7"
 
 [dev-dependencies]
-async-std = "1.6.2"
+async-std = { version = "1.6.2", features = ["attributes"] }
 env_logger = "0.10"
 libp2p-core = { workspace = true }
 libp2p-mplex = { workspace = true }
@@ -30,7 +30,7 @@ quickcheck = { workspace = true }
 rand = "0.8"
 rw-stream-sink = { workspace = true }
 
-# Passing arguments to the docsrs builder in order to properly document cfg's. 
+# Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true

--- a/misc/multistream-select/src/negotiated.rs
+++ b/misc/multistream-select/src/negotiated.rs
@@ -305,9 +305,7 @@ where
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        // Ensure all data has been flushed and expected negotiation messages
-        // have been received.
-        ready!(self.as_mut().poll(cx).map_err(Into::<io::Error>::into)?);
+        // Ensure all data has been flushed.
         ready!(self
             .as_mut()
             .poll_flush(cx)

--- a/misc/multistream-select/src/negotiated.rs
+++ b/misc/multistream-select/src/negotiated.rs
@@ -305,7 +305,7 @@ where
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        // Ensure all data has been flushed.
+        // Ensure all data has been flushed, including optimistic multistream-select messages.
         ready!(self
             .as_mut()
             .poll_flush(cx)
@@ -314,7 +314,13 @@ where
         // Continue with the shutdown of the underlying I/O stream.
         match self.project().state.project() {
             StateProj::Completed { io, .. } => io.poll_close(cx),
-            StateProj::Expecting { io, .. } => io.poll_close(cx),
+            StateProj::Expecting { io, .. } => {
+                let close_poll = io.poll_close(cx);
+                if let Poll::Ready(Ok(())) = close_poll {
+                    log::debug!("Stream closed. Confirmation from remote for optimstic protocol negotiation still pending.")
+                }
+                close_poll
+            }
             StateProj::Invalid => panic!("Negotiated: Invalid state"),
         }
     }

--- a/misc/multistream-select/tests/dialer_select.rs
+++ b/misc/multistream-select/tests/dialer_select.rs
@@ -20,9 +20,9 @@
 
 //! Integration tests for protocol negotiation.
 
-use std::time::Duration;
 use futures::prelude::*;
 use multistream_select::{dialer_select_proto, listener_select_proto, NegotiationError, Version};
+use std::time::Duration;
 
 #[test]
 fn select_proto_basic() {


### PR DESCRIPTION
## Description

With `Version::V1Lazy` and negotiation of a single protocol, a stream initiator optimistically
sends application data right after proposing its protocol. More specifically an application can
write data via `AsyncWrite::poll_write` even though the remote has not yet confirmed the stream protocol.

This saves one round-trip.

``` mermaid
sequenceDiagram
    A->>B: "/multistream/1.0.0"
    A->>B: "/perf/1.0.0"
    A->>B: <some-perf-protocol-data>
    B->>A: "/multistream/1.0.0"
    B->>A: "/perf/1.0.0"
    B->>A: <some-perf-protocol-data>
```

When considering stream closing, i.e. `AsyncWrite::poll_close`, and using stream closing as an
operation in ones protocol, e.g. using stream closing to signal the end of a request, this becomes tricky.

The behavior without this commit was as following:

``` mermaid
sequenceDiagram
    A->>B: "/multistream/1.0.0"
    A->>B: "/perf/1.0.0"
    A->>B: <some-perf-protocol-data>
    Note left of A: Call `AsyncWrite::poll_close` which first waits for the<br/>optimistic multistream-select negotiation to finish, before closing the stream,<br/> i.e. setting the FIN bit.
    B->>A: "/multistream/1.0.0"
    B->>A: "/perf/1.0.0"
    Note right of B: Waiting for A to close the stream (i.e. set the `FIN` bit)<br/>before sending the response.
    A->>B: FIN
    B->>A: <some-perf-protocol-data>
```

The above takes 2 round trips:

1. Send the optimistic multistream-select protocol proposals as well as the initiator protocol
payload and waits for the confirmation of the protocols.
2. Close the stream, i.e. sends the `FIN` bit and waits for the responder protocol payload.

This commit proposes that the stream initiator should not wait for the multistream-select protocol
confirmation when closing the stream, but close the stream within the first round-trip.

``` mermaid
sequenceDiagram
    A->>B: "/multistream/1.0.0"
    A->>B: "/perf/1.0.0"
    A->>B: <some-perf-protocol-data>
    A->>B: FIN
    B->>A: "/multistream/1.0.0"
    B->>A: "/perf/1.0.0"
    B->>A: <some-perf-protocol-data>
```

This takes 1 round-trip.

The downside of this commit is, that the stream initiator will no longer notice a negotiation error
when closing the stream. They will only notice it when reading from the stream. E.g. say that B does
not support "/perf/1.0.0", A will only notice on `AsyncRead::poll_read`, not on
`AsyncWrite::poll_close`. This is problematic for protocols where A only sends data, but never
receives data, i.e. never calls `AsyncRead::poll_read`. Though one can argue that such protocol is
flawed in the first place. With a response-less protocol, as even if negotiation succceeds, A
doesn't know whether B received the protocol payload.

## Notes & open questions

Confirmed against libp2p-perf.max-inden.de/ and with https://github.com/libp2p/test-plans/pull/184.