### PR TITLE
refactor(swarm): update ConnectionDenied::new

### DIFF
--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1728,9 +1728,9 @@ pub struct ConnectionDenied {
 }
 
 impl ConnectionDenied {
-    pub fn new(cause: impl error::Error + Send + Sync + 'static) -> Self {
+    pub fn new(cause: impl Into<Box<dyn error::Error + Send + Sync + 'static>>) -> Self {
         Self {
-            inner: Box::new(cause),
+            inner: cause.into(),
         }
     }
 


### PR DESCRIPTION
to accept `Into<Box<dyn Error>>`

## Description
This allows us to input `String`'s and `&str` on ConnectionDenied::new() as there's [`From<String> for Box<dyn Error + Send + Sync>`](https://doc.rust-lang.org/std/error/trait.Error.html#impl-From%3CString%3E-for-Box%3Cdyn+Error+%2B+Send+%2B+Sync,+Global%3E).
## Notes & open questions
I don't think this is breaking as [`T` impl's `Into<T>`.](https://doc.rust-lang.org/std/convert/trait.Into.html#generic-implementations) 
## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
