### PR TITLE
fix(interop): install `wasm-opt` in `Dockerfile.chromium`

### DIFF
--- a/interop-tests/Dockerfile.chromium
+++ b/interop-tests/Dockerfile.chromium
@@ -9,6 +9,9 @@ RUN rustup target add wasm32-unknown-unknown
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo install wasm-pack@0.11.1 --locked
 
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo install wasm-opt@0.113.0 --locked
+
 RUN --mount=type=cache,target=./target \
     --mount=type=cache,target=/usr/local/cargo/registry \
     wasm-pack build --target web interop-tests


### PR DESCRIPTION
## Description

I'm not able to build this container on my machine arm64 linux because the builder is missing the `wasm-opt` binary. I'm not sure why CI manages to do so. I'm guessing the x86 image is slightly different and may include `wasm-opt`.

This makes a change to that dockerfile to explicitly install `wasm-opt`.

Here's the previous error:


```
// ...
#0 36.90     Finished release [optimized] target(s) in 35.97s
#0 36.91   Installing /root/.cache/.wasm-pack/.wasm-bindgen-cargo-install-0.2.87/bin/wasm-bindgen
#0 36.91   Installing /root/.cache/.wasm-pack/.wasm-bindgen-cargo-install-0.2.87/bin/wasm-bindgen-test-runner
#0 36.91   Installing /root/.cache/.wasm-pack/.wasm-bindgen-cargo-install-0.2.87/bin/wasm2es6js
#0 36.91    Installed package `wasm-bindgen-cli v0.2.87` (executables `wasm-bindgen`, `wasm-bindgen-test-runner`, `wasm2es6js`)
#0 37.06 warning: be sure to add `/root/.cache/.wasm-pack/.wasm-bindgen-cargo-install-0.2.87/bin` to your PATH to be able to run the installed binaries
#0 37.22 Error: no prebuilt wasm-opt binaries are available for this platform: Unrecognized target!
#0 37.22 To disable `wasm-opt`, add `wasm-opt = false` to your package metadata in your `Cargo.toml`.
#0 37.22 Caused by: no prebuilt wasm-opt binaries are available for this platform: Unrecognized target!
#0 37.22 To disable `wasm-opt`, add `wasm-opt = false` to your package metadata in your `Cargo.toml`.
------
ERROR: failed to solve: executor failed running [/bin/sh -c wasm-pack build --target web interop-tests]: exit code: 1
```

Another solution would be to diable wasm-opt as mentioned in the error message as well.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works. 
  - I don't understand why CI doesn't fail like it does for me locally.
- [ ] A changelog entry has been made in the appropriate crates
