### PR TITLE
ci: create dependency cache layer of interop tests

### DIFF
--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -18,9 +18,23 @@ jobs:
         flavour: [chromium, native]
     steps:
       - uses: actions/checkout@v4
+
       - uses: docker/setup-buildx-action@v3
+
+      # This uses the same S3 cache as all test-plans images. Because we use `cargo-chef` in the Dockerfile, we have a layer available with all dependencies built.
       - name: Build ${{ matrix.flavour }} image
-        run: docker buildx build --load -t ${{ matrix.flavour }}-rust-libp2p-head . -f interop-tests/Dockerfile.${{ matrix.flavour }}
+        run: |
+          docker buildx build \
+            --load \
+            --cache-to   type=s3,mode=max,bucket=libp2p-by-tf-aws-bootstrap,region=us-east-1,prefix=buildCache,name=${{ matrix.flavour }}-rust-libp2p-head \
+            --cache-from type=s3,mode=max,bucket=libp2p-by-tf-aws-bootstrap,region=us-east-1,prefix=buildCache,name=${{ matrix.flavour }}-rust-libp2p-head \
+            -t ${{ matrix.flavour }}-rust-libp2p-head \
+            . \
+            -f interop-tests/Dockerfile.${{ matrix.flavour }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ vars.TEST_PLANS_BUILD_CACHE_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_PLANS_BUILD_CACHE_KEY }}
+
       - name: Run ${{ matrix.flavour }} tests
         uses: libp2p/test-plans/.github/actions/run-interop-ping-test@master
         with:

--- a/interop-tests/Dockerfile.chromium
+++ b/interop-tests/Dockerfile.chromium
@@ -1,28 +1,26 @@
-FROM rust:1.67.0 as builder
-
-# Run with access to the target cache to speed up builds
-WORKDIR /workspace
-ADD . .
-
+# syntax=docker/dockerfile:1.5-labs
+FROM rust:1.67.0 as chef
 RUN rustup target add wasm32-unknown-unknown
-
 RUN wget -q -O- https://github.com/rustwasm/wasm-pack/releases/download/v0.12.1/wasm-pack-v0.12.1-x86_64-unknown-linux-musl.tar.gz | tar -zx -C /usr/local/bin --strip-components 1 --wildcards "wasm-pack-*/wasm-pack"
 RUN wget -q -O- https://github.com/WebAssembly/binaryen/releases/download/version_115/binaryen-version_115-x86_64-linux.tar.gz | tar -zx -C /usr/local/bin --strip-components 2 --wildcards "binaryen-version_*/bin/wasm-opt"
+RUN wget -q -O- https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.62/cargo-chef-x86_64-unknown-linux-gnu.tar.gz | tar -zx -C /usr/local/bin
+WORKDIR /app
 
-RUN --mount=type=cache,target=./target \
-    --mount=type=cache,target=/usr/local/cargo/registry \
-    wasm-pack build --target web interop-tests
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-RUN --mount=type=cache,target=./target \
-    --mount=type=cache,target=/usr/local/cargo/registry \
-    cargo build --release --package interop-tests --bin wasm_ping
-
-RUN --mount=type=cache,target=./target \
-    mv ./target/release/wasm_ping /usr/local/bin/testplan
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --package interop-tests --target wasm32-unknown-unknown --recipe-path recipe.json
+RUN cargo chef cook --release --package interop-tests --bin wasm_ping --recipe-path recipe.json
+# Build application
+COPY . .
+RUN wasm-pack build --target web interop-tests
+RUN cargo build --release --package interop-tests --bin wasm_ping
 
 FROM selenium/standalone-chrome:115.0
-COPY --from=builder /usr/local/bin/testplan /usr/local/bin/testplan
-
+COPY --from=builder /app/target/release/wasm_ping /usr/local/bin/testplan
 ENV RUST_BACKTRACE=1
-
 ENTRYPOINT ["testplan"]

--- a/interop-tests/Dockerfile.native
+++ b/interop-tests/Dockerfile.native
@@ -1,17 +1,21 @@
 # syntax=docker/dockerfile:1.5-labs
-FROM rust:1.67.0 as builder
+FROM rust:1.67.0 as chef
+RUN wget -q -O- https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.62/cargo-chef-x86_64-unknown-linux-gnu.tar.gz | tar -zx -C /usr/local/bin
+WORKDIR /app
 
-# Run with access to the target cache to speed up builds
-WORKDIR /workspace
-ADD . .
-RUN --mount=type=cache,target=./target \
-    --mount=type=cache,target=/usr/local/cargo/registry \
-    cargo build --release --package interop-tests --bin native_ping
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-RUN --mount=type=cache,target=./target \
-    mv ./target/release/native_ping /usr/local/bin/testplan
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --package interop-tests --bin native_ping --recipe-path recipe.json
+# Build application
+COPY . .
+RUN cargo build --release --package interop-tests --bin native_ping
 
 FROM gcr.io/distroless/cc
-COPY --from=builder /usr/local/bin/testplan /usr/local/bin/testplan
+COPY --from=builder /app/target/release/native_ping /usr/local/bin/testplan
 ENV RUST_BACKTRACE=1
 ENTRYPOINT ["testplan"]


### PR DESCRIPTION
## Description

Currently, the Docker images for the HEAD branch of the pull-request get re-built completely every time we push a new commit to a branch. That is because the RUN caches use the local disk of the host system but those are ephemeral in GitHub actions.

To fix this, we rewrite the dockerfiles to use `cargo chef`, a tool developed to create a cached layer of built dependencies that doesn't get invalidated as the application source changes.

Normally, these layers are also cached on the local filesystem. To have them available across pull-requests and branches, we instruct buildkit to use the same S3 cache as we use in the interop tests already for docker layers. As a result, this should greatly speed up our CI.

Resolves: #3925.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
