### PR TITLE
fix(server): remove `support_draft_29`

### DIFF
--- a/misc/server/src/main.rs
+++ b/misc/server/src/main.rs
@@ -76,10 +76,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             noise::Config::new,
             yamux::Config::default,
         )?
-        .with_quic_config(|mut cfg| {
-            cfg.support_draft_29 = true;
-            cfg
-        })
+        .with_quic()
         .with_dns()?
         .with_behaviour(|key| {
             behaviour::Behaviour::new(key.public(), opt.enable_kademlia, opt.enable_autonat)


### PR DESCRIPTION
## Description

Support for QUIC draft 29 was removed with https://github.com/libp2p/rust-libp2p/pull/4467.

https://github.com/libp2p/rust-libp2p/pull/4120 reintroduced it as a faulty merge.

This commit removes it again.



<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

My bad. I am sorry for the trouble.

@mcamou thank you for bringing this to the surface.

@thomaseizinger merging here as is. Happy to do follow-ups. For context, @mcamou saw our rust-libp2p IPFS staging server fail with `Address already in use`.

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
