### PR TITLE
fix: remove automated contribution message

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,17 +8,8 @@ defaults:
         {{ body | get_section("## Description", "") }}
 
         Pull-Request: #{{ number }}.
-        {# Here comes some fancy Jinja2 stuff for correctly attributing co-authorship: #}
-        {%- set _ = 0 -%}
-        {%- for commit in commits -%}
-          {%- if commit.parents|length != 1 -%}
-            {%- set _ = commit.update({'merge': true}) -%}
-          {%- endif -%}
-        {%- endfor -%}
-        {%- for commit in (commits | rejectattr("merge") | unique(False, 'email_author')) | rejectattr("author", "==", author) -%}
-        Co-authored-by: {{ commit.author }} <{{ commit.email_author }}>
-        {% endfor %}
-        {# GitHub requires that the `Co-authored-by` lines are AT THE VERY END of a commit, hence nothing must come after this. #}
+
+        {{ body | get_section("## Attributions", "") }}
 
 pull_request_rules:
   - name: Ask to resolve conflict


### PR DESCRIPTION
## Description

Unfortunately, the automated contribution message does not work properly. To evaluate this correctly, we need to first filter out all merge commits. To do this, we need to check the length of the `parents` property. I did not find a way to do this with jinja2 filters. Which would allow us to do something like `rejectattr`.

In the code snippet removed in this PR, I attempted to create a property to filter the merge commits on. This also doesn't work because the underlying object exposed by mergify is not a dictionary but a class and thus does not have the `update` function.

Mergify is shipping an additional property next month: https://github.com/Mergifyio/mergify/discussions/4636#discussioncomment-6295474. Thus, I am replacing this automated mechanism with a manual section that we can add to the PR until mergify ships the additional property that we can utilize to implement this in a clean way.

Related: #4130.
Related: #4104.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
