### PR TITLE
refactor(identity): fix import warnings in `keypair.rs`

### DIFF
--- a/identity/src/keypair.rs
+++ b/identity/src/keypair.rs
@@ -18,7 +18,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::error::OtherVariantError;
 use crate::error::{DecodingError, SigningError};
 #[cfg(any(
     feature = "ecdsa",
@@ -27,8 +26,6 @@ use crate::error::{DecodingError, SigningError};
     feature = "rsa"
 ))]
 use crate::proto;
-use quick_protobuf::{BytesReader, Writer};
-use std::convert::TryFrom;
 
 #[cfg(feature = "ed25519")]
 use crate::ed25519;
@@ -159,6 +156,7 @@ impl Keypair {
 
     /// Sign a message using the private key of this keypair, producing
     /// a signature that can be verified using the corresponding public key.
+    #[allow(unused_variables)]
     pub fn sign(&self, msg: &[u8]) -> Result<Vec<u8>, SigningError> {
         match self.keypair {
             #[cfg(feature = "ed25519")]

--- a/identity/src/keypair.rs
+++ b/identity/src/keypair.rs
@@ -18,7 +18,12 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-#[allow(unused_imports)]
+#[cfg(any(
+    feature = "ecdsa",
+    feature = "secp256k1",
+    feature = "ed25519",
+    feature = "rsa"
+))]
 use crate::error::OtherVariantError;
 use crate::error::{DecodingError, SigningError};
 #[cfg(any(
@@ -28,9 +33,19 @@ use crate::error::{DecodingError, SigningError};
     feature = "rsa"
 ))]
 use crate::proto;
-#[allow(unused_imports)]
+#[cfg(any(
+    feature = "ecdsa",
+    feature = "secp256k1",
+    feature = "ed25519",
+    feature = "rsa"
+))]
 use quick_protobuf::{BytesReader, Writer};
-#[allow(unused_imports)]
+#[cfg(any(
+    feature = "ecdsa",
+    feature = "secp256k1",
+    feature = "ed25519",
+    feature = "rsa"
+))]
 use std::convert::TryFrom;
 
 #[cfg(feature = "ed25519")]

--- a/identity/src/keypair.rs
+++ b/identity/src/keypair.rs
@@ -18,6 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+#[allow(unused_imports)]
+use crate::error::OtherVariantError;
 use crate::error::{DecodingError, SigningError};
 #[cfg(any(
     feature = "ecdsa",
@@ -26,6 +28,10 @@ use crate::error::{DecodingError, SigningError};
     feature = "rsa"
 ))]
 use crate::proto;
+#[allow(unused_imports)]
+use quick_protobuf::{BytesReader, Writer};
+#[allow(unused_imports)]
+use std::convert::TryFrom;
 
 #[cfg(feature = "ed25519")]
 use crate::ed25519;


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

- Adding conditional `cfg` in `keypair.rs` imports.
- Adding `#[allow(unused_variables)]` on the top of the `sign` function.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
