### PR TITLE
chore: don't use workspace inheritance for dev-dependencies

### DIFF
--- a/misc/allow-block-list/Cargo.toml
+++ b/misc/allow-block-list/Cargo.toml
@@ -17,5 +17,5 @@ void = "1"
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
-libp2p-swarm-derive = { workspace = true }
-libp2p-swarm-test = { workspace = true }
+libp2p-swarm-derive = { path = "../../swarm-derive" }
+libp2p-swarm-test = { path = "../../swarm-test" }

--- a/misc/connection-limits/Cargo.toml
+++ b/misc/connection-limits/Cargo.toml
@@ -19,7 +19,7 @@ void = "1"
 async-std = { version = "1.12.0", features = ["attributes"] }
 libp2p-identify = { workspace = true }
 libp2p-ping = { workspace = true }
-libp2p-swarm-derive = { workspace = true }
-libp2p-swarm-test = { workspace = true }
+libp2p-swarm-derive = { path = "../../swarm-derive" }
+libp2p-swarm-test = { path = "../../swarm-test" }
 quickcheck = { workspace = true }
 rand = "0.8.5"

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -28,7 +28,7 @@ async-std = { version = "1.7.0", features = ["attributes"] }
 criterion = "0.5"
 env_logger = "0.10"
 futures = "0.3"
-libp2p-muxer-test-harness = { workspace = true }
+libp2p-muxer-test-harness = { path = "../test-harness" }
 libp2p-plaintext = { workspace = true }
 libp2p-tcp = { workspace = true, features = ["async-io"] }
 quickcheck = { workspace = true }

--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4"
 
 [dev-dependencies]
 async-std = { version = "1.7.0", features = ["attributes"] }
-libp2p-muxer-test-harness = { workspace = true }
+libp2p-muxer-test-harness = { path = "../test-harness" }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -26,7 +26,7 @@ quick-protobuf = "0.8"
 [dev-dependencies]
 async-std = { version = "1.10", features = ["attributes"] }
 env_logger = "0.10"
-libp2p-swarm-test = { workspace = true }
+libp2p-swarm-test = { path = "../../swarm-test" }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/protocols/dcutr/Cargo.toml
+++ b/protocols/dcutr/Cargo.toml
@@ -36,7 +36,7 @@ libp2p-ping = { workspace = true }
 libp2p-plaintext = { workspace = true }
 libp2p-relay = { workspace = true }
 libp2p-swarm = { workspace = true, features = ["macros"] }
-libp2p-swarm-test = { workspace = true }
+libp2p-swarm-test = { path = "../../swarm-test" }
 libp2p-tcp = { workspace = true, features = ["async-io"] }
 libp2p-yamux = { workspace = true }
 rand = "0.8"

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -49,7 +49,7 @@ hex = "0.4.2"
 libp2p-core = { workspace = true }
 libp2p-yamux = { workspace = true }
 libp2p-noise = { workspace = true }
-libp2p-swarm-test = { workspace = true }
+libp2p-swarm-test = { path = "../../swarm-test" }
 quickcheck = { workspace = true }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -38,7 +38,7 @@ libp2p-swarm = { workspace = true, features = ["tokio", "async-std"] }
 libp2p-tcp = { workspace = true, features = ["tokio", "async-io"] }
 libp2p-yamux = { workspace = true }
 tokio = { version = "1.28", default-features = false, features = ["macros", "rt", "rt-multi-thread", "time"] }
-libp2p-swarm-test = { workspace = true }
+libp2p-swarm-test = { path = "../../swarm-test" }
 
 [[test]]
 name = "use-async-std"

--- a/protocols/perf/Cargo.toml
+++ b/protocols/perf/Cargo.toml
@@ -35,7 +35,7 @@ void = "1"
 
 [dev-dependencies]
 rand = "0.8"
-libp2p-swarm-test = { workspace = true }
+libp2p-swarm-test = { path = "../../swarm-test" }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -26,7 +26,7 @@ void = "1.0"
 async-std = "1.6.2"
 env_logger = "0.10.0"
 libp2p-swarm = { workspace = true, features = ["macros"] }
-libp2p-swarm-test = { workspace = true }
+libp2p-swarm-test = { path = "../../swarm-test" }
 quickcheck = { workspace = true }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.

--- a/protocols/rendezvous/Cargo.toml
+++ b/protocols/rendezvous/Cargo.toml
@@ -38,7 +38,7 @@ libp2p-yamux = { workspace = true }
 libp2p-tcp = { workspace = true, features = ["tokio"] }
 rand = "0.8"
 tokio = { version = "1.28", features = [ "rt-multi-thread", "time", "macros", "sync", "process", "fs", "net" ] }
-libp2p-swarm-test = { workspace = true }
+libp2p-swarm-test = { path = "../../swarm-test" }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -36,7 +36,7 @@ libp2p-noise = { workspace = true }
 libp2p-tcp = { workspace = true, features = ["async-io"] }
 libp2p-yamux = { workspace = true }
 rand = "0.8"
-libp2p-swarm-test = { workspace = true }
+libp2p-swarm-test = { path = "../../swarm-test" }
 futures_ringbuf = "0.4.0"
 serde = { version = "1.0", features = ["derive"]}
 

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -48,7 +48,7 @@ libp2p-identity = { workspace = true, features = ["ed25519"] }
 libp2p-kad = { path = "../protocols/kad" } # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
 libp2p-ping = { path = "../protocols/ping" } # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
 libp2p-plaintext = { path = "../transports/plaintext" } # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
-libp2p-swarm-derive = { workspace = true }
+libp2p-swarm-derive = { path = "../swarm-derive" }
 libp2p-swarm-test = { path = "../swarm-test" } # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
 libp2p-yamux = { workspace = true }
 quickcheck = { workspace = true }

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -39,7 +39,7 @@ rustc-args = ["--cfg", "docsrs"]
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
 env_logger = "0.10.0"
-libp2p-muxer-test-harness = { workspace = true }
+libp2p-muxer-test-harness = { path = "../../muxers/test-harness" }
 libp2p-noise = { workspace = true }
 libp2p-tcp = { workspace = true, features = ["async-io"] }
 libp2p-yamux = { workspace = true }


### PR DESCRIPTION
## Description

Using workspace inheritance breaks `cargo release` because it cannot resolve that the dev-dependencies should only use a `path` and not a version.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
