### PR TITLE
feat: add public construction for `QueryId`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+
+.idea

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.44.5 - unreleased
 - Migrate to `quick-protobuf-codec` crate for codec logic.
   See [PR 4501].
+- Add `From` impl for `QueryId` to allow construction for library consumers
 
 [PR 4501]: https://github.com/libp2p/rust-libp2p/pull/4501
 

--- a/protocols/kad/src/query.rs
+++ b/protocols/kad/src/query.rs
@@ -225,6 +225,12 @@ impl<TInner> QueryPool<TInner> {
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct QueryId(usize);
 
+impl<T: Into<usize>> From<T> for QueryId {
+    fn from(id: T) -> Self {
+        QueryId(id.into())
+    }
+}
+
 /// The configuration for queries in a `QueryPool`.
 #[derive(Debug, Clone)]
 pub(crate) struct QueryConfig {


### PR DESCRIPTION
## Description

Adding a way for `QueryId` to be constructed by the library consumer

## Notes & open questions

The reason I need this is I am creating an abstraction of Libp2p in my code so that I can have a `Swarm` trait rather than depending on the concrete swarm directly. This allows me to fake swarm behavior in my tests. I need to be able to generate `QueryId`s in these fakes :)

I don't believe these changes require documentation or tests, but happy to add anything the maintainers would like :)

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
