### PR TITLE
refactor(plaintext): rename symbols to follow naming convention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2868,7 +2868,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "asynchronous-codec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ libp2p-muxer-test-harness = { path = "muxers/test-harness" }
 libp2p-noise = { version = "0.43.1", path = "transports/noise" }
 libp2p-perf = { version = "0.2.0", path = "protocols/perf" }
 libp2p-ping = { version = "0.43.1", path = "protocols/ping" }
-libp2p-plaintext = { version = "0.40.0", path = "transports/plaintext" }
+libp2p-plaintext = { version = "0.40.1", path = "transports/plaintext" }
 libp2p-pnet = { version = "0.23.0", path = "transports/pnet" }
 libp2p-quic = { version = "0.9.2", path = "transports/quic" }
 libp2p-relay = { version = "0.16.1", path = "protocols/relay" }

--- a/muxers/mplex/benches/split_send_size.rs
+++ b/muxers/mplex/benches/split_send_size.rs
@@ -32,7 +32,7 @@ use libp2p_core::{multiaddr::multiaddr, muxing, transport, upgrade, Multiaddr, T
 use libp2p_identity as identity;
 use libp2p_identity::PeerId;
 use libp2p_mplex as mplex;
-use libp2p_plaintext::PlainText2Config;
+use libp2p_plaintext as plaintext;
 use std::pin::Pin;
 use std::time::Duration;
 
@@ -166,30 +166,28 @@ fn run(
 }
 
 fn tcp_transport(split_send_size: usize) -> BenchTransport {
-    let key = identity::Keypair::generate_ed25519();
-    let local_public_key = key.public();
-
     let mut mplex = mplex::MplexConfig::default();
     mplex.set_split_send_size(split_send_size);
 
     libp2p_tcp::async_io::Transport::new(libp2p_tcp::Config::default().nodelay(true))
         .upgrade(upgrade::Version::V1)
-        .authenticate(PlainText2Config { local_public_key })
+        .authenticate(plaintext::Config::new(
+            &identity::Keypair::generate_ed25519(),
+        ))
         .multiplex(mplex)
         .timeout(Duration::from_secs(5))
         .boxed()
 }
 
 fn mem_transport(split_send_size: usize) -> BenchTransport {
-    let key = identity::Keypair::generate_ed25519();
-    let local_public_key = key.public();
-
     let mut mplex = mplex::MplexConfig::default();
     mplex.set_split_send_size(split_send_size);
 
     transport::MemoryTransport::default()
         .upgrade(upgrade::Version::V1)
-        .authenticate(PlainText2Config { local_public_key })
+        .authenticate(plaintext::Config::new(
+            &identity::Keypair::generate_ed25519(),
+        ))
         .multiplex(mplex)
         .timeout(Duration::from_secs(5))
         .boxed()

--- a/protocols/dcutr/tests/lib.rs
+++ b/protocols/dcutr/tests/lib.rs
@@ -24,7 +24,7 @@ use libp2p_core::transport::{MemoryTransport, Transport};
 use libp2p_dcutr as dcutr;
 use libp2p_identity as identity;
 use libp2p_identity::PeerId;
-use libp2p_plaintext::PlainText2Config;
+use libp2p_plaintext as plaintext;
 use libp2p_relay as relay;
 use libp2p_swarm::{NetworkBehaviour, Swarm, SwarmBuilder, SwarmEvent};
 use libp2p_swarm_test::SwarmExt as _;
@@ -111,8 +111,7 @@ fn build_relay() -> Swarm<relay::Behaviour> {
 
 fn build_client() -> Swarm<Client> {
     let local_key = identity::Keypair::generate_ed25519();
-    let local_public_key = local_key.public();
-    let local_peer_id = local_public_key.to_peer_id();
+    let local_peer_id = local_key.public().to_peer_id();
 
     let (relay_transport, behaviour) = relay::client::new(local_peer_id);
 
@@ -120,7 +119,7 @@ fn build_client() -> Swarm<Client> {
         .or_transport(MemoryTransport::default())
         .or_transport(libp2p_tcp::async_io::Transport::default())
         .upgrade(Version::V1)
-        .authenticate(PlainText2Config { local_public_key })
+        .authenticate(plaintext::Config::new(&local_key))
         .multiplex(libp2p_yamux::Config::default())
         .boxed();
 

--- a/protocols/relay/tests/lib.rs
+++ b/protocols/relay/tests/lib.rs
@@ -30,9 +30,8 @@ use libp2p_core::transport::{Boxed, MemoryTransport, Transport};
 use libp2p_core::upgrade;
 use libp2p_identity as identity;
 use libp2p_identity::PeerId;
-use libp2p_identity::PublicKey;
 use libp2p_ping as ping;
-use libp2p_plaintext::PlainText2Config;
+use libp2p_plaintext as plaintext;
 use libp2p_relay as relay;
 use libp2p_swarm::{NetworkBehaviour, Swarm, SwarmBuilder, SwarmEvent};
 use std::time::Duration;
@@ -307,10 +306,9 @@ fn reuse_connection() {
 
 fn build_relay() -> Swarm<Relay> {
     let local_key = identity::Keypair::generate_ed25519();
-    let local_public_key = local_key.public();
-    let local_peer_id = local_public_key.to_peer_id();
+    let local_peer_id = local_key.public().to_peer_id();
 
-    let transport = upgrade_transport(MemoryTransport::default().boxed(), local_public_key);
+    let transport = upgrade_transport(MemoryTransport::default().boxed(), &local_key);
 
     SwarmBuilder::with_async_std_executor(
         transport,
@@ -331,13 +329,12 @@ fn build_relay() -> Swarm<Relay> {
 
 fn build_client() -> Swarm<Client> {
     let local_key = identity::Keypair::generate_ed25519();
-    let local_public_key = local_key.public();
-    let local_peer_id = local_public_key.to_peer_id();
+    let local_peer_id = local_key.public().to_peer_id();
 
     let (relay_transport, behaviour) = relay::client::new(local_peer_id);
     let transport = upgrade_transport(
         OrTransport::new(relay_transport, MemoryTransport::default()).boxed(),
-        local_public_key,
+        &local_key,
     );
 
     SwarmBuilder::with_async_std_executor(
@@ -353,14 +350,14 @@ fn build_client() -> Swarm<Client> {
 
 fn upgrade_transport<StreamSink>(
     transport: Boxed<StreamSink>,
-    local_public_key: PublicKey,
+    identity: &identity::Keypair,
 ) -> Boxed<(PeerId, StreamMuxerBox)>
 where
     StreamSink: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     transport
         .upgrade(upgrade::Version::V1)
-        .authenticate(PlainText2Config { local_public_key })
+        .authenticate(plaintext::Config::new(identity))
         .multiplex(libp2p_yamux::Config::default())
         .boxed()
 }

--- a/swarm-test/src/lib.rs
+++ b/swarm-test/src/lib.rs
@@ -41,8 +41,8 @@ pub trait SwarmExt {
 
     /// Create a new [`Swarm`] with an ephemeral identity.
     ///
-    /// The swarm will use a [`MemoryTransport`] together with [`Config`] authentication layer and
-    /// yamux as the multiplexer. However, these details should not be relied upon by the test
+    /// The swarm will use a [`MemoryTransport`] together with a [`plaintext::Config`] authentication layer and
+    /// [`yamux::Config`] as the multiplexer. However, these details should not be relied upon by the test
     /// and may change at any time.
     fn new_ephemeral(behaviour_fn: impl FnOnce(Keypair) -> Self::NB) -> Self
     where

--- a/swarm-test/src/lib.rs
+++ b/swarm-test/src/lib.rs
@@ -25,7 +25,7 @@ use libp2p_core::{
     multiaddr::Protocol, transport::MemoryTransport, upgrade::Version, Multiaddr, Transport,
 };
 use libp2p_identity::{Keypair, PeerId};
-use libp2p_plaintext::PlainText2Config;
+use libp2p_plaintext as plaintext;
 use libp2p_swarm::dial_opts::PeerCondition;
 use libp2p_swarm::{
     dial_opts::DialOpts, NetworkBehaviour, Swarm, SwarmBuilder, SwarmEvent, THandlerErr,
@@ -41,7 +41,7 @@ pub trait SwarmExt {
 
     /// Create a new [`Swarm`] with an ephemeral identity.
     ///
-    /// The swarm will use a [`MemoryTransport`] together with [`PlainText2Config`] authentication layer and
+    /// The swarm will use a [`MemoryTransport`] together with [`Config`] authentication layer and
     /// yamux as the multiplexer. However, these details should not be relied upon by the test
     /// and may change at any time.
     fn new_ephemeral(behaviour_fn: impl FnOnce(Keypair) -> Self::NB) -> Self
@@ -211,9 +211,7 @@ where
         let transport = MemoryTransport::default()
             .or_transport(libp2p_tcp::async_io::Transport::default())
             .upgrade(Version::V1)
-            .authenticate(PlainText2Config {
-                local_public_key: identity.public(),
-            })
+            .authenticate(plaintext::Config::new(&identity))
             .multiplex(yamux::Config::default())
             .timeout(Duration::from_secs(20))
             .boxed();

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1848,9 +1848,7 @@ mod tests {
         let local_public_key = id_keys.public();
         let transport = transport::MemoryTransport::default()
             .upgrade(upgrade::Version::V1)
-            .authenticate(plaintext::PlainText2Config {
-                local_public_key: local_public_key.clone(),
-            })
+            .authenticate(plaintext::Config::new(&id_keys))
             .multiplex(yamux::Config::default())
             .boxed();
         let behaviour = CallTraceBehaviour::new(MockBehaviour::new(dummy::ConnectionHandler));

--- a/transports/plaintext/CHANGELOG.md
+++ b/transports/plaintext/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.40.1 - unreleased
 
 - Rename `Plaintext2Config` to `Config` to follow naming conventions across repository.
-  See [PR XXXX](XXXX).  
+  See [PR 4535](https://github.com/libp2p/rust-libp2p/pull/4535).
 
 ## 0.40.0 
 

--- a/transports/plaintext/CHANGELOG.md
+++ b/transports/plaintext/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.40.1 - unreleased
+
+- Rename `Plaintext2Config` to `Config` to follow naming conventions across repository.
+  See [PR XXXX](XXXX).  
+
 ## 0.40.0 
 
 - Raise MSRV to 1.65.

--- a/transports/plaintext/Cargo.toml
+++ b/transports/plaintext/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-plaintext"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Plaintext encryption dummy protocol for libp2p"
-version = "0.40.0"
+version = "0.40.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/transports/plaintext/src/error.rs
+++ b/transports/plaintext/src/error.rs
@@ -23,9 +23,9 @@ use std::fmt;
 use std::io::Error as IoError;
 
 #[derive(Debug)]
-pub enum PlainTextError {
+pub enum Error {
     /// I/O error.
-    IoError(IoError),
+    Io(IoError),
 
     /// Failed to parse the handshake protobuf message.
     InvalidPayload(DecodeError),
@@ -55,52 +55,52 @@ impl error::Error for DecodeError {
     }
 }
 
-impl error::Error for PlainTextError {
+impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
-            PlainTextError::IoError(ref err) => Some(err),
-            PlainTextError::InvalidPayload(ref err) => Some(err),
-            PlainTextError::InvalidPublicKey(ref err) => Some(err),
-            PlainTextError::InvalidPeerId(ref err) => Some(err),
+            Error::Io(ref err) => Some(err),
+            Error::InvalidPayload(ref err) => Some(err),
+            Error::InvalidPublicKey(ref err) => Some(err),
+            Error::InvalidPeerId(ref err) => Some(err),
             _ => None,
         }
     }
 }
 
-impl fmt::Display for PlainTextError {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
-            PlainTextError::IoError(e) => write!(f, "I/O error: {e}"),
-            PlainTextError::InvalidPayload(_) => f.write_str("Failed to decode protobuf"),
-            PlainTextError::PeerIdMismatch => f.write_str(
+            Error::Io(e) => write!(f, "I/O error: {e}"),
+            Error::InvalidPayload(_) => f.write_str("Failed to decode protobuf"),
+            Error::PeerIdMismatch => f.write_str(
                 "The peer id of the exchange isn't consistent with the remote public key",
             ),
-            PlainTextError::InvalidPublicKey(_) => f.write_str("Failed to decode public key"),
-            PlainTextError::InvalidPeerId(_) => f.write_str("Failed to decode PeerId"),
+            Error::InvalidPublicKey(_) => f.write_str("Failed to decode public key"),
+            Error::InvalidPeerId(_) => f.write_str("Failed to decode PeerId"),
         }
     }
 }
 
-impl From<IoError> for PlainTextError {
-    fn from(err: IoError) -> PlainTextError {
-        PlainTextError::IoError(err)
+impl From<IoError> for Error {
+    fn from(err: IoError) -> Error {
+        Error::Io(err)
     }
 }
 
-impl From<DecodeError> for PlainTextError {
-    fn from(err: DecodeError) -> PlainTextError {
-        PlainTextError::InvalidPayload(err)
+impl From<DecodeError> for Error {
+    fn from(err: DecodeError) -> Error {
+        Error::InvalidPayload(err)
     }
 }
 
-impl From<libp2p_identity::DecodingError> for PlainTextError {
-    fn from(err: libp2p_identity::DecodingError) -> PlainTextError {
-        PlainTextError::InvalidPublicKey(err)
+impl From<libp2p_identity::DecodingError> for Error {
+    fn from(err: libp2p_identity::DecodingError) -> Error {
+        Error::InvalidPublicKey(err)
     }
 }
 
-impl From<libp2p_identity::ParseError> for PlainTextError {
-    fn from(err: libp2p_identity::ParseError) -> PlainTextError {
-        PlainTextError::InvalidPeerId(err)
+impl From<libp2p_identity::ParseError> for Error {
+    fn from(err: libp2p_identity::ParseError) -> Error {
+        Error::InvalidPeerId(err)
     }
 }

--- a/transports/plaintext/src/handshake.rs
+++ b/transports/plaintext/src/handshake.rs
@@ -18,9 +18,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::error::{DecodeError, PlainTextError};
+use crate::error::{DecodeError, Error};
 use crate::proto::Exchange;
-use crate::PlainText2Config;
+use crate::Config;
 
 use asynchronous_codec::{Framed, FramedParts};
 use bytes::{Bytes, BytesMut};
@@ -32,7 +32,7 @@ use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use unsigned_varint::codec::UviBytes;
 
 struct HandshakeContext<T> {
-    config: PlainText2Config,
+    config: Config,
     state: T,
 }
 
@@ -50,7 +50,8 @@ pub(crate) struct Remote {
 }
 
 impl HandshakeContext<Local> {
-    fn new(config: PlainText2Config) -> Self {
+    fn new(config: Config) -> Self {
+        #[allow(deprecated)]
         let exchange = Exchange {
             id: Some(config.local_public_key.to_peer_id().to_bytes()),
             pubkey: Some(config.local_public_key.encode_protobuf()),
@@ -69,10 +70,7 @@ impl HandshakeContext<Local> {
         }
     }
 
-    fn with_remote(
-        self,
-        exchange_bytes: BytesMut,
-    ) -> Result<HandshakeContext<Remote>, PlainTextError> {
+    fn with_remote(self, exchange_bytes: BytesMut) -> Result<HandshakeContext<Remote>, Error> {
         let mut reader = BytesReader::from_bytes(&exchange_bytes);
         let prop = Exchange::from_reader(&mut reader, &exchange_bytes).map_err(DecodeError)?;
 
@@ -81,7 +79,7 @@ impl HandshakeContext<Local> {
 
         // Check the validity of the remote's `Exchange`.
         if peer_id != public_key.to_peer_id() {
-            return Err(PlainTextError::PeerIdMismatch);
+            return Err(Error::PeerIdMismatch);
         }
 
         Ok(HandshakeContext {
@@ -94,10 +92,7 @@ impl HandshakeContext<Local> {
     }
 }
 
-pub(crate) async fn handshake<S>(
-    socket: S,
-    config: PlainText2Config,
-) -> Result<(S, Remote, Bytes), PlainTextError>
+pub(crate) async fn handshake<S>(socket: S, config: Config) -> Result<(S, Remote, Bytes), Error>
 where
     S: AsyncRead + AsyncWrite + Send + Unpin,
 {

--- a/transports/plaintext/tests/smoke.rs
+++ b/transports/plaintext/tests/smoke.rs
@@ -21,7 +21,7 @@
 use futures::io::{AsyncReadExt, AsyncWriteExt};
 use libp2p_core::InboundUpgrade;
 use libp2p_identity as identity;
-use libp2p_plaintext::PlainText2Config;
+use libp2p_plaintext as plaintext;
 use log::debug;
 use quickcheck::QuickCheck;
 
@@ -34,10 +34,7 @@ fn variable_msg_length() {
         let msg_to_receive = msg;
 
         let server_id = identity::Keypair::generate_ed25519();
-        let server_id_public = server_id.public();
-
         let client_id = identity::Keypair::generate_ed25519();
-        let client_id_public = client_id.public();
 
         let (server, client) = futures_ringbuf::Endpoint::pair(100, 100);
 
@@ -46,14 +43,8 @@ fn variable_msg_length() {
                 (received_client_id, mut server_channel),
                 (received_server_id, mut client_channel),
             ) = futures::future::try_join(
-                PlainText2Config {
-                    local_public_key: server_id_public,
-                }
-                .upgrade_inbound(server, ""),
-                PlainText2Config {
-                    local_public_key: client_id_public,
-                }
-                .upgrade_inbound(client, ""),
+                plaintext::Config::new(&server_id).upgrade_inbound(server, ""),
+                plaintext::Config::new(&client_id).upgrade_inbound(client, ""),
             )
             .await
             .unwrap();


### PR DESCRIPTION
## Description

Related: #2217.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

I've recently worked with the plaintext protocol again as part of debugging the hole punching tests and thus noticed that we haven't renamed the symbols in that one yet.

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
