### PR TITLE
feat(swarm): use NotDialing condition by default

### DIFF
--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.43.1 - unreleased
 
+- Change the default `PeerCondition` to `NotDialing`. This will prevent multiple simultaneous dials to the same peer, by default.
+  See [PR 4185].
+
+[PR 4185]: https://github.com/libp2p/rust-libp2p/pull/4185
+
 - Do not announce external address candidate before address translation, unless translation does not apply.
   This will prevent ephemeral TCP addresses being announced as external address candidates.
   See [PR 4158].

--- a/swarm/src/dial_opts.rs
+++ b/swarm/src/dial_opts.rs
@@ -313,11 +313,11 @@ pub enum PeerCondition {
     /// A new dialing attempt is initiated _only if_ the peer is currently
     /// considered disconnected, i.e. there is no established connection
     /// and no ongoing dialing attempt.
-    #[default]
     Disconnected,
     /// A new dialing attempt is initiated _only if_ there is currently
     /// no ongoing dialing attempt, i.e. the peer is either considered
     /// disconnected or connected but without an ongoing dialing attempt.
+    #[default]
     NotDialing,
     /// A new dialing attempt is always initiated, only subject to the
     /// configured connection limits.


### PR DESCRIPTION
It appears to be the case that `kad` behavior is dialing multiple times to the same peer (not sure of the reason). By changing the default dial condition, this behavior can be inhibited at least in that case.