### PR TITLE
fix(interop/WASM): use selenium/standalone-chrome:115.0

### DIFF
--- a/interop-tests/Dockerfile.chromium
+++ b/interop-tests/Dockerfile.chromium
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=./target \
 RUN --mount=type=cache,target=./target \
     mv ./target/release/wasm_ping /usr/local/bin/testplan
 
-FROM selenium/standalone-chrome:112.0
+FROM selenium/standalone-chrome:115.0
 COPY --from=builder /usr/local/bin/testplan /usr/local/bin/testplan
 
 ENV RUST_BACKTRACE=1


### PR DESCRIPTION
## Description

Our WASM Webtransport interoperability tests previously used Chrome 112. This Chrome version fails to connect to go-libp2p with quic-go v0.38.0. See https://github.com/libp2p/go-libp2p/pull/2506 for failure. This is due to quic-go v0.38.0 moving to the updated code point for HTTP datagrams. See https://github.com/quic-go/quic-go/pull/3588 for details.

This commit upgrades our interop tests to use Chrome 115.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
