### PR TITLE
feat(swarm): attempt to reuse `String` allocation for protocols

### DIFF
--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -54,6 +54,7 @@
 //!
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![feature(string_leak)]
 
 mod connection;
 mod executor;


### PR DESCRIPTION
## Description

This is a naive attempt to avoid allocations when constructing `StreamProtocol`s. I don't know if that is correct and/or safe. Needs to be tested with Miri etc.

Can only be used on > 1.72 where `String::leak` is stable.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
