### PR TITLE
refactor(wasm-ext): replace `parity-send-wrapper` with `send-wrapper`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,7 +1682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 dependencies = [
  "gloo-timers",
- "send_wrapper",
+ "send_wrapper 0.4.0",
 ]
 
 [[package]]
@@ -3037,7 +3037,7 @@ dependencies = [
  "futures",
  "js-sys",
  "libp2p-core",
- "parity-send-wrapper",
+ "send_wrapper 0.6.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -3577,12 +3577,6 @@ dependencies = [
  "cfg-if",
  "libm",
 ]
-
-[[package]]
-name = "parity-send-wrapper"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
 
 [[package]]
 name = "parking"
@@ -4456,6 +4450,12 @@ name = "send_wrapper"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"

--- a/transports/wasm-ext/Cargo.toml
+++ b/transports/wasm-ext/Cargo.toml
@@ -14,14 +14,14 @@ categories = ["network-programming", "asynchronous"]
 futures = "0.3.28"
 js-sys = "0.3.63"
 libp2p-core = { workspace = true }
-parity-send-wrapper = "0.1.0"
+send_wrapper = "0.6.0"
 wasm-bindgen = "0.2.86"
 wasm-bindgen-futures = "0.4.36"
 
 [features]
 websocket = []
 
-# Passing arguments to the docsrs builder in order to properly document cfg's. 
+# Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true

--- a/transports/wasm-ext/src/lib.rs
+++ b/transports/wasm-ext/src/lib.rs
@@ -40,7 +40,7 @@ use libp2p_core::{
     transport::{ListenerId, TransportError, TransportEvent},
     Multiaddr, Transport,
 };
-use parity_send_wrapper::SendWrapper;
+use send_wrapper::SendWrapper;
 use std::{collections::VecDeque, error, fmt, io, mem, pin::Pin, task::Context, task::Poll};
 use wasm_bindgen::{prelude::*, JsCast};
 use wasm_bindgen_futures::JsFuture;


### PR DESCRIPTION
## Description

Co-authored-by: Yiannis Marangos <yiannis@eiger.co>

Related: #4065.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
