### PR TITLE
feat(quic): promote to stable release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,7 +831,6 @@ dependencies = [
  "env_logger 0.10.0",
  "futures",
  "libp2p",
- "libp2p-quic",
 ]
 
 [[package]]
@@ -1309,7 +1308,6 @@ dependencies = [
  "futures",
  "futures-timer",
  "libp2p",
- "libp2p-quic",
  "log",
 ]
 
@@ -2354,7 +2352,6 @@ dependencies = [
  "instant",
  "libp2p",
  "libp2p-mplex",
- "libp2p-quic",
  "libp2p-webrtc",
  "log",
  "mime_guess",
@@ -2512,7 +2509,7 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "libp2p"
-version = "0.52.2"
+version = "0.52.3"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2543,6 +2540,7 @@ dependencies = [
  "libp2p-ping",
  "libp2p-plaintext",
  "libp2p-pnet",
+ "libp2p-quic",
  "libp2p-relay",
  "libp2p-rendezvous",
  "libp2p-request-response",
@@ -3058,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.9.2-alpha"
+version = "0.9.2"
 dependencies = [
  "async-std",
  "bytes",
@@ -4610,7 +4608,6 @@ dependencies = [
  "env_logger 0.10.0",
  "futures",
  "libp2p",
- "libp2p-quic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ libp2p-perf = { version = "0.2.0", path = "protocols/perf" }
 libp2p-ping = { version = "0.43.0", path = "protocols/ping" }
 libp2p-plaintext = { version = "0.40.0", path = "transports/plaintext" }
 libp2p-pnet = { version = "0.23.0", path = "transports/pnet" }
-libp2p-quic = { version = "0.9.2-alpha", path = "transports/quic" }
+libp2p-quic = { version = "0.9.2", path = "transports/quic" }
 libp2p-relay = { version = "0.16.1", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.13.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.25.1", path = "protocols/request-response" }

--- a/examples/chat-example/Cargo.toml
+++ b/examples/chat-example/Cargo.toml
@@ -11,4 +11,3 @@ async-trait = "0.1"
 env_logger = "0.10.0"
 futures = "0.3.28"
 libp2p = { path = "../../libp2p", features = ["async-std", "gossipsub", "mdns", "noise", "macros", "tcp", "yamux"] }
-libp2p-quic = { path = "../../transports/quic", features = ["async-std"] }

--- a/examples/chat-example/Cargo.toml
+++ b/examples/chat-example/Cargo.toml
@@ -10,4 +10,4 @@ async-std = { version = "1.12", features = ["attributes"] }
 async-trait = "0.1"
 env_logger = "0.10.0"
 futures = "0.3.28"
-libp2p = { path = "../../libp2p", features = ["async-std", "gossipsub", "mdns", "noise", "macros", "tcp", "yamux"] }
+libp2p = { path = "../../libp2p", features = ["async-std", "gossipsub", "mdns", "noise", "macros", "tcp", "yamux", "quic"] }

--- a/examples/chat-example/src/main.rs
+++ b/examples/chat-example/src/main.rs
@@ -24,12 +24,11 @@ use async_std::io;
 use futures::{future::Either, prelude::*, select};
 use libp2p::{
     core::{muxing::StreamMuxerBox, transport::OrTransport, upgrade},
-    gossipsub, identity, mdns, noise,
+    gossipsub, identity, mdns, noise, quic,
     swarm::NetworkBehaviour,
     swarm::{SwarmBuilder, SwarmEvent},
     tcp, yamux, PeerId, Transport,
 };
-use libp2p_quic as quic;
 use std::collections::hash_map::DefaultHasher;
 use std::error::Error;
 use std::hash::{Hash, Hasher};

--- a/examples/dcutr/Cargo.toml
+++ b/examples/dcutr/Cargo.toml
@@ -10,6 +10,5 @@ clap = { version = "4.3.21", features = ["derive"] }
 env_logger = "0.10.0"
 futures = "0.3.28"
 futures-timer = "3.0"
-libp2p = { path = "../../libp2p", features = ["async-std", "dns", "dcutr", "identify", "macros", "noise", "ping", "relay", "rendezvous", "tcp", "tokio", "yamux"] }
-libp2p-quic = { path = "../../transports/quic", features = ["async-std"] }
+libp2p = { path = "../../libp2p", features = ["async-std", "dns", "dcutr", "identify", "macros", "noise", "ping", "quic", "relay", "rendezvous", "tcp", "tokio", "yamux"] }
 log = "0.4"

--- a/examples/dcutr/src/main.rs
+++ b/examples/dcutr/src/main.rs
@@ -35,11 +35,10 @@ use libp2p::{
     },
     dcutr,
     dns::DnsConfig,
-    identify, identity, noise, ping, relay,
+    identify, identity, noise, ping, quic, relay,
     swarm::{NetworkBehaviour, SwarmBuilder, SwarmEvent},
     tcp, yamux, PeerId,
 };
-use libp2p_quic as quic;
 use log::info;
 use std::error::Error;
 use std::str::FromStr;

--- a/examples/relay-server/Cargo.toml
+++ b/examples/relay-server/Cargo.toml
@@ -11,5 +11,4 @@ async-std = { version = "1.12", features = ["attributes"] }
 async-trait = "0.1"
 env_logger = "0.10.0"
 futures = "0.3.28"
-libp2p = { path = "../../libp2p", features = ["async-std", "noise", "macros", "ping", "tcp", "identify", "yamux", "relay"] }
-libp2p-quic = { path = "../../transports/quic", features = ["async-std"] }
+libp2p = { path = "../../libp2p", features = ["async-std", "noise", "macros", "ping", "tcp", "identify", "yamux", "relay", "quic"] }

--- a/examples/relay-server/src/main.rs
+++ b/examples/relay-server/src/main.rs
@@ -31,11 +31,10 @@ use libp2p::{
     core::{Multiaddr, Transport},
     identify, identity,
     identity::PeerId,
-    noise, ping, relay,
+    noise, ping, quic, relay,
     swarm::{NetworkBehaviour, SwarmBuilder, SwarmEvent},
     tcp,
 };
-use libp2p_quic as quic;
 use std::error::Error;
 use std::net::{Ipv4Addr, Ipv6Addr};
 

--- a/interop-tests/Cargo.toml
+++ b/interop-tests/Cargo.toml
@@ -19,8 +19,7 @@ rand = "0.8.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 axum = "0.6"
-libp2p = { path = "../libp2p", features = ["ping", "noise", "tls", "rsa", "macros", "websocket", "tokio", "yamux", "tcp", "dns", "identify"] }
-libp2p-quic = { workspace = true, features = ["tokio"] }
+libp2p = { path = "../libp2p", features = ["ping", "noise", "tls", "rsa", "macros", "websocket", "tokio", "yamux", "tcp", "dns", "identify", "quic"] }
 libp2p-webrtc = { workspace = true, features = ["tokio"] }
 libp2p-mplex = { path = "../muxers/mplex" }
 mime_guess = "2.0"

--- a/interop-tests/src/arch.rs
+++ b/interop-tests/src/arch.rs
@@ -26,9 +26,8 @@ pub(crate) mod native {
     use libp2p::identity::Keypair;
     use libp2p::swarm::{NetworkBehaviour, SwarmBuilder};
     use libp2p::websocket::WsConfig;
-    use libp2p::{noise, tcp, tls, yamux, PeerId, Transport as _};
+    use libp2p::{noise, quic, tcp, tls, yamux, PeerId, Transport as _};
     use libp2p_mplex as mplex;
-    use libp2p_quic as quic;
     use libp2p_webrtc as webrtc;
     use redis::AsyncCommands;
 

--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.52.3
+
+- Add `libp2p-quic` stable release.
+
 ## 0.52.2
 
 - Include gossipsub when compiling for wasm.

--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.52.3
+## 0.52.3 - unreleased
 
 - Add `libp2p-quic` stable release.
 

--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p"
 edition = "2021"
 rust-version = "1.65.0"
 description = "Peer-to-peer networking library"
-version = "0.52.2"
+version = "0.52.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -33,6 +33,7 @@ full = [
     "ping",
     "plaintext",
     "pnet",
+    "quic",
     "relay",
     "rendezvous",
     "request-response",
@@ -51,7 +52,7 @@ full = [
     "yamux",
 ]
 
-async-std = ["libp2p-swarm/async-std", "libp2p-mdns?/async-io", "libp2p-tcp?/async-io", "libp2p-dns?/async-std"]
+async-std = ["libp2p-swarm/async-std", "libp2p-mdns?/async-io", "libp2p-tcp?/async-io", "libp2p-dns?/async-std", "libp2p-quic?/async-std"]
 autonat = ["dep:libp2p-autonat"]
 cbor = ["libp2p-request-response?/cbor"]
 dcutr = ["dep:libp2p-dcutr", "libp2p-metrics?/dcutr"]
@@ -72,6 +73,7 @@ noise = ["dep:libp2p-noise"]
 ping = ["dep:libp2p-ping", "libp2p-metrics?/ping"]
 plaintext = ["dep:libp2p-plaintext"]
 pnet = ["dep:libp2p-pnet"]
+quic = ["dep:libp2p-quic"]
 relay = ["dep:libp2p-relay", "libp2p-metrics?/relay"]
 rendezvous = ["dep:libp2p-rendezvous"]
 request-response = ["dep:libp2p-request-response"]
@@ -80,7 +82,7 @@ secp256k1 = ["libp2p-identity/secp256k1"]
 serde = ["libp2p-core/serde", "libp2p-kad?/serde", "libp2p-gossipsub?/serde"]
 tcp = ["dep:libp2p-tcp"]
 tls = ["dep:libp2p-tls"]
-tokio = ["libp2p-swarm/tokio", "libp2p-mdns?/tokio", "libp2p-tcp?/tokio", "libp2p-dns?/tokio"]
+tokio = ["libp2p-swarm/tokio", "libp2p-mdns?/tokio", "libp2p-tcp?/tokio", "libp2p-dns?/tokio", "libp2p-quic?/tokio"]
 uds = ["dep:libp2p-uds"]
 wasm-bindgen = ["futures-timer/wasm-bindgen", "instant/wasm-bindgen", "getrandom/js", "libp2p-swarm/wasm-bindgen", "libp2p-gossipsub?/wasm-bindgen"]
 wasm-ext = ["dep:libp2p-wasm-ext"]
@@ -127,6 +129,7 @@ libp2p-deflate = { workspace = true, optional = true }
 libp2p-dns = { workspace = true, optional = true }
 libp2p-mdns = { workspace = true, optional = true }
 libp2p-memory-connection-limits = { workspace = true, optional = true }
+libp2p-quic = { workspace = true, optional = true }
 libp2p-tcp = { workspace = true, optional = true }
 libp2p-tls = { workspace = true, optional = true }
 libp2p-uds = { workspace = true, optional = true }

--- a/libp2p/src/lib.rs
+++ b/libp2p/src/lib.rs
@@ -98,6 +98,9 @@ pub use libp2p_plaintext as plaintext;
 #[cfg(feature = "pnet")]
 #[doc(inline)]
 pub use libp2p_pnet as pnet;
+#[cfg(feature = "quic")]
+#[cfg(not(target_arch = "wasm32"))]
+pub use libp2p_quic as quic;
 #[cfg(feature = "relay")]
 #[doc(inline)]
 pub use libp2p_relay as relay;

--- a/transports/quic/CHANGELOG.md
+++ b/transports/quic/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.2 - unreleased
+
+- Cut stable release.
+
 ## 0.9.2-alpha
 
 - Add support for reusing an existing socket when dialing localhost address.

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-quic"
-version = "0.9.2-alpha"
+version = "0.9.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 rust-version = { workspace = true }


### PR DESCRIPTION
## Description

- Cut a stable release of `libp2p-quic`.
- Export `libp2p-quic` as `libp2p::quic`.
- Update examples to use `libp2p-quic` through `libp2p`.



<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

With no bugs thus far reported for `libp2p-quic` `v0.9.2-alpha` and the two bug fixes https://github.com/libp2p/rust-libp2p/issues/4165 https://github.com/libp2p/rust-libp2p/pull/4304 I suggest we cut a stable release of `libp2p-quic`. Note that the bug fixes already existed in the previous `quinn-proto` implementation.

Objections by anyone?

//CC @jxs for https://github.com/sigp/lighthouse/pull/4577

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
