### PR TITLE
docs(swarm): fix stale docs around confirmed addresses

### DIFF
--- a/swarm/src/behaviour.rs
+++ b/swarm/src/behaviour.rs
@@ -443,7 +443,7 @@ pub enum FromSwarm<'a, Handler> {
     ListenerClosed(ListenerClosed<'a>),
     /// Informs the behaviour that we have discovered a new candidate for an external address for us.
     NewExternalAddrCandidate(NewExternalAddrCandidate<'a>),
-    /// Informs the behaviour that an external address of the local node was removed.
+    /// Informs the behaviour that an external address of the local node was confirmed.
     ExternalAddrConfirmed(ExternalAddrConfirmed<'a>),
     /// Informs the behaviour that an external address of the local node expired, i.e. is no-longer confirmed.
     ExternalAddrExpired(ExternalAddrExpired<'a>),
@@ -541,14 +541,13 @@ pub struct ListenerClosed<'a> {
     pub reason: Result<(), &'a std::io::Error>,
 }
 
-/// [`FromSwarm`] variant that informs the behaviour
-/// that we have discovered a new candidate for an external address for us.
+/// [`FromSwarm`] variant that informs the behaviour about a new candidate for an external address for us.
 #[derive(Clone, Copy)]
 pub struct NewExternalAddrCandidate<'a> {
     pub addr: &'a Multiaddr,
 }
 
-/// [`FromSwarm`] variant that informs the behaviour that an external address was removed.
+/// [`FromSwarm`] variant that informs the behaviour that an external address was confirmed.
 #[derive(Clone, Copy)]
 pub struct ExternalAddrConfirmed<'a> {
     pub addr: &'a Multiaddr,


### PR DESCRIPTION
## Description

Discovered in https://github.com/libp2p/rust-libp2p/pull/3954#pullrequestreview-1506377385.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

cc @divagant-martian

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
