### PR TITLE
deps(websocket): bump futures-rustls to 0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "async-std",
  "either",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,17 +1824,6 @@ dependencies = [
 
 [[package]]
 name = "futures-rustls"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2411eed028cdf8c8034eaf21f9915f956b6c3abec4d4c7949ee67f0721127bd"
-dependencies = [
- "futures-io",
- "rustls 0.20.8",
- "webpki 0.22.0",
-]
-
-[[package]]
-name = "futures-rustls"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd3cf68c183738046838e300353e4716c674dc5e56890de4826801a6622a28"
@@ -3278,7 +3267,7 @@ name = "libp2p-tls"
 version = "0.2.0"
 dependencies = [
  "futures",
- "futures-rustls 0.24.0",
+ "futures-rustls",
  "hex",
  "hex-literal",
  "libp2p-core",
@@ -3364,7 +3353,7 @@ dependencies = [
  "async-std",
  "either",
  "futures",
- "futures-rustls 0.22.2",
+ "futures-rustls",
  "libp2p-core",
  "libp2p-dns",
  "libp2p-identity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ libp2p-tls = { version = "0.2.0", path = "transports/tls" }
 libp2p-uds = { version = "0.39.0", path = "transports/uds" }
 libp2p-wasm-ext = { version = "0.40.0", path = "transports/wasm-ext" }
 libp2p-webrtc = { version = "0.6.0-alpha", path = "transports/webrtc" }
-libp2p-websocket = { version = "0.42.0", path = "transports/websocket" }
+libp2p-websocket = { version = "0.42.1", path = "transports/websocket" }
 libp2p-webtransport-websys = { version = "0.1.0", path = "transports/webtransport-websys" }
 libp2p-yamux = { version = "0.44.1", path = "muxers/yamux" }
 multistream-select = { version = "0.13.0", path = "misc/multistream-select" }

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## 0.42.1 - unreleased
 
 - Bump `futures-rustls` to `0.24.0`.
+  This is a part of the resolution of the [RUSTSEC-2023-0052].
   See [PR 4378].
 
 [PR 4378]: https://github.com/libp2p/rust-libp2p/pull/4378
+[RUSTSEC-2023-0052]: https://rustsec.org/advisories/RUSTSEC-2023-0052.html
 
 ## 0.42.0
 

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 0.42.0 
+## 0.42.1
+
+- Bump `futures-rustls` to `0.24.0`.
+  See [PR 4378].
+
+[PR 4378]: https://github.com/libp2p/rust-libp2p/pull/4378
+
+## 0.42.0
 
 - Raise MSRV to 1.65.
   See [PR 3715].

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.42.1
+## 0.42.1 - unreleased
 
 - Bump `futures-rustls` to `0.24.0`.
   See [PR 4378].

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-futures-rustls = "0.22"
+futures-rustls = "0.24.0"
 either = "1.9.0"
 futures = "0.3.28"
 libp2p-core = { workspace = true }

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-websocket"
 edition = "2021"
 rust-version = { workspace = true }
 description = "WebSocket transport for libp2p"
-version = "0.42.0"
+version = "0.42.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/transports/websocket/src/tls.rs
+++ b/transports/websocket/src/tls.rs
@@ -92,7 +92,7 @@ impl Config {
 /// Setup the rustls client configuration.
 fn client_root_store() -> rustls::RootCertStore {
     let mut client_root_store = rustls::RootCertStore::empty();
-    client_root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
+    client_root_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
         rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
             ta.subject,
             ta.spki,


### PR DESCRIPTION
## Description

A simple dependency update to make the CVE detector happy.

## Notes & open questions

This is a part of the work to make https://rustsec.org/advisories/RUSTSEC-2023-0052.html alerts go away.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
