### PR TITLE
refactor: make debug-print of `StreamProtocol` more concise

### DIFF
--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -5,7 +5,7 @@
   In some special cases, users may need to use `Swarm::new` and `Config` instead of the new `libp2p::SwarmBuilder`.
   See [PR 4120].
 - Make the `Debug` implementation of `StreamProtocol` more concise.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+  See [PR 4631](https://github.com/libp2p/rust-libp2p/pull/4631).
 
 [PR 4120]: https://github.com/libp2p/rust-libp2p/pull/4120
 

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -4,6 +4,8 @@
   Most users should use `libp2p::SwarmBuilder`.
   In some special cases, users may need to use `Swarm::new` and `Config` instead of the new `libp2p::SwarmBuilder`.
   See [PR 4120].
+- Make the `Debug` implementation of `StreamProtocol` more concise.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
 
 [PR 4120]: https://github.com/libp2p/rust-libp2p/pull/4120
 

--- a/swarm/src/stream_protocol.rs
+++ b/swarm/src/stream_protocol.rs
@@ -125,7 +125,7 @@ mod tests {
             "protocol to debug print as string with quotes"
         );
         assert_eq!(
-            debug, "/foo/bar/1.0.0",
+            display, "/foo/bar/1.0.0",
             "protocol to display print as string without quotes"
         );
     }

--- a/swarm/src/stream_protocol.rs
+++ b/swarm/src/stream_protocol.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 ///
 /// libp2p nodes use stream protocols to negotiate what to do with a newly opened stream.
 /// Stream protocols are string-based and must start with a forward slash: `/`.
-#[derive(Debug, Clone, Eq)]
+#[derive(Clone, Eq)]
 pub struct StreamProtocol {
     inner: Either<&'static str, Arc<str>>,
 }
@@ -47,6 +47,12 @@ impl StreamProtocol {
 impl AsRef<str> for StreamProtocol {
     fn as_ref(&self) -> &str {
         either::for_both!(&self.inner, s => s)
+    }
+}
+
+impl fmt::Debug for StreamProtocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        either::for_both!(&self.inner, s => s.fmt(f))
     }
 }
 
@@ -102,3 +108,25 @@ impl fmt::Display for InvalidProtocol {
 }
 
 impl std::error::Error for InvalidProtocol {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_protocol_print() {
+        let protocol = StreamProtocol::new("/foo/bar/1.0.0");
+
+        let debug = format!("{protocol:?}");
+        let display = format!("{protocol}");
+
+        assert_eq!(
+            debug, r#""/foo/bar/1.0.0""#,
+            "protocol to debug print as string with quotes"
+        );
+        assert_eq!(
+            debug, "/foo/bar/1.0.0",
+            "protocol to display print as string without quotes"
+        );
+    }
+}


### PR DESCRIPTION
## Description

The` fmt::Debug` implementation of a type should in most cases reveal its internal structure. `StreamProtocol` is likely to be debug-printed a lot and in many cases, the only contract is the `fmt::Debug` impl. The internals of `StreamProtocol` only exist for performance reasons to avoid allocations for statically-known protocol strings. Revealing this implementation detail isn't particularly beneficial to end users. At the same time, the current implementation is very noise.

Previously, the `protocols` field of an `identify::Info` would e.g. read as:

```
protocols: [StreamProtocol { inner: Right("/ipfs/id/1.0.0") }, StreamProtocol { inner: Right("/ipfs/id/push/1.0.0") }, StreamProtocol { inner: Right("/ipfs/kad/1.0.0") }]
```

With this patch, it reads as:

```
protocols: ["/ipfs/id/1.0.0", "/ipfs/kad/1.0.0", "/ipfs/id/push/1.0.0"]
```

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
