### PR TITLE
refactor: use never type instead of `void`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,8 +1528,8 @@ dependencies = [
  "env_logger 0.10.0",
  "futures",
  "libp2p",
+ "never-say-never",
  "serde",
- "void",
 ]
 
 [[package]]
@@ -2342,7 +2342,7 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-swarm-derive",
  "libp2p-swarm-test",
- "void",
+ "never-say-never",
 ]
 
 [[package]]
@@ -2377,9 +2377,9 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-swarm-derive",
  "libp2p-swarm-test",
+ "never-say-never",
  "quickcheck-ext",
  "rand 0.8.5",
- "void",
 ]
 
 [[package]]
@@ -2399,6 +2399,7 @@ dependencies = [
  "multiaddr",
  "multihash",
  "multistream-select",
+ "never-say-never",
  "once_cell",
  "parking_lot",
  "pin-project",
@@ -2410,7 +2411,6 @@ dependencies = [
  "smallvec",
  "thiserror",
  "unsigned-varint",
- "void",
 ]
 
 [[package]]
@@ -2438,11 +2438,11 @@ dependencies = [
  "libp2p-tcp",
  "libp2p-yamux",
  "log",
+ "never-say-never",
  "quick-protobuf",
  "quick-protobuf-codec",
  "rand 0.8.5",
  "thiserror",
- "void",
 ]
 
 [[package]]
@@ -2520,6 +2520,7 @@ dependencies = [
  "libp2p-swarm-test",
  "libp2p-yamux",
  "log",
+ "never-say-never",
  "prometheus-client",
  "quick-protobuf",
  "quick-protobuf-codec",
@@ -2530,7 +2531,6 @@ dependencies = [
  "sha2 0.10.6",
  "smallvec",
  "unsigned-varint",
- "void",
 ]
 
 [[package]]
@@ -2549,11 +2549,11 @@ dependencies = [
  "libp2p-swarm-test",
  "log",
  "lru",
+ "never-say-never",
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
  "thiserror",
- "void",
 ]
 
 [[package]]
@@ -2569,6 +2569,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "multihash",
+ "never-say-never",
  "p256 0.13.2",
  "quick-protobuf",
  "quickcheck-ext",
@@ -2580,7 +2581,6 @@ dependencies = [
  "serde_json",
  "sha2 0.10.6",
  "thiserror",
- "void",
  "zeroize",
 ]
 
@@ -2606,6 +2606,7 @@ dependencies = [
  "libp2p-swarm-test",
  "libp2p-yamux",
  "log",
+ "never-say-never",
  "quick-protobuf",
  "quickcheck-ext",
  "rand 0.8.5",
@@ -2615,7 +2616,6 @@ dependencies = [
  "thiserror",
  "uint",
  "unsigned-varint",
- "void",
 ]
 
 [[package]]
@@ -2636,12 +2636,12 @@ dependencies = [
  "libp2p-tcp",
  "libp2p-yamux",
  "log",
+ "never-say-never",
  "rand 0.8.5",
  "smallvec",
  "socket2 0.5.3",
  "tokio",
  "trust-dns-proto",
- "void",
 ]
 
 [[package]]
@@ -2744,12 +2744,12 @@ dependencies = [
  "libp2p-tls",
  "libp2p-yamux",
  "log",
+ "never-say-never",
  "rand 0.8.5",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
- "void",
 ]
 
 [[package]]
@@ -2767,9 +2767,9 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-swarm-test",
  "log",
+ "never-say-never",
  "quickcheck-ext",
  "rand 0.8.5",
- "void",
 ]
 
 [[package]]
@@ -2856,13 +2856,13 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-yamux",
  "log",
+ "never-say-never",
  "quick-protobuf",
  "quick-protobuf-codec",
  "quickcheck-ext",
  "rand 0.8.5",
  "static_assertions",
  "thiserror",
- "void",
 ]
 
 [[package]]
@@ -2887,12 +2887,12 @@ dependencies = [
  "libp2p-tcp",
  "libp2p-yamux",
  "log",
+ "never-say-never",
  "quick-protobuf",
  "quick-protobuf-codec",
  "rand 0.8.5",
  "thiserror",
  "tokio",
- "void",
 ]
 
 [[package]]
@@ -2913,12 +2913,12 @@ dependencies = [
  "libp2p-tcp",
  "libp2p-yamux",
  "log",
+ "never-say-never",
  "rand 0.8.5",
  "serde",
  "serde_cbor",
  "serde_json",
  "smallvec",
- "void",
 ]
 
 [[package]]
@@ -2944,13 +2944,13 @@ dependencies = [
  "libp2p-yamux",
  "log",
  "multistream-select",
+ "never-say-never",
  "once_cell",
  "quickcheck-ext",
  "rand 0.8.5",
  "smallvec",
  "tokio",
  "trybuild",
- "void",
  "wasm-bindgen-futures",
 ]
 
@@ -3067,6 +3067,7 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "multihash",
+ "never-say-never",
  "quick-protobuf",
  "quick-protobuf-codec",
  "quickcheck",
@@ -3080,7 +3081,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "unsigned-varint",
- "void",
  "webrtc",
 ]
 
@@ -3433,6 +3433,12 @@ dependencies = [
  "log",
  "tokio",
 ]
+
+[[package]]
+name = "never-say-never"
+version = "6.6.666"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
 
 [[package]]
 name = "nix"
@@ -5215,12 +5221,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "waitgroup"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1", optional = true, features = ["derive"] }
 smallvec = "1.6.1"
 thiserror = "1.0"
 unsigned-varint = "0.7"
-void = "1"
+never-say-never = "6.6.666"
 
 [dev-dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }

--- a/core/src/upgrade/denied.rs
+++ b/core/src/upgrade/denied.rs
@@ -20,8 +20,8 @@
 
 use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use futures::future;
+use never_say_never::Never;
 use std::iter;
-use void::Void;
 
 /// Dummy implementation of `UpgradeInfo`/`InboundUpgrade`/`OutboundUpgrade` that doesn't support
 /// any protocol.
@@ -38,8 +38,8 @@ impl UpgradeInfo for DeniedUpgrade {
 }
 
 impl<C> InboundUpgrade<C> for DeniedUpgrade {
-    type Output = Void;
-    type Error = Void;
+    type Output = Never;
+    type Error = Never;
     type Future = future::Pending<Result<Self::Output, Self::Error>>;
 
     fn upgrade_inbound(self, _: C, _: Self::Info) -> Self::Future {
@@ -48,8 +48,8 @@ impl<C> InboundUpgrade<C> for DeniedUpgrade {
 }
 
 impl<C> OutboundUpgrade<C> for DeniedUpgrade {
-    type Output = Void;
-    type Error = Void;
+    type Output = Never;
+    type Error = Never;
     type Future = future::Pending<Result<Self::Output, Self::Error>>;
 
     fn upgrade_outbound(self, _: C, _: Self::Info) -> Self::Future {

--- a/core/src/upgrade/pending.rs
+++ b/core/src/upgrade/pending.rs
@@ -21,8 +21,8 @@
 
 use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use futures::future;
+use never_say_never::Never;
 use std::iter;
-use void::Void;
 
 /// Implementation of [`UpgradeInfo`], [`InboundUpgrade`] and [`OutboundUpgrade`] that always
 /// returns a pending upgrade.
@@ -53,8 +53,8 @@ impl<C, P> InboundUpgrade<C> for PendingUpgrade<P>
 where
     P: AsRef<str> + Clone,
 {
-    type Output = Void;
-    type Error = Void;
+    type Output = Never;
+    type Error = Never;
     type Future = future::Pending<Result<Self::Output, Self::Error>>;
 
     fn upgrade_inbound(self, _: C, _: Self::Info) -> Self::Future {
@@ -66,8 +66,8 @@ impl<C, P> OutboundUpgrade<C> for PendingUpgrade<P>
 where
     P: AsRef<str> + Clone,
 {
-    type Output = Void;
-    type Error = Void;
+    type Output = Never;
+    type Error = Never;
     type Future = future::Pending<Result<Self::Output, Self::Error>>;
 
     fn upgrade_outbound(self, _: C, _: Self::Info) -> Self::Future {

--- a/core/src/upgrade/ready.rs
+++ b/core/src/upgrade/ready.rs
@@ -21,8 +21,8 @@
 
 use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use futures::future;
+use never_say_never::Never;
 use std::iter;
-use void::Void;
 
 /// Implementation of [`UpgradeInfo`], [`InboundUpgrade`] and [`OutboundUpgrade`] that directly yields the substream.
 #[derive(Debug, Copy, Clone)]
@@ -53,7 +53,7 @@ where
     P: AsRef<str> + Clone,
 {
     type Output = C;
-    type Error = Void;
+    type Error = Never;
     type Future = future::Ready<Result<Self::Output, Self::Error>>;
 
     fn upgrade_inbound(self, stream: C, _: Self::Info) -> Self::Future {
@@ -66,7 +66,7 @@ where
     P: AsRef<str> + Clone,
 {
     type Output = C;
-    type Error = Void;
+    type Error = Never;
     type Future = future::Ready<Result<Self::Output, Self::Error>>;
 
     fn upgrade_outbound(self, stream: C, _: Self::Info) -> Self::Future {

--- a/examples/file-sharing/Cargo.toml
+++ b/examples/file-sharing/Cargo.toml
@@ -13,4 +13,4 @@ either = "1.8"
 env_logger = "0.10"
 futures = "0.3.28"
 libp2p = { path = "../../libp2p", features = ["async-std", "cbor", "dns", "kad", "noise", "macros", "request-response", "tcp", "websocket", "yamux"] }
-void = "1.0.2"
+never-say-never = "6.6.666"

--- a/examples/file-sharing/src/network.rs
+++ b/examples/file-sharing/src/network.rs
@@ -209,10 +209,7 @@ impl EventLoop {
         }
     }
 
-    async fn handle_event(
-        &mut self,
-        event: SwarmEvent<ComposedEvent, Either<void::Void, io::Error>>,
-    ) {
+    async fn handle_event(&mut self, event: SwarmEvent<ComposedEvent, Either<Never, io::Error>>) {
         match event {
             SwarmEvent::Behaviour(ComposedEvent::Kademlia(
                 KademliaEvent::OutboundQueryProgressed {

--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -25,7 +25,7 @@ sec1 = { version = "0.7", default-features = false, optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 sha2 = { version = "0.10.0", optional = true }
 thiserror = { version = "1.0", optional = true }
-void = { version = "1.0", optional = true }
+never-say-never = { version = "6.6.666", optional = true }
 zeroize = { version = "1.6", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -33,7 +33,7 @@ ring = { version = "0.16.9", features = ["alloc", "std"], default-features = fal
 
 [features]
 secp256k1 = [ "dep:libsecp256k1", "dep:asn1_der", "dep:rand", "dep:sha2", "dep:zeroize" ]
-ecdsa = [ "dep:p256", "dep:rand", "dep:void", "dep:zeroize", "dep:sec1" ]
+ecdsa = [ "dep:p256", "dep:rand", "dep:never-say-never", "dep:zeroize", "dep:sec1" ]
 rsa = [ "dep:ring", "dep:asn1_der", "dep:rand", "dep:zeroize" ]
 ed25519 = [ "dep:ed25519-dalek", "dep:rand", "dep:zeroize" ]
 peerid = [ "dep:multihash", "dep:bs58", "dep:rand", "dep:thiserror", "dep:sha2" ]

--- a/identity/src/ecdsa.rs
+++ b/identity/src/ecdsa.rs
@@ -24,6 +24,7 @@ use super::error::DecodingError;
 use core::cmp;
 use core::fmt;
 use core::hash;
+use never_say_never::Never;
 use p256::{
     ecdsa::{
         signature::{Signer, Verifier},
@@ -32,7 +33,6 @@ use p256::{
     EncodedPoint,
 };
 use sec1::{DecodeEcPrivateKey, EncodeEcPrivateKey};
-use void::Void;
 use zeroize::Zeroize;
 
 /// An ECDSA keypair generated using `secp256r1` curve.
@@ -181,7 +181,7 @@ impl PublicKey {
     /// Try to decode a public key from a DER encoded byte buffer as defined by SEC1 standard.
     pub fn try_decode_der(k: &[u8]) -> Result<PublicKey, DecodingError> {
         let buf = Self::del_asn1_header(k).ok_or_else(|| {
-            DecodingError::failed_to_parse::<Void, _>("ASN.1-encoded ecdsa p256 public key", None)
+            DecodingError::failed_to_parse::<Never, _>("ASN.1-encoded ecdsa p256 public key", None)
         })?;
         Self::try_from_bytes(buf)
     }

--- a/misc/allow-block-list/Cargo.toml
+++ b/misc/allow-block-list/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 libp2p-core = { workspace = true }
 libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true, features = ["peerid"] }
-void = "1"
+never-say-never = "6.6.666"
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }

--- a/misc/allow-block-list/src/lib.rs
+++ b/misc/allow-block-list/src/lib.rs
@@ -67,10 +67,10 @@ use libp2p_swarm::{
     dummy, CloseConnection, ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour,
     PollParameters, THandler, THandlerInEvent, THandlerOutEvent, ToSwarm,
 };
+use never_say_never::Never;
 use std::collections::{HashSet, VecDeque};
 use std::fmt;
 use std::task::{Context, Poll, Waker};
-use void::Void;
 
 /// A [`NetworkBehaviour`] that can act as an allow or block list.
 #[derive(Default, Debug)]
@@ -191,7 +191,7 @@ where
     S: Enforce,
 {
     type ConnectionHandler = dummy::ConnectionHandler;
-    type ToSwarm = Void;
+    type ToSwarm = Never;
 
     fn handle_established_inbound_connection(
         &mut self,
@@ -255,7 +255,7 @@ where
         _: ConnectionId,
         event: THandlerOutEvent<Self>,
     ) {
-        void::unreachable(event)
+        event
     }
 
     fn poll(

--- a/misc/connection-limits/Cargo.toml
+++ b/misc/connection-limits/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 libp2p-core = { workspace = true }
 libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true, features = ["peerid"] }
-void = "1"
+never-say-never = "6.6.666"
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }

--- a/misc/connection-limits/src/lib.rs
+++ b/misc/connection-limits/src/lib.rs
@@ -24,10 +24,10 @@ use libp2p_swarm::{
     dummy, ConnectionClosed, ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour,
     PollParameters, THandler, THandlerInEvent, THandlerOutEvent, ToSwarm,
 };
+use never_say_never::Never;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::task::{Context, Poll};
-use void::Void;
 
 /// A [`NetworkBehaviour`] that enforces a set of [`ConnectionLimits`].
 ///
@@ -201,7 +201,7 @@ impl ConnectionLimits {
 
 impl NetworkBehaviour for Behaviour {
     type ConnectionHandler = dummy::ConnectionHandler;
-    type ToSwarm = Void;
+    type ToSwarm = Never;
 
     fn handle_pending_inbound_connection(
         &mut self,
@@ -349,7 +349,7 @@ impl NetworkBehaviour for Behaviour {
         _: ConnectionId,
         event: THandlerOutEvent<Self>,
     ) {
-        void::unreachable(event)
+        event
     }
 
     fn poll(

--- a/protocols/dcutr/Cargo.toml
+++ b/protocols/dcutr/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4"
 quick-protobuf = "0.8"
 quick-protobuf-codec = { workspace = true }
 thiserror = "1.0"
-void = "1"
+never-say-never = "6.6.666"
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }

--- a/protocols/dcutr/src/behaviour_impl.rs
+++ b/protocols/dcutr/src/behaviour_impl.rs
@@ -35,10 +35,10 @@ use libp2p_swarm::{
     ExternalAddresses, NetworkBehaviour, NotifyHandler, PollParameters, StreamUpgradeError,
     THandlerInEvent, ToSwarm,
 };
+use never_say_never::Never;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::task::{Context, Poll};
 use thiserror::Error;
-use void::Void;
 
 pub(crate) const MAX_NUMBER_OF_UPGRADE_ATTEMPTS: u8 = 3;
 
@@ -67,12 +67,12 @@ pub enum Error {
     #[error("Failed to dial peer.")]
     Dial,
     #[error("Failed to establish substream: {0}.")]
-    Handler(StreamUpgradeError<Void>),
+    Handler(StreamUpgradeError<Never>),
 }
 
 pub struct Behaviour {
     /// Queue of actions to return when polled.
-    queued_events: VecDeque<ToSwarm<Event, Either<handler::relayed::Command, Void>>>,
+    queued_events: VecDeque<ToSwarm<Event, Either<handler::relayed::Command, Never>>>,
 
     /// All direct (non-relayed) connections.
     direct_connections: HashMap<PeerId, HashSet<ConnectionId>>,
@@ -341,7 +341,7 @@ impl NetworkBehaviour for Behaviour {
                     .or_default() += 1;
                 self.queued_events.push_back(ToSwarm::Dial { opts });
             }
-            Either::Right(never) => void::unreachable(never),
+            Either::Right(never) => never,
         };
     }
 

--- a/protocols/dcutr/src/handler/relayed.rs
+++ b/protocols/dcutr/src/handler/relayed.rs
@@ -35,6 +35,7 @@ use libp2p_swarm::handler::{
 use libp2p_swarm::{
     ConnectionHandler, ConnectionHandlerEvent, KeepAlive, StreamUpgradeError, SubstreamProtocol,
 };
+use never_say_never::Never;
 use std::collections::VecDeque;
 use std::task::{Context, Poll};
 
@@ -45,19 +46,11 @@ pub enum Command {
 
 #[derive(Debug)]
 pub enum Event {
-    InboundConnectRequest {
-        remote_addr: Multiaddr,
-    },
-    InboundNegotiationFailed {
-        error: StreamUpgradeError<void::Void>,
-    },
+    InboundConnectRequest { remote_addr: Multiaddr },
+    InboundNegotiationFailed { error: StreamUpgradeError<Never> },
     InboundConnectNegotiated(Vec<Multiaddr>),
-    OutboundNegotiationFailed {
-        error: StreamUpgradeError<void::Void>,
-    },
-    OutboundConnectNegotiated {
-        remote_addrs: Vec<Multiaddr>,
-    },
+    OutboundNegotiationFailed { error: StreamUpgradeError<Never> },
+    OutboundConnectNegotiated { remote_addrs: Vec<Multiaddr> },
 }
 
 pub struct Handler {
@@ -135,7 +128,7 @@ impl Handler {
                 self.attempts += 1;
             }
             // A connection listener denies all incoming substreams, thus none can ever be fully negotiated.
-            future::Either::Right(output) => void::unreachable(output),
+            future::Either::Right(output) => output,
         }
     }
 
@@ -170,7 +163,7 @@ impl Handler {
     ) {
         self.pending_error = Some(StreamUpgradeError::Apply(match error {
             Either::Left(e) => Either::Left(e),
-            Either::Right(v) => void::unreachable(v),
+            Either::Right(v) => v,
         }));
     }
 

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1", optional = true, features = ["derive"] }
 sha2 = "0.10.0"
 smallvec = "1.6.1"
 unsigned-varint = { version = "0.7.0", features = ["asynchronous_codec"] }
-void = "1.0.2"
+never-say-never = "6.6.666"
 
 # Metrics dependencies
 prometheus-client = "0.21.0"

--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -34,13 +34,13 @@ use libp2p_swarm::handler::{
     SubstreamProtocol,
 };
 use libp2p_swarm::Stream;
+use never_say_never::Never;
 use smallvec::SmallVec;
 use std::{
     pin::Pin,
     task::{Context, Poll},
     time::Duration,
 };
-use void::Void;
 
 /// The event emitted by the Handler. This informs the behaviour of various events created
 /// by the handler.
@@ -395,7 +395,7 @@ impl EnabledHandler {
 impl ConnectionHandler for Handler {
     type FromBehaviour = HandlerIn;
     type ToBehaviour = HandlerEvent;
-    type Error = Void;
+    type Error = Never;
     type InboundOpenInfo = ();
     type InboundProtocol = either::Either<ProtocolConfig, DeniedUpgrade>;
     type OutboundOpenInfo = ();
@@ -520,7 +520,7 @@ impl ConnectionHandler for Handler {
                         ..
                     }) => match protocol {
                         Either::Left(protocol) => handler.on_fully_negotiated_inbound(protocol),
-                        Either::Right(v) => void::unreachable(v),
+                        Either::Right(v) => v,
                     },
                     ConnectionEvent::FullyNegotiatedOutbound(fully_negotiated_outbound) => {
                         handler.on_fully_negotiated_outbound(fully_negotiated_outbound)
@@ -534,7 +534,7 @@ impl ConnectionHandler for Handler {
                     ConnectionEvent::DialUpgradeError(DialUpgradeError {
                         error: StreamUpgradeError::Apply(e),
                         ..
-                    }) => void::unreachable(e),
+                    }) => e,
                     ConnectionEvent::DialUpgradeError(DialUpgradeError {
                         error: StreamUpgradeError::NegotiationFailed,
                         ..

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -35,10 +35,10 @@ use libp2p_core::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use libp2p_identity::{PeerId, PublicKey};
 use libp2p_swarm::StreamProtocol;
 use log::{debug, warn};
+use never_say_never::Never;
 use quick_protobuf::Writer;
 use std::pin::Pin;
 use unsigned_varint::codec;
-use void::Void;
 
 pub(crate) const SIGNING_PREFIX: &[u8] = b"libp2p-pubsub:";
 
@@ -105,7 +105,7 @@ where
     TSocket: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     type Output = (Framed<TSocket, GossipsubCodec>, PeerKind);
-    type Error = Void;
+    type Error = Never;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
 
     fn upgrade_inbound(self, socket: TSocket, protocol_id: Self::Info) -> Self::Future {
@@ -126,7 +126,7 @@ where
     TSocket: AsyncWrite + AsyncRead + Unpin + Send + 'static,
 {
     type Output = (Framed<TSocket, GossipsubCodec>, PeerKind);
-    type Error = Void;
+    type Error = Never;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
 
     fn upgrade_outbound(self, socket: TSocket, protocol_id: Self::Info) -> Self::Future {

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -23,7 +23,7 @@ quick-protobuf-codec = { workspace = true }
 quick-protobuf = "0.8"
 smallvec = "1.6.1"
 thiserror = "1.0"
-void = "1.0"
+never-say-never = "6.6.666"
 either = "1.8.0"
 
 [dev-dependencies]

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -30,10 +30,10 @@ use libp2p_identity as identity;
 use libp2p_identity::PublicKey;
 use libp2p_swarm::StreamProtocol;
 use log::{debug, trace};
+use never_say_never::Never;
 use std::convert::TryFrom;
 use std::{io, iter, pin::Pin};
 use thiserror::Error;
-use void::Void;
 
 const MAX_MESSAGE_SIZE_BYTES: usize = 4096;
 
@@ -128,7 +128,7 @@ where
     C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     type Output = BoxFuture<'static, Result<Info, UpgradeError>>;
-    type Error = Void;
+    type Error = Never;
     type Future = future::Ready<Result<Self::Output, Self::Error>>;
 
     fn upgrade_inbound(self, socket: C, _: Self::Info) -> Self::Future {

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -27,7 +27,7 @@ sha2 = "0.10.0"
 smallvec = "1.6.1"
 uint = "0.9"
 unsigned-varint = { version = "0.7", features = ["asynchronous_codec"] }
-void = "1.0"
+never-say-never = "6.6.666"
 futures-timer = "3.0.2"
 instant = "0.1.12"
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -542,7 +542,7 @@ impl KademliaHandler {
         // is a `Void`.
         let protocol = match protocol {
             future::Either::Left(p) => p,
-            future::Either::Right(p) => void::unreachable(p),
+            future::Either::Right(p) => p,
         };
 
         if let ProtocolStatus::Unknown = self.protocol_status {

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -24,7 +24,7 @@ smallvec = "1.6.1"
 socket2 = { version = "0.5.3", features = ["all"] }
 tokio = { version = "1.28", default-features = false, features = ["net", "time"], optional = true}
 trust-dns-proto = { version = "0.22.0", default-features = false, features = ["mdns", "tokio-runtime"] }
-void = "1.0.2"
+never-say-never = "6.6.666"
 
 [features]
 tokio = ["dep:tokio", "if-watch/tokio"]

--- a/protocols/mdns/src/behaviour.rs
+++ b/protocols/mdns/src/behaviour.rs
@@ -221,7 +221,7 @@ where
         _: ConnectionId,
         ev: THandlerOutEvent<Self>,
     ) {
-        void::unreachable(ev)
+        ev
     }
 
     fn on_swarm_event(&mut self, event: FromSwarm<Self::ConnectionHandler>) {

--- a/protocols/perf/Cargo.toml
+++ b/protocols/perf/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.28.2", features = ["full"] }
-void = "1"
+never-say-never = "6.6.666"
 
 [dev-dependencies]
 rand = "0.8"

--- a/protocols/perf/src/client/behaviour.rs
+++ b/protocols/perf/src/client/behaviour.rs
@@ -32,7 +32,7 @@ use libp2p_swarm::{
     NetworkBehaviour, NotifyHandler, PollParameters, StreamUpgradeError, THandlerInEvent,
     THandlerOutEvent, ToSwarm,
 };
-use void::Void;
+use never_say_never::Never;
 
 use crate::client::handler::Handler;
 
@@ -41,7 +41,7 @@ use super::{RunId, RunParams, RunStats};
 #[derive(Debug)]
 pub struct Event {
     pub id: RunId,
-    pub result: Result<RunStats, StreamUpgradeError<Void>>,
+    pub result: Result<RunStats, StreamUpgradeError<Never>>,
 }
 
 #[derive(Default)]

--- a/protocols/perf/src/client/handler.rs
+++ b/protocols/perf/src/client/handler.rs
@@ -34,7 +34,7 @@ use libp2p_swarm::{
     ConnectionHandler, ConnectionHandlerEvent, KeepAlive, StreamProtocol, StreamUpgradeError,
     SubstreamProtocol,
 };
-use void::Void;
+use never_say_never::Never;
 
 use super::{RunId, RunParams, RunStats};
 
@@ -47,7 +47,7 @@ pub struct Command {
 #[derive(Debug)]
 pub struct Event {
     pub(crate) id: RunId,
-    pub(crate) result: Result<RunStats, StreamUpgradeError<Void>>,
+    pub(crate) result: Result<RunStats, StreamUpgradeError<Never>>,
 }
 
 pub struct Handler {
@@ -88,7 +88,7 @@ impl Default for Handler {
 impl ConnectionHandler for Handler {
     type FromBehaviour = Command;
     type ToBehaviour = Event;
-    type Error = Void;
+    type Error= Never;
     type InboundProtocol = DeniedUpgrade;
     type OutboundProtocol = ReadyUpgrade<StreamProtocol>;
     type OutboundOpenInfo = ();

--- a/protocols/perf/src/server/handler.rs
+++ b/protocols/perf/src/server/handler.rs
@@ -33,7 +33,7 @@ use libp2p_swarm::{
     ConnectionHandler, ConnectionHandlerEvent, KeepAlive, StreamProtocol, SubstreamProtocol,
 };
 use log::error;
-use void::Void;
+use never_say_never::Never;
 
 use super::RunStats;
 
@@ -63,12 +63,12 @@ impl Default for Handler {
 }
 
 impl ConnectionHandler for Handler {
-    type FromBehaviour = Void;
+    type FromBehaviour= Never;
     type ToBehaviour = Event;
-    type Error = Void;
+    type Error= Never;
     type InboundProtocol = ReadyUpgrade<StreamProtocol>;
     type OutboundProtocol = DeniedUpgrade;
-    type OutboundOpenInfo = Void;
+    type OutboundOpenInfo= Never;
     type InboundOpenInfo = ();
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
@@ -76,7 +76,7 @@ impl ConnectionHandler for Handler {
     }
 
     fn on_behaviour_event(&mut self, v: Self::FromBehaviour) {
-        void::unreachable(v)
+        {}
     }
 
     fn on_connection_event(

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -20,7 +20,7 @@ libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true }
 log = "0.4.19"
 rand = "0.8"
-void = "1.0"
+never-say-never = "6.6.666"
 
 [dev-dependencies]
 async-std = "1.6.2"

--- a/protocols/ping/src/handler.rs
+++ b/protocols/ping/src/handler.rs
@@ -31,6 +31,7 @@ use libp2p_swarm::{
     ConnectionHandler, ConnectionHandlerEvent, KeepAlive, Stream, StreamProtocol,
     StreamUpgradeError, SubstreamProtocol,
 };
+use never_say_never::Never;
 use std::collections::VecDeque;
 use std::{
     error::Error,
@@ -38,7 +39,6 @@ use std::{
     task::{Context, Poll},
     time::Duration,
 };
-use void::Void;
 
 /// The configuration for outbound pings.
 #[derive(Debug, Clone)]
@@ -202,7 +202,7 @@ impl Handler {
                     "ping protocol negotiation timed out",
                 )),
             },
-            StreamUpgradeError::Apply(e) => void::unreachable(e),
+            StreamUpgradeError::Apply(e) => e,
             StreamUpgradeError::Io(e) => Failure::Other { error: Box::new(e) },
         };
 
@@ -211,9 +211,9 @@ impl Handler {
 }
 
 impl ConnectionHandler for Handler {
-    type FromBehaviour = Void;
+    type FromBehaviour = Never;
     type ToBehaviour = Result<Duration, Failure>;
-    type Error = Void;
+    type Error = Never;
     type InboundProtocol = ReadyUpgrade<StreamProtocol>;
     type OutboundProtocol = ReadyUpgrade<StreamProtocol>;
     type OutboundOpenInfo = ();
@@ -223,7 +223,7 @@ impl ConnectionHandler for Handler {
         SubstreamProtocol::new(ReadyUpgrade::new(PROTOCOL_NAME), ())
     }
 
-    fn on_behaviour_event(&mut self, _: Void) {}
+    fn on_behaviour_event(&mut self, _: Never) {}
 
     fn connection_keep_alive(&self) -> KeepAlive {
         KeepAlive::No

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -26,7 +26,7 @@ quick-protobuf-codec = { workspace = true }
 rand = "0.8.4"
 static_assertions = "1"
 thiserror = "1.0"
-void = "1"
+never-say-never = "6.6.666"
 
 [dev-dependencies]
 env_logger = "0.10.0"

--- a/protocols/relay/src/behaviour.rs
+++ b/protocols/relay/src/behaviour.rs
@@ -36,12 +36,12 @@ use libp2p_swarm::{
     dummy, ConnectionDenied, ConnectionId, ExternalAddresses, NetworkBehaviour, NotifyHandler,
     PollParameters, StreamUpgradeError, THandler, THandlerInEvent, THandlerOutEvent, ToSwarm,
 };
+use never_say_never::Never;
 use std::collections::{hash_map, HashMap, HashSet, VecDeque};
 use std::num::NonZeroU32;
 use std::ops::Add;
 use std::task::{Context, Poll};
 use std::time::Duration;
-use void::Void;
 
 /// Configuration for the relay [`Behaviour`].
 ///
@@ -331,7 +331,7 @@ impl NetworkBehaviour for Behaviour {
     ) {
         let event = match event {
             Either::Left(e) => e,
-            Either::Right(v) => void::unreachable(v),
+            Either::Right(v) => v,
         };
 
         match event {
@@ -775,7 +775,7 @@ impl Add<u64> for CircuitId {
 /// before being returned in [`Behaviour::poll`].
 #[allow(clippy::large_enum_variant)]
 enum Action {
-    Done(ToSwarm<Event, Either<handler::In, Void>>),
+    Done(ToSwarm<Event, Either<handler::In, Never>>),
     AcceptReservationPrototype {
         inbound_reservation_req: inbound_hop::ReservationReq,
         handler: NotifyHandler,
@@ -783,8 +783,8 @@ enum Action {
     },
 }
 
-impl From<ToSwarm<Event, Either<handler::In, Void>>> for Action {
-    fn from(action: ToSwarm<Event, Either<handler::In, Void>>) -> Self {
+impl From<ToSwarm<Event, Either<handler::In, Never>>> for Action {
+    fn from(action: ToSwarm<Event, Either<handler::In, Never>>) -> Self {
         Self::Done(action)
     }
 }
@@ -794,7 +794,7 @@ impl Action {
         self,
         local_peer_id: PeerId,
         external_addresses: &ExternalAddresses,
-    ) -> ToSwarm<Event, Either<handler::In, Void>> {
+    ) -> ToSwarm<Event, Either<handler::In, Never>> {
         match self {
             Action::Done(action) => action,
             Action::AcceptReservationPrototype {

--- a/protocols/relay/src/priv_client/handler.rs
+++ b/protocols/relay/src/priv_client/handler.rs
@@ -39,6 +39,7 @@ use libp2p_swarm::{
     ConnectionHandler, ConnectionHandlerEvent, KeepAlive, StreamUpgradeError, SubstreamProtocol,
 };
 use log::debug;
+use never_say_never::Never;
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::task::{Context, Poll};
@@ -138,7 +139,7 @@ pub struct Handler {
     /// Once all substreams are dropped and this handler has no other work,
     /// [`KeepAlive::Until`] can be set, allowing the connection to be closed
     /// eventually.
-    alive_lend_out_substreams: FuturesUnordered<oneshot::Receiver<void::Void>>,
+    alive_lend_out_substreams: FuturesUnordered<oneshot::Receiver<Never>>,
 
     circuit_deny_futs:
         HashMap<PeerId, BoxFuture<'static, Result<(), protocol::inbound_stop::UpgradeError>>>,
@@ -499,7 +500,7 @@ impl ConnectionHandler for Handler {
         loop {
             match self.alive_lend_out_substreams.poll_next_unpin(cx) {
                 Poll::Ready(Some(Err(oneshot::Canceled))) => {}
-                Poll::Ready(Some(Ok(v))) => void::unreachable(v),
+                Poll::Ready(Some(Ok(v))) => v,
                 Poll::Ready(None) | Poll::Pending => break,
             }
         }

--- a/protocols/rendezvous/Cargo.toml
+++ b/protocols/rendezvous/Cargo.toml
@@ -26,7 +26,7 @@ quick-protobuf = "0.8"
 quick-protobuf-codec = { workspace = true }
 rand = "0.8"
 thiserror = "1"
-void = "1"
+never-say-never = "6.6.666"
 
 [dev-dependencies]
 env_logger = "0.10.0"

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0", optional = true}
 serde_json = { version = "1.0.96", optional = true }
 serde_cbor = { version = "0.11.2", optional = true }
 smallvec = "1.6.1"
-void = "1.0.2"
+never-say-never = "6.6.666"
 log = "0.4.19"
 
 [features]

--- a/protocols/request-response/src/handler.rs
+++ b/protocols/request-response/src/handler.rs
@@ -36,6 +36,7 @@ use libp2p_swarm::{
     handler::{ConnectionHandler, ConnectionHandlerEvent, KeepAlive, StreamUpgradeError},
     SubstreamProtocol,
 };
+use never_say_never::Never;
 use smallvec::SmallVec;
 use std::{
     collections::VecDeque,
@@ -239,7 +240,7 @@ where
 {
     type FromBehaviour = RequestProtocol<TCodec>;
     type ToBehaviour = Event<TCodec>;
-    type Error = void::Void;
+    type Error = Never;
     type InboundProtocol = ResponseProtocol<TCodec>;
     type OutboundProtocol = RequestProtocol<TCodec>;
     type OutboundOpenInfo = RequestId;

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -22,7 +22,7 @@ libp2p-swarm-derive = { workspace = true, optional = true }
 log = "0.4"
 rand = "0.8"
 smallvec = "1.6.1"
-void = "1"
+never-say-never = "6.6.666"
 wasm-bindgen-futures = { version = "0.4.36", optional = true }
 getrandom = { version = "0.2.9", features = ["js"], optional = true } # Explicit dependency to be used in `wasm-bindgen` feature
 once_cell = "1.18.0"
@@ -52,7 +52,7 @@ libp2p-swarm-derive = { workspace = true }
 libp2p-swarm-test = { workspace = true }
 libp2p-yamux = { workspace = true }
 quickcheck = { workspace = true }
-void = "1"
+never-say-never = "6.6.666"
 once_cell = "1.18.0"
 trybuild = "1.0.80"
 

--- a/swarm/src/behaviour/toggle.rs
+++ b/swarm/src/behaviour/toggle.rs
@@ -212,7 +212,7 @@ where
     ) {
         let out = match out {
             future::Either::Left(out) => out,
-            future::Either::Right(v) => void::unreachable(v),
+            future::Either::Right(never) => never,
         };
 
         if let Either::Left(info) = info {
@@ -253,7 +253,7 @@ where
 
         let err = match err {
             Either::Left(e) => e,
-            Either::Right(v) => void::unreachable(v),
+            Either::Right(never) => never,
         };
 
         inner.on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {

--- a/swarm/src/connection.rs
+++ b/swarm/src/connection.rs
@@ -695,9 +695,9 @@ mod tests {
     use futures::AsyncWrite;
     use libp2p_core::upgrade::{DeniedUpgrade, InboundUpgrade, OutboundUpgrade, UpgradeInfo};
     use libp2p_core::StreamMuxer;
+    use never_say_never::Never;
     use quickcheck::*;
     use std::sync::{Arc, Weak};
-    use void::Void;
 
     #[test]
     fn max_negotiating_inbound_streams() {
@@ -845,7 +845,7 @@ mod tests {
 
     impl StreamMuxer for DummyStreamMuxer {
         type Substream = PendingSubstream;
-        type Error = Void;
+        type Error = Never;
 
         fn poll_inbound(
             self: Pin<&mut Self>,
@@ -878,7 +878,7 @@ mod tests {
 
     impl StreamMuxer for PendingStreamMuxer {
         type Substream = PendingSubstream;
-        type Error = Void;
+        type Error = Never;
 
         fn poll_inbound(
             self: Pin<&mut Self>,
@@ -938,7 +938,7 @@ mod tests {
 
     struct MockConnectionHandler {
         outbound_requested: bool,
-        error: Option<StreamUpgradeError<Void>>,
+        error: Option<StreamUpgradeError<Never>>,
         upgrade_timeout: Duration,
     }
 
@@ -958,7 +958,7 @@ mod tests {
 
     #[derive(Default)]
     struct ConfigurableProtocolConnectionHandler {
-        events: Vec<ConnectionHandlerEvent<DeniedUpgrade, (), Void, Void>>,
+        events: Vec<ConnectionHandlerEvent<DeniedUpgrade, (), Never, Never>>,
         active_protocols: HashSet<StreamProtocol>,
         local_added: Vec<Vec<StreamProtocol>>,
         local_removed: Vec<Vec<StreamProtocol>>,
@@ -991,9 +991,9 @@ mod tests {
     }
 
     impl ConnectionHandler for MockConnectionHandler {
-        type FromBehaviour = Void;
-        type ToBehaviour = Void;
-        type Error = Void;
+        type FromBehaviour = Never;
+        type ToBehaviour = Never;
+        type Error = Never;
         type InboundProtocol = DeniedUpgrade;
         type OutboundProtocol = DeniedUpgrade;
         type InboundOpenInfo = ();
@@ -1018,11 +1018,11 @@ mod tests {
                 ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
                     protocol,
                     ..
-                }) => void::unreachable(protocol),
+                }) => protocol,
                 ConnectionEvent::FullyNegotiatedOutbound(FullyNegotiatedOutbound {
                     protocol,
                     ..
-                }) => void::unreachable(protocol),
+                }) => protocol,
                 ConnectionEvent::DialUpgradeError(DialUpgradeError { error, .. }) => {
                     self.error = Some(error)
                 }
@@ -1034,7 +1034,7 @@ mod tests {
         }
 
         fn on_behaviour_event(&mut self, event: Self::FromBehaviour) {
-            void::unreachable(event)
+            event
         }
 
         fn connection_keep_alive(&self) -> KeepAlive {
@@ -1065,9 +1065,9 @@ mod tests {
     }
 
     impl ConnectionHandler for ConfigurableProtocolConnectionHandler {
-        type FromBehaviour = Void;
-        type ToBehaviour = Void;
-        type Error = Void;
+        type FromBehaviour = Never;
+        type ToBehaviour = Never;
+        type Error = Never;
         type InboundProtocol = ManyProtocolsUpgrade;
         type OutboundProtocol = DeniedUpgrade;
         type InboundOpenInfo = ();
@@ -1111,7 +1111,7 @@ mod tests {
         }
 
         fn on_behaviour_event(&mut self, event: Self::FromBehaviour) {
-            void::unreachable(event)
+            event
         }
 
         fn connection_keep_alive(&self) -> KeepAlive {
@@ -1152,7 +1152,7 @@ mod tests {
 
     impl<C> InboundUpgrade<C> for ManyProtocolsUpgrade {
         type Output = C;
-        type Error = Void;
+        type Error = Never;
         type Future = future::Ready<Result<Self::Output, Self::Error>>;
 
         fn upgrade_inbound(self, stream: C, _: Self::Info) -> Self::Future {
@@ -1162,7 +1162,7 @@ mod tests {
 
     impl<C> OutboundUpgrade<C> for ManyProtocolsUpgrade {
         type Output = C;
-        type Error = Void;
+        type Error = Never;
         type Future = future::Ready<Result<Self::Output, Self::Error>>;
 
         fn upgrade_outbound(self, stream: C, _: Self::Info) -> Self::Future {

--- a/swarm/src/connection/pool.rs
+++ b/swarm/src/connection/pool.rs
@@ -40,6 +40,7 @@ use futures::{
 use instant::Instant;
 use libp2p_core::connection::Endpoint;
 use libp2p_core::muxing::{StreamMuxerBox, StreamMuxerExt};
+use never_say_never::Never;
 use std::task::Waker;
 use std::{
     collections::{hash_map, HashMap},
@@ -49,7 +50,6 @@ use std::{
     task::Context,
     task::Poll,
 };
-use void::Void;
 
 mod concurrent_dial;
 mod task;
@@ -194,7 +194,7 @@ struct PendingConnection {
     peer_id: Option<PeerId>,
     endpoint: PendingPoint,
     /// When dropped, notifies the task which then knows to terminate.
-    abort_notifier: Option<oneshot::Sender<Void>>,
+    abort_notifier: Option<oneshot::Sender<Never>>,
     /// The moment we became aware of this possible connection, useful for timing metrics.
     accepted_at: Instant,
 }

--- a/swarm/src/connection/pool/task.rs
+++ b/swarm/src/connection/pool/task.rs
@@ -36,8 +36,8 @@ use futures::{
     SinkExt, StreamExt,
 };
 use libp2p_core::muxing::StreamMuxerBox;
+use never_say_never::Never;
 use std::pin::Pin;
-use void::Void;
 
 /// Commands that can be sent to a task driving an established connection.
 #[derive(Debug)]
@@ -94,7 +94,7 @@ pub(crate) enum EstablishedConnectionEvent<THandler: ConnectionHandler> {
 pub(crate) async fn new_for_pending_outgoing_connection(
     connection_id: ConnectionId,
     dial: ConcurrentDial,
-    abort_receiver: oneshot::Receiver<Void>,
+    abort_receiver: oneshot::Receiver<Never>,
     mut events: mpsc::Sender<PendingConnectionEvent>,
 ) {
     match futures::future::select(abort_receiver, Box::pin(dial)).await {
@@ -106,7 +106,7 @@ pub(crate) async fn new_for_pending_outgoing_connection(
                 })
                 .await;
         }
-        Either::Left((Ok(v), _)) => void::unreachable(v),
+        Either::Left((Ok(v), _)) => v,
         Either::Right((Ok((address, output, errors)), _)) => {
             let _ = events
                 .send(PendingConnectionEvent::ConnectionEstablished {
@@ -130,7 +130,7 @@ pub(crate) async fn new_for_pending_outgoing_connection(
 pub(crate) async fn new_for_pending_incoming_connection<TFut>(
     connection_id: ConnectionId,
     future: TFut,
-    abort_receiver: oneshot::Receiver<Void>,
+    abort_receiver: oneshot::Receiver<Never>,
     mut events: mpsc::Sender<PendingConnectionEvent>,
 ) where
     TFut: Future<Output = Result<(PeerId, StreamMuxerBox), std::io::Error>> + Send + 'static,
@@ -144,7 +144,7 @@ pub(crate) async fn new_for_pending_incoming_connection<TFut>(
                 })
                 .await;
         }
-        Either::Left((Ok(v), _)) => void::unreachable(v),
+        Either::Left((Ok(v), _)) => v,
         Either::Right((Ok(output), _)) => {
             let _ = events
                 .send(PendingConnectionEvent::ConnectionEstablished {

--- a/swarm/src/dummy.rs
+++ b/swarm/src/dummy.rs
@@ -11,15 +11,15 @@ use libp2p_core::upgrade::DeniedUpgrade;
 use libp2p_core::Endpoint;
 use libp2p_core::Multiaddr;
 use libp2p_identity::PeerId;
+use never_say_never::Never;
 use std::task::{Context, Poll};
-use void::Void;
 
 /// Implementation of [`NetworkBehaviour`] that doesn't do anything.
 pub struct Behaviour;
 
 impl NetworkBehaviour for Behaviour {
     type ConnectionHandler = ConnectionHandler;
-    type ToSwarm = Void;
+    type ToSwarm = Never;
 
     fn handle_established_inbound_connection(
         &mut self,
@@ -47,7 +47,7 @@ impl NetworkBehaviour for Behaviour {
         _: ConnectionId,
         event: THandlerOutEvent<Self>,
     ) {
-        void::unreachable(event)
+        event
     }
 
     fn poll(
@@ -82,20 +82,20 @@ impl NetworkBehaviour for Behaviour {
 pub struct ConnectionHandler;
 
 impl crate::handler::ConnectionHandler for ConnectionHandler {
-    type FromBehaviour = Void;
-    type ToBehaviour = Void;
-    type Error = Void;
+    type FromBehaviour = Never;
+    type ToBehaviour = Never;
+    type Error = Never;
     type InboundProtocol = DeniedUpgrade;
     type OutboundProtocol = DeniedUpgrade;
     type InboundOpenInfo = ();
-    type OutboundOpenInfo = Void;
+    type OutboundOpenInfo = Never;
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
         SubstreamProtocol::new(DeniedUpgrade, ())
     }
 
     fn on_behaviour_event(&mut self, event: Self::FromBehaviour) {
-        void::unreachable(event)
+        event
     }
 
     fn connection_keep_alive(&self) -> KeepAlive {
@@ -128,13 +128,13 @@ impl crate::handler::ConnectionHandler for ConnectionHandler {
         match event {
             ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
                 protocol, ..
-            }) => void::unreachable(protocol),
+            }) => protocol,
             ConnectionEvent::FullyNegotiatedOutbound(FullyNegotiatedOutbound {
                 protocol, ..
-            }) => void::unreachable(protocol),
+            }) => protocol,
             ConnectionEvent::DialUpgradeError(DialUpgradeError { info: _, error }) => match error {
                 StreamUpgradeError::Timeout => unreachable!(),
-                StreamUpgradeError::Apply(e) => void::unreachable(e),
+                StreamUpgradeError::Apply(e) => e,
                 StreamUpgradeError::NegotiationFailed | StreamUpgradeError::Io(_) => {
                     unreachable!("Denied upgrade does not support any protocols")
                 }

--- a/swarm/src/handler/one_shot.rs
+++ b/swarm/src/handler/one_shot.rs
@@ -255,11 +255,11 @@ mod tests {
     use futures::executor::block_on;
     use futures::future::poll_fn;
     use libp2p_core::upgrade::DeniedUpgrade;
-    use void::Void;
+    use never_say_never::Never;
 
     #[test]
     fn do_not_keep_idle_connection_alive() {
-        let mut handler: OneShotHandler<_, DeniedUpgrade, Void> = OneShotHandler::new(
+        let mut handler: OneShotHandler<_, DeniedUpgrade, Never> = OneShotHandler::new(
             SubstreamProtocol::new(DeniedUpgrade {}, ()),
             Default::default(),
         );

--- a/swarm/src/handler/pending.rs
+++ b/swarm/src/handler/pending.rs
@@ -24,8 +24,8 @@ use crate::handler::{
     FullyNegotiatedOutbound, KeepAlive, SubstreamProtocol,
 };
 use libp2p_core::upgrade::PendingUpgrade;
+use never_say_never::Never;
 use std::task::{Context, Poll};
-use void::Void;
 
 /// Implementation of [`ConnectionHandler`] that returns a pending upgrade.
 #[derive(Clone, Debug)]
@@ -40,12 +40,12 @@ impl PendingConnectionHandler {
 }
 
 impl ConnectionHandler for PendingConnectionHandler {
-    type FromBehaviour = Void;
-    type ToBehaviour = Void;
-    type Error = Void;
+    type FromBehaviour = Never;
+    type ToBehaviour = Never;
+    type Error = Never;
     type InboundProtocol = PendingUpgrade<String>;
     type OutboundProtocol = PendingUpgrade<String>;
-    type OutboundOpenInfo = Void;
+    type OutboundOpenInfo = Never;
     type InboundOpenInfo = ();
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
@@ -53,7 +53,7 @@ impl ConnectionHandler for PendingConnectionHandler {
     }
 
     fn on_behaviour_event(&mut self, v: Self::FromBehaviour) {
-        void::unreachable(v)
+        v
     }
 
     fn connection_keep_alive(&self) -> KeepAlive {
@@ -86,17 +86,10 @@ impl ConnectionHandler for PendingConnectionHandler {
         match event {
             ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
                 protocol, ..
-            }) => void::unreachable(protocol),
+            }) => protocol,
             ConnectionEvent::FullyNegotiatedOutbound(FullyNegotiatedOutbound {
-                protocol,
-                info: _info,
-            }) => {
-                void::unreachable(protocol);
-                #[allow(unreachable_code, clippy::used_underscore_binding)]
-                {
-                    void::unreachable(_info);
-                }
-            }
+                protocol, ..
+            }) => protocol,
             ConnectionEvent::AddressChange(_)
             | ConnectionEvent::DialUpgradeError(_)
             | ConnectionEvent::ListenUpgradeError(_)

--- a/swarm/src/keep_alive.rs
+++ b/swarm/src/keep_alive.rs
@@ -8,8 +8,8 @@ use crate::{ConnectionDenied, THandler, THandlerInEvent, THandlerOutEvent};
 use libp2p_core::upgrade::DeniedUpgrade;
 use libp2p_core::{Endpoint, Multiaddr};
 use libp2p_identity::PeerId;
+use never_say_never::Never;
 use std::task::{Context, Poll};
-use void::Void;
 
 /// Implementation of [`NetworkBehaviour`] that doesn't do anything other than keep all connections alive.
 ///
@@ -22,7 +22,7 @@ pub struct Behaviour;
 
 impl NetworkBehaviour for Behaviour {
     type ConnectionHandler = ConnectionHandler;
-    type ToSwarm = Void;
+    type ToSwarm = Never;
 
     fn handle_established_inbound_connection(
         &mut self,
@@ -50,7 +50,7 @@ impl NetworkBehaviour for Behaviour {
         _: ConnectionId,
         event: THandlerOutEvent<Self>,
     ) {
-        void::unreachable(event)
+        event
     }
 
     fn poll(
@@ -85,20 +85,20 @@ impl NetworkBehaviour for Behaviour {
 pub struct ConnectionHandler;
 
 impl crate::handler::ConnectionHandler for ConnectionHandler {
-    type FromBehaviour = Void;
-    type ToBehaviour = Void;
-    type Error = Void;
+    type FromBehaviour = Never;
+    type ToBehaviour = Never;
+    type Error = Never;
     type InboundProtocol = DeniedUpgrade;
     type OutboundProtocol = DeniedUpgrade;
     type InboundOpenInfo = ();
-    type OutboundOpenInfo = Void;
+    type OutboundOpenInfo = Never;
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
         SubstreamProtocol::new(DeniedUpgrade, ())
     }
 
     fn on_behaviour_event(&mut self, v: Self::FromBehaviour) {
-        void::unreachable(v)
+        v
     }
 
     fn connection_keep_alive(&self) -> KeepAlive {
@@ -131,10 +131,10 @@ impl crate::handler::ConnectionHandler for ConnectionHandler {
         match event {
             ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
                 protocol, ..
-            }) => void::unreachable(protocol),
+            }) => protocol,
             ConnectionEvent::FullyNegotiatedOutbound(FullyNegotiatedOutbound {
                 protocol, ..
-            }) => void::unreachable(protocol),
+            }) => protocol,
             ConnectionEvent::DialUpgradeError(_)
             | ConnectionEvent::ListenUpgradeError(_)
             | ConnectionEvent::AddressChange(_)

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1374,7 +1374,7 @@ where
     ///
     /// Spawning a task is similar too:
     /// ```typescript
-    /// function spawn(task: () => Promise<void>) {
+    /// function spawn(task: () => Promise<Never>) {
     ///     task()
     /// }
     /// ```

--- a/swarm/tests/listener.rs
+++ b/swarm/tests/listener.rs
@@ -1,3 +1,4 @@
+use never_say_never::Never;
 use std::{
     collections::{HashSet, VecDeque},
     task::{Context, Poll},
@@ -75,7 +76,7 @@ impl Behaviour {
 
 impl NetworkBehaviour for Behaviour {
     type ConnectionHandler = dummy::ConnectionHandler;
-    type ToSwarm = void::Void;
+    type ToSwarm = Never;
 
     fn handle_established_inbound_connection(
         &mut self,

--- a/swarm/tests/swarm_derive.rs
+++ b/swarm/tests/swarm_derive.rs
@@ -26,6 +26,7 @@ use libp2p_swarm::{
     behaviour::FromSwarm, dummy, ConnectionDenied, NetworkBehaviour, SwarmEvent, THandler,
     THandlerInEvent, THandlerOutEvent,
 };
+use never_say_never::Never;
 use std::fmt::Debug;
 
 /// Small utility to check that a type implements `NetworkBehaviour`.
@@ -467,7 +468,7 @@ fn custom_out_event_no_type_parameters() {
 
     impl<T> NetworkBehaviour for TemplatedBehaviour<T> {
         type ConnectionHandler = dummy::ConnectionHandler;
-        type ToSwarm = void::Void;
+        type ToSwarm = Never;
 
         fn handle_established_inbound_connection(
             &mut self,
@@ -495,7 +496,7 @@ fn custom_out_event_no_type_parameters() {
             _connection: ConnectionId,
             message: THandlerOutEvent<Self>,
         ) {
-            void::unreachable(message);
+            message
         }
 
         fn poll(
@@ -534,12 +535,6 @@ fn custom_out_event_no_type_parameters() {
     #[derive(Debug)]
     enum OutEvent {
         None,
-    }
-
-    impl From<void::Void> for OutEvent {
-        fn from(_e: void::Void) -> Self {
-            Self::None
-        }
     }
 
     require_net_behaviour::<Behaviour<String>>();

--- a/transports/webrtc/Cargo.toml
+++ b/transports/webrtc/Cargo.toml
@@ -48,7 +48,7 @@ libp2p-swarm = { workspace = true, features = ["macros", "tokio"] }
 libp2p-ping = { workspace = true }
 tokio = { version = "1.28", features = ["full"] }
 unsigned-varint = { version = "0.7", features = ["asynchronous_codec"] }
-void = "1"
+never-say-never = "6.6.666"
 quickcheck = "1.0.3"
 
 [[test]]

--- a/transports/webrtc/examples/listen_ping.rs
+++ b/transports/webrtc/examples/listen_ping.rs
@@ -5,8 +5,8 @@ use libp2p_core::Transport;
 use libp2p_identity as identity;
 use libp2p_ping as ping;
 use libp2p_swarm::{keep_alive, NetworkBehaviour, Swarm, SwarmBuilder};
+use never_say_never::Never;
 use rand::thread_rng;
-use void::Void;
 
 /// An example WebRTC server that will accept connections and run the ping protocol on them.
 #[tokio::main]
@@ -52,11 +52,5 @@ enum Event {
 impl From<ping::Event> for Event {
     fn from(e: ping::Event) -> Self {
         Event::Ping(e)
-    }
-}
-
-impl From<Void> for Event {
-    fn from(event: Void) -> Self {
-        void::unreachable(event)
     }
 }


### PR DESCRIPTION
## Description

I am opening this to just show what it would look like. There are some interesting observations. For example, the true never type `!` automatically converges to any type, meaning instead of calling `void::unreachable` we can in pretty much all cases simply state the variable.

For event-handlers without return values, like `on_behaviour_event`, this means `!` will automatically converge to `()`. For cases where we `match`, it will converge to the type of the other pattern.

Unfortunately, this does not work with the `swarm-derive` macro as it is today. The standard library already has an implementation for `From<!> for T` but it is unstable. This means we cannot add one but it is also not effective. Even if it were, we don't know in the derive, which behaviour will emit `!`.

One idea on how to tackle that would be to introduce a new attribute: `#[behaviour(no_event)]` or something like that. For all behaviours tagged with this event, we would not generate a variant in the enum.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
