### PR TITLE
ci: do not tolerate rustc warnings in any job

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [alias]
 # Temporary solution to have clippy config in a single place until https://github.com/rust-lang/rust-clippy/blob/master/doc/roadmap-2021.md#lintstoml-configuration is shipped.
-custom-clippy = "clippy --workspace --all-features --all-targets -- -A clippy::type_complexity -A clippy::pedantic -W clippy::used_underscore_binding -W unreachable_pub -D warnings"
+custom-clippy = "clippy --workspace --all-features --all-targets -- -A clippy::type_complexity -A clippy::pedantic -W clippy::used_underscore_binding -W unreachable_pub"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2 # Fail cache download after 2 minutes.
+  RUSTFLAGS: '-Dwarnings' # Never tolerate warnings.
 
 jobs:
   test:

--- a/identity/src/error.rs
+++ b/identity/src/error.rs
@@ -77,11 +77,7 @@ impl DecodingError {
         }
     }
 
-    #[cfg(any(
-        all(feature = "rsa", not(target_arch = "wasm32")),
-        feature = "secp256k1",
-        feature = "ecdsa"
-    ))]
+    #[cfg(all(feature = "rsa", not(target_arch = "wasm32")))]
     pub(crate) fn encoding_unsupported(key_type: &'static str) -> Self {
         Self {
             msg: format!("encoding {key_type} key to Protobuf is unsupported"),
@@ -111,7 +107,7 @@ pub struct SigningError {
 
 /// An error during encoding of key material.
 impl SigningError {
-    #[cfg(any(feature = "secp256k1", feature = "rsa"))]
+    #[cfg(all(feature = "rsa", not(target_arch = "wasm32")))]
     pub(crate) fn new<S: ToString>(msg: S) -> Self {
         Self {
             msg: msg.to_string(),
@@ -119,7 +115,7 @@ impl SigningError {
         }
     }
 
-    #[cfg(feature = "rsa")]
+    #[cfg(all(feature = "rsa", not(target_arch = "wasm32")))]
     pub(crate) fn source(self, source: impl Error + Send + Sync + 'static) -> Self {
         Self {
             source: Some(Box::new(source)),

--- a/transports/webrtc/src/lib.rs
+++ b/transports/webrtc/src/lib.rs
@@ -83,6 +83,7 @@
 mod proto {
     #![allow(unreachable_pub)]
     include!("generated/mod.rs");
+    #[cfg(feature = "tokio")]
     pub(crate) use self::webrtc::pb::{mod_Message::Flag, Message};
 }
 


### PR DESCRIPTION
## Description

Previously, only the clippy job was denying warnings. We have many other CI jobs that compile our library in all sorts of configurations. All of them should be free of warnings.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
