### PR TITLE
docs: fix last OutboundQueryCompleted in kad doc

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 [PR 4224]: https://github.com/libp2p/rust-libp2p/pull/4224
 
-- Rename missed `KademliaEvent::OutboundQueryCompleted` to `KademliaEvent::OutboundQueryProgressed` in documentation. See [PR 4257].
+- Rename missed `KademliaEvent::OutboundQueryCompleted` to `KademliaEvent::OutboundQueryProgressed` in documentation.
+  See [PR 4257].
 
 [PR 4257]: https://github.com/libp2p/rust-libp2p/pull/4257
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 [PR 4224]: https://github.com/libp2p/rust-libp2p/pull/4224
 
+- Rename missed `KademliaEvent::OutboundQueryCompleted` to `KademliaEvent::OutboundQueryProgressed` in documentation. See [PR 4257].
+
+[PR 4257]: https://github.com/libp2p/rust-libp2p/pull/4257
+
 ## 0.44.2
 
 - Allow to explicitly set `Mode::{Client,Server}`.

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -665,7 +665,7 @@ where
     /// Initiates an iterative query for the closest peers to the given key.
     ///
     /// The result of the query is delivered in a
-    /// [`KademliaEvent::OutboundQueryCompleted{QueryResult::GetClosestPeers}`].
+    /// [`KademliaEvent::OutboundQueryProgressed{QueryResult::GetClosestPeers}`].
     pub fn get_closest_peers<K>(&mut self, key: K) -> QueryId
     where
         K: Into<kbucket::Key<K>> + Into<Vec<u8>> + Clone,
@@ -692,7 +692,7 @@ where
     /// Performs a lookup for a record in the DHT.
     ///
     /// The result of this operation is delivered in a
-    /// [`KademliaEvent::OutboundQueryCompleted{QueryResult::GetRecord}`].
+    /// [`KademliaEvent::OutboundQueryProgressed{QueryResult::GetRecord}`].
     pub fn get_record(&mut self, key: record_priv::Key) -> QueryId {
         let record = if let Some(record) = self.store.get(&key) {
             if record.is_expired(Instant::now()) {
@@ -753,7 +753,7 @@ where
     /// Returns `Ok` if a record has been stored locally, providing the
     /// `QueryId` of the initial query that replicates the record in the DHT.
     /// The result of the query is eventually reported as a
-    /// [`KademliaEvent::OutboundQueryCompleted{QueryResult::PutRecord}`].
+    /// [`KademliaEvent::OutboundQueryProgressed{QueryResult::PutRecord}`].
     ///
     /// The record is always stored locally with the given expiration. If the record's
     /// expiration is `None`, the common case, it does not expire in local storage
@@ -869,7 +869,7 @@ where
     ///
     /// Returns `Ok` if bootstrapping has been initiated with a self-lookup, providing the
     /// `QueryId` for the entire bootstrapping process. The progress of bootstrapping is
-    /// reported via [`KademliaEvent::OutboundQueryCompleted{QueryResult::Bootstrap}`] events,
+    /// reported via [`KademliaEvent::OutboundQueryProgressed{QueryResult::Bootstrap}`] events,
     /// with one such event per bootstrapping query.
     ///
     /// Returns `Err` if bootstrapping is impossible due an empty routing table.
@@ -913,7 +913,7 @@ where
     /// of the libp2p Kademlia provider API.
     ///
     /// The results of the (repeated) provider announcements sent by this node are
-    /// reported via [`KademliaEvent::OutboundQueryCompleted{QueryResult::StartProviding}`].
+    /// reported via [`KademliaEvent::OutboundQueryProgressed{QueryResult::StartProviding}`].
     pub fn start_providing(&mut self, key: record_priv::Key) -> Result<QueryId, store::Error> {
         // Note: We store our own provider records locally without local addresses
         // to avoid redundant storage and outdated addresses. Instead these are
@@ -950,7 +950,7 @@ where
     /// Performs a lookup for providers of a value to the given key.
     ///
     /// The result of this operation is delivered in a
-    /// reported via [`KademliaEvent::OutboundQueryCompleted{QueryResult::GetProviders}`].
+    /// reported via [`KademliaEvent::OutboundQueryProgressed{QueryResult::GetProviders}`].
     pub fn get_providers(&mut self, key: record_priv::Key) -> QueryId {
         let providers: HashSet<_> = self
             .store


### PR DESCRIPTION
## Description

`OutboundQueryCompleted` hasn't been fully replaced by `OutboundQueryProgressed` in kad doc.

## Notes & open questions

While playing with the `distributed-key-value-store`, I noticed that I couldn't find the `OutboundQueryCompleted` anywhere except in the documentation of some functions. I checked the changelog and it looks like it has been replaced by `OutboundQueryProgressed` -> https://github.com/libp2p/rust-libp2p/blob/master/protocols/kad/CHANGELOG.md#0420

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
