### PR TITLE
fix(test): only listen on `127.0.0.1` for ephemeral swarm

### DIFF
--- a/misc/allow-block-list/src/lib.rs
+++ b/misc/allow-block-list/src/lib.rs
@@ -418,7 +418,7 @@ mod tests {
 
         let (
             [SwarmEvent::OutgoingConnectionError { error: DialError::Denied { cause: outgoing_cause }, .. }],
-            [_, _, _, SwarmEvent::IncomingConnectionError { error: ListenError::Denied { cause: incoming_cause }, .. }],
+            [_, SwarmEvent::IncomingConnectionError { error: ListenError::Denied { cause: incoming_cause }, .. }],
         ) = libp2p_swarm_test::drive(&mut dialer, &mut listener).await else {
             panic!("unexpected events")
         };

--- a/protocols/kad/tests/client_mode.rs
+++ b/protocols/kad/tests/client_mode.rs
@@ -59,7 +59,7 @@ async fn two_servers_add_each_other_to_routing_table() {
 
     match libp2p_swarm_test::drive(&mut server2, &mut server1).await {
         (
-            [Identify(_), Kad(RoutingUpdated { peer: peer2, .. }), Identify(_)],
+            [Identify(_), Kad(UnroutablePeer { .. }), Identify(_), Kad(RoutingUpdated { peer: peer2, .. }), Identify(_)],
             [Identify(_), Identify(_)],
         ) => {
             assert_eq!(peer2, server1_peer_id);

--- a/protocols/mdns/tests/use-tokio.rs
+++ b/protocols/mdns/tests/use-tokio.rs
@@ -19,7 +19,7 @@
 // DEALINGS IN THE SOFTWARE.use futures::StreamExt;
 use futures::future::Either;
 use libp2p_mdns::{tokio::Behaviour, Config, Event};
-use libp2p_swarm::Swarm;
+use libp2p_swarm::{Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt as _;
 use std::time::Duration;
 
@@ -104,7 +104,20 @@ async fn run_discovery_test(config: Config) {
 async fn create_swarm(config: Config) -> Swarm<Behaviour> {
     let mut swarm =
         Swarm::new_ephemeral(|key| Behaviour::new(config, key.public().to_peer_id()).unwrap());
-    swarm.listen().await;
+
+    // Manually listen on all interfaces because mDNS only works for non-loopback addresses.
+    let expected_listener_id = swarm
+        .listen_on("/ip4/0.0.0.0/tcp/0".parse().unwrap())
+        .unwrap();
+
+    swarm
+        .wait(|e| match e {
+            SwarmEvent::NewListenAddr { listener_id, .. } => {
+                (listener_id == expected_listener_id).then_some(())
+            }
+            _ => None,
+        })
+        .await;
 
     swarm
 }

--- a/swarm-test/src/lib.rs
+++ b/swarm-test/src/lib.rs
@@ -312,7 +312,7 @@ where
         self.add_external_address(memory_multiaddr.clone());
 
         let tcp_addr_listener_id = self
-            .listen_on("/ip4/0.0.0.0/tcp/0".parse().unwrap())
+            .listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap())
             .unwrap();
 
         let tcp_multiaddr = self


### PR DESCRIPTION
## Description

This resolves an issue where our tests were depending on the number of network interfaces available on the local machine.

Related #4110.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
