### PR TITLE
feat(swarm): allow multiple `PeerCondition`s for new connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3137,6 +3137,7 @@ name = "libp2p-swarm"
 version = "0.43.1"
 dependencies = [
  "async-std",
+ "bitflags 2.3.3",
  "either",
  "env_logger 0.10.0",
  "fnv",

--- a/misc/connection-limits/src/lib.rs
+++ b/misc/connection-limits/src/lib.rs
@@ -364,7 +364,10 @@ impl NetworkBehaviour for Behaviour {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use libp2p_swarm::{dial_opts::DialOpts, DialError, ListenError, Swarm, SwarmEvent};
+    use libp2p_swarm::{
+        dial_opts::{DialOpts, PeerCondition},
+        DialError, ListenError, Swarm, SwarmEvent,
+    };
     use libp2p_swarm_test::SwarmExt;
     use quickcheck::*;
 
@@ -387,6 +390,7 @@ mod tests {
             network
                 .dial(
                     DialOpts::peer_id(target)
+                        .condition(PeerCondition::Always)
                         .addresses(vec![addr.clone()])
                         .build(),
                 )
@@ -394,7 +398,12 @@ mod tests {
         }
 
         match network
-            .dial(DialOpts::peer_id(target).addresses(vec![addr]).build())
+            .dial(
+                DialOpts::peer_id(target)
+                    .condition(PeerCondition::Always)
+                    .addresses(vec![addr])
+                    .build(),
+            )
             .expect_err("Unexpected dialing success.")
         {
             DialError::Denied { cause } => {

--- a/misc/connection-limits/src/lib.rs
+++ b/misc/connection-limits/src/lib.rs
@@ -365,7 +365,7 @@ impl NetworkBehaviour for Behaviour {
 mod tests {
     use super::*;
     use libp2p_swarm::{
-        dial_opts::{DialOpts, PeerCondition},
+        dial_opts::{DialConditions, DialOpts},
         DialError, ListenError, Swarm, SwarmEvent,
     };
     use libp2p_swarm_test::SwarmExt;
@@ -390,7 +390,7 @@ mod tests {
             network
                 .dial(
                     DialOpts::peer_id(target)
-                        .condition(PeerCondition::Always)
+                        .dial_conditions(DialConditions::empty())
                         .addresses(vec![addr.clone()])
                         .build(),
                 )
@@ -400,7 +400,7 @@ mod tests {
         match network
             .dial(
                 DialOpts::peer_id(target)
-                    .condition(PeerCondition::Always)
+                    .dial_conditions(DialConditions::empty())
                     .addresses(vec![addr])
                     .build(),
             )

--- a/misc/connection-limits/src/lib.rs
+++ b/misc/connection-limits/src/lib.rs
@@ -390,7 +390,7 @@ mod tests {
             network
                 .dial(
                     DialOpts::peer_id(target)
-                        .dial_conditions(DialConditions::empty())
+                        .only_dial_if(DialConditions::always())
                         .addresses(vec![addr.clone()])
                         .build(),
                 )
@@ -400,7 +400,7 @@ mod tests {
         match network
             .dial(
                 DialOpts::peer_id(target)
-                    .dial_conditions(DialConditions::empty())
+                    .only_dial_if(DialConditions::always())
                     .addresses(vec![addr])
                     .build(),
             )

--- a/protocols/autonat/src/behaviour/as_server.rs
+++ b/protocols/autonat/src/behaviour/as_server.rs
@@ -29,7 +29,7 @@ use libp2p_request_response::{
     self as request_response, InboundFailure, RequestId, ResponseChannel,
 };
 use libp2p_swarm::{
-    dial_opts::{DialOpts, PeerCondition},
+    dial_opts::{DialConditions, DialOpts},
     ConnectionId, DialError, PollParameters, ToSwarm,
 };
 use std::{
@@ -131,7 +131,7 @@ impl<'a> HandleInnerEvent for AsServer<'a> {
                             )),
                             ToSwarm::Dial {
                                 opts: DialOpts::peer_id(peer)
-                                    .condition(PeerCondition::Always)
+                                    .dial_conditions(DialConditions::empty())
                                     .override_dial_concurrency_factor(
                                         NonZeroU8::new(1).expect("1 > 0"),
                                     )

--- a/protocols/autonat/src/behaviour/as_server.rs
+++ b/protocols/autonat/src/behaviour/as_server.rs
@@ -131,7 +131,7 @@ impl<'a> HandleInnerEvent for AsServer<'a> {
                             )),
                             ToSwarm::Dial {
                                 opts: DialOpts::peer_id(peer)
-                                    .dial_conditions(DialConditions::empty())
+                                    .only_dial_if(DialConditions::always())
                                     .override_dial_concurrency_factor(
                                         NonZeroU8::new(1).expect("1 > 0"),
                                     )

--- a/protocols/dcutr/src/behaviour_impl.rs
+++ b/protocols/dcutr/src/behaviour_impl.rs
@@ -307,7 +307,7 @@ impl NetworkBehaviour for Behaviour {
             Either::Left(handler::relayed::Event::InboundConnectNegotiated(remote_addrs)) => {
                 let opts = DialOpts::peer_id(event_source)
                     .addresses(remote_addrs)
-                    .dial_conditions(dial_opts::DialConditions::empty())
+                    .only_dial_if(dial_opts::DialConditions::always())
                     .build();
 
                 let maybe_direct_connection_id = opts.connection_id();
@@ -326,7 +326,7 @@ impl NetworkBehaviour for Behaviour {
             }
             Either::Left(handler::relayed::Event::OutboundConnectNegotiated { remote_addrs }) => {
                 let opts = DialOpts::peer_id(event_source)
-                    .dial_conditions(dial_opts::DialConditions::empty())
+                    .only_dial_if(dial_opts::DialConditions::always())
                     .addresses(remote_addrs)
                     .override_role()
                     .build();

--- a/protocols/dcutr/src/behaviour_impl.rs
+++ b/protocols/dcutr/src/behaviour_impl.rs
@@ -307,7 +307,7 @@ impl NetworkBehaviour for Behaviour {
             Either::Left(handler::relayed::Event::InboundConnectNegotiated(remote_addrs)) => {
                 let opts = DialOpts::peer_id(event_source)
                     .addresses(remote_addrs)
-                    .condition(dial_opts::PeerCondition::Always)
+                    .dial_conditions(dial_opts::DialConditions::empty())
                     .build();
 
                 let maybe_direct_connection_id = opts.connection_id();
@@ -326,7 +326,7 @@ impl NetworkBehaviour for Behaviour {
             }
             Either::Left(handler::relayed::Event::OutboundConnectNegotiated { remote_addrs }) => {
                 let opts = DialOpts::peer_id(event_source)
-                    .condition(dial_opts::PeerCondition::Always)
+                    .dial_conditions(dial_opts::DialConditions::empty())
                     .addresses(remote_addrs)
                     .override_role()
                     .build();

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -42,10 +42,9 @@ use libp2p_swarm::behaviour::{
     AddressChange, ConnectionClosed, ConnectionEstablished, DialFailure, FromSwarm,
 };
 use libp2p_swarm::{
-    dial_opts::{self, DialOpts},
-    ConnectionDenied, ConnectionId, DialError, ExternalAddresses, ListenAddresses,
-    NetworkBehaviour, NotifyHandler, PollParameters, StreamProtocol, THandler, THandlerInEvent,
-    THandlerOutEvent, ToSwarm,
+    dial_opts::DialOpts, ConnectionDenied, ConnectionId, DialError, ExternalAddresses,
+    ListenAddresses, NetworkBehaviour, NotifyHandler, PollParameters, StreamProtocol, THandler,
+    THandlerInEvent, THandlerOutEvent, ToSwarm,
 };
 use log::{debug, info, warn};
 use smallvec::SmallVec;
@@ -2014,14 +2013,9 @@ where
                     query.on_failure(&peer_id);
                 }
             }
-            DialError::DialPeerConditionFalse(
-                dial_opts::PeerCondition::Disconnected | dial_opts::PeerCondition::NotDialing,
-            ) => {
+            DialError::DialPeerConditionFalse(..) => {
                 // We might (still) be connected, or about to be connected, thus do not report the
                 // failure to the queries.
-            }
-            DialError::DialPeerConditionFalse(dial_opts::PeerCondition::Always) => {
-                unreachable!("DialPeerCondition::Always can not trigger DialPeerConditionFalse.");
             }
         }
     }

--- a/swarm-test/src/lib.rs
+++ b/swarm-test/src/lib.rs
@@ -26,7 +26,7 @@ use libp2p_core::{
 };
 use libp2p_identity::{Keypair, PeerId};
 use libp2p_plaintext::PlainText2Config;
-use libp2p_swarm::dial_opts::PeerCondition;
+use libp2p_swarm::dial_opts::DialConditions;
 use libp2p_swarm::{
     dial_opts::DialOpts, NetworkBehaviour, Swarm, SwarmBuilder, SwarmEvent, THandlerErr,
 };
@@ -230,7 +230,7 @@ where
 
         let dial_opts = DialOpts::peer_id(*other.local_peer_id())
             .addresses(external_addresses)
-            .condition(PeerCondition::Always)
+            .dial_conditions(DialConditions::empty())
             .build();
 
         self.dial(dial_opts).unwrap();

--- a/swarm-test/src/lib.rs
+++ b/swarm-test/src/lib.rs
@@ -230,7 +230,7 @@ where
 
         let dial_opts = DialOpts::peer_id(*other.local_peer_id())
             .addresses(external_addresses)
-            .dial_conditions(DialConditions::empty())
+            .only_dial_if(DialConditions::always())
             .build();
 
         self.dial(dial_opts).unwrap();

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -27,6 +27,7 @@ wasm-bindgen-futures = { version = "0.4.37", optional = true }
 getrandom = { version = "0.2.9", features = ["js"], optional = true } # Explicit dependency to be used in `wasm-bindgen` feature
 once_cell = "1.18.0"
 multistream-select = { workspace = true }
+bitflags = "2.3.3"
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")))'.dependencies]
 async-std = { version = "1.6.2", optional = true }

--- a/swarm/src/dial_opts.rs
+++ b/swarm/src/dial_opts.rs
@@ -155,7 +155,7 @@ pub struct WithPeerId {
 
 impl WithPeerId {
     /// Specify a [`PeerCondition`] for the dial.
-    #[deprecated(note = "Use `dial_conditions` instead")]
+    #[deprecated(note = "Use `dial_only_if` instead")]
     pub fn condition(mut self, condition: PeerCondition) -> Self {
         self.condition = Some(condition);
         self
@@ -163,7 +163,7 @@ impl WithPeerId {
 
     /// Specify zero, one, or more conditions under which a dial attempt is initiated.
     /// See [`DialConditions`] for more details and examples.
-    pub fn dial_conditions(mut self, condition: DialConditions) -> Self {
+    pub fn only_dial_if(mut self, condition: DialConditions) -> Self {
         self.dial_conditions = condition;
         self
     }
@@ -227,7 +227,7 @@ pub struct WithPeerIdWithAddresses {
 
 impl WithPeerIdWithAddresses {
     /// Specify a [`PeerCondition`] for the dial.
-    #[deprecated(note = "Use `dial_conditions` instead")]
+    #[deprecated(note = "Use `dial_only_if` instead")]
     pub fn condition(mut self, condition: PeerCondition) -> Self {
         self.condition = Some(condition);
         self
@@ -235,7 +235,7 @@ impl WithPeerIdWithAddresses {
 
     /// Specify zero, one, or more conditions under which a dial attempt is initiated.
     /// See [`DialConditions`] for more details and examples.
-    pub fn dial_conditions(mut self, condition: DialConditions) -> Self {
+    pub fn only_dial_if(mut self, condition: DialConditions) -> Self {
         self.dial_condition = condition;
         self
     }
@@ -316,7 +316,7 @@ impl WithoutPeerIdWithAddress {
             peer_id: None,
             condition: None,
             // Always make a dial attempt to the peer
-            dial_conditions: DialConditions::empty(),
+            dial_conditions: DialConditions::always(),
             addresses: vec![self.address],
             extend_addresses_through_behaviour: false,
             role_override: self.role_override,
@@ -374,16 +374,15 @@ bitflags::bitflags! {
     ///
     /// # Examples
     ///
-    /// We can have zero conditions by using [`empty()`](DialConditions::empty()).
-    /// With an empty bitflag, meaning zero/no conditions, a dialing attempt will
-    /// always be initiated:
+    /// We can have zero conditions by using [`always()`](DialConditions::always()).
+    /// Without conditions, a dialing attempt will always be initiated:
     ///
     /// ```
     /// # use libp2p_swarm::dial_opts::{DialOpts, DialCondition};
     /// # use libp2p_identity::PeerId;
     /// #
     /// DialOpts::peer_id(PeerId::random())
-    ///    .dial_conditions(DialCondition::empty())
+    ///    .dial_conditions(DialConditions::always())
     ///    .build();
     /// ```
     ///
@@ -396,7 +395,7 @@ bitflags::bitflags! {
     /// # use libp2p_identity::PeerId;
     /// #
     /// DialOpts::peer_id(PeerId::random())
-    ///    .dial_conditions(DialCondition::Disconnected | DialCondition::NotDialing)
+    ///    .dial_conditions(DialConditions::Disconnected | DialConditions::NotDialing)
     ///    .build();
     /// ```
     #[derive(Debug, Copy, Clone)]
@@ -410,12 +409,20 @@ bitflags::bitflags! {
     }
 }
 
+impl DialConditions {
+    /// Create an empty bitflag, meaning zero/no conditions. This means a dial
+    /// attempt will always be initiated.
+    pub fn always() -> Self {
+        DialConditions::empty()
+    }
+}
+
 impl Default for DialConditions {
     /// Default to using all conditions available. Currently being both
     /// [`Disconected`](DialConditions::Disconnected) and [`NotDialing`](DialConditions::NotDialing).
     ///
     /// This is equivalent to calling [`all()`](DialConditions::all())
     fn default() -> Self {
-        DialConditions::all()
+        DialConditions::always()
     }
 }

--- a/swarm/src/dial_opts.rs
+++ b/swarm/src/dial_opts.rs
@@ -155,7 +155,7 @@ pub struct WithPeerId {
 
 impl WithPeerId {
     /// Specify a [`PeerCondition`] for the dial.
-    #[deprecated(note = "Use `dial_only_if` instead")]
+    #[deprecated(note = "Use `only_dial_if` instead")]
     pub fn condition(mut self, condition: PeerCondition) -> Self {
         self.condition = Some(condition);
         self
@@ -180,7 +180,7 @@ impl WithPeerId {
         WithPeerIdWithAddresses {
             peer_id: self.peer_id,
             condition: self.condition,
-            dial_condition: self.dial_conditions,
+            dial_conditions: self.dial_conditions,
             addresses,
             extend_addresses_through_behaviour: false,
             role_override: self.role_override,
@@ -218,7 +218,7 @@ impl WithPeerId {
 pub struct WithPeerIdWithAddresses {
     peer_id: PeerId,
     condition: Option<PeerCondition>,
-    dial_condition: DialConditions,
+    dial_conditions: DialConditions,
     addresses: Vec<Multiaddr>,
     extend_addresses_through_behaviour: bool,
     role_override: Endpoint,
@@ -227,7 +227,7 @@ pub struct WithPeerIdWithAddresses {
 
 impl WithPeerIdWithAddresses {
     /// Specify a [`PeerCondition`] for the dial.
-    #[deprecated(note = "Use `dial_only_if` instead")]
+    #[deprecated(note = "Use `only_dial_if` instead")]
     pub fn condition(mut self, condition: PeerCondition) -> Self {
         self.condition = Some(condition);
         self
@@ -236,7 +236,7 @@ impl WithPeerIdWithAddresses {
     /// Specify zero, one, or more conditions under which a dial attempt is initiated.
     /// See [`DialConditions`] for more details and examples.
     pub fn only_dial_if(mut self, condition: DialConditions) -> Self {
-        self.dial_condition = condition;
+        self.dial_conditions = condition;
         self
     }
 
@@ -270,7 +270,7 @@ impl WithPeerIdWithAddresses {
         DialOpts {
             peer_id: Some(self.peer_id),
             condition: self.condition,
-            dial_conditions: self.dial_condition,
+            dial_conditions: self.dial_conditions,
             addresses: self.addresses,
             extend_addresses_through_behaviour: self.extend_addresses_through_behaviour,
             role_override: self.role_override,
@@ -378,11 +378,11 @@ bitflags::bitflags! {
     /// Without conditions, a dialing attempt will always be initiated:
     ///
     /// ```
-    /// # use libp2p_swarm::dial_opts::{DialOpts, DialCondition};
+    /// # use libp2p_swarm::dial_opts::{DialOpts, DialConditions};
     /// # use libp2p_identity::PeerId;
     /// #
     /// DialOpts::peer_id(PeerId::random())
-    ///    .dial_conditions(DialConditions::always())
+    ///    .only_dial_if(DialConditions::always())
     ///    .build();
     /// ```
     ///
@@ -391,11 +391,11 @@ bitflags::bitflags! {
     /// [`NotDialing`](DialConditions::NotDialing) by using the bitwise `|` (OR) operator:
     ///
     /// ```
-    /// # use libp2p_swarm::dial_opts::{DialOpts, DialCondition};
+    /// # use libp2p_swarm::dial_opts::{DialOpts, DialConditions};
     /// # use libp2p_identity::PeerId;
     /// #
     /// DialOpts::peer_id(PeerId::random())
-    ///    .dial_conditions(DialConditions::Disconnected | DialConditions::NotDialing)
+    ///    .only_dial_if(DialConditions::Disconnected | DialConditions::NotDialing)
     ///    .build();
     /// ```
     #[derive(Debug, Copy, Clone)]

--- a/swarm/src/dial_opts.rs
+++ b/swarm/src/dial_opts.rs
@@ -155,13 +155,14 @@ pub struct WithPeerId {
 
 impl WithPeerId {
     /// Specify a [`PeerCondition`] for the dial.
-    #[deprecated]
+    #[deprecated(note = "Use `dial_conditions` instead")]
     pub fn condition(mut self, condition: PeerCondition) -> Self {
         self.condition = Some(condition);
         self
     }
 
-    /// Specify zero, one, or more [`DialConditions`]s for the dial.
+    /// Specify zero, one, or more conditions under which a dial attempt is initiated.
+    /// See [`DialConditions`] for more details and examples.
     pub fn dial_conditions(mut self, condition: DialConditions) -> Self {
         self.dial_conditions = condition;
         self
@@ -226,13 +227,14 @@ pub struct WithPeerIdWithAddresses {
 
 impl WithPeerIdWithAddresses {
     /// Specify a [`PeerCondition`] for the dial.
-    #[deprecated]
+    #[deprecated(note = "Use `dial_conditions` instead")]
     pub fn condition(mut self, condition: PeerCondition) -> Self {
         self.condition = Some(condition);
         self
     }
 
-    /// Specify zero, one, or more [`DialConditions`]s for the dial.
+    /// Specify zero, one, or more conditions under which a dial attempt is initiated.
+    /// See [`DialConditions`] for more details and examples.
     pub fn dial_conditions(mut self, condition: DialConditions) -> Self {
         self.dial_condition = condition;
         self
@@ -353,7 +355,41 @@ pub enum PeerCondition {
 
 bitflags::bitflags! {
     /// The available conditions under which a new dialing attempt to
-    /// a known peer is initiated. These conditions can be combined.
+    /// a known peer is initiated.
+    ///
+    /// # Bitflag
+    ///
+    /// The [`DialConditions`] is a bitflag, meaning conditions can be enabled
+    /// separately from each other. This way can have zero conditions, one condition,
+    /// or even combine multiple conditions.
+    ///
+    /// [`bitflags`] can be operated on by bitwise `|` (OR), `&` (AND), `-` (SUB) and `^` (XOR) operators.
+    /// See the [`bitflags`] crate for more details.
+    ///
+    /// # Combination of conditions
+    ///
+    /// When [`Disconected`](DialConditions::Disconnected) and [`NotDialing`](DialConditions::NotDialing)
+    /// are combined, this means a dial attempt will only be initiated if the peer is
+    /// *both* considered disconnected and there is no ongoing dialing attempt.
+    ///
+    /// # Examples
+    ///
+    /// We can have zero conditions by using [`empty()`](DialConditions::empty()).
+    /// With an empty bitflag, meaning zero/no conditions, a dialing attempt will
+    /// always be initiated:
+    ///
+    /// ```
+    /// # use libp2p_swarm::dial_opts::{DialOpts, DialCondition};
+    /// # use libp2p_identity::PeerId;
+    /// #
+    /// DialOpts::peer_id(PeerId::random())
+    ///    .dial_conditions(DialCondition::empty())
+    ///    .build();
+    /// ```
+    ///
+    /// We can also have one condition by using e.g. [`DialConditions::Disconnected`].
+    /// But it's also possible to combine both [`Disconected`](DialConditions::Disconnected) and
+    /// [`NotDialing`](DialConditions::NotDialing) by using the bitwise `|` (OR) operator:
     ///
     /// ```
     /// # use libp2p_swarm::dial_opts::{DialOpts, DialCondition};
@@ -375,6 +411,10 @@ bitflags::bitflags! {
 }
 
 impl Default for DialConditions {
+    /// Default to using all conditions available. Currently being both
+    /// [`Disconected`](DialConditions::Disconnected) and [`NotDialing`](DialConditions::NotDialing).
+    ///
+    /// This is equivalent to calling [`all()`](DialConditions::all())
     fn default() -> Self {
         DialConditions::all()
     }

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -419,7 +419,7 @@ where
         let connection_id = dial_opts.connection_id();
 
         // `peer_condition` is deprecated; only use if explicitly set (`Some`).
-        // Block to be removed once `peer_condition` is removed.
+        // Code block to be removed once `peer_condition` is removed.
         if let Some(condition) = condition {
             let false_condition = match (condition, peer_id) {
                 (PeerCondition::Disconnected, Some(peer_id))
@@ -445,35 +445,35 @@ where
 
                 return Err(e);
             }
-        } else {
-            let false_condition = if let Some(peer_id) = peer_id {
-                if dial_conditions.contains(DialConditions::Disconnected)
-                    && self.pool.is_connected(peer_id)
-                {
-                    Some(PeerCondition::Disconnected)
-                } else if dial_conditions.contains(DialConditions::NotDialing)
-                    && self.pool.is_dialing(peer_id)
-                {
-                    Some(PeerCondition::NotDialing)
-                } else {
-                    None
-                }
+        }
+
+        let false_condition = if let Some(peer_id) = peer_id {
+            if dial_conditions.contains(DialConditions::Disconnected)
+                && self.pool.is_connected(peer_id)
+            {
+                Some(PeerCondition::Disconnected)
+            } else if dial_conditions.contains(DialConditions::NotDialing)
+                && self.pool.is_dialing(peer_id)
+            {
+                Some(PeerCondition::NotDialing)
             } else {
                 None
-            };
-
-            if let Some(condition) = false_condition {
-                let e = DialError::DialPeerConditionFalse(condition);
-
-                self.behaviour
-                    .on_swarm_event(FromSwarm::DialFailure(DialFailure {
-                        peer_id,
-                        error: &e,
-                        connection_id,
-                    }));
-
-                return Err(e);
             }
+        } else {
+            None
+        };
+
+        if let Some(condition) = false_condition {
+            let e = DialError::DialPeerConditionFalse(condition);
+
+            self.behaviour
+                .on_swarm_event(FromSwarm::DialFailure(DialFailure {
+                    peer_id,
+                    error: &e,
+                    connection_id,
+                }));
+
+            return Err(e);
         }
 
         let addresses = {


### PR DESCRIPTION
This allows for specifying both the `Disconnected` and `NotDialing` conditions simultaneously, so
that we can prevent both dialing an already connected peer and one we're already dialing.

The default is made to be both conditions. This only caused a problem with the `connection_limits`
behavior, which was adjusted to use no condition at all.

@mxinden, let me know if this is desired at all. I'll be happy to make changes if it's not according to the style of rust-libp2p or if you have different thoughts on this. The `bitflags` dependency was already used indirectly by other dependencies, so I thought it's okay to depend on. I can make CHANGELOG changes and doc changes later when the idea is approved of.