### PR TITLE
refactor(tcp): reducing branching in `Transport::create_socket`

### DIFF
--- a/transports/quic/src/transport.rs
+++ b/transports/quic/src/transport.rs
@@ -926,17 +926,21 @@ mod tests {
         let keypair = libp2p_identity::Keypair::generate_ed25519();
         let config = Config::new(&keypair);
         let mut transport = crate::tokio::Transport::new(config);
+        let port = {
+            let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+            socket.local_addr().unwrap().port()
+        };
 
         transport
             .listen_on(
                 ListenerId::next(),
-                "/ip4/0.0.0.0/udp/4001/quic-v1".parse().unwrap(),
+                format!("/ip4/0.0.0.0/udp/{port}/quic-v1").parse().unwrap(),
             )
             .unwrap();
         transport
             .listen_on(
                 ListenerId::next(),
-                "/ip6/::/udp/4001/quic-v1".parse().unwrap(),
+                format!("/ip6/::/udp/{port}/quic-v1").parse().unwrap(),
             )
             .unwrap();
     }

--- a/transports/tcp/src/lib.rs
+++ b/transports/tcp/src/lib.rs
@@ -1351,12 +1351,15 @@ mod tests {
                 test::<async_io::Tcp>(3001);
             })
         }
-        let rt = ::tokio::runtime::Builder::new_current_thread()
-            .enable_io()
-            .build()
-            .unwrap();
-        rt.block_on(async {
-            test::<async_io::Tcp>(4001);
-        });
+        #[cfg(feature = "tokio")]
+        {
+            let rt = ::tokio::runtime::Builder::new_current_thread()
+                .enable_io()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                test::<async_io::Tcp>(4001);
+            });
+        }
     }
 }

--- a/transports/tcp/src/lib.rs
+++ b/transports/tcp/src/lib.rs
@@ -346,13 +346,12 @@ where
         }
     }
 
-    fn create_socket(&self, socket_addr: &SocketAddr) -> io::Result<Socket> {
-        let domain = if socket_addr.is_ipv4() {
-            Domain::IPV4
-        } else {
-            Domain::IPV6
-        };
-        let socket = Socket::new(domain, Type::STREAM, Some(socket2::Protocol::TCP))?;
+    fn create_socket(&self, socket_addr: SocketAddr) -> io::Result<Socket> {
+        let socket = Socket::new(
+            Domain::for_address(socket_addr),
+            Type::STREAM,
+            Some(socket2::Protocol::TCP),
+        )?;
         if socket_addr.is_ipv6() {
             socket.set_only_v6(true)?;
         }
@@ -375,7 +374,7 @@ where
         id: ListenerId,
         socket_addr: SocketAddr,
     ) -> io::Result<ListenStream<T>> {
-        let socket = self.create_socket(&socket_addr)?;
+        let socket = self.create_socket(socket_addr)?;
         socket.bind(&socket_addr.into())?;
         socket.listen(self.config.backlog as _)?;
         socket.set_nonblocking(true)?;
@@ -476,7 +475,7 @@ where
         log::debug!("dialing {}", socket_addr);
 
         let socket = self
-            .create_socket(&socket_addr)
+            .create_socket(socket_addr)
             .map_err(TransportError::Other)?;
 
         if let Some(addr) = self.port_reuse.local_dial_addr(&socket_addr.ip()) {
@@ -1328,5 +1327,36 @@ mod tests {
                 .unwrap();
             assert!(rt.block_on(cycle_listeners::<tokio::Tcp>()));
         }
+    }
+
+    #[test]
+    fn test_listens_ipv4_ipv6_separately() {
+        fn test<T: Provider>(port: u16) {
+            let mut tcp = Transport::<T>::default().boxed();
+            let listener_id = ListenerId::next();
+            tcp.listen_on(
+                listener_id,
+                format!("/ip4/0.0.0.0/tcp/{port}").parse().unwrap(),
+            )
+            .unwrap();
+            tcp.listen_on(
+                ListenerId::next(),
+                format!("/ip6/::/tcp/{port}").parse().unwrap(),
+            )
+            .unwrap();
+        }
+        #[cfg(feature = "async-io")]
+        {
+            async_std::task::block_on(async {
+                test::<async_io::Tcp>(3001);
+            })
+        }
+        let rt = ::tokio::runtime::Builder::new_current_thread()
+            .enable_io()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            test::<async_io::Tcp>(4001);
+        });
     }
 }

--- a/transports/tcp/src/lib.rs
+++ b/transports/tcp/src/lib.rs
@@ -1331,7 +1331,11 @@ mod tests {
 
     #[test]
     fn test_listens_ipv4_ipv6_separately() {
-        fn test<T: Provider>(port: u16) {
+        fn test<T: Provider>() {
+            let port = {
+                let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+                listener.local_addr().unwrap().port()
+            };
             let mut tcp = Transport::<T>::default().boxed();
             let listener_id = ListenerId::next();
             tcp.listen_on(
@@ -1348,7 +1352,7 @@ mod tests {
         #[cfg(feature = "async-io")]
         {
             async_std::task::block_on(async {
-                test::<async_io::Tcp>(3001);
+                test::<async_io::Tcp>();
             })
         }
         #[cfg(feature = "tokio")]
@@ -1358,7 +1362,7 @@ mod tests {
                 .build()
                 .unwrap();
             rt.block_on(async {
-                test::<async_io::Tcp>(4001);
+                test::<async_io::Tcp>();
             });
         }
     }


### PR DESCRIPTION
and add test for listening on ipv4 and ipv6 separately.

## Description

Following https://github.com/libp2p/rust-libp2p/pull/4289#discussion_r1285812762, hereby is the PR to also improve the `create_socket`  using [`for_addr`](https://docs.rs/socket2/latest/socket2/struct.Domain.html#method.for_address). We also add a test for listening on IPv4 and IPv6 separately.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
