### PR TITLE
refactor(request-reponse): replace `serde_cbor` with `cbor4ii`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,6 +760,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbor4ii"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e8c816014cad3f58c2f0607677e8d2c6f76754dd8e735461a440b27b95199c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3109,10 +3118,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "async-std",
  "async-trait",
+ "cbor4ii",
  "env_logger 0.10.0",
  "futures",
  "futures_ringbuf",
@@ -3127,7 +3137,6 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "serde",
- "serde_cbor",
  "serde_json",
  "smallvec",
  "void",
@@ -5016,16 +5025,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ libp2p-pnet = { version = "0.23.0", path = "transports/pnet" }
 libp2p-quic = { version = "0.8.0-alpha", path = "transports/quic" }
 libp2p-relay = { version = "0.16.0", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.13.0", path = "protocols/rendezvous" }
-libp2p-request-response = { version = "0.25.0", path = "protocols/request-response" }
+libp2p-request-response = { version = "0.25.1", path = "protocols/request-response" }
 libp2p-swarm = { version = "0.43.1", path = "swarm" }
 libp2p-swarm-derive = { version = "0.33.0", path = "swarm-derive" }
 libp2p-swarm-test = { version = "0.2.0", path = "swarm-test" }

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 0.25.0 
+## 0.25.1 - unreleased
+
+- Replace unmaintained `serde_cbor` dependency with `cbor4ii`.
+  See [PR 4187].
+
+[PR 4187]: https://github.com/libp2p/rust-libp2p/pull/4187
+
+## 0.25.0
 
 - Add `request_response::json::Behaviour` and `request_response::cbor::Behaviour` building on top of the `serde` traits.
   To conveniently construct these, we remove the `Codec` parameter from `Behaviour::new` and add `Behaviour::with_codec`.

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 async-trait = "0.1"
-cbor4ii = { version = "0.3.1", features = ["serde1"], optional = true }
+cbor4ii = { version = "0.3.1", features = ["serde1", "use_std"], optional = true }
 futures = "0.3.28"
 instant = "0.1.12"
 libp2p-core = { workspace = true }

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-request-response"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Generic Request/Response Protocols"
-version = "0.25.0"
+version = "0.25.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -12,6 +12,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 async-trait = "0.1"
+cbor4ii = { version = "0.3.1", features = ["serde1"], optional = true }
 futures = "0.3.28"
 instant = "0.1.12"
 libp2p-core = { workspace = true }
@@ -20,14 +21,13 @@ libp2p-identity = { workspace = true }
 rand = "0.8"
 serde = { version = "1.0", optional = true}
 serde_json = { version = "1.0.100", optional = true }
-serde_cbor = { version = "0.11.2", optional = true }
 smallvec = "1.11.0"
 void = "1.0.2"
 log = "0.4.19"
 
 [features]
 json = ["dep:serde", "dep:serde_json", "libp2p-swarm/macros"]
-cbor = ["dep:serde", "dep:serde_cbor", "libp2p-swarm/macros"]
+cbor = ["dep:serde", "dep:cbor4ii", "libp2p-swarm/macros"]
 
 [dev-dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }

--- a/protocols/request-response/src/cbor.rs
+++ b/protocols/request-response/src/cbor.rs
@@ -147,18 +147,13 @@ mod codec {
             cbor4ii::serde::DecodeError::Core(DecodeError::Read(e)) => {
                 io::Error::new(io::ErrorKind::Other, e)
             }
-            cbor4ii::serde::DecodeError::Core(DecodeError::Unsupported { .. }) => {
-                io::Error::new(io::ErrorKind::Unsupported, err.to_string())
+            cbor4ii::serde::DecodeError::Core(e @ DecodeError::Unsupported { .. }) => {
+                io::Error::new(io::ErrorKind::Unsupported, e)
             }
-
-            cbor4ii::serde::DecodeError::Core(DecodeError::Eof { .. }) => {
-                io::Error::new(io::ErrorKind::UnexpectedEof, err.to_string())
+            cbor4ii::serde::DecodeError::Core(e @ DecodeError::Eof { .. }) => {
+                io::Error::new(io::ErrorKind::UnexpectedEof, e)
             }
-
-            cbor4ii::serde::DecodeError::Core(e) => {
-                io::Error::new(io::ErrorKind::InvalidData, e.to_string())
-            }
-
+            cbor4ii::serde::DecodeError::Core(e) => io::Error::new(io::ErrorKind::InvalidData, e),
             cbor4ii::serde::DecodeError::Custom(e) => {
                 io::Error::new(io::ErrorKind::Other, e.to_string())
             }

--- a/protocols/request-response/src/cbor.rs
+++ b/protocols/request-response/src/cbor.rs
@@ -18,7 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-/// A request-response behaviour using [`serde_cbor`] for serializing and deserializing the messages.
+/// A request-response behaviour using [`cbor4ii::serde`] for serializing and
+/// deserializing the messages.
 ///
 /// # Example
 ///
@@ -44,11 +45,12 @@ pub type Behaviour<Req, Resp> = crate::Behaviour<codec::Codec<Req, Resp>>;
 
 mod codec {
     use async_trait::async_trait;
+    use cbor4ii::core::error::DecodeError;
     use futures::prelude::*;
     use futures::{AsyncRead, AsyncWrite};
     use libp2p_swarm::StreamProtocol;
     use serde::{de::DeserializeOwned, Serialize};
-    use std::{io, marker::PhantomData};
+    use std::{collections::TryReserveError, convert::Infallible, io, marker::PhantomData};
 
     /// Max request size in bytes
     const REQUEST_SIZE_MAXIMUM: u64 = 1024 * 1024;
@@ -91,7 +93,7 @@ mod codec {
 
             io.take(REQUEST_SIZE_MAXIMUM).read_to_end(&mut vec).await?;
 
-            serde_cbor::from_slice(vec.as_slice()).map_err(into_io_error)
+            cbor4ii::serde::from_slice(vec.as_slice()).map_err(decode_into_io_error)
         }
 
         async fn read_response<T>(&mut self, _: &Self::Protocol, io: &mut T) -> io::Result<Resp>
@@ -102,7 +104,7 @@ mod codec {
 
             io.take(RESPONSE_SIZE_MAXIMUM).read_to_end(&mut vec).await?;
 
-            serde_cbor::from_slice(vec.as_slice()).map_err(into_io_error)
+            cbor4ii::serde::from_slice(vec.as_slice()).map_err(decode_into_io_error)
         }
 
         async fn write_request<T>(
@@ -114,7 +116,8 @@ mod codec {
         where
             T: AsyncWrite + Unpin + Send,
         {
-            let data: Vec<u8> = serde_cbor::to_vec(&req).map_err(into_io_error)?;
+            let data: Vec<u8> =
+                cbor4ii::serde::to_vec(Vec::new(), &req).map_err(encode_into_io_error)?;
 
             io.write_all(data.as_ref()).await?;
 
@@ -130,7 +133,8 @@ mod codec {
         where
             T: AsyncWrite + Unpin + Send,
         {
-            let data: Vec<u8> = serde_cbor::to_vec(&resp).map_err(into_io_error).unwrap();
+            let data: Vec<u8> =
+                cbor4ii::serde::to_vec(Vec::new(), &resp).map_err(encode_into_io_error)?;
 
             io.write_all(data.as_ref()).await?;
 
@@ -138,15 +142,30 @@ mod codec {
         }
     }
 
-    fn into_io_error(err: serde_cbor::Error) -> io::Error {
-        if err.is_syntax() || err.is_data() {
-            return io::Error::new(io::ErrorKind::InvalidData, err);
-        }
+    fn decode_into_io_error(err: cbor4ii::serde::DecodeError<Infallible>) -> io::Error {
+        match err {
+            cbor4ii::serde::DecodeError::Core(DecodeError::Read(e)) => {
+                io::Error::new(io::ErrorKind::Other, e)
+            }
+            cbor4ii::serde::DecodeError::Core(DecodeError::Unsupported { .. }) => {
+                io::Error::new(io::ErrorKind::Unsupported, err.to_string())
+            }
 
-        if err.is_eof() {
-            return io::Error::new(io::ErrorKind::UnexpectedEof, err);
-        }
+            cbor4ii::serde::DecodeError::Core(DecodeError::Eof { .. }) => {
+                io::Error::new(io::ErrorKind::UnexpectedEof, err.to_string())
+            }
 
+            cbor4ii::serde::DecodeError::Core(e) => {
+                io::Error::new(io::ErrorKind::InvalidData, e.to_string())
+            }
+
+            cbor4ii::serde::DecodeError::Custom(e) => {
+                io::Error::new(io::ErrorKind::Other, e.to_string())
+            }
+        }
+    }
+
+    fn encode_into_io_error(err: cbor4ii::serde::EncodeError<TryReserveError>) -> io::Error {
         io::Error::new(io::ErrorKind::Other, err)
     }
 }


### PR DESCRIPTION
## Description

As per `RUSTSEC-2021-0127`, serde_cbor is unmaintained.

Fixes #4182.
Related: https://github.com/rustsec/advisory-db/pull/1114.

## Change checklist

- [X] I have performed a self-review of my own code and ran the current test suite. 
