### PR TITLE
chore(libp2p): expose `json` feature from `request-response`

### DIFF
--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -3,6 +3,10 @@
 - Include gossipsub when compiling for wasm.
   See [PR 4217].
 
+- Add `json` feature which exposes `request_response::json`.
+  See [PR 4188].
+
+[PR 4188]: https://github.com/libp2p/rust-libp2p/pull/4188
 [PR 4217]: https://github.com/libp2p/rust-libp2p/pull/4217
 
 ## 0.52.1

--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -23,6 +23,7 @@ full = [
     "floodsub",
     "gossipsub",
     "identify",
+    "json",
     "kad",
     "macros",
     "mdns",
@@ -60,6 +61,7 @@ ed25519 = ["libp2p-identity/ed25519"]
 floodsub = ["dep:libp2p-floodsub"]
 gossipsub = ["dep:libp2p-gossipsub", "libp2p-metrics?/gossipsub"]
 identify = ["dep:libp2p-identify", "libp2p-metrics?/identify"]
+json = ["libp2p-request-response?/json"]
 kad = ["dep:libp2p-kad", "libp2p-metrics?/kad"]
 macros = ["libp2p-swarm/macros"]
 mdns = ["dep:libp2p-mdns"]


### PR DESCRIPTION
## Description

`cbor` feature was exposed in `libp2p` but not `json`.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
