### PR TITLE
fix(swarm): make test not flaky

### DIFF
--- a/swarm/src/behaviour/external_addresses.rs
+++ b/swarm/src/behaviour/external_addresses.rs
@@ -80,6 +80,7 @@ impl ExternalAddresses {
 
 #[cfg(test)]
 mod tests {
+    use std::iter;
     use super::*;
     use crate::dummy;
     use libp2p_core::multiaddr::Protocol;
@@ -126,7 +127,7 @@ mod tests {
     fn when_pushing_more_than_max_addresses_oldest_is_evicted() {
         let mut addresses = ExternalAddresses::default();
 
-        for _ in 0..MAX_LOCAL_EXTERNAL_ADDRS {
+        while addresses.as_slice().len() < MAX_LOCAL_EXTERNAL_ADDRS {
             let random_address =
                 Multiaddr::empty().with(Protocol::Memory(rand::thread_rng().gen_range(0..1000)));
             addresses.on_swarm_event(

--- a/swarm/src/behaviour/external_addresses.rs
+++ b/swarm/src/behaviour/external_addresses.rs
@@ -80,7 +80,6 @@ impl ExternalAddresses {
 
 #[cfg(test)]
 mod tests {
-    use std::iter;
     use super::*;
     use crate::dummy;
     use libp2p_core::multiaddr::Protocol;


### PR DESCRIPTION
## Description

In the unlikely event that we generated a random number twice, the 2nd address would not get added. Ensure we loop until we have 20 addresses.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
