### PR TITLE
fix(swarm): prevent overflow in keep-alive computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.43.4"
+version = "0.43.5"
 dependencies = [
  "async-std",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ libp2p-rendezvous = { version = "0.13.0", path = "protocols/rendezvous" }
 libp2p-upnp = { version = "0.1.1", path = "protocols/upnp" }
 libp2p-request-response = { version = "0.25.1", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.3", path = "misc/server" }
-libp2p-swarm = { version = "0.43.4", path = "swarm" }
+libp2p-swarm = { version = "0.43.5", path = "swarm" }
 libp2p-swarm-derive = { version = "0.33.0", path = "swarm-derive" }
 libp2p-swarm-test = { version = "0.2.0", path = "swarm-test" }
 libp2p-tcp = { version = "0.40.0", path = "transports/tcp" }

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.43.5 - unreleased
+
+- Fix overflow in `KeepAlive` computation that could occur if `SwarmBuilder::idle_connection_timeout` is configured with `u64::MAX`.
+  See [PR XXXX](XXXX.
+
 ## 0.43.4
 
 - Implement `Debug` for event structs.

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.43.5 - unreleased
 
 - Fix overflow in `KeepAlive` computation that could occur if `SwarmBuilder::idle_connection_timeout` is configured with `u64::MAX`.
-  See [PR XXXX](XXXX.
+  See [PR 4559](https://github.com/libp2p/rust-libp2p/pull/4559).
 
 ## 0.43.4
 

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.43.5 - unreleased
+## 0.43.5
 
 - Fix overflow in `KeepAlive` computation that could occur if `SwarmBuilder::idle_connection_timeout` is configured with `u64::MAX`.
   See [PR 4559](https://github.com/libp2p/rust-libp2p/pull/4559).

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-swarm"
 edition = "2021"
 rust-version = { workspace = true }
 description = "The libp2p swarm"
-version = "0.43.4"
+version = "0.43.5"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/swarm/src/connection.rs
+++ b/swarm/src/connection.rs
@@ -488,7 +488,7 @@ fn sleep_until_or_at_least_very_long(mut duration: Duration) -> (Delay, Instant)
     while Instant::now().checked_add(duration).is_none() {
         log::debug!("Cannot represent time {duration:?} in the future, halving it ...");
 
-        duration = duration / 2;
+        duration /= 2;
     }
 
     (Delay::new(duration), Instant::now() + duration)

--- a/swarm/src/connection.rs
+++ b/swarm/src/connection.rs
@@ -488,7 +488,7 @@ fn gather_supported_protocols(handler: &impl ConnectionHandler) -> HashSet<Strea
 /// The [`Duration`] computed by the this function may not be the longest possible that we can add to `now` but it will work.
 fn checked_add_fraction(start: Instant, mut duration: Duration) -> Duration {
     while start.checked_add(duration).is_none() {
-        log::debug!("{now:?} + {duration:?} cannot be presented, halving duration");
+        log::debug!("{start:?} + {duration:?} cannot be presented, halving duration");
 
         duration /= 2;
     }

--- a/swarm/src/connection.rs
+++ b/swarm/src/connection.rs
@@ -483,8 +483,11 @@ fn gather_supported_protocols(handler: &impl ConnectionHandler) -> HashSet<Strea
 }
 
 /// Repeatedly halves and adds the [`Duration`] to the [`Instant`] until [`Instant::checked_add`] succeeds.
-fn checked_add_fraction(now: Instant, mut duration: Duration) -> Duration {
-    while now.checked_add(duration).is_none() {
+///
+/// [`Instant`] depends on the underlying platform and has a limit of which points in time it can represent.
+/// The [`Duration`] computed by the this function may not be the longest possible that we can add to `now` but it will work.
+fn checked_add_fraction(start: Instant, mut duration: Duration) -> Duration {
+    while start.checked_add(duration).is_none() {
         log::debug!("{now:?} + {duration:?} cannot be presented, halving duration");
 
         duration /= 2;

--- a/swarm/src/connection.rs
+++ b/swarm/src/connection.rs
@@ -976,7 +976,7 @@ mod tests {
 
     #[test]
     fn checked_add_fraction_can_add_u64_max() {
-        env_logger::init();
+        let _ = env_logger::try_init();
         let start = Instant::now();
 
         let duration = checked_add_fraction(start, Duration::from_secs(u64::MAX));

--- a/swarm/src/connection.rs
+++ b/swarm/src/connection.rs
@@ -486,14 +486,14 @@ fn gather_supported_protocols(handler: &impl ConnectionHandler) -> HashSet<Strea
 /// Constructs a [`Delay`] for the given [`Duration`] from `start` and returns the [`Instant`] at which it will fire.
 ///
 /// If [`Duration`] + [`Instant::now`] overflows, we will return a [`Delay`] that at least sleeps _very_ long.
-fn sleep_until_or_at_least_very_long(start: Instant, mut duration: Duration) -> (Delay, Instant) {
-    while start.checked_add(duration).is_none() {
+fn sleep_until_or_at_least_very_long(now: Instant, mut duration: Duration) -> (Delay, Instant) {
+    while now.checked_add(duration).is_none() {
         log::debug!("Cannot represent time {duration:?} in the future, halving it ...");
 
         duration /= 2;
     }
 
-    (Delay::new(duration), start + duration)
+    (Delay::new(duration), now + duration)
 }
 
 /// Borrowed information about an incoming connection currently being negotiated.


### PR DESCRIPTION
## Description

When adding a very large `Duration` to an `Instant`, an overflow can occur. To fix this, we check this before instantiating `Delay` and half the given duration until it no longer overflows.

Fixes: #4555.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
