### PR TITLE
fix(core/choice): log on dial and fix listen log

### DIFF
--- a/core/src/transport/choice.rs
+++ b/core/src/transport/choice.rs
@@ -53,14 +53,14 @@ where
         addr: Multiaddr,
     ) -> Result<(), TransportError<Self::Error>> {
         trace!(
-            "Attempting to dial {} using {}",
+            "Attempting to listen on {} using {}",
             addr,
             std::any::type_name::<A>()
         );
         let addr = match self.0.listen_on(id, addr) {
             Err(TransportError::MultiaddrNotSupported(addr)) => {
                 debug!(
-                    "Failed to dial {} using {}",
+                    "Failed to listen on {} using {}",
                     addr,
                     std::any::type_name::<A>()
                 );
@@ -70,14 +70,14 @@ where
         };
 
         trace!(
-            "Attempting to dial {} using {}",
+            "Attempting to listen on {} using {}",
             addr,
             std::any::type_name::<B>()
         );
         let addr = match self.1.listen_on(id, addr) {
             Err(TransportError::MultiaddrNotSupported(addr)) => {
                 debug!(
-                    "Failed to dial {} using {}",
+                    "Failed to listen on {} using {}",
                     addr,
                     std::any::type_name::<B>()
                 );
@@ -94,17 +94,41 @@ where
     }
 
     fn dial(&mut self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
+        trace!(
+            "Attempting to dial {} using {}",
+            addr,
+            std::any::type_name::<A>()
+        );
         let addr = match self.0.dial(addr) {
             Ok(connec) => return Ok(EitherFuture::First(connec)),
-            Err(TransportError::MultiaddrNotSupported(addr)) => addr,
+            Err(TransportError::MultiaddrNotSupported(addr)) => {
+                debug!(
+                    "Failed to dial {} using {}",
+                    addr,
+                    std::any::type_name::<A>()
+                );
+                addr
+            }
             Err(TransportError::Other(err)) => {
                 return Err(TransportError::Other(Either::Left(err)))
             }
         };
 
+        trace!(
+            "Attempting to dial {} using {}",
+            addr,
+            std::any::type_name::<A>()
+        );
         let addr = match self.1.dial(addr) {
             Ok(connec) => return Ok(EitherFuture::Second(connec)),
-            Err(TransportError::MultiaddrNotSupported(addr)) => addr,
+            Err(TransportError::MultiaddrNotSupported(addr)) => {
+                debug!(
+                    "Failed to dial {} using {}",
+                    addr,
+                    std::any::type_name::<A>()
+                );
+                addr
+            }
             Err(TransportError::Other(err)) => {
                 return Err(TransportError::Other(Either::Right(err)))
             }


### PR DESCRIPTION
## Description

- Fixes typo in `<OrTransport as Transport>::listen_on` using the word "dial" instead of "listen_on".
- Adds logging to `<OrTransport as Transport>::dial`.

Follow-up to https://github.com/libp2p/rust-libp2p/pull/4133

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
