### PR TITLE
fix(relay): remove unconditional `async-std` dependency

### DIFF
--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,15 +1,19 @@
 ## 0.16.1 - unreleased
 
-- Export `RateLimiter` type. 
+- Export `RateLimiter` type.
   See [PR 3742].
 
 - Add functions to access data within `Limit`.
   See [PR 4162].
 
+- remove unconditional `async-std` dependency.
+  See [PR 4283].
+
 [PR 3742]: https://github.com/libp2p/rust-libp2p/pull/3742
 [PR 4162]: https://github.com/libp2p/rust-libp2p/pull/4162
+[PR 4283]: https://github.com/libp2p/rust-libp2p/pull/4283
 
-## 0.16.0 
+## 0.16.0
 
 - Raise MSRV to 1.65.
   See [PR 3715].

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add functions to access data within `Limit`.
   See [PR 4162].
 
-- remove unconditional `async-std` dependency.
+- Remove unconditional `async-std` dependency.
   See [PR 4283].
 
 [PR 3742]: https://github.com/libp2p/rust-libp2p/pull/3742

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3.28"
 futures-timer = "3"
 instant = "0.1.12"
 libp2p-core = { workspace = true }
-libp2p-swarm = { workspace = true, features = ["async-std"] }
+libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true }
 log = "0.4"
 quick-protobuf = "0.8"
@@ -32,7 +32,7 @@ void = "1"
 env_logger = "0.10.0"
 libp2p-ping = { workspace = true }
 libp2p-plaintext = { workspace = true }
-libp2p-swarm = { workspace = true, features = ["macros"] }
+libp2p-swarm = { workspace = true, features = ["macros", "async-std"] }
 libp2p-yamux = { workspace = true }
 quickcheck = { workspace = true }
 


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

`libp2p-relay` crate specifies the `libp2p-swarm/async-std` feature, which causes an `async-std` dependency to always be introduced.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
