### PR TITLE
feat(interop-tests): add ability to run chromedriver tests on Windows

### DIFF
--- a/interop-tests/src/bin/wasm_ping.rs
+++ b/interop-tests/src/bin/wasm_ping.rs
@@ -108,7 +108,6 @@ async fn open_in_browser() -> Result<(Child, WebDriver)> {
     } else {
         "chromedriver"
     };
-    
     let mut chrome = tokio::process::Command::new(chromedriver)
         .arg("--port=45782")
         .stdout(Stdio::piped())

--- a/interop-tests/src/bin/wasm_ping.rs
+++ b/interop-tests/src/bin/wasm_ping.rs
@@ -103,7 +103,13 @@ async fn open_in_browser() -> Result<(Child, WebDriver)> {
     // start a webdriver process
     // currently only the chromedriver is supported as firefox doesn't
     // have support yet for the certhashes
-    let mut chrome = tokio::process::Command::new("chromedriver")
+    let chromedriver = if cfg!(windows) {
+        "chromedriver.cmd"
+    } else {
+        "chromedriver"
+    };
+    
+    let mut chrome = tokio::process::Command::new(chromedriver)
         .arg("--port=45782")
         .stdout(Stdio::piped())
         .spawn()?;


### PR DESCRIPTION
## Description

When running on Windows OS, the command needs the `.cmd` extension in order to work.

## Notes & open questions

It's a small simple feature.  As discussed previously, this was moved to it's own PR.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
