### PR TITLE
chore(libp2p): expose `Behaviour::connected` and `Behaviour::addresses`

### DIFF
--- a/protocols/autonat/src/behaviour.rs
+++ b/protocols/autonat/src/behaviour.rs
@@ -263,6 +263,13 @@ impl Behaviour {
         self.confidence
     }
 
+    // Connected peers with the observed address of each connection.
+    // If the endpoint of a connection is relayed or not global (in case of Config::only_global_ips),
+    // the observed address is `None`.
+    pub fn connected(&self) -> HashMap<PeerId, HashMap<ConnectionId, Option<Multiaddr>>> {
+        self.connected.clone()
+    }
+
     /// Add a peer to the list over servers that may be used for probes.
     /// These peers are used for dial-request even if they are currently not connection, in which case a connection will be
     /// establish before sending the dial-request.

--- a/protocols/identify/src/behaviour.rs
+++ b/protocols/identify/src/behaviour.rs
@@ -176,6 +176,11 @@ impl Behaviour {
         }
     }
 
+    /// For each peer we're connected to, the observed address to send back to it.
+    pub fn connected(&self) -> HashMap<PeerId, HashMap<ConnectionId, Multiaddr>> {
+        self.connected.clone()
+    }
+
     /// Initiates an active push of the local peer information to the given peers.
     pub fn push<I>(&mut self, peers: I)
     where

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -351,6 +351,17 @@ where
     {
         Self::with_codec(TCodec::default(), protocols, cfg)
     }
+
+    /// The currently connected peers, their pending outbound and inbound responses and their known,
+    /// reachable addresses, if any.
+    pub fn connected(&self) -> HashMap<PeerId, SmallVec<[Connection; 2]>> {
+        self.connected.clone()
+    }
+
+    /// Externally managed addresses via `add_address` and `remove_address`.
+    pub fn addresses(&self) -> HashMap<PeerId, SmallVec<[Multiaddr; 6]>> {
+        self.addresses.clone()
+    }
 }
 
 impl<TCodec> Behaviour<TCodec>
@@ -922,7 +933,8 @@ where
 const EMPTY_QUEUE_SHRINK_THRESHOLD: usize = 100;
 
 /// Internal information tracked for an established connection.
-struct Connection {
+#[derive(Clone)]
+pub struct Connection {
     id: ConnectionId,
     address: Option<Multiaddr>,
     /// Pending outbound responses where corresponding inbound requests have
@@ -942,5 +954,13 @@ impl Connection {
             pending_outbound_responses: Default::default(),
             pending_inbound_responses: Default::default(),
         }
+    }
+
+    pub fn id(&self) -> ConnectionId {
+        self.id
+    }
+
+    pub fn address(&self) -> Option<Multiaddr> {
+        self.address.clone()
     }
 }


### PR DESCRIPTION
## Description

This pull request aims to meet the need of `addresses_of_peer` function which was removed from the codebase. By exposing these fields, developers will be able to create their own abstracted layers without the need for direct implementation in the libp2p tree.

## Notes

see https://github.com/libp2p/rust-libp2p/pull/3254#issuecomment-1496418416

