### PR TITLE
fix(swarm): external address candidate only after address translation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3104,7 +3104,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "async-std",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ libp2p-quic = { version = "0.8.0-alpha", path = "transports/quic" }
 libp2p-relay = { version = "0.16.0", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.13.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.25.0", path = "protocols/request-response" }
-libp2p-swarm = { version = "0.43.0", path = "swarm" }
+libp2p-swarm = { version = "0.43.1", path = "swarm" }
 libp2p-swarm-derive = { version = "0.33.0", path = "swarm-derive" }
 libp2p-swarm-test = { version = "0.2.0", path = "swarm-test" }
 libp2p-tcp = { version = "0.40.0", path = "transports/tcp" }

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 0.43.0 
+## 0.43.1 - unreleased
+
+- Do not announce external address candidate before address translation, unless translation does not apply.
+  This will prevent ephemeral TCP addresses being announced as external address candidates.
+  See [PR 4158].
+
+
+## 0.43.0
 
 - Allow `NetworkBehaviours` to create and remove listeners.
   See [PR 3292].

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-swarm"
 edition = "2021"
 rust-version = { workspace = true }
 description = "The libp2p swarm"
-version = "0.43.0"
+version = "0.43.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
The `NewExternalAddrCandidate` event is yielded both before and after address translation. This will
cause, in the case of TCP, ephemeral ports to be added as candidate.

In turn, that will cause protocols like AutoNAT to fail as these candidates are not actually
reachable/external.

Whilst technically not wrong, yielding candidates that are for sure invalid is mere noise. Thus, we only yield the candidate if address translation did not yield any new candidates.

Fixes #4153.
