### PR TITLE
refactor(noise): modify message framing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,6 +2795,7 @@ dependencies = [
 name = "libp2p-noise"
 version = "0.43.1"
 dependencies = [
+ "asynchronous-codec",
  "bytes",
  "curve25519-dalek 4.1.0",
  "env_logger 0.10.0",
@@ -2806,13 +2807,16 @@ dependencies = [
  "multiaddr",
  "multihash",
  "once_cell",
+ "pin-project",
  "quick-protobuf",
+ "quick-protobuf-codec",
  "quickcheck-ext",
  "rand 0.8.5",
  "sha2 0.10.7",
  "snow",
  "static_assertions",
  "thiserror",
+ "unsigned-varint",
  "x25519-dalek 1.1.1",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "asynchronous-codec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ libp2p-memory-connection-limits = { version = "0.1.0", path = "misc/memory-conne
 libp2p-metrics = { version = "0.13.1", path = "misc/metrics" }
 libp2p-mplex = { version = "0.40.0", path = "muxers/mplex" }
 libp2p-muxer-test-harness = { path = "muxers/test-harness" }
-libp2p-noise = { version = "0.43.1", path = "transports/noise" }
+libp2p-noise = { version = "0.43.2", path = "transports/noise" }
 libp2p-perf = { version = "0.2.0", path = "protocols/perf" }
 libp2p-ping = { version = "0.43.1", path = "protocols/ping" }
 libp2p-plaintext = { version = "0.40.0", path = "transports/plaintext" }

--- a/transports/noise/CHANGELOG.md
+++ b/transports/noise/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.43.2
+
+- Refactor noise io framing and protobuf encoding/decoding.
+  This migrates to the `asynchronous_codec::Framed` type to provide an implementation of `Sink` and
+  `Stream` for noise payloads, and introduces using `quick_protobuf_codec::Codec` for encoding/decoding
+  protobuf messages.
+  See [PR 4544].
+
+[PR 4544]: https://github.com/libp2p/rust-libp2p/pull/4544
+
 ## 0.43.1
 
 - Update dependencies.

--- a/transports/noise/Cargo.toml
+++ b/transports/noise/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-noise"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Cryptographic handshake protocol using the noise framework."
-version = "0.43.1"
+version = "0.43.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/transports/noise/Cargo.toml
+++ b/transports/noise/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
 
 [dependencies]
+asynchronous-codec = "0.6"
 bytes = "1"
 curve25519-dalek = "4.1.0"
 futures = "0.3.28"
@@ -18,11 +19,14 @@ log = "0.4"
 multiaddr = { workspace = true }
 multihash = { workspace = true }
 once_cell = "1.18.0"
+pin-project = "1.1.3"
 quick-protobuf = "0.8"
+quick-protobuf-codec = { workspace = true }
 rand = "0.8.3"
 sha2 = "0.10.7"
 static_assertions = "1"
 thiserror = "1.0.48"
+unsigned-varint = { version = "0.7" }
 x25519-dalek = "1.1.0"
 zeroize = "1"
 

--- a/transports/noise/src/io.rs
+++ b/transports/noise/src/io.rs
@@ -29,7 +29,7 @@ use futures::ready;
 use log::trace;
 use std::{
     cmp::min,
-    fmt, io,
+    io,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -43,12 +43,6 @@ pub struct Output<T> {
     recv_offset: usize,
     send_buffer: Vec<u8>,
     send_offset: usize,
-}
-
-impl<T> fmt::Debug for Output<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("NoiseOutput").field("io", &self.io).finish()
-    }
 }
 
 impl<T> Output<T> {
@@ -91,7 +85,7 @@ impl<T: AsyncRead + Unpin> AsyncRead for Output<T> {
                 Poll::Ready(None) => return Poll::Ready(Ok(0)),
                 Poll::Ready(Some(Err(e))) => return Poll::Ready(Err(e)),
                 Poll::Ready(Some(Ok(frame))) => {
-                    self.recv_buffer = frame;
+                    self.recv_buffer = frame.into();
                     self.recv_offset = 0;
                 }
             }
@@ -113,7 +107,7 @@ impl<T: AsyncWrite + Unpin> AsyncWrite for Output<T> {
         if this.send_offset == MAX_FRAME_LEN {
             trace!("write: sending {} bytes", MAX_FRAME_LEN);
             ready!(io.as_mut().poll_ready(cx))?;
-            io.as_mut().start_send(frame_buf)?;
+            io.as_mut().start_send(frame_buf.clone())?;
             this.send_offset = 0;
         }
 
@@ -137,7 +131,7 @@ impl<T: AsyncWrite + Unpin> AsyncWrite for Output<T> {
         if this.send_offset > 0 {
             ready!(io.as_mut().poll_ready(cx))?;
             trace!("flush: sending {} bytes", this.send_offset);
-            io.as_mut().start_send(frame_buf)?;
+            io.as_mut().start_send(frame_buf.clone())?;
             this.send_offset = 0;
         }
 

--- a/transports/noise/src/io/framed.rs
+++ b/transports/noise/src/io/framed.rs
@@ -25,15 +25,15 @@ use crate::io::Output;
 use crate::{protocol::PublicKey, Error};
 use bytes::{Bytes, BytesMut};
 use futures::prelude::*;
-use futures::ready;
-use log::{debug, trace};
+use log::{debug, error};
 use std::{
-    fmt, io,
+    io,
     pin::Pin,
     task::{Context, Poll},
 };
+use unsigned_varint::codec::UviBytes;
 
-/// Max. size of a noise message.
+/// Max size of a noise message.
 const MAX_NOISE_MSG_LEN: usize = 65535;
 /// Space given to the encryption buffer to hold key material.
 const EXTRA_ENCRYPT_SPACE: usize = 1024;
@@ -48,45 +48,42 @@ static_assertions::const_assert! {
 ///
 /// `T` is the type of the underlying I/O resource and `S` the
 /// type of the Noise session state.
+#[pin_project::pin_project]
 pub(crate) struct NoiseFramed<T, S> {
-    io: T,
-    session: S,
-    read_state: ReadState,
-    write_state: WriteState,
-    read_buffer: Vec<u8>,
-    write_buffer: Vec<u8>,
-    decrypt_buffer: BytesMut,
+    #[pin]
+    io: asynchronous_codec::Framed<T, Codec<S>>,
 }
 
-impl<T, S> fmt::Debug for NoiseFramed<T, S> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("NoiseFramed")
-            .field("read_state", &self.read_state)
-            .field("write_state", &self.write_state)
-            .finish()
-    }
-}
-
-impl<T> NoiseFramed<T, snow::HandshakeState> {
-    /// Creates a nwe `NoiseFramed` for beginning a Noise protocol handshake.
+impl<T> NoiseFramed<T, snow::HandshakeState>
+where
+    T: AsyncRead + AsyncWrite,
+{
+    /// Creates a new `NoiseFramed` for beginning a Noise protocol handshake.
     pub(crate) fn new(io: T, state: snow::HandshakeState) -> Self {
+        let mut uvi = UviBytes::default();
+        uvi.set_max_len(MAX_NOISE_MSG_LEN);
+
         NoiseFramed {
-            io,
-            session: state,
-            read_state: ReadState::Ready,
-            write_state: WriteState::Ready,
-            read_buffer: Vec::new(),
-            write_buffer: Vec::new(),
-            decrypt_buffer: BytesMut::new(),
+            io: asynchronous_codec::Framed::new(
+                io,
+                Codec {
+                    uvi,
+                    session: state,
+                    write_buffer: Vec::new(),
+                    decrypt_buffer: BytesMut::new(),
+                },
+            ),
         }
     }
 
+    /// Checks if the underlying noise session was started in the `initiator` role.
     pub(crate) fn is_initiator(&self) -> bool {
-        self.session.is_initiator()
+        self.io.codec().session.is_initiator()
     }
 
+    /// Checks if the underlying noise session was started in the `responder` role.
     pub(crate) fn is_responder(&self) -> bool {
-        !self.session.is_initiator()
+        !self.io.codec().session.is_initiator()
     }
 
     /// Converts the `NoiseFramed` into a `NoiseOutput` encrypted data stream
@@ -98,7 +95,7 @@ impl<T> NoiseFramed<T, snow::HandshakeState> {
     /// an error is returned. Similarly if the remote's static DH key, if
     /// present, cannot be parsed.
     pub(crate) fn into_transport(self) -> Result<(PublicKey, Output<T>), Error> {
-        let dh_remote_pubkey = self.session.get_remote_static().ok_or_else(|| {
+        let dh_remote_pubkey = self.io.codec().session.get_remote_static().ok_or_else(|| {
             Error::Io(io::Error::new(
                 io::ErrorKind::Other,
                 "expect key to always be present at end of XX session",
@@ -106,270 +103,124 @@ impl<T> NoiseFramed<T, snow::HandshakeState> {
         })?;
 
         let dh_remote_pubkey = PublicKey::from_slice(dh_remote_pubkey)?;
+        let framed_parts = self.io.into_parts();
 
+        let mut uvi = UviBytes::default();
+        uvi.set_max_len(MAX_FRAME_LEN + EXTRA_ENCRYPT_SPACE);
         let io = NoiseFramed {
-            session: self.session.into_transport_mode()?,
-            io: self.io,
-            read_state: ReadState::Ready,
-            write_state: WriteState::Ready,
-            read_buffer: self.read_buffer,
-            write_buffer: self.write_buffer,
-            decrypt_buffer: self.decrypt_buffer,
+            io: asynchronous_codec::Framed::new(
+                framed_parts.io,
+                Codec {
+                    uvi,
+                    session: framed_parts.codec.session.into_transport_mode()?,
+                    write_buffer: Vec::new(),
+                    decrypt_buffer: BytesMut::new(),
+                },
+            ),
         };
 
         Ok((dh_remote_pubkey, Output::new(io)))
     }
 }
 
-/// The states for reading Noise protocol frames.
-#[derive(Debug)]
-enum ReadState {
-    /// Ready to read another frame.
-    Ready,
-    /// Reading frame length.
-    ReadLen { buf: [u8; 2], off: usize },
-    /// Reading frame data.
-    ReadData { len: usize, off: usize },
-    /// EOF has been reached (terminal state).
-    ///
-    /// The associated result signals if the EOF was unexpected or not.
-    Eof(Result<(), ()>),
-    /// A decryption error occurred (terminal state).
-    DecErr,
+/// Codec for writing and reading length-delimited noise session messages.
+pub(crate) struct Codec<S> {
+    uvi: UviBytes,
+    write_buffer: Vec<u8>,
+    decrypt_buffer: BytesMut,
+    session: S,
 }
 
-/// The states for writing Noise protocol frames.
-#[derive(Debug)]
-enum WriteState {
-    /// Ready to write another frame.
-    Ready,
-    /// Writing the frame length.
-    WriteLen {
-        len: usize,
-        buf: [u8; 2],
-        off: usize,
-    },
-    /// Writing the frame data.
-    WriteData { len: usize, off: usize },
-    /// EOF has been reached unexpectedly (terminal state).
-    Eof,
-    /// An encryption error occurred (terminal state).
-    EncErr,
+impl<S> asynchronous_codec::Encoder for Codec<S>
+where
+    S: SessionState,
+{
+    type Error = io::Error;
+    type Item = Vec<u8>;
+
+    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        self.write_buffer
+            .resize(item.len() + EXTRA_ENCRYPT_SPACE, 0u8);
+
+        let n = match self.session.write_message(&item, &mut self.write_buffer) {
+            Ok(n) => n,
+            Err(e) => {
+                error!("encryption error: {:?}", e);
+                return Err(io::ErrorKind::InvalidData.into());
+            }
+        };
+        self.write_buffer.truncate(n);
+        self.uvi
+            .encode(Bytes::copy_from_slice(&self.write_buffer), dst)?;
+
+        Ok(())
+    }
 }
 
-impl WriteState {
-    fn is_ready(&self) -> bool {
-        if let WriteState::Ready = self {
-            return true;
-        }
-        false
+impl<S> asynchronous_codec::Decoder for Codec<S>
+where
+    S: SessionState,
+{
+    type Error = io::Error;
+    type Item = BytesMut;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        let msg = match self.uvi.decode(src)? {
+            None => return Ok(None),
+            Some(msg) => msg,
+        };
+
+        self.decrypt_buffer.resize(msg.len(), 0u8);
+        let n = match self.session.read_message(&msg, &mut self.decrypt_buffer) {
+            Ok(n) => n,
+            Err(e) => {
+                debug!("read: decryption error {e}");
+                return Err(io::ErrorKind::InvalidData.into());
+            }
+        };
+        self.decrypt_buffer.truncate(n);
+        Ok(Some(self.decrypt_buffer.split()))
     }
 }
 
 impl<T, S> futures::stream::Stream for NoiseFramed<T, S>
 where
     T: AsyncRead + Unpin,
-    S: SessionState + Unpin,
+    S: SessionState,
 {
-    type Item = io::Result<Bytes>;
+    type Item = io::Result<BytesMut>;
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = Pin::into_inner(self);
-        loop {
-            trace!("read state: {:?}", this.read_state);
-            match this.read_state {
-                ReadState::Ready => {
-                    this.read_state = ReadState::ReadLen {
-                        buf: [0, 0],
-                        off: 0,
-                    };
-                }
-                ReadState::ReadLen { mut buf, mut off } => {
-                    let n = match read_frame_len(&mut this.io, cx, &mut buf, &mut off) {
-                        Poll::Ready(Ok(Some(n))) => n,
-                        Poll::Ready(Ok(None)) => {
-                            trace!("read: eof");
-                            this.read_state = ReadState::Eof(Ok(()));
-                            return Poll::Ready(None);
-                        }
-                        Poll::Ready(Err(e)) => return Poll::Ready(Some(Err(e))),
-                        Poll::Pending => {
-                            this.read_state = ReadState::ReadLen { buf, off };
-                            return Poll::Pending;
-                        }
-                    };
-                    trace!("read: frame len = {}", n);
-                    if n == 0 {
-                        trace!("read: empty frame");
-                        this.read_state = ReadState::Ready;
-                        continue;
-                    }
-                    this.read_buffer.resize(usize::from(n), 0u8);
-                    this.read_state = ReadState::ReadData {
-                        len: usize::from(n),
-                        off: 0,
-                    }
-                }
-                ReadState::ReadData { len, ref mut off } => {
-                    let n = {
-                        let f =
-                            Pin::new(&mut this.io).poll_read(cx, &mut this.read_buffer[*off..len]);
-                        match ready!(f) {
-                            Ok(n) => n,
-                            Err(e) => return Poll::Ready(Some(Err(e))),
-                        }
-                    };
-                    trace!("read: {}/{} bytes", *off + n, len);
-                    if n == 0 {
-                        trace!("read: eof");
-                        this.read_state = ReadState::Eof(Err(()));
-                        return Poll::Ready(Some(Err(io::ErrorKind::UnexpectedEof.into())));
-                    }
-                    *off += n;
-                    if len == *off {
-                        trace!("read: decrypting {} bytes", len);
-                        this.decrypt_buffer.resize(len, 0);
-                        if let Ok(n) = this
-                            .session
-                            .read_message(&this.read_buffer, &mut this.decrypt_buffer)
-                        {
-                            this.decrypt_buffer.truncate(n);
-                            trace!("read: payload len = {} bytes", n);
-                            this.read_state = ReadState::Ready;
-                            // Return an immutable view into the current buffer.
-                            // If the view is dropped before the next frame is
-                            // read, the `BytesMut` will reuse the same buffer
-                            // for the next frame.
-                            let view = this.decrypt_buffer.split().freeze();
-                            return Poll::Ready(Some(Ok(view)));
-                        } else {
-                            debug!("read: decryption error");
-                            this.read_state = ReadState::DecErr;
-                            return Poll::Ready(Some(Err(io::ErrorKind::InvalidData.into())));
-                        }
-                    }
-                }
-                ReadState::Eof(Ok(())) => {
-                    trace!("read: eof");
-                    return Poll::Ready(None);
-                }
-                ReadState::Eof(Err(())) => {
-                    trace!("read: eof (unexpected)");
-                    return Poll::Ready(Some(Err(io::ErrorKind::UnexpectedEof.into())));
-                }
-                ReadState::DecErr => {
-                    return Poll::Ready(Some(Err(io::ErrorKind::InvalidData.into())))
-                }
-            }
-        }
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.io.poll_next_unpin(cx)
     }
 }
-
-impl<T, S> futures::sink::Sink<&Vec<u8>> for NoiseFramed<T, S>
+impl<T, S> futures::sink::Sink<Vec<u8>> for NoiseFramed<T, S>
 where
     T: AsyncWrite + Unpin,
-    S: SessionState + Unpin,
+    S: SessionState,
 {
     type Error = io::Error;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        let this = Pin::into_inner(self);
-        loop {
-            trace!("write state {:?}", this.write_state);
-            match this.write_state {
-                WriteState::Ready => {
-                    return Poll::Ready(Ok(()));
-                }
-                WriteState::WriteLen { len, buf, mut off } => {
-                    trace!("write: frame len ({}, {:?}, {}/2)", len, buf, off);
-                    match write_frame_len(&mut this.io, cx, &buf, &mut off) {
-                        Poll::Ready(Ok(true)) => (),
-                        Poll::Ready(Ok(false)) => {
-                            trace!("write: eof");
-                            this.write_state = WriteState::Eof;
-                            return Poll::Ready(Err(io::ErrorKind::WriteZero.into()));
-                        }
-                        Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                        Poll::Pending => {
-                            this.write_state = WriteState::WriteLen { len, buf, off };
-                            return Poll::Pending;
-                        }
-                    }
-                    this.write_state = WriteState::WriteData { len, off: 0 }
-                }
-                WriteState::WriteData { len, ref mut off } => {
-                    let n = {
-                        let f =
-                            Pin::new(&mut this.io).poll_write(cx, &this.write_buffer[*off..len]);
-                        match ready!(f) {
-                            Ok(n) => n,
-                            Err(e) => return Poll::Ready(Err(e)),
-                        }
-                    };
-                    if n == 0 {
-                        trace!("write: eof");
-                        this.write_state = WriteState::Eof;
-                        return Poll::Ready(Err(io::ErrorKind::WriteZero.into()));
-                    }
-                    *off += n;
-                    trace!("write: {}/{} bytes written", *off, len);
-                    if len == *off {
-                        trace!("write: finished with {} bytes", len);
-                        this.write_state = WriteState::Ready;
-                    }
-                }
-                WriteState::Eof => {
-                    trace!("write: eof");
-                    return Poll::Ready(Err(io::ErrorKind::WriteZero.into()));
-                }
-                WriteState::EncErr => return Poll::Ready(Err(io::ErrorKind::InvalidData.into())),
-            }
-        }
+        self.project().io.poll_ready(cx)
     }
-
-    fn start_send(self: Pin<&mut Self>, frame: &Vec<u8>) -> Result<(), Self::Error> {
-        assert!(frame.len() <= MAX_FRAME_LEN);
-        let this = Pin::into_inner(self);
-        assert!(this.write_state.is_ready());
-
-        this.write_buffer
-            .resize(frame.len() + EXTRA_ENCRYPT_SPACE, 0u8);
-        match this
-            .session
-            .write_message(frame, &mut this.write_buffer[..])
-        {
-            Ok(n) => {
-                trace!("write: cipher text len = {} bytes", n);
-                this.write_buffer.truncate(n);
-                this.write_state = WriteState::WriteLen {
-                    len: n,
-                    buf: u16::to_be_bytes(n as u16),
-                    off: 0,
-                };
-                Ok(())
-            }
-            Err(e) => {
-                log::error!("encryption error: {:?}", e);
-                this.write_state = WriteState::EncErr;
-                Err(io::ErrorKind::InvalidData.into())
-            }
-        }
+    fn start_send(self: Pin<&mut Self>, item: Vec<u8>) -> Result<(), Self::Error> {
+        self.project().io.start_send(item)
     }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        ready!(self.as_mut().poll_ready(cx))?;
-        Pin::new(&mut self.io).poll_flush(cx)
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.project().io.poll_flush(cx)
     }
-
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        ready!(self.as_mut().poll_flush(cx))?;
-        Pin::new(&mut self.io).poll_close(cx)
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.project().io.poll_close(cx)
     }
 }
 
 /// A stateful context in which Noise protocol messages can be read and written.
 pub(crate) trait SessionState {
+    /// Decrypt the payload `msg` with the session state and read the result to `buf`.
     fn read_message(&mut self, msg: &[u8], buf: &mut [u8]) -> Result<usize, snow::Error>;
+
+    /// Encrypt the payload `msg` with the session state and write the result to `buf`.
     fn write_message(&mut self, msg: &[u8], buf: &mut [u8]) -> Result<usize, snow::Error>;
 }
 
@@ -390,71 +241,5 @@ impl SessionState for snow::TransportState {
 
     fn write_message(&mut self, msg: &[u8], buf: &mut [u8]) -> Result<usize, snow::Error> {
         self.write_message(msg, buf)
-    }
-}
-
-/// Read 2 bytes as frame length from the given source into the given buffer.
-///
-/// Panics if `off >= 2`.
-///
-/// When [`Poll::Pending`] is returned, the given buffer and offset
-/// may have been updated (i.e. a byte may have been read) and must be preserved
-/// for the next invocation.
-///
-/// Returns `None` if EOF has been encountered.
-fn read_frame_len<R: AsyncRead + Unpin>(
-    mut io: &mut R,
-    cx: &mut Context<'_>,
-    buf: &mut [u8; 2],
-    off: &mut usize,
-) -> Poll<io::Result<Option<u16>>> {
-    loop {
-        match ready!(Pin::new(&mut io).poll_read(cx, &mut buf[*off..])) {
-            Ok(n) => {
-                if n == 0 {
-                    return Poll::Ready(Ok(None));
-                }
-                *off += n;
-                if *off == 2 {
-                    return Poll::Ready(Ok(Some(u16::from_be_bytes(*buf))));
-                }
-            }
-            Err(e) => {
-                return Poll::Ready(Err(e));
-            }
-        }
-    }
-}
-
-/// Write 2 bytes as frame length from the given buffer into the given sink.
-///
-/// Panics if `off >= 2`.
-///
-/// When [`Poll::Pending`] is returned, the given offset
-/// may have been updated (i.e. a byte may have been written) and must
-/// be preserved for the next invocation.
-///
-/// Returns `false` if EOF has been encountered.
-fn write_frame_len<W: AsyncWrite + Unpin>(
-    mut io: &mut W,
-    cx: &mut Context<'_>,
-    buf: &[u8; 2],
-    off: &mut usize,
-) -> Poll<io::Result<bool>> {
-    loop {
-        match ready!(Pin::new(&mut io).poll_write(cx, &buf[*off..])) {
-            Ok(n) => {
-                if n == 0 {
-                    return Poll::Ready(Ok(false));
-                }
-                *off += n;
-                if *off == 2 {
-                    return Poll::Ready(Ok(true));
-                }
-            }
-            Err(e) => {
-                return Poll::Ready(Err(e));
-            }
-        }
     }
 }


### PR DESCRIPTION
## Description
- Migrate to `asynchronous_codec::Framed` for message framing.
- Migrate to `quick_protobuf_codec::Codec` for protobuf encoding and decoding.

Resolves #4488.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
