### PR TITLE
fix: clippy useless_conversion and useless_vec

### DIFF
--- a/core/src/upgrade/apply.rs
+++ b/core/src/upgrade/apply.rs
@@ -55,7 +55,7 @@ where
 {
     InboundUpgradeApply {
         inner: InboundUpgradeApplyState::Init {
-            future: multistream_select::listener_select_proto(conn, up.protocol_info().into_iter()),
+            future: multistream_select::listener_select_proto(conn, up.protocol_info()),
             upgrade: up,
         },
     }

--- a/misc/allow-block-list/src/lib.rs
+++ b/misc/allow-block-list/src/lib.rs
@@ -354,9 +354,16 @@ mod tests {
             .block_peer(*listener.local_peer_id());
 
         let (
-            [SwarmEvent::ConnectionClosed { peer_id: closed_dialer_peer, .. }],
-            [SwarmEvent::ConnectionClosed { peer_id: closed_listener_peer, .. }]
-        ) = libp2p_swarm_test::drive(&mut dialer, &mut listener).await else {
+            [SwarmEvent::ConnectionClosed {
+                peer_id: closed_dialer_peer,
+                ..
+            }],
+            [SwarmEvent::ConnectionClosed {
+                peer_id: closed_listener_peer,
+                ..
+            }],
+        ) = libp2p_swarm_test::drive(&mut dialer, &mut listener).await
+        else {
             panic!("unexpected events")
         };
         assert_eq!(closed_dialer_peer, *listener.local_peer_id());
@@ -417,9 +424,22 @@ mod tests {
             .unwrap();
 
         let (
-            [SwarmEvent::OutgoingConnectionError { error: DialError::Denied { cause: outgoing_cause }, .. }],
-            [_, SwarmEvent::IncomingConnectionError { error: ListenError::Denied { cause: incoming_cause }, .. }],
-        ) = libp2p_swarm_test::drive(&mut dialer, &mut listener).await else {
+            [SwarmEvent::OutgoingConnectionError {
+                error:
+                    DialError::Denied {
+                        cause: outgoing_cause,
+                    },
+                ..
+            }],
+            [_, SwarmEvent::IncomingConnectionError {
+                error:
+                    ListenError::Denied {
+                        cause: incoming_cause,
+                    },
+                ..
+            }],
+        ) = libp2p_swarm_test::drive(&mut dialer, &mut listener).await
+        else {
             panic!("unexpected events")
         };
         assert!(outgoing_cause.downcast::<NotAllowed>().is_ok());
@@ -447,9 +467,16 @@ mod tests {
             .list
             .disallow_peer(*listener.local_peer_id());
         let (
-            [SwarmEvent::ConnectionClosed { peer_id: closed_dialer_peer, .. }],
-            [SwarmEvent::ConnectionClosed { peer_id: closed_listener_peer, .. }]
-        ) = libp2p_swarm_test::drive(&mut dialer, &mut listener).await else {
+            [SwarmEvent::ConnectionClosed {
+                peer_id: closed_dialer_peer,
+                ..
+            }],
+            [SwarmEvent::ConnectionClosed {
+                peer_id: closed_listener_peer,
+                ..
+            }],
+        ) = libp2p_swarm_test::drive(&mut dialer, &mut listener).await
+        else {
             panic!("unexpected events")
         };
         assert_eq!(closed_dialer_peer, *listener.local_peer_id());

--- a/misc/multistream-select/src/length_delimited.rs
+++ b/misc/multistream-select/src/length_delimited.rs
@@ -411,7 +411,7 @@ mod tests {
         assert!(len < (1 << 15));
         let frame = (0..len).map(|n| (n & 0xff) as u8).collect::<Vec<_>>();
         let mut data = vec![(len & 0x7f) as u8 | 0x80, (len >> 7) as u8];
-        data.extend(frame.clone().into_iter());
+        data.extend(frame.clone());
         let mut framed = LengthDelimited::new(Cursor::new(data));
         let recved = futures::executor::block_on(async move { framed.next().await }).unwrap();
         assert_eq!(recved.unwrap(), frame);

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -858,7 +858,7 @@ fn test_handle_received_subscriptions() {
     // UNSUBSCRIBE  - Remove topic from peer_topics for peer.
     //              - Remove peer from topic_peers.
 
-    let topics = vec!["topic1", "topic2", "topic3", "topic4"]
+    let topics = ["topic1", "topic2", "topic3", "topic4"]
         .iter()
         .map(|&t| String::from(t))
         .collect();
@@ -1280,7 +1280,7 @@ fn test_handle_graft_is_not_subscribed() {
 #[test]
 // tests multiple topics in a single graft message
 fn test_handle_graft_multiple_topics() {
-    let topics: Vec<String> = vec!["topic1", "topic2", "topic3", "topic4"]
+    let topics: Vec<String> = ["topic1", "topic2", "topic3", "topic4"]
         .iter()
         .map(|&t| String::from(t))
         .collect();

--- a/protocols/gossipsub/src/subscription_filter.rs
+++ b/protocols/gossipsub/src/subscription_filter.rs
@@ -222,7 +222,7 @@ mod test {
         let t1 = TopicHash::from_raw("t1");
         let t2 = TopicHash::from_raw("t2");
 
-        let old = BTreeSet::from_iter(vec![t1.clone()].into_iter());
+        let old = BTreeSet::from_iter(vec![t1.clone()]);
         let subscriptions = vec![
             Subscription {
                 action: Unsubscribe,

--- a/transports/noise/tests/webtransport_certhashes.rs
+++ b/transports/noise/tests/webtransport_certhashes.rs
@@ -40,9 +40,10 @@ fn webtransport_server_empty_certhashes() {
 
     // Invalid case, because a MITM attacker may strip certificates of the server.
     let Err(noise::Error::UnknownWebTransportCerthashes(expected, received)) =
-        handshake_with_certhashes(vec![certhash1, certhash2], vec![]) else {
-            panic!("unexpected result");
-        };
+        handshake_with_certhashes(vec![certhash1, certhash2], vec![])
+    else {
+        panic!("unexpected result");
+    };
 
     assert_eq!(expected, HashSet::from([certhash1, certhash2]));
     assert_eq!(received, HashSet::new());
@@ -68,9 +69,10 @@ fn webtransport_server_uninit_certhashes() {
 
     // Invalid case, because a MITM attacker may strip certificates of the server.
     let Err(noise::Error::UnknownWebTransportCerthashes(expected, received)) =
-        handshake_with_certhashes(vec![certhash1, certhash2], None) else {
-            panic!("unexpected result");
-        };
+        handshake_with_certhashes(vec![certhash1, certhash2], None)
+    else {
+        panic!("unexpected result");
+    };
 
     assert_eq!(expected, HashSet::from([certhash1, certhash2]));
     assert_eq!(received, HashSet::new());
@@ -81,9 +83,10 @@ fn webtransport_different_server_certhashes() {
     let (certhash1, certhash2, certhash3) = certhashes();
 
     let Err(noise::Error::UnknownWebTransportCerthashes(expected, received)) =
-        handshake_with_certhashes(vec![certhash1, certhash3], vec![certhash1, certhash2]) else {
-            panic!("unexpected result");
-        };
+        handshake_with_certhashes(vec![certhash1, certhash3], vec![certhash1, certhash2])
+    else {
+        panic!("unexpected result");
+    };
 
     assert_eq!(expected, HashSet::from([certhash1, certhash3]));
     assert_eq!(received, HashSet::from([certhash1, certhash2]));
@@ -94,9 +97,10 @@ fn webtransport_superset_of_certhashes() {
     let (certhash1, certhash2, _) = certhashes();
 
     let Err(noise::Error::UnknownWebTransportCerthashes(expected, received)) =
-        handshake_with_certhashes(vec![certhash1, certhash2], vec![certhash1]) else {
-            panic!("unexpected result");
-        };
+        handshake_with_certhashes(vec![certhash1, certhash2], vec![certhash1])
+    else {
+        panic!("unexpected result");
+    };
 
     assert_eq!(expected, HashSet::from([certhash1, certhash2]));
     assert_eq!(received, HashSet::from([certhash1]));


### PR DESCRIPTION
Another PR had CI fail on clippy beta ([see here](https://github.com/libp2p/rust-libp2p/actions/runs/5530306139/jobs/10089549582?pr=4189))

- *: Fix clippy useless_conversion
- *: fix clippy useless_vec

There is still some clippy lints showing on my nightly:

<details>
  <summary>Clippy output</summary>

```
error: try not to call a closure in the expression where it is declared
   --> transports/uds/src/lib.rs:100:36
    |
100 |                       let listener = $build_listener(path)
    |                                      ^^^^^^^^^^^^^^^^^^^^^
...
221 | / codegen!(
222 | |     "async-std",
223 | |     UdsConfig,
224 | |     |addr| async move { async_std::os::unix::net::UnixListener::bind(&addr).await },
225 | |     async_std::os::unix::net::UnixStream,
226 | | );
    | |_- in this macro invocation
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure_call
    = note: `-D clippy::redundant-closure-call` implied by `-D warnings`
    = note: this error originates in the macro `codegen` (in Nightly builds, run with -Z macro-backtrace for more info)

error: try not to call a closure in the expression where it is declared
   --> transports/uds/src/lib.rs:100:36
    |
100 |                       let listener = $build_listener(path)
    |                                      ^^^^^^^^^^^^^^^^^^^^^
...
228 | / codegen!(
229 | |     "tokio",
230 | |     TokioUdsConfig,
231 | |     |addr| async move { tokio::net::UnixListener::bind(&addr) },
232 | |     tokio::net::UnixStream,
233 | | );
    | |_- in this macro invocation
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure_call
    = note: this error originates in the macro `codegen` (in Nightly builds, run with -Z macro-backtrace for more info)

    Checking libp2p-quic v0.8.0-alpha (/home/zamaan/src/rust-libp2p/transports/quic)
error: could not compile `libp2p-uds` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: usage of `Arc<T>` where `T` is not `Send` or `Sync`
   --> transports/dns/src/lib.rs:146:20
    |
146 |             inner: Arc::new(Mutex::new(inner)),
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using `Rc<T>` instead or wrapping `T` in a std::sync type like `Mutex<T>`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync
    = note: `#[deny(clippy::arc_with_non_send_sync)]` on by default

error: usage of `Arc<T>` where `T` is not `Send` or `Sync`
   --> transports/dns/src/lib.rs:168:20
    |
168 |             inner: Arc::new(Mutex::new(inner)),
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using `Rc<T>` instead or wrapping `T` in a std::sync type like `Mutex<T>`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync

error: could not compile `libp2p-uds` (lib test) due to 2 previous errors
error: could not compile `libp2p-dns` (lib) due to 2 previous errors
error: usage of `Arc<T>` where `T` is not `Send` or `Sync`
  --> transports/websocket/src/framed.rs:64:24
   |
64 |             transport: Arc::new(Mutex::new(transport)),
   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: consider using `Rc<T>` instead or wrapping `T` in a std::sync type like `Mutex<T>`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync
   = note: `#[deny(clippy::arc_with_non_send_sync)]` on by default

error: could not compile `libp2p-dns` (lib test) due to 2 previous errors
error: usage of `Arc<T>` where `T` is not `Send` or `Sync`
  --> muxers/mplex/src/lib.rs:58:17
   |
58 |             io: Arc::new(Mutex::new(io::Multiplexed::new(socket, self))),
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: consider using `Rc<T>` instead or wrapping `T` in a std::sync type like `Mutex<T>`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync
   = note: `#[deny(clippy::arc_with_non_send_sync)]` on by default

error: usage of `Arc<T>` where `T` is not `Send` or `Sync`
  --> muxers/mplex/src/lib.rs:73:17
   |
73 |             io: Arc::new(Mutex::new(io::Multiplexed::new(socket, self))),
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: consider using `Rc<T>` instead or wrapping `T` in a std::sync type like `Mutex<T>`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync

error: could not compile `libp2p-mplex` (lib) due to 2 previous errors
error: could not compile `libp2p-websocket` (lib) due to previous error
error: could not compile `libp2p-mplex` (lib test) due to 2 previous errors
error: redundant pattern matching, consider using `is_none()`
   --> transports/quic/src/transport.rs:750:12
    |
750 |         && matches!(fifth, None)
    |            ^^^^^^^^^^^^^^^^^^^^^ help: try this: `fifth.is_none()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`

error: could not compile `libp2p-quic` (lib) due to previous error
```
</details>
