### PR TITLE
feat: add info to rendevzous example

### DIFF
--- a/examples/rendezvous/README.md
+++ b/examples/rendezvous/README.md
@@ -15,6 +15,12 @@ To run the example, follow these steps:
 
    This command starts the rendezvous server, which will listen for incoming connections and handle peer registrations and discovery.
 
+   Grab the value of `Local peer id` logged in your console and replace the existing value of the `rendezvous_point` variable in the following files:
+   * `bin/rzv-register` line 36
+   * `bin/rzv-discover` line 40
+   * `bin/rzv-identify` line 36
+   `rendezvous_point` denotes the endpoint on the rendezvous server used by peer ids generated in these files.
+
 2. Register a peer by executing the following command:
 
    ```sh


### PR DESCRIPTION
## Description
This is a small addition to the readme for the rendezvous example, adding an instruction to change the hardcoded rendezvous server endpoints in the `bin/` files. 

## Notes & open questions

I would be happy to continue to work on this PR to modify the code to take this endpoint from the cli when calling each `bin/` file, removing the need to copy and paste into the code each time, if this is of interest to you. 

## Change checklist

- [x ] I have performed a self-review of my own code
- [ x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
