### PR TITLE
docs(roadmap): update to reflect ongoing wasm browser work

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,7 +67,7 @@ Though (a) I think we should prioritize improving existing functionality over ne
 
 | Category     | Status | Target Completion | Tracking                                   | Dependencies                                                                              | Dependents |
 |--------------|--------|-------------------|--------------------------------------------|-------------------------------------------------------------------------------------------|------------|
-| Connectivity | todo   |                   | https://github.com/libp2p/specs/issues/475 | [Improved WASM support](#improved-wasm-support), https://github.com/libp2p/specs/pull/497 |            |
+| Connectivity | In progress   |                   | https://github.com/libp2p/specs/issues/475 | [Improved WASM support](#improved-wasm-support), https://github.com/libp2p/specs/pull/497 | https://github.com/libp2p/rust-libp2p/pull/4248 |
 
 Use the browser's WebRTC stack to support [`/webrtc`](https://github.com/libp2p/specs/blob/master/webrtc/webrtc.md) and [`/webrtc-direct`](https://github.com/libp2p/specs/blob/master/webrtc/webrtc-direct.md) from within the browser using rust-libp2p compiled to WASM.
 This makes rust-libp2p a truly end-to-end solution, enabling users to use rust-libp2p on both the client (browser) and server side.


### PR DESCRIPTION
For visibility to the community, perhaps we should add PR libp2p#4248 to the ROADMAP now instead of after the PR is merged?

## Description

Update ROADMAP to reflect in-progress works

## Notes & open questions

n/a

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] ~~A changelog entry has been made in the appropriate crates~~
