### PR TITLE
deps(tls): switch from webpki to rustls-webpki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tls"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "futures",
  "futures-rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3277,9 +3277,9 @@ dependencies = [
  "rcgen 0.10.0",
  "ring",
  "rustls 0.21.6",
+ "rustls-webpki",
  "thiserror",
  "tokio",
- "webpki 0.22.0",
  "x509-parser 0.15.1",
  "yasna",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ libp2p-swarm = { version = "0.43.3", path = "swarm" }
 libp2p-swarm-derive = { version = "0.33.0", path = "swarm-derive" }
 libp2p-swarm-test = { version = "0.2.0", path = "swarm-test" }
 libp2p-tcp = { version = "0.40.0", path = "transports/tcp" }
-libp2p-tls = { version = "0.2.0", path = "transports/tls" }
+libp2p-tls = { version = "0.2.1", path = "transports/tls" }
 libp2p-uds = { version = "0.39.0", path = "transports/uds" }
 libp2p-wasm-ext = { version = "0.40.0", path = "transports/wasm-ext" }
 libp2p-webrtc = { version = "0.6.0-alpha", path = "transports/webrtc" }

--- a/transports/tls/CHANGELOG.md
+++ b/transports/tls/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## 0.2.1 - unreleased
 
 - Switch from webpki to rustls-webpki.
+  This is a part of the resolution of the [RUSTSEC-2023-0052].
   See [PR 4381].
 
 [PR 4381]: https://github.com/libp2p/rust-libp2p/pull/4381
+[RUSTSEC-2023-0052]: https://rustsec.org/advisories/RUSTSEC-2023-0052.html
 
 ## 0.2.0
 

--- a/transports/tls/CHANGELOG.md
+++ b/transports/tls/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 0.2.0 
+## 0.2.1 - unreleased
+
+- Switch from webpki to rustls-webpki.
+  See [PR 4381].
+
+[PR 4381]: https://github.com/libp2p/rust-libp2p/pull/4381
+
+## 0.2.0
 
 - Raise MSRV to 1.65.
   See [PR 3715].

--- a/transports/tls/Cargo.toml
+++ b/transports/tls/Cargo.toml
@@ -16,7 +16,7 @@ libp2p-identity = { workspace = true }
 rcgen = "0.10.0"
 ring = "0.16.20"
 thiserror = "1.0.44"
-webpki = { version = "0.22.0", features = ["std"] }
+webpki = { version = "0.101.4", package = "rustls-webpki", features = ["std"] }
 x509-parser = "0.15.1"
 yasna = "0.5.2"
 

--- a/transports/tls/Cargo.toml
+++ b/transports/tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-tls"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = { workspace = true }
 description = "TLS configuration based on libp2p TLS specs."


### PR DESCRIPTION
## Description

A simple dependency update to make the CVE detector happy.
Continuation of #4378.

## Notes & open questions

This is a part of the work to make https://rustsec.org/advisories/RUSTSEC-2023-0052.html alerts go away.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
