### PR TITLE
fix(libp2p): add shortcut `with_tcp(...).with_bandwidth_logging()`

### DIFF
--- a/libp2p/src/builder.rs
+++ b/libp2p/src/builder.rs
@@ -356,7 +356,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "tokio"))]
+    #[cfg(feature = "tokio")]
     fn other_transport_bandwidth_logging() -> Result<(), Box<dyn std::error::Error>> {
         let (builder, _logging) = SwarmBuilder::with_new_identity()
             .with_tokio()

--- a/libp2p/src/builder/phase/quic.rs
+++ b/libp2p/src/builder/phase/quic.rs
@@ -7,7 +7,7 @@ use libp2p_core::muxing::StreamMuxer;
     all(not(target_arch = "wasm32"), feature = "websocket")
 ))]
 use libp2p_core::{InboundUpgrade, Negotiated, OutboundUpgrade, UpgradeInfo};
-use std::marker::PhantomData;
+use std::{marker::PhantomData, sync::Arc};
 
 pub struct QuicPhase<T> {
     pub(crate) transport: T,
@@ -237,3 +237,23 @@ impl_quic_phase_with_websocket!(
     super::provider::Tokio,
     rw_stream_sink::RwStreamSink<libp2p_websocket::BytesConnection<libp2p_tcp::tokio::TcpStream>>
 );
+impl<Provider, T: AuthenticatedMultiplexedTransport>
+    SwarmBuilder<Provider, QuicPhase<T>>
+{
+    pub fn with_bandwidth_logging(
+        self,
+    ) -> (
+        SwarmBuilder<
+            Provider,
+            BehaviourPhase<impl AuthenticatedMultiplexedTransport, NoRelayBehaviour>,
+        >,
+        Arc<crate::bandwidth::BandwidthSinks>,
+    ) {
+        self.without_quic()
+            .without_any_other_transports()
+            .without_dns()
+            .without_relay()
+            .without_websocket()
+            .with_bandwidth_logging()
+    }
+}

--- a/libp2p/src/builder/phase/quic.rs
+++ b/libp2p/src/builder/phase/quic.rs
@@ -237,9 +237,7 @@ impl_quic_phase_with_websocket!(
     super::provider::Tokio,
     rw_stream_sink::RwStreamSink<libp2p_websocket::BytesConnection<libp2p_tcp::tokio::TcpStream>>
 );
-impl<Provider, T: AuthenticatedMultiplexedTransport>
-    SwarmBuilder<Provider, QuicPhase<T>>
-{
+impl<Provider, T: AuthenticatedMultiplexedTransport> SwarmBuilder<Provider, QuicPhase<T>> {
     pub fn with_bandwidth_logging(
         self,
     ) -> (


### PR DESCRIPTION


## Description

Add the shortcut method `.with_bandwidth_logging` to `SwarmBuilder<_, QuicPhase<_>>`, thus allowing `with_tcp(...).with_bandwidth_logging()`.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
