### PR TITLE
ci: automatically merge PRs of semver-compatible updates

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -64,8 +64,8 @@ pull_request_rules:
     conditions:
       - author=dependabot[bot]
       - or:
-          - title~=bump [^\s]+ from ([1-9]+)\..+ to \1\.      # For major > 1 versions, only approve updates with the same major version.
-          - title~=bump [^\s]+ from 0\.([\d]+)\..+ to 0\.\1\. # For major = 0 versions, only approve updates with the same major version.
+          - title~=bump [^\s]+ from ([1-9]+)\..+ to \1\.      # For major >= 1 versions, only approve updates with the same major version.
+          - title~=bump [^\s]+ from 0\.([\d]+)\..+ to 0\.\1\. # For major == 0 versions, only approve updates with the same minor version.
     actions:
       review:
 

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -33,6 +33,14 @@ pull_request_rules:
     actions:
       queue:
 
+  - name: Add approved dependabot PRs to merge queue
+    conditions:
+      # All branch protection rules are implicit: https://docs.mergify.com/conditions/#about-branch-protection
+      - author=dependabot[bot]
+      - base=master
+    actions:
+      queue:
+
   - name: Remove reviews on updates after PR is queued for merging
     conditions:
       - base=master
@@ -49,6 +57,15 @@ pull_request_rules:
       - base=master
       - label=trivial
       - author=@libp2p/rust-libp2p-maintainers
+    actions:
+      review:
+
+  - name: Approve dependabot PRs of semver-compatible updates
+    conditions:
+      - author=dependabot[bot]
+      - or:
+          - title~=bump [^\s]+ from ([1-9]+)\..+ to \1\.      # For major > 1 versions, only approve updates with the same major version.
+          - title~=bump [^\s]+ from 0\.([\d]+)\..+ to 0\.\1\. # For major = 0 versions, only approve updates with the same major version.
     actions:
       review:
 


### PR DESCRIPTION
## Description

We receive a lot of PRs from dependabot for version updates to our lockfile and Cargo.toml. Whilst it is nice that those are explicit, they require quite some work from maintainers. Often, these PRs only get queued to be merged when a maintainer is next active on a repository which is also likely at a time they want to merge other PRs.

We don't want to automatically merge all updates that are coming in because they might be breaking changes for us if they are exposed in our public API. We solve this by only merging updates that are in a semver-compatible range:

- For major >= 1 updates, only approve them if they have the same major version.
- For major == 0 updates, only approve them if they have the same minor version.

We also add a rule to automatically queue PRs from dependabot with an approval. This avoids us having to approve AND apply the `send-it` label.

Resolves #4186.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

I've tested this using mergify's config editor and could confirm that:

- https://github.com/libp2p/rust-libp2p/pull/4183 would not be approved :x: 
- https://github.com/libp2p/rust-libp2p/pull/4198 would not be approved :x:
- https://github.com/libp2p/rust-libp2p/pull/4207 would be approved :heavy_check_mark: 
- https://github.com/libp2p/rust-libp2p/pull/4208 would be approved :heavy_check_mark: 

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
