### PR TITLE
feat(request-response): use `cbor` codec in `ping` example

### DIFF
--- a/protocols/request-response/tests/ping.rs
+++ b/protocols/request-response/tests/ping.rs
@@ -20,16 +20,15 @@
 
 //! Integration tests for the `Behaviour`.
 
-use async_trait::async_trait;
-use futures::{prelude::*, AsyncWriteExt};
-use libp2p_core::upgrade::{read_length_prefixed, write_length_prefixed};
+use futures::prelude::*;
 use libp2p_identity::PeerId;
 use libp2p_request_response as request_response;
 use libp2p_request_response::ProtocolSupport;
 use libp2p_swarm::{StreamProtocol, Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt;
 use rand::{self, Rng};
-use std::{io, iter};
+use serde::{Deserialize, Serialize};
+use std::iter;
 
 #[async_std::test]
 async fn is_response_outbound() {
@@ -37,14 +36,14 @@ async fn is_response_outbound() {
     let ping = Ping("ping".to_string().into_bytes());
     let offline_peer = PeerId::random();
 
-    let protocols = iter::once((
-        StreamProtocol::new("/ping/1"),
-        request_response::ProtocolSupport::Full,
-    ));
-    let cfg = request_response::Config::default();
-
     let mut swarm1 = Swarm::new_ephemeral(|_| {
-        request_response::Behaviour::with_codec(PingCodec(), protocols, cfg)
+        request_response::cbor::Behaviour::<Ping, Pong>::new(
+            [(
+                StreamProtocol::new("/ping/1"),
+                request_response::ProtocolSupport::Full,
+            )],
+            request_response::Config::default(),
+        )
     });
 
     let request_id1 = swarm1
@@ -88,11 +87,11 @@ async fn ping_protocol() {
     let cfg = request_response::Config::default();
 
     let mut swarm1 = Swarm::new_ephemeral(|_| {
-        request_response::Behaviour::with_codec(PingCodec(), protocols.clone(), cfg.clone())
+        request_response::cbor::Behaviour::<Ping, Pong>::new(protocols.clone(), cfg.clone())
     });
     let peer1_id = *swarm1.local_peer_id();
     let mut swarm2 = Swarm::new_ephemeral(|_| {
-        request_response::Behaviour::with_codec(PingCodec(), protocols, cfg)
+        request_response::cbor::Behaviour::<Ping, Pong>::new(protocols, cfg)
     });
     let peer2_id = *swarm2.local_peer_id();
 
@@ -180,11 +179,11 @@ async fn emits_inbound_connection_closed_failure() {
     let cfg = request_response::Config::default();
 
     let mut swarm1 = Swarm::new_ephemeral(|_| {
-        request_response::Behaviour::with_codec(PingCodec(), protocols.clone(), cfg.clone())
+        request_response::cbor::Behaviour::<Ping, Pong>::new(protocols.clone(), cfg.clone())
     });
     let peer1_id = *swarm1.local_peer_id();
     let mut swarm2 = Swarm::new_ephemeral(|_| {
-        request_response::Behaviour::with_codec(PingCodec(), protocols, cfg)
+        request_response::cbor::Behaviour::<Ping, Pong>::new(protocols, cfg)
     });
     let peer2_id = *swarm2.local_peer_id();
 
@@ -244,11 +243,11 @@ async fn emits_inbound_connection_closed_if_channel_is_dropped() {
     let cfg = request_response::Config::default();
 
     let mut swarm1 = Swarm::new_ephemeral(|_| {
-        request_response::Behaviour::with_codec(PingCodec(), protocols.clone(), cfg.clone())
+        request_response::cbor::Behaviour::<Ping, Pong>::new(protocols.clone(), cfg.clone())
     });
     let peer1_id = *swarm1.local_peer_id();
     let mut swarm2 = Swarm::new_ephemeral(|_| {
-        request_response::Behaviour::with_codec(PingCodec(), protocols, cfg)
+        request_response::cbor::Behaviour::<Ping, Pong>::new(protocols, cfg)
     });
     let peer2_id = *swarm2.local_peer_id();
 
@@ -289,77 +288,7 @@ async fn emits_inbound_connection_closed_if_channel_is_dropped() {
 }
 
 // Simple Ping-Pong Protocol
-
-#[derive(Clone)]
-struct PingCodec();
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct Ping(Vec<u8>);
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct Pong(Vec<u8>);
-
-#[async_trait]
-impl libp2p_request_response::Codec for PingCodec {
-    type Protocol = StreamProtocol;
-    type Request = Ping;
-    type Response = Pong;
-
-    async fn read_request<T>(&mut self, _: &StreamProtocol, io: &mut T) -> io::Result<Self::Request>
-    where
-        T: AsyncRead + Unpin + Send,
-    {
-        let vec = read_length_prefixed(io, 1024).await?;
-
-        if vec.is_empty() {
-            return Err(io::ErrorKind::UnexpectedEof.into());
-        }
-
-        Ok(Ping(vec))
-    }
-
-    async fn read_response<T>(
-        &mut self,
-        _: &StreamProtocol,
-        io: &mut T,
-    ) -> io::Result<Self::Response>
-    where
-        T: AsyncRead + Unpin + Send,
-    {
-        let vec = read_length_prefixed(io, 1024).await?;
-
-        if vec.is_empty() {
-            return Err(io::ErrorKind::UnexpectedEof.into());
-        }
-
-        Ok(Pong(vec))
-    }
-
-    async fn write_request<T>(
-        &mut self,
-        _: &StreamProtocol,
-        io: &mut T,
-        Ping(data): Ping,
-    ) -> io::Result<()>
-    where
-        T: AsyncWrite + Unpin + Send,
-    {
-        write_length_prefixed(io, data).await?;
-        io.close().await?;
-
-        Ok(())
-    }
-
-    async fn write_response<T>(
-        &mut self,
-        _: &StreamProtocol,
-        io: &mut T,
-        Pong(data): Pong,
-    ) -> io::Result<()>
-    where
-        T: AsyncWrite + Unpin + Send,
-    {
-        write_length_prefixed(io, data).await?;
-        io.close().await?;
-
-        Ok(())
-    }
-}

--- a/protocols/request-response/tests/ping.rs
+++ b/protocols/request-response/tests/ping.rs
@@ -31,6 +31,7 @@ use serde::{Deserialize, Serialize};
 use std::iter;
 
 #[async_std::test]
+#[cfg(feature = "cbor")]
 async fn is_response_outbound() {
     let _ = env_logger::try_init();
     let ping = Ping("ping".to_string().into_bytes());
@@ -79,6 +80,7 @@ async fn is_response_outbound() {
 
 /// Exercises a simple ping protocol.
 #[async_std::test]
+#[cfg(feature = "cbor")]
 async fn ping_protocol() {
     let ping = Ping("ping".to_string().into_bytes());
     let pong = Pong("pong".to_string().into_bytes());
@@ -172,6 +174,7 @@ async fn ping_protocol() {
 }
 
 #[async_std::test]
+#[cfg(feature = "cbor")]
 async fn emits_inbound_connection_closed_failure() {
     let ping = Ping("ping".to_string().into_bytes());
 
@@ -236,6 +239,7 @@ async fn emits_inbound_connection_closed_failure() {
 /// If the substream were not properly closed when dropped, the sender would instead
 /// run into a timeout waiting for the response.
 #[async_std::test]
+#[cfg(feature = "cbor")]
 async fn emits_inbound_connection_closed_if_channel_is_dropped() {
     let ping = Ping("ping".to_string().into_bytes());
 


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

Remove the use of the core `upgrade::transfer` module in `ping` example (`request-response` protocol) in favor of `cbor` codec.

Related #4011.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
