### PR TITLE
fix(ci): set `merge` attribute to false for non-merge commits

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -13,7 +13,7 @@ defaults:
         {%- for commit in commits -%}
           {%- if commit.parents|length != 1 -%}
             {%- set _ = commit.update({'merge': true}) -%}
-          {%- elif -%}
+          {%- else -%}
             {%- set _ = commit.update({'merge': false}) -%}
           {%- endif -%}
         {%- endfor -%}

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -13,6 +13,8 @@ defaults:
         {%- for commit in commits -%}
           {%- if commit.parents|length != 1 -%}
             {%- set _ = commit.update({'merge': true}) -%}
+          {%- elif -%}
+            {%- set _ = commit.update({'merge': false}) -%}
           {%- endif -%}
         {%- endfor -%}
         {%- for commit in (commits | rejectattr("merge") | unique(False, 'email_author')) | rejectattr("author", "==", author) -%}


### PR DESCRIPTION
## Description

The previous version of this commit-message template had a bug where `merge` was unset for non-merge commits and thus the template rendering failed. See https://github.com/libp2p/rust-libp2p/pull/4128/checks?check_run_id=14597190466 for example.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
