### PR TITLE
chore(deps): bump asynchronous-codec to "0.6.2"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ dependencies = [
  "log",
  "memchr",
  "once_cell",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -503,7 +503,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
 ]
 
 [[package]]
@@ -548,7 +548,7 @@ dependencies = [
  "memchr",
  "mime",
  "percent-encoding",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "rustversion",
  "serde",
  "serde_json",
@@ -945,7 +945,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "memchr",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "tokio",
  "tokio-util",
 ]
@@ -1794,7 +1794,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "waker-fn",
 ]
 
@@ -1876,7 +1876,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "pin-utils",
  "slab",
 ]
@@ -2134,7 +2134,7 @@ checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
  "http",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
 ]
 
 [[package]]
@@ -2177,7 +2177,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "socket2 0.4.9",
  "tokio",
  "tower-service",
@@ -3463,9 +3463,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
  "value-bag",
 ]
@@ -4082,9 +4082,9 @@ checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
 
 [[package]]
 name = "pin-utils"
@@ -4174,7 +4174,7 @@ dependencies = [
  "concurrent-queue",
  "libc",
  "log",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "windows-sys",
 ]
 
@@ -4361,7 +4361,7 @@ dependencies = [
  "async-std",
  "bytes",
  "futures-io",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
@@ -4540,7 +4540,7 @@ dependencies = [
  "futures-util",
  "itoa",
  "percent-encoding",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "ryu",
  "tokio",
  "tokio-util",
@@ -4649,7 +4649,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "percent-encoding",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5669,20 +5669,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
- "autocfg",
  "backtrace",
  "bytes",
  "libc",
  "mio",
  "num_cpus",
  "parking_lot",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "tokio-macros",
  "windows-sys",
 ]
@@ -5729,7 +5728,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "tokio",
  "tracing",
 ]
@@ -5743,7 +5742,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -5767,7 +5766,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "percent-encoding",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -5795,7 +5794,7 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "tracing-attributes",
  "tracing-core",
 ]

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
-name = "libp2p-mplex"
-edition = "2021"
-rust-version = { workspace = true }
-description = "Mplex multiplexing protocol for libp2p"
-version = "0.40.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+categories = ["asynchronous", "network-programming"]
+description = "Mplex multiplexing protocol for libp2p"
+edition = "2021"
+keywords = ["libp2p", "networking", "peer-to-peer"]
 license = "MIT"
+name = "libp2p-mplex"
 repository = "https://github.com/libp2p/rust-libp2p"
-keywords = ["peer-to-peer", "libp2p", "networking"]
-categories = ["network-programming", "asynchronous"]
+rust-version = { workspace = true }
+version = "0.40.0"
 
 [dependencies]
+asynchronous-codec = "0.6.2"
 bytes = "1"
 futures = "0.3.28"
-asynchronous-codec = "0.6"
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true }
 log = "0.4"
@@ -34,12 +34,12 @@ libp2p-tcp = { workspace = true, features = ["async-io"] }
 quickcheck = { workspace = true }
 
 [[bench]]
-name = "split_send_size"
 harness = false
+name = "split_send_size"
 
-# Passing arguments to the docsrs builder in order to properly document cfg's. 
+# Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/protocols/dcutr/Cargo.toml
+++ b/protocols/dcutr/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
-name = "libp2p-dcutr"
-edition = "2021"
-rust-version = { workspace = true }
-description = "Direct connection upgrade through relay"
-version = "0.10.0"
 authors = ["Max Inden <mail@max-inden.de>"]
+categories = ["asynchronous", "network-programming"]
+description = "Direct connection upgrade through relay"
+edition = "2021"
+keywords = ["libp2p", "networking", "peer-to-peer"]
 license = "MIT"
+name = "libp2p-dcutr"
 repository = "https://github.com/libp2p/rust-libp2p"
-keywords = ["peer-to-peer", "libp2p", "networking"]
-categories = ["network-programming", "asynchronous"]
+rust-version = { workspace = true }
+version = "0.10.0"
 
 [dependencies]
-asynchronous-codec = "0.6"
+asynchronous-codec = "0.6.2"
 either = "1.9.0"
 futures = "0.3.28"
 futures-timer = "3.0"
 instant = "0.1.12"
 libp2p-core = { workspace = true }
-libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true }
+libp2p-swarm = { workspace = true }
 log = "0.4"
 quick-protobuf = "0.8"
 quick-protobuf-codec = { workspace = true }
@@ -45,5 +45,5 @@ rand = "0.8"
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name = "libp2p-floodsub"
-edition = "2021"
-rust-version = { workspace = true }
-description = "Floodsub protocol for libp2p"
-version = "0.43.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+categories = ["asynchronous", "network-programming"]
+description = "Floodsub protocol for libp2p"
+edition = "2021"
+keywords = ["libp2p", "networking", "peer-to-peer"]
 license = "MIT"
+name = "libp2p-floodsub"
 repository = "https://github.com/libp2p/rust-libp2p"
-keywords = ["peer-to-peer", "libp2p", "networking"]
-categories = ["network-programming", "asynchronous"]
+rust-version = { workspace = true }
+version = "0.43.0"
 
 [dependencies]
-asynchronous-codec = "0.6"
+asynchronous-codec = "0.6.2"
 cuckoofilter = "0.5.0"
 fnv = "1.0"
 futures = "0.3.28"
 libp2p-core = { workspace = true }
-libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true }
+libp2p-swarm = { workspace = true }
 log = "0.4"
 quick-protobuf = "0.8"
 quick-protobuf-codec = { workspace = true }
@@ -29,5 +29,5 @@ thiserror = "1.0.44"
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
-name = "libp2p-gossipsub"
-edition = "2021"
-rust-version = { workspace = true }
-description = "Gossipsub protocol for libp2p"
-version = "0.45.1"
 authors = ["Age Manning <Age@AgeManning.com>"]
+categories = ["asynchronous", "network-programming"]
+description = "Gossipsub protocol for libp2p"
+edition = "2021"
+keywords = ["libp2p", "networking", "peer-to-peer"]
 license = "MIT"
+name = "libp2p-gossipsub"
 repository = "https://github.com/libp2p/rust-libp2p"
-keywords = ["peer-to-peer", "libp2p", "networking"]
-categories = ["network-programming", "asynchronous"]
+rust-version = { workspace = true }
+version = "0.45.1"
 
 [features]
 wasm-bindgen = ["getrandom/js", "instant/wasm-bindgen"]
 
 [dependencies]
-asynchronous-codec = "0.6"
+asynchronous-codec = "0.6.2"
 base64 = "0.21.2"
 byteorder = "1.3.4"
 bytes = "1.4"
@@ -47,14 +47,14 @@ async-std = { version = "1.6.3", features = ["unstable"] }
 env_logger = "0.10.0"
 hex = "0.4.2"
 libp2p-core = { workspace = true }
-libp2p-yamux = { workspace = true }
 libp2p-noise = { workspace = true }
 libp2p-swarm-test = { path = "../../swarm-test" }
+libp2p-yamux = { workspace = true }
 quickcheck = { workspace = true }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -18,7 +18,7 @@ futures-timer = "3.0.2"
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true }
 libp2p-swarm = { workspace = true }
-log = "0.4.19"
+log = "0.4.20"
 lru = "0.11.0"
 quick-protobuf = "0.8"
 quick-protobuf-codec = { workspace = true }

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -17,7 +17,6 @@ futures = "0.3.28"
 futures-timer = "3.0.2"
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true }
-libp2p-swarm = { workspace = true }
 log = "0.4.20"
 lru = "0.11.0"
 quick-protobuf = "0.8"

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -1,40 +1,40 @@
 [package]
-name = "libp2p-identify"
-edition = "2021"
-rust-version = { workspace = true }
-description = "Nodes identifcation protocol for libp2p"
-version = "0.43.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+categories = ["asynchronous", "network-programming"]
+description = "Nodes identifcation protocol for libp2p"
+edition = "2021"
+keywords = ["libp2p", "networking", "peer-to-peer"]
 license = "MIT"
+name = "libp2p-identify"
 repository = "https://github.com/libp2p/rust-libp2p"
-keywords = ["peer-to-peer", "libp2p", "networking"]
-categories = ["network-programming", "asynchronous"]
+rust-version = { workspace = true }
+version = "0.43.0"
 
 [dependencies]
-asynchronous-codec = "0.6"
+asynchronous-codec = "0.6.2"
+either = "1.9.0"
 futures = "0.3.28"
 futures-timer = "3.0.2"
 libp2p-core = { workspace = true }
-libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true }
+libp2p-swarm = { workspace = true }
 log = "0.4.19"
 lru = "0.11.0"
-quick-protobuf-codec = { workspace = true }
 quick-protobuf = "0.8"
+quick-protobuf-codec = { workspace = true }
 smallvec = "1.11.0"
 thiserror = "1.0"
 void = "1.0"
-either = "1.9.0"
 
 [dev-dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }
 env_logger = "0.10"
-libp2p-swarm-test = { path = "../../swarm-test" }
 libp2p-swarm = { workspace = true, features = ["macros"] }
+libp2p-swarm-test = { path = "../../swarm-test" }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -1,37 +1,37 @@
 [package]
-name = "libp2p-kad"
-edition = "2021"
-rust-version = "1.65.0"
-description = "Kademlia protocol for libp2p"
-version = "0.44.4"
 authors = ["Parity Technologies <admin@parity.io>"]
+categories = ["asynchronous", "network-programming"]
+description = "Kademlia protocol for libp2p"
+edition = "2021"
+keywords = ["libp2p", "networking", "peer-to-peer"]
 license = "MIT"
+name = "libp2p-kad"
 repository = "https://github.com/libp2p/rust-libp2p"
-keywords = ["peer-to-peer", "libp2p", "networking"]
-categories = ["network-programming", "asynchronous"]
+rust-version = "1.65.0"
+version = "0.44.4"
 
 [dependencies]
 arrayvec = "0.7.4"
+asynchronous-codec = "0.6.2"
 bytes = "1"
 either = "1.9"
 fnv = "1.0"
-asynchronous-codec = "0.6"
 futures = "0.3.28"
-log = "0.4"
+futures-timer = "3.0.2"
+instant = "0.1.12"
 libp2p-core = { workspace = true }
-libp2p-swarm = { workspace = true }
-quick-protobuf = "0.8"
 libp2p-identity = { workspace = true }
+libp2p-swarm = { workspace = true }
+log = "0.4"
+quick-protobuf = "0.8"
 rand = "0.8"
+serde = { version = "1.0", optional = true, features = ["derive"] }
 sha2 = "0.10.7"
 smallvec = "1.11.0"
+thiserror = "1"
 uint = "0.9"
 unsigned-varint = { version = "0.7", features = ["asynchronous_codec"] }
 void = "1.0"
-futures-timer = "3.0.2"
-instant = "0.1.12"
-serde = { version = "1.0", optional = true, features = ["derive"] }
-thiserror = "1"
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
@@ -45,11 +45,11 @@ libp2p-yamux = { workspace = true }
 quickcheck = { workspace = true }
 
 [features]
-serde = ["dep:serde", "bytes/serde"]
+serde = ["bytes/serde", "dep:serde"]
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -1,25 +1,28 @@
 [package]
-name = "libp2p-relay"
-edition = "2021"
-rust-version = { workspace = true }
+authors = [
+    "Max Inden <mail@max-inden.de>",
+    "Parity Technologies <admin@parity.io>",
+]
+categories = ["asynchronous", "network-programming"]
 description = "Communications relaying for libp2p"
-version = "0.16.1"
-authors = ["Parity Technologies <admin@parity.io>", "Max Inden <mail@max-inden.de>"]
+edition = "2021"
+keywords = ["libp2p", "networking", "peer-to-peer"]
 license = "MIT"
+name = "libp2p-relay"
 repository = "https://github.com/libp2p/rust-libp2p"
-keywords = ["peer-to-peer", "libp2p", "networking"]
-categories = ["network-programming", "asynchronous"]
+rust-version = { workspace = true }
+version = "0.16.1"
 
 [dependencies]
-asynchronous-codec = "0.6"
+asynchronous-codec = "0.6.2"
 bytes = "1"
 either = "1.9.0"
 futures = "0.3.28"
 futures-timer = "3"
 instant = "0.1.12"
 libp2p-core = { workspace = true }
-libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true }
+libp2p-swarm = { workspace = true }
 log = "0.4"
 quick-protobuf = "0.8"
 quick-protobuf-codec = { workspace = true }
@@ -32,7 +35,7 @@ void = "1"
 env_logger = "0.10.0"
 libp2p-ping = { workspace = true }
 libp2p-plaintext = { workspace = true }
-libp2p-swarm = { workspace = true, features = ["macros", "async-std"] }
+libp2p-swarm = { workspace = true, features = ["async-std", "macros"] }
 libp2p-yamux = { workspace = true }
 quickcheck = { workspace = true }
 
@@ -40,5 +43,5 @@ quickcheck = { workspace = true }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/protocols/rendezvous/Cargo.toml
+++ b/protocols/rendezvous/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
-name = "libp2p-rendezvous"
-edition = "2021"
-rust-version = { workspace = true }
-description = "Rendezvous protocol for libp2p"
-version = "0.13.0"
 authors = ["The COMIT guys <hello@comit.network>"]
+categories = ["asynchronous", "network-programming"]
+description = "Rendezvous protocol for libp2p"
+edition = "2021"
+keywords = ["libp2p", "networking", "peer-to-peer"]
 license = "MIT"
+name = "libp2p-rendezvous"
 repository = "https://github.com/libp2p/rust-libp2p"
-keywords = ["peer-to-peer", "libp2p", "networking"]
-categories = ["network-programming", "asynchronous"]
+rust-version = { workspace = true }
+version = "0.13.0"
 
 [dependencies]
-asynchronous-codec = "0.6"
 async-trait = "0.1"
+asynchronous-codec = "0.6.2"
 bimap = "0.6.3"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 futures-timer = "3.0.2"
 instant = "0.1.12"
 libp2p-core = { workspace = true }
-libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true }
 libp2p-request-response = { workspace = true }
+libp2p-swarm = { workspace = true }
 log = "0.4"
 quick-protobuf = "0.8"
 quick-protobuf-codec = { workspace = true }
@@ -30,19 +30,27 @@ void = "1"
 
 [dev-dependencies]
 env_logger = "0.10.0"
-libp2p-swarm = { workspace = true, features = ["macros", "tokio"] }
+libp2p-identify = { workspace = true }
 libp2p-noise = { workspace = true }
 libp2p-ping = { workspace = true }
-libp2p-identify = { workspace = true }
-libp2p-yamux = { workspace = true }
-libp2p-tcp = { workspace = true, features = ["tokio"] }
-rand = "0.8"
-tokio = { version = "1.29", features = [ "rt-multi-thread", "time", "macros", "sync", "process", "fs", "net" ] }
+libp2p-swarm = { workspace = true, features = ["macros", "tokio"] }
 libp2p-swarm-test = { path = "../../swarm-test" }
+libp2p-tcp = { workspace = true, features = ["tokio"] }
+libp2p-yamux = { workspace = true }
+rand = "0.8"
+tokio = { version = "1.29", features = [
+    "fs",
+    "macros",
+    "net",
+    "process",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/protocols/rendezvous/Cargo.toml
+++ b/protocols/rendezvous/Cargo.toml
@@ -38,15 +38,7 @@ libp2p-swarm-test = { path = "../../swarm-test" }
 libp2p-tcp = { workspace = true, features = ["tokio"] }
 libp2p-yamux = { workspace = true }
 rand = "0.8"
-tokio = { version = "1.29", features = [
-    "fs",
-    "macros",
-    "net",
-    "process",
-    "rt-multi-thread",
-    "sync",
-    "time",
-] }
+tokio = { version = "1.31", features = [ "rt-multi-thread", "time", "macros", "sync", "process", "fs", "net" ] }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/transports/plaintext/Cargo.toml
+++ b/transports/plaintext/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "libp2p-plaintext"
-edition = "2021"
-rust-version = { workspace = true }
-description = "Plaintext encryption dummy protocol for libp2p"
-version = "0.40.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+categories = ["asynchronous", "network-programming"]
+description = "Plaintext encryption dummy protocol for libp2p"
+edition = "2021"
+keywords = ["libp2p", "networking", "peer-to-peer"]
 license = "MIT"
+name = "libp2p-plaintext"
 repository = "https://github.com/libp2p/rust-libp2p"
-keywords = ["peer-to-peer", "libp2p", "networking"]
-categories = ["network-programming", "asynchronous"]
+rust-version = { workspace = true }
+version = "0.40.0"
 
 [dependencies]
-asynchronous-codec = "0.6"
+asynchronous-codec = "0.6.2"
 bytes = "1"
 futures = "0.3.28"
 libp2p-core = { workspace = true }
@@ -22,14 +22,14 @@ unsigned-varint = { version = "0.7", features = ["asynchronous_codec"] }
 
 [dev-dependencies]
 env_logger = "0.10.0"
+futures_ringbuf = "0.4.0"
 libp2p-identity = { workspace = true, features = ["ed25519"] }
 quickcheck = { workspace = true }
 rand = "0.8"
-futures_ringbuf = "0.4.0"
 
-# Passing arguments to the docsrs builder in order to properly document cfg's. 
+# Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
## Description

Bump asynchronous-codec to "0.6.2"

I also just realized my TOML formatter has sorted everything lexically (alphabetically) -- is that ok? Or do you hve a different lint process?

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

Giving me .lock file headaches when merging

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
