### PR TITLE
feat(swarm): add `ConnectionDenied::downcast_ref`

### DIFF
--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -64,6 +64,8 @@
 
 - Remove deprecated items. See [PR 3956].
 
+- Add ability to `downcast_ref` ConnectionDenied errors. See [PR 4020].
+
 [PR 3292]: https://github.com/libp2p/rust-libp2p/pull/3292
 [PR 3605]: https://github.com/libp2p/rust-libp2p/pull/3605
 [PR 3651]: https://github.com/libp2p/rust-libp2p/pull/3651
@@ -80,6 +82,7 @@
 [PR 3927]: https://github.com/libp2p/rust-libp2p/pull/3927
 [PR 3955]: https://github.com/libp2p/rust-libp2p/pull/3955
 [PR 3956]: https://github.com/libp2p/rust-libp2p/pull/3956
+[PR 4020]: https://github.com/libp2p/rust-libp2p/pull/4020
 [PR 4037]: https://github.com/libp2p/rust-libp2p/pull/4037
 
 ## 0.42.2

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1730,6 +1730,14 @@ impl ConnectionDenied {
 
         Ok(*inner)
     }
+
+    /// Attempt to downcast to a particular reason for why the connection was denied.
+    pub fn downcast_ref<E>(&self) -> Option<&E>
+    where
+        E: error::Error + Send + Sync + 'static,
+    {
+        self.inner.downcast_ref::<E>()
+    }
 }
 
 impl fmt::Display for ConnectionDenied {


### PR DESCRIPTION

## Description

Prior to this change it was only possible to downcast a `ConnectionDenied` error when you had ownership of it which isn't the case inside `NetworkBehaviour`s. This change allows downcasting by reference.

See https://github.com/libp2p/rust-libp2p/discussions/4018.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
