### PR TITLE
feat(misc/server): add `libp2p-lookup` to `rust-libp2p-server`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-server"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "base64 0.21.3",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ libp2p-quic = { version = "0.9.2", path = "transports/quic" }
 libp2p-relay = { version = "0.16.1", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.13.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.25.1", path = "protocols/request-response" }
-libp2p-server = { version = "0.12.2", path = "misc/server" }
+libp2p-server = { version = "0.12.3", path = "misc/server" }
 libp2p-swarm = { version = "0.43.4", path = "swarm" }
 libp2p-swarm-derive = { version = "0.33.0", path = "swarm-derive" }
 libp2p-swarm-test = { version = "0.2.0", path = "swarm-test" }

--- a/misc/server/CHANGELOG.md
+++ b/misc/server/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.12.2]
+### Changed
+- Add libp2p-lookup to Dockerfile to enable healthchecks
+
+## [0.12.2]
 ### Fixed
 - Adhere to `--metrics-path` flag and listen on `0.0.0.0:8888` (default IPFS metrics port).
   [PR 4392]

--- a/misc/server/CHANGELOG.md
+++ b/misc/server/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.2]
 ### Changed
-- Add libp2p-lookup to Dockerfile to enable healthchecks
+- Add libp2p-lookup to Dockerfile to enable healthchecks.
 
 ## [0.12.2]
 ### Fixed

--- a/misc/server/CHANGELOG.md
+++ b/misc/server/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.12.2]
+## [0.12.3] - unreleased
 ### Changed
 - Add libp2p-lookup to Dockerfile to enable healthchecks.
 

--- a/misc/server/Cargo.toml
+++ b/misc/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-server"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2021"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/misc/server/Dockerfile
+++ b/misc/server/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/rust-libp2p-server
 WORKDIR /workspace
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    cargo install --root /usr/local libp2p-lookup
+    cargo install --root /usr/local libp2p-lookup  --version 0.6.4
 
 ADD . .
 RUN --mount=type=cache,target=./target \

--- a/misc/server/Dockerfile
+++ b/misc/server/Dockerfile
@@ -1,8 +1,12 @@
-FROM rust:1.66-bullseye as builder
+FROM rust:1.67-bullseye as builder
 WORKDIR /usr/src/rust-libp2p-server
 
 # Run with access to the target cache to speed up builds
 WORKDIR /workspace
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo install --root /usr/local libp2p-lookup
+
 ADD . .
 RUN --mount=type=cache,target=./target \
     --mount=type=cache,target=/usr/local/cargo/registry \
@@ -12,5 +16,5 @@ RUN --mount=type=cache,target=./target \
     mv ./target/release/libp2p-server /usr/local/bin/libp2p-server
 
 FROM gcr.io/distroless/cc
-COPY --from=builder /usr/local/bin/libp2p-server /usr/local/bin/libp2p-server
+COPY --from=builder /usr/local/bin/libp2p-server /usr/local/bin/libp2p-lookup /usr/local/bin/
 CMD ["libp2p-server"]

--- a/misc/server/Dockerfile
+++ b/misc/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.67-bullseye as builder
+FROM rust:1.72-bullseye as builder
 WORKDIR /usr/src/rust-libp2p-server
 
 # Run with access to the target cache to speed up builds

--- a/misc/server/Dockerfile
+++ b/misc/server/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/rust-libp2p-server
 WORKDIR /workspace
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    cargo install --root /usr/local libp2p-lookup  --version 0.6.4
+    cargo install --locked --root /usr/local libp2p-lookup  --version 0.6.4
 
 ADD . .
 RUN --mount=type=cache,target=./target \

--- a/misc/server/README.md
+++ b/misc/server/README.md
@@ -33,3 +33,9 @@ Local peer id: PeerId("12D3KooWSa1YEeQVSwvoqAMhwjKQ6kqZQckhWPb3RWEGV3sZGU6Z")
 Listening on "/ip4/127.0.0.1/udp/4001/quic"
 [...]
 ```
+
+The Docker container includes [libp2-lookup](https://github.com/mxinden/libp2p-lookup/) to enable adding a proper healthcheck for container startup, e.g.
+
+``` shell
+docker run --health-cmd 'libp2p-lookup direct --address /ip4/127.0.0.1/tcp/4001/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa' /home/ipfs/.ipfs:/ipfs ghcr.io/libp2p/rust-libp2p-server --config /ipfs/config
+```


### PR DESCRIPTION
## Description

As mentioned in #4444, we need to include https://github.com/mxinden/libp2p-lookup/ in the image so that we can enable a healthcheck when it starts up.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
