### PR TITLE
fix(examples): call `Swarm::add_external_address` in dcutr and relay

### DIFF
--- a/examples/dcutr/src/main.rs
+++ b/examples/dcutr/src/main.rs
@@ -214,6 +214,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     ..
                 })) => {
                     info!("Relay told us our public address: {:?}", observed_addr);
+                    swarm.add_external_address(observed_addr);
                     learned_observed_addr = true;
                 }
                 event => panic!("{event:?}"),

--- a/examples/relay-server/src/main.rs
+++ b/examples/relay-server/src/main.rs
@@ -82,6 +82,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         loop {
             match swarm.next().await.expect("Infinite Stream.") {
                 SwarmEvent::Behaviour(event) => {
+                    if let BehaviourEvent::Identify(identify::Event::Received {
+                        info: identify::Info { observed_addr, .. },
+                        ..
+                    }) = &event
+                    {
+                        swarm.add_external_address(observed_addr.clone());
+                    }
+
                     println!("{event:?}")
                 }
                 SwarmEvent::NewListenAddr { address, .. } => {

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Observed addresses (aka. external address candidates) of the local node, reported by a remote node via `libp2p-identify`, are no longer automatically considered confirmed external addresses, in other words they are no longer trusted by default.
   Instead users need to confirm the reported observed address either manually, or by using `libp2p-autonat`.
   In trusted environments users can simply extract observed addresses from a `libp2p-identify::Event::Received { info: libp2p_identify::Info { observed_addr }}` and confirm them via `Swarm::add_external_address`.
-  See [PR 3954] and [PR XXX].
+  See [PR 3954] and [PR 4052].
 
 - Remove deprecated `Identify` prefixed symbols. See [PR 3698].
 - Raise MSRV to 1.65.
@@ -24,7 +24,7 @@
 [PR 3876]: https://github.com/libp2p/rust-libp2p/pull/3876
 [PR 3954]: https://github.com/libp2p/rust-libp2p/pull/3954
 [PR 3980]: https://github.com/libp2p/rust-libp2p/pull/3980
-[PR XXX]: https://github.com/libp2p/rust-libp2p/pull/XXX
+[PR 4052]: https://github.com/libp2p/rust-libp2p/pull/4052
 
 ## 0.42.2
 

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.43.0 - unreleased
 
+- Observed addresses (aka. external address candidates) of the local node, reported by a remote node via `libp2p-identify`, are no longer automatically considered confirmed external addresses, in other words they are no longer trusted by default.
+  Instead users need to confirm the reported observed address either manually, or by using `libp2p-autonat`.
+  In trusted environments users can simply extract observed addresses from a `libp2p-identify::Event::Received { info: libp2p_identify::Info { observed_addr }}` and confirm them via `Swarm::add_external_address`.
+  See [PR 3954] and [PR XXX].
+
 - Remove deprecated `Identify` prefixed symbols. See [PR 3698].
 - Raise MSRV to 1.65.
   See [PR 3715].
@@ -17,7 +22,9 @@
 [PR 3698]: https://github.com/libp2p/rust-libp2p/pull/3698
 [PR 3715]: https://github.com/libp2p/rust-libp2p/pull/3715
 [PR 3876]: https://github.com/libp2p/rust-libp2p/pull/3876
+[PR 3954]: https://github.com/libp2p/rust-libp2p/pull/3954
 [PR 3980]: https://github.com/libp2p/rust-libp2p/pull/3980
+[PR XXX]: https://github.com/libp2p/rust-libp2p/pull/XXX
 
 ## 0.42.2
 


### PR DESCRIPTION
## Description

> Observed addresses (aka. external address candidates) of the local node, reported by a remote node
> via `libp2p-identify`, are no longer automatically considered confirmed external addresses, in
> other words they are no longer trusted by default. Instead users need to confirm the reported
> observed address either manually, or by using `libp2p-autonat`. In trusted environments users can
> simply extract observed addresses from a `libp2p-identify::Event::Received { info:
> libp2p_identify::Info { observed_addr }}` and confirm them via `Swarm::add_external_address`.

Follow-up to https://github.com/libp2p/rust-libp2p/pull/3954.



<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

//CC @arpankapoor

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
