### PR TITLE
chore: address latest clippy lints

### DIFF
--- a/protocols/dcutr/src/behaviour_impl.rs
+++ b/protocols/dcutr/src/behaviour_impl.rs
@@ -103,8 +103,8 @@ impl Behaviour {
     fn observed_addresses(&self) -> Vec<Multiaddr> {
         self.external_addresses
             .iter()
-            .cloned()
             .filter(|a| !a.iter().any(|p| p == Protocol::P2pCircuit))
+            .cloned()
             .map(|a| a.with(Protocol::P2p(self.local_peer_id)))
             .collect()
     }

--- a/protocols/gossipsub/src/types.rs
+++ b/protocols/gossipsub/src/types.rs
@@ -330,7 +330,7 @@ impl From<Rpc> for proto::RPC {
                             .into_iter()
                             .map(|info| proto::PeerInfo {
                                 peer_id: info.peer_id.map(|id| id.to_bytes()),
-                                /// TODO, see https://github.com/libp2p/specs/pull/217
+                                // TODO, see https://github.com/libp2p/specs/pull/217
                                 signed_peer_record: None,
                             })
                             .collect(),

--- a/protocols/perf/src/bin/perf.rs
+++ b/protocols/perf/src/bin/perf.rs
@@ -428,14 +428,12 @@ async fn connect(
     let start = Instant::now();
     swarm.dial(server_address.clone()).unwrap();
 
-    let server_peer_id = loop {
-        match swarm.next().await.unwrap() {
-            SwarmEvent::ConnectionEstablished { peer_id, .. } => break peer_id,
-            SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
-                bail!("Outgoing connection error to {:?}: {:?}", peer_id, error);
-            }
-            e => panic!("{e:?}"),
+    let server_peer_id = match swarm.next().await.unwrap() {
+        SwarmEvent::ConnectionEstablished { peer_id, .. } => peer_id,
+        SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
+            bail!("Outgoing connection error to {:?}: {:?}", peer_id, error);
         }
+        e => panic!("{e:?}"),
     };
 
     let duration = start.elapsed();

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -2153,19 +2153,14 @@ mod tests {
                     )
                     .unwrap();
                 for mut transport in transports.into_iter() {
-                    loop {
-                        match futures::future::select(transport.select_next_some(), swarm.next())
-                            .await
-                        {
-                            future::Either::Left((TransportEvent::Incoming { .. }, _)) => {
-                                break;
-                            }
-                            future::Either::Left(_) => {
-                                panic!("Unexpected transport event.")
-                            }
-                            future::Either::Right((e, _)) => {
-                                panic!("Expect swarm to not emit any event {e:?}")
-                            }
+                    match futures::future::select(transport.select_next_some(), swarm.next()).await
+                    {
+                        future::Either::Left((TransportEvent::Incoming { .. }, _)) => {}
+                        future::Either::Left(_) => {
+                            panic!("Unexpected transport event.")
+                        }
+                        future::Either::Right((e, _)) => {
+                            panic!("Expect swarm to not emit any event {e:?}")
                         }
                     }
                 }


### PR DESCRIPTION
## Description

I ran clippy on the current nightly and fixed issues found by it. Noteworthy are two instances of the [never_loop](https://rust-lang.github.io/rust-clippy/master/index.html#/never_loop) lint.

## Notes & open questions

None

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] A changelog entry has been made in the appropriate crates (not necessary since it doesn't affect the public API)
