### PR TITLE
feat(transport): Add TCP transport to wasm-ext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.direnv/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5449,6 +5449,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tcptransport-tests"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "getrandom 0.2.10",
+ "gloo-timers",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-noise",
+ "libp2p-wasm-ext",
+ "multiaddr",
+ "multihash",
+ "rand 0.8.5",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
     "transports/websocket",
     "transports/webtransport-websys",
     "wasm-tests/webtransport-tests",
+    "wasm-tests/tcptransport-tests",
 ]
 resolver = "2"
 

--- a/transports/wasm-ext/CHANGELOG.md
+++ b/transports/wasm-ext/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 0.40.0 
+
+- Add TCP transport to wasm-ext. Update the underlying wasm-ext `ffi` module's API.
+  See [PR 4253]
+
+[PR 4253]: https://github.com/libp2p/rust-libp2p/pull/4253
+
+## 0.40.0
 
 - Raise MSRV to 1.65.
   See [PR 3715].

--- a/transports/wasm-ext/Cargo.toml
+++ b/transports/wasm-ext/Cargo.toml
@@ -20,6 +20,7 @@ wasm-bindgen-futures = "0.4.37"
 
 [features]
 websocket = []
+tcp = []
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/transports/wasm-ext/src/tcp.js
+++ b/transports/wasm-ext/src/tcp.js
@@ -1,0 +1,258 @@
+const Socket = require('node:net').Socket;
+const createServer = require('node:net').createServer;
+
+module.exports.tcp_transport = () => {
+    return {
+        dial: dial,
+        listen_on: listen_on
+    }
+}
+
+/// Convert a string multiaddress into a host/port tuple.
+const multiaddr_to_tcp_host_and_port = (addr) => {
+    let parsed = addr.match(/^\/(ip4|ip6|dns4|dns6|dns)\/(.*?)\/tcp\/(\d+)(.*?)$/);
+    if (parsed != null) {
+        return {
+            host: parsed[2],
+            port: Number(parsed[3]),
+        };
+    }
+
+    let err = new Error("Address not supported: " + addr);
+    err.name = "NotSupportedError";
+    throw err;
+}
+
+/// Convert a host/port/family tuple into a multiaddr
+const tcp_host_family_port_to_multiaddr = (host, port, family) => {
+    if (family != 'IPv4' && family != 'IPv6') {
+        let err = new Error("Address family not supported: " + family);
+        err.name = "NotSupportedError";
+        throw err;
+    }
+
+    const family_ma = (family == 'IPv4') ? 'ip4' : 'ip6'
+    return `/${family_ma}/${host}/tcp/${port}`
+}
+
+/// Create a connection object.
+let to_connection = (socket, reader) => {
+    return {
+        read: (function* () { while (socket.readyState == 'open') { yield reader.next(); } })(),
+        write: (data) => {
+            if (socket.readyState == 'open') {
+                let state = { done: false }
+                socket.write(data.slice(0), () => state.done = true);
+
+                return new Promise((resolve, reject) => {
+                    function check() {
+                        if (state.done) {
+                            resolve();
+                            return;
+                        }
+                        
+                        if (socket.readyState != 'open') {
+                            reject("Socket is not open");
+                            return;
+                        }
+                        
+                        setTimeout(check, 1);
+                    }
+
+                    check();
+                })
+            } else {
+                return Promise.reject("Socket is closed");
+            }
+        },
+        shutdown: () => socket.destroy(),
+        close: () => socket.end()
+    }
+}
+
+/// Attempt to dial a multiaddress.
+const dial = (addr) => {
+    return new Promise((resolve, reject) => {
+        let reader = read_queue();
+        const target = multiaddr_to_tcp_host_and_port(addr);
+        let socket = new Socket();
+
+        socket.on('error', (ev) => {
+            // If `resolve` has been called earlier, calling `reject` seems to be
+            // silently ignored. It is easier to unconditionally call `reject` rather than
+            // check in which state the connection is, which would be error-prone.
+            reject(ev);
+            // Injecting an EOF is how we report to the reading side that the connection has been
+            // closed. Injecting multiple EOFs is harmless.
+            reader.inject_eof();
+        })
+
+        socket.on('close', (ev) => {
+            // Same remarks as above.
+            reject(ev);
+            reader.inject_eof();
+        })
+
+        socket.on('end', (ev) => {
+            // Same remarks as above.
+            reject(ev);
+            reader.inject_eof();
+        })
+
+        socket.on('data', (ev) => reader.inject_array_buffer(ev));
+        socket.connect(target, () => resolve(to_connection(socket, reader)))
+    });
+}
+
+/// Attempt to listen on a multiaddress
+const listen_on = (addr) => {
+    let listen_state = {
+        events: [],
+        resolve: null
+    }
+
+    const push_event = (event) => {
+        if (listen_state.resolve == null) {
+            listen_state.events.push(event)
+        } else {
+            listen_state.resolve(event)
+            listen_state.resolve = null
+        }
+    }
+
+    const listen_event = (new_addreses, exp_addrs, new_conns) => {
+        return {
+            new_addrs: new_addreses,
+            expired_addrs: exp_addrs,
+            new_connections: new_conns,
+            // NOTE: after going thought the libp2p-wasm-ext source, this does not 
+            // appear to be used anywhere, but instead the iterator is used to extract
+            // the next ListenEvent
+            next_event: Promise.resolve(),
+        }
+    };
+
+    const connection_event = (socket) => {
+        let reader = read_queue();
+
+        socket.on('error', (ev) => {
+            reader.inject_eof();
+            socket.destroy();
+        })
+        socket.on('close', (ev) => {
+            reader.inject_eof();
+            
+        })
+
+        // We inject all incoming messages into the queue unconditionally. The caller isn't
+        // supposed to access this queue unless the connection is open.
+        socket.on('data', (ev) => reader.inject_array_buffer(ev));
+
+        return {
+            connection: to_connection(socket, reader),
+            observed_addr: tcp_host_family_port_to_multiaddr(socket.remoteAddress, socket.remotePort, socket.remoteFamily),
+            local_addr: addr
+        }
+    }
+
+    // initiate the socket
+    const port = multiaddr_to_tcp_host_and_port(addr).port
+    let server = createServer()
+    server.on('listening', () => {
+        push_event(listen_event([addr], undefined, undefined))
+    })
+    server.on('connection', (socket) => {
+        push_event(listen_event(undefined, undefined, [connection_event(socket)]))
+    })
+    server.on('error', (e) => { server.destroy(); })
+    server.on('close', () => {
+        push_event(listen_event(undefined, [addr], undefined))
+    })
+    server.on('drop', (data) => {
+        console.error("Connection dropped due to incoming connection limit")
+    })
+
+    server.listen(port)
+
+    const iterator = {
+        next() {
+            if (listen_state.events.length > 0) {
+                return {
+                    value: Promise.resolve(listen_state.events.shift(0)),
+                    done: false
+                }
+            } else {
+                if (listen_state.resolve !== null)
+                    throw new Error('Internal error: already have a pending promise');
+
+                if (server.listening) {
+                    return {
+                        value: new Promise((resolve, reject) => {
+                            listen_state.resolve = resolve;
+                        }),
+                        done: false
+                    };
+                } else {
+                    return {
+                        value: Promise.resolve(),
+                        done: true
+                    };
+                }
+            }
+        },
+    };
+
+    return {
+        events: iterator,
+        finalizer: () => { server.close() }
+    }
+}
+
+
+/// Creates a queue reading system.
+const read_queue = () => {
+    // State of the queue.
+    let state = {
+        // Array of promises resolving to `ArrayBuffer`s, that haven't been transmitted back with
+        // `next` yet.
+        queue: new Array(),
+        // If `resolve` isn't null, it is a "resolve" function of a promise that has already been
+        // returned by `next`. It should be called with some data.
+        resolve: null,
+    };
+
+    return {
+        // Inserts a new Blob in the queue.
+        inject_array_buffer: (buffer) => {
+            if (state.resolve != null) {
+                state.resolve(buffer);
+                state.resolve = null;
+            } else {
+                state.queue.push(buffer);
+            }
+        },
+
+        // Inserts an EOF message in the queue.
+        inject_eof: () => {
+            if (state.resolve != null) {
+                state.resolve(null);
+                state.resolve = null;
+            } else {
+                state.queue.push(null);
+            }
+        },
+
+        // Returns a Promise that yields the next entry as an ArrayBuffer.
+        next: () => {
+            if (state.queue.length != 0) {
+                return Promise.resolve(state.queue.shift(0));
+            } else {
+                if (state.resolve !== null)
+                    throw new Error('Internal error: already have a pending promise');
+                return new Promise((resolve, reject) => {
+                    state.resolve = resolve;
+                });
+            }
+        }
+    };
+};

--- a/wasm-tests/run-all.sh
+++ b/wasm-tests/run-all.sh
@@ -5,3 +5,4 @@ set -e
 cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
 
 ./webtransport-tests/run.sh
+./tcptransport-tests/run.sh

--- a/wasm-tests/tcptransport-tests/Cargo.toml
+++ b/wasm-tests/tcptransport-tests/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "tcptransport-tests"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+[dependencies]
+futures = "0.3.28"
+rand = "0.8"
+getrandom = { version = "0.2.9", features = ["js"] }
+libp2p-core = { workspace = true }
+libp2p-identity = { workspace = true }
+libp2p-noise = { workspace = true }
+libp2p-wasm-ext = { workspace = true, features = ["tcp"]}
+multiaddr = { workspace = true }
+multihash = { workspace = true }
+wasm-bindgen = "0.2.87"
+wasm-bindgen-futures = "0.4.37"
+wasm-bindgen-test = "0.3.37"
+gloo-timers = { version = "0.2.6", features = ["futures"] }

--- a/wasm-tests/tcptransport-tests/README.md
+++ b/wasm-tests/tcptransport-tests/README.md
@@ -1,0 +1,7 @@
+# Manually run tests
+
+Execute the command:
+
+```
+wasm-pack test --node
+```

--- a/wasm-tests/tcptransport-tests/run.sh
+++ b/wasm-tests/tcptransport-tests/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Run tests
+wasm-pack test --node
+exit_code=$?
+
+# Propagate wasm-pack's exit code
+exit $exit_code

--- a/wasm-tests/tcptransport-tests/src/lib.rs
+++ b/wasm-tests/tcptransport-tests/src/lib.rs
@@ -1,0 +1,230 @@
+use futures::channel::oneshot;
+use futures::{
+    future::FutureExt, // for `.fuse()`
+    pin_mut,
+    select,
+};
+use futures::{AsyncReadExt, AsyncWriteExt, AsyncWrite};
+use getrandom::getrandom;
+use libp2p_core::Transport;
+use libp2p_core::multiaddr::multiaddr;
+use libp2p_core::transport::TransportEvent;
+use libp2p_identity::PeerId;
+use libp2p_wasm_ext::{ffi::tcp_transport, Connection};
+use multiaddr::Multiaddr;
+use rand::Rng;
+use std::future::poll_fn;
+use std::pin::Pin;
+use wasm_bindgen_futures::spawn_local;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+
+use wasm_bindgen::prelude::*;
+#[wasm_bindgen]
+extern "C" {
+    // Use `js_namespace` here to bind `console.log(..)` instead of just
+    // `log(..)`
+    #[wasm_bindgen(js_namespace = console, js_name = error)]
+    fn _log(s: &str);
+}
+
+
+async fn new_echo_listener() -> (Multiaddr, oneshot::Sender<()>) {
+    let (sender, receiver) = oneshot::channel::<()>();
+
+    let port = rand::thread_rng().gen_range(2000u16..65535u16);
+    let listener_multiaddress = multiaddr!(Ip4([127, 0, 0, 1]), Tcp(port));
+    let addr_copy = listener_multiaddress.clone();
+
+    spawn_local(async move {
+        let mut transport = build_tcp_transport();
+        let listener_id = libp2p_core::transport::ListenerId::next();
+        let _ = transport.listen_on(listener_id, addr_copy).unwrap();
+
+        let mut echo_loops: Vec<oneshot::Sender<()>> = vec![];
+
+        let t1 = receiver.fuse();
+
+        pin_mut!(t1);
+
+        loop {
+            select! {
+                _ = t1 => {
+                    for l in echo_loops.into_iter() {
+                        let _ = l.send(());
+                    }
+                    assert_eq!(transport.remove_listener(listener_id), true);
+                    return ();
+                },
+                b = poll_fn(|cx| Pin::new(&mut transport).poll(cx)).fuse() => {
+                    match b {
+                        TransportEvent::Incoming { listener_id: _, upgrade, local_addr: _, send_back_addr: _ } => {
+                            let mut conn = upgrade.await.unwrap();
+                            
+                            let (tx, rx) = oneshot::channel::<()>();
+                            echo_loops.push(tx);
+
+                            spawn_local(async move {
+                                let frx = rx.fuse();
+
+                                pin_mut!(frx);
+
+                                loop {
+                                    select!{
+                                        _ = frx => return (),
+                                        _ = echo_back(&mut conn).fuse() => continue
+                                    }
+                                }
+                                
+                            });
+                        },
+                        TransportEvent::NewAddress { listener_id: _, listen_addr: _ } => {},
+                        TransportEvent::AddressExpired { listener_id: _, listen_addr: _ } => panic!("This should not happen"),
+                        TransportEvent::ListenerClosed { listener_id: _, reason: _ } => panic!("This should not happen, listener should not close"),
+                        TransportEvent::ListenerError { listener_id: _, error: _ } => panic!("There should not be a listener error"),
+                    }
+                }
+            }
+        }
+    });
+
+    (listener_multiaddress, sender)
+}
+
+
+#[wasm_bindgen_test]
+async fn single_connection_to_single_listener() {
+    let (addr, terminate) = new_echo_listener().await;
+
+    let mut conn = new_connection_to_echo_listener(addr).await;
+    send_recv(&mut conn).await;
+
+    let _ = terminate.send(());
+}
+
+#[wasm_bindgen_test]
+async fn read_leftovers() {
+    let (addr, terminate) = new_echo_listener().await;
+
+    let mut conn = new_connection_to_echo_listener(addr).await;
+
+    send_recv(&mut conn).await;
+
+    conn.write_all(b"hello").await.unwrap();
+
+    let mut buf = [0u8; 3];
+
+    // Read first half
+    let len = conn.read(&mut buf[..]).await.unwrap();
+    assert_eq!(len, 3);
+    assert_eq!(&buf[..len], b"hel");
+
+    // Read second half
+    let len = conn.read(&mut buf[..2]).await.unwrap();
+    assert_eq!(len, 2);
+    assert_eq!(&buf[..len], b"lo");
+
+    let _ = terminate.send(());
+}
+
+#[wasm_bindgen_test]
+async fn read_error_after_connection_close() {
+    let (addr, terminate) = new_echo_listener().await;
+
+    let mut conn = new_connection_to_echo_listener(addr).await;
+    send_recv(&mut conn).await;
+
+    poll_fn(|cx| Pin::new(&mut conn).poll_close(cx))
+        .await
+        .unwrap();
+
+    let mut buf = [0u8; 16];
+    conn
+        .read(&mut buf)
+        .await
+        .expect_err("read error after conn drop");
+
+    let _ = terminate.send(());
+}
+
+#[wasm_bindgen_test]
+async fn write_error_after_connection_close() {
+    let (addr, terminate) = new_echo_listener().await;
+
+    let mut conn = new_connection_to_echo_listener(addr).await;
+    send_recv(&mut conn).await;
+    
+    poll_fn(|cx| Pin::new(&mut conn).poll_close(cx))
+        .await
+        .unwrap();
+
+    let buf = [1u8; 16];
+    // dummy write - the poll_write operation checks the status of the current promise in the next call
+    // before the close is properly propagated.
+    conn
+        .write(&buf)
+        .await
+        .unwrap();
+
+    conn
+        .write(&buf)
+        .await
+        .expect_err("write error after conn drop");
+
+    let _ = terminate.send(());
+}
+
+#[wasm_bindgen_test]
+async fn connect_without_peer_id() {
+    let (mut addr, terminate) = new_echo_listener().await;
+
+    // Remove peer id
+    addr.push(multiaddr::Protocol::P2p(PeerId::random()));
+    addr.pop();
+
+    let mut transport = build_tcp_transport();
+    transport.dial(addr).unwrap().await.unwrap();
+
+    let _ = terminate.send(());
+}
+
+fn build_tcp_transport() -> libp2p_wasm_ext::ExtTransport {
+    libp2p_wasm_ext::ExtTransport::new(tcp_transport())
+}
+
+async fn new_connection_to_echo_listener(addr: Multiaddr) -> Connection {
+    let mut transport = build_tcp_transport();
+    transport.dial(addr).unwrap().await.unwrap()
+}
+
+fn send_recv_task(mut conn: Connection) -> oneshot::Receiver<()> {
+    let (tx, rx) = oneshot::channel();
+
+    spawn_local(async move {
+        send_recv(&mut conn).await;
+        tx.send(()).unwrap();
+    });
+
+    rx
+}
+
+async fn send_recv(conn: &mut Connection) {
+    let mut send_buf = [0u8; 1024];
+    let mut recv_buf = [0u8; 1024];
+
+    for _ in 0..30 {
+        getrandom(&mut send_buf).unwrap();
+
+        conn.write_all(&send_buf).await.unwrap();
+        conn.read_exact(&mut recv_buf).await.unwrap();
+
+        assert_eq!(send_buf, recv_buf);
+    }
+}
+
+async fn echo_back(conn: &mut Connection) {
+    let mut buf = [0u8; 1024];
+
+    conn.read(&mut buf).await.unwrap();
+    conn.write_all(&buf).await.unwrap();
+}


### PR DESCRIPTION
## Description
Introduce a `wasm-ext` TCP `Transport` that can be used in the `NodeJS` application context for peers with public addresses.

## Notes
In certain projects (e.g. migrating from JS to Rust) a need might arise where the `Transport` needs to be implemented in the context of a WASM environment. Since the `wasm-ext` package can be used in the `NodeJS` wasm context, it is beneficial to introduce the raw TCP `Transport`

## Open questions
The pre-existing `write` future `poll_write` first checks the previous write's future resolution and only then inserts the new future, leading to inconsistent state, where after the `write(...).await` call on the `Connection` object there's no guarantee that the current write has been awaited, rather a previous one is awaited. This results in application inconsistencies, difficult to read tests and overall API ambiguity. The write future could be rewritten in order to facilitate proper await on the current write request.

## Notable changes to existing `wasm-ext` API
As part of `listen_on` it was not really possible to terminate the listening operation inside the WASM JS implementation. Therefore the `ffi` module was extended with a `ffi::Listener` interface, which returns not only an iterator over the `ListenEvents`, but also a `finalizer` - a callable that will terminate/close the listening JS backend.

## Change checklist
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
