### PR TITLE
fix(kad): reduce noise of "remote supports our protocol" log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.43.2"
+version = "0.43.3"
 dependencies = [
  "async-std",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ libp2p-quic = { version = "0.9.0-alpha", path = "transports/quic" }
 libp2p-relay = { version = "0.16.1", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.13.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.25.1", path = "protocols/request-response" }
-libp2p-swarm = { version = "0.43.2", path = "swarm" }
+libp2p-swarm = { version = "0.43.3", path = "swarm" }
 libp2p-swarm-derive = { version = "0.33.0", path = "swarm-derive" }
 libp2p-swarm-test = { version = "0.2.0", path = "swarm-test" }
 libp2p-tcp = { version = "0.40.0", path = "transports/tcp" }

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 - Implement common traits on `RoutingUpdate`.
   See [PR 4270].
+- Reduce noise of "remote supports our protocol" log.
+  See [PR 4278].
 
 [PR 4270]: https://github.com/libp2p/rust-libp2p/pull/4270
+[PR 4278]: https://github.com/libp2p/rust-libp2p/pull/4278
 
 ## 0.44.3
 

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -2081,6 +2081,7 @@ where
             connected_point,
             peer,
             self.mode,
+            connection_id,
         ))
     }
 
@@ -2103,6 +2104,7 @@ where
             connected_point,
             peer,
             self.mode,
+            connection_id,
         ))
     }
 

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -809,7 +809,7 @@ impl ConnectionHandler for KademliaHandler {
                         (true, ProtocolStatus::Confirmed | ProtocolStatus::Reported) => {}
                         (true, _) => {
                             log::debug!(
-                                "Remote {} now supports our kademlia protocol. {:?}",
+                                "Remote {} now supports our kademlia protocol on connection {}",
                                 self.remote_peer_id,
                                 self.connection_id,
                             );
@@ -818,7 +818,7 @@ impl ConnectionHandler for KademliaHandler {
                         }
                         (false, ProtocolStatus::Confirmed | ProtocolStatus::Reported) => {
                             log::debug!(
-                                "Remote {} no longer supports our kademlia protocol. {:?}",
+                                "Remote {} no longer supports our kademlia protocol on connection {}",
                                 self.remote_peer_id,
                                 self.connection_id,
                             );

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -35,7 +35,7 @@ use libp2p_swarm::handler::{
     ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
 };
 use libp2p_swarm::{
-    ConnectionHandler, ConnectionHandlerEvent, KeepAlive, Stream, StreamUpgradeError,
+    ConnectionHandler, ConnectionHandlerEvent, ConnectionId, KeepAlive, Stream, StreamUpgradeError,
     SubstreamProtocol, SupportedProtocols,
 };
 use log::trace;
@@ -94,6 +94,9 @@ pub struct KademliaHandler {
     protocol_status: ProtocolStatus,
 
     remote_supported_protocols: SupportedProtocols,
+
+    /// The current connection ID from the behaviour.
+    connection_id: ConnectionId,
 }
 
 /// The states of protocol confirmation that a connection
@@ -474,6 +477,7 @@ impl KademliaHandler {
         endpoint: ConnectedPoint,
         remote_peer_id: PeerId,
         mode: Mode,
+        connection_id: ConnectionId,
     ) -> Self {
         match &endpoint {
             ConnectedPoint::Dialer { .. } => {
@@ -504,6 +508,7 @@ impl KademliaHandler {
             keep_alive,
             protocol_status: ProtocolStatus::Unknown,
             remote_supported_protocols: Default::default(),
+            connection_id,
         }
     }
 
@@ -803,17 +808,19 @@ impl ConnectionHandler for KademliaHandler {
                     match (remote_supports_our_kademlia_protocols, self.protocol_status) {
                         (true, ProtocolStatus::Confirmed | ProtocolStatus::Reported) => {}
                         (true, _) => {
-                            log::info!(
-                                "Remote {} now supports our kademlia protocol",
-                                self.remote_peer_id
+                            log::debug!(
+                                "Remote {} now supports our kademlia protocol. {:?}",
+                                self.remote_peer_id,
+                                self.connection_id,
                             );
 
                             self.protocol_status = ProtocolStatus::Confirmed;
                         }
                         (false, ProtocolStatus::Confirmed | ProtocolStatus::Reported) => {
-                            log::info!(
-                                "Remote {} no longer supports our kademlia protocol",
-                                self.remote_peer_id
+                            log::debug!(
+                                "Remote {} no longer supports our kademlia protocol. {:?}",
+                                self.remote_peer_id,
+                                self.connection_id,
                             );
 
                             self.protocol_status = ProtocolStatus::NotSupported;

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -95,7 +95,7 @@ pub struct KademliaHandler {
 
     remote_supported_protocols: SupportedProtocols,
 
-    /// The current connection ID from the behaviour.
+    /// The ID of this connection.
     connection_id: ConnectionId,
 }
 

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.43.3 - unreleased
+
+- Implement `Display` for `ConnectionId`
+  See [PR 4278].
+
+[PR 4278]: https://github.com/libp2p/rust-libp2p/pull/4278
+
 ## 0.43.2
 - Display the cause of a `ListenError::Denied`.
   See [PR 4232]

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.43.3 - unreleased
 
-- Implement `Display` for `ConnectionId`
+- Implement `Display` for `ConnectionId`.
   See [PR 4278].
 
 [PR 4278]: https://github.com/libp2p/rust-libp2p/pull/4278

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-swarm"
 edition = "2021"
 rust-version = { workspace = true }
 description = "The libp2p swarm"
-version = "0.43.2"
+version = "0.43.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/swarm/src/connection.rs
+++ b/swarm/src/connection.rs
@@ -53,6 +53,7 @@ use libp2p_core::upgrade::{NegotiationError, ProtocolError};
 use libp2p_core::Endpoint;
 use libp2p_identity::PeerId;
 use std::collections::HashSet;
+use std::fmt::{Display, Formatter};
 use std::future::Future;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::task::Waker;
@@ -79,6 +80,12 @@ impl ConnectionId {
     /// Returns the next available [`ConnectionId`].
     pub(crate) fn next() -> Self {
         Self(NEXT_CONNECTION_ID.fetch_add(1, Ordering::SeqCst))
+    }
+}
+
+impl Display for ConnectionId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 


### PR DESCRIPTION
## Description

This PR changes the logging of the Kademlia connection handler related to the remote Kademlia mode changes:
- Downgrade log level for the remote kademlia protocol report from `info` to `debug`.
- Introduce connection_id for the handler to improve logging.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
