### PR TITLE
ci: attribute co-authorship of a PR based on its commits

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,6 +8,7 @@ defaults:
         {{ body | get_section("## Description", "") }}
         
         Pull-Request: #{{ number }}.
+        
         {# Here comes some fancy Jinja2 stuff for correctly attributing co-authorship: #}
         {% set unique_authors = {} %}
         {% for commit in commits %}

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,10 +8,9 @@ defaults:
         {{ body | get_section("## Description", "") }}
         
         Pull-Request: #{{ number }}.
-        
         {# Here comes some fancy Jinja2 stuff for correctly attributing co-authorship: #}
-        {% for commit in commits | unique(False, 'email_author') %}
-          {% if commit.parents|length == 1 and commit.author != author %}
+        {% for commit in (commits | unique(False, 'email_author')) | rejectattr("author", "==", author) %}
+          {% if commit.parents|length == 1 %}
         Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
           {% endif %}
         {% endfor %}

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -13,14 +13,17 @@ defaults:
         {% set unique_authors = {} %}
         {% for commit in commits %}
           {% set should_add_coauthor = true %}
+          {# Merge commits should not add attribution #}
           {% if commit.parents|length > 1 %}
-            {% set should_add_coauthor = false %} {# Merge commits should not add attribution #}
+            {% set should_add_coauthor = false %}
           {% endif %}
+          {# The original author will already be attributed by GitHub #}
           {% if commit.author == author %}
-            {% set should_add_coauthor = false %} {# The original author will already be attributed by GitHub #}
+            {% set should_add_coauthor = false %}
           {% endif %}
+          {# Only attribute each author once #}
           {% if unique_authors.get(commit.email_author) %}
-            {% set should_add_coauthor = false %} {# Only attribute each author once #}
+            {% set should_add_coauthor = false %}
           {% endif %}
           {% if should_add_coauthor %}
             {% set _ = unique_authors.update({commit.email_author: true}) %}

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -11,6 +11,7 @@ defaults:
         
         {# Here comes some fancy Jinja2 stuff for correctly attributing co-authorship: #}
         {% set co_authored_by = {} %}
+        {# We exclude merge commits (> 1 parent), commits from the PR author and only want to render one `Co-Authored-By` line per contributor. #}
         {% for commit in commits
             if  commit.parents|length <= 1 
             and commit.author != author

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,35 +8,24 @@ defaults:
         {{ body | get_section("## Description", "") }}
         
         Pull-Request: #{{ number }}.
-        
         {# Here comes some fancy Jinja2 stuff for correctly attributing co-authorship: #}
-
         {% set unique_authors = {} %}
         {% for commit in commits %}
           {% set should_add_coauthor = true %}
-        
-          {# Merge commits should not add attribution #}
           {% if commit.parents|length > 1 %}
-            {% set should_add_coauthor = false %}
+            {% set should_add_coauthor = false %} {# Merge commits should not add attribution #}
           {% endif %}
-        
-          {# The original author will already be attributed by GitHub #}
           {% if commit.author == author %}
-            {% set should_add_coauthor = false %}
+            {% set should_add_coauthor = false %} {# The original author will already be attributed by GitHub #}
           {% endif %}
-        
-          {# Only attribute each author once #}
           {% if unique_authors.get(commit.email_author) %}
-            {% set should_add_coauthor = false %}
+            {% set should_add_coauthor = false %} {# Only attribute each author once #}
           {% endif %}
-        
           {% if should_add_coauthor %}
+            {% set _ = unique_authors.update({commit.email_author: true}) %}
             Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
           {% endif %}
-        
-          {% set _ = unique_authors.update({commit.email_author: true}) %}
         {% endfor %}
-        
         {# GitHub requires that the `Co-authored-by` lines are AT THE VERY END of a commit, hence nothing must come after this. #}
 
 pull_request_rules:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -10,14 +10,10 @@ defaults:
         Pull-Request: #{{ number }}.
         
         {# Here comes some fancy Jinja2 stuff for correctly attributing co-authorship: #}
-        {% set co_authored_by = {} %}
-        {# We exclude merge commits (> 1 parent), commits from the PR author and only want to render one `Co-Authored-By` line per contributor. #}
-        {% for commit in commits
-            if  commit.parents|length <= 1 
-            and commit.author != author
-            and not co_authored_by.get(commit.email_author) %}
-          {% set _ = co_authored_by.update({commit.email_author: true}) %}
+        {% for commit in commits | unique(False, 'email_author') %}
+          {% if commit.parents|length == 1 and commit.author != author %}
         Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
+          {% endif %}
         {% endfor %}
         {# GitHub requires that the `Co-authored-by` lines are AT THE VERY END of a commit, hence nothing must come after this. #}
 

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -21,7 +21,7 @@ defaults:
           {% endif %}
         
           {# The original author will already be attributed by GitHub #}
-          {% if commit.author == pull_request.user.login %}
+          {% if commit.author == author %}
             {% set should_add_coauthor = false %}
           {% endif %}
         

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -10,25 +10,13 @@ defaults:
         Pull-Request: #{{ number }}.
         
         {# Here comes some fancy Jinja2 stuff for correctly attributing co-authorship: #}
-        {% set unique_authors = {} %}
-        {% for commit in commits %}
-          {% set should_add_coauthor = true %}
-          {# Merge commits should not add attribution #}
-          {% if commit.parents|length > 1 %}
-            {% set should_add_coauthor = false %}
-          {% endif %}
-          {# The original author will already be attributed by GitHub #}
-          {% if commit.author == author %}
-            {% set should_add_coauthor = false %}
-          {% endif %}
-          {# Only attribute each author once #}
-          {% if unique_authors.get(commit.email_author) %}
-            {% set should_add_coauthor = false %}
-          {% endif %}
-          {% if should_add_coauthor %}
-            {% set _ = unique_authors.update({commit.email_author: true}) %}
-            Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
-          {% endif %}
+        {% set co_authored_by = {} %}
+        {% for commit in commits
+            if  commit.parents|length <= 1 
+            and commit.author != author
+            and not co_authored_by.get(commit.email_author) %}
+          {% set _ = co_authored_by.update({commit.email_author: true}) %}
+        Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
         {% endfor %}
         {# GitHub requires that the `Co-authored-by` lines are AT THE VERY END of a commit, hence nothing must come after this. #}
 

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,6 +8,10 @@ defaults:
         {{ body | get_section("## Description", "") }}
         
         Pull-Request: #{{ number }}.
+        
+        {% for commit in commits %}
+        Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
+        {% endfor %}
 
 pull_request_rules:
   - name: Ask to resolve conflict

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -9,9 +9,35 @@ defaults:
         
         Pull-Request: #{{ number }}.
         
+        {# Here comes some fancy Jinja2 stuff for correctly attributing co-authorship: #}
+
+        {% set unique_authors = {} %}
         {% for commit in commits %}
-        Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
+          {% set should_add_coauthor = true %}
+        
+          {# Merge commits should not add attribution #}
+          {% if commit.parents|length > 1 %}
+            {% set should_add_coauthor = false %}
+          {% endif %}
+        
+          {# The original author will already be attributed by GitHub #}
+          {% if commit.author == pull_request.user.login %}
+            {% set should_add_coauthor = false %}
+          {% endif %}
+        
+          {# Only attribute each author once #}
+          {% if unique_authors.get(commit.email_author) %}
+            {% set should_add_coauthor = false %}
+          {% endif %}
+        
+          {% if should_add_coauthor %}
+            Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
+          {% endif %}
+        
+          {% set _ = unique_authors.update({commit.email_author: true}) %}
         {% endfor %}
+        
+        {# GitHub requires that the `Co-authored-by` lines are AT THE VERY END of a commit, hence nothing must come after this. #}
 
 pull_request_rules:
   - name: Ask to resolve conflict


### PR DESCRIPTION
## Description

It often happens that multiple people contribute to a single PR. To correctly attribute authorship, GitHub supports the `Co-authored-by` convention. This line however needs to be at the very end of the commit message.

Because we are also automatically adding the pull-request number to the commit message, we cannot add these lines ourselves. Doing this manually is error-prone anyway so with this patch, we are extending the commit message template to automatically populate this from the commits within the pull request.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

I've tested the template logic using https://j2live.ttl255.com/. The `commits` array is documented here: https://docs.mergify.com/configuration/#commits

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
