### PR TITLE
refactor(kad): delete unused code

### DIFF
--- a/protocols/kad/src/jobs.rs
+++ b/protocols/kad/src/jobs.rs
@@ -87,6 +87,7 @@ struct PeriodicJob<T> {
 }
 
 impl<T> PeriodicJob<T> {
+    #[cfg(test)]
     fn is_running(&self) -> bool {
         match self.state {
             PeriodicJobState::Running(..) => true,
@@ -96,6 +97,7 @@ impl<T> PeriodicJob<T> {
 
     /// Cuts short the remaining delay, if the job is currently waiting
     /// for the delay to expire.
+    #[cfg(test)]
     fn asap(&mut self) {
         if let PeriodicJobState::Waiting(delay, deadline) = &mut self.state {
             let new_deadline = Instant::now().checked_sub(Duration::from_secs(1)).unwrap();
@@ -169,6 +171,7 @@ impl PutRecordJob {
     }
 
     /// Checks whether the job is currently running.
+    #[cfg(test)]
     pub(crate) fn is_running(&self) -> bool {
         self.inner.is_running()
     }
@@ -177,6 +180,7 @@ impl PutRecordJob {
     /// for the delay to expire.
     ///
     /// The job is guaranteed to run on the next invocation of `poll`.
+    #[cfg(test)]
     pub(crate) fn asap(&mut self, publish: bool) {
         if publish {
             self.next_publish = Some(Instant::now().checked_sub(Duration::from_secs(1)).unwrap())
@@ -273,6 +277,7 @@ impl AddProviderJob {
     }
 
     /// Checks whether the job is currently running.
+    #[cfg(test)]
     pub(crate) fn is_running(&self) -> bool {
         self.inner.is_running()
     }
@@ -281,6 +286,7 @@ impl AddProviderJob {
     /// for the delay to expire.
     ///
     /// The job is guaranteed to run on the next invocation of `poll`.
+    #[cfg(test)]
     pub(crate) fn asap(&mut self) {
         self.inner.asap()
     }

--- a/protocols/kad/src/kbucket/bucket.rs
+++ b/protocols/kad/src/kbucket/bucket.rs
@@ -54,10 +54,6 @@ pub enum NodeStatus {
 }
 
 impl<TKey, TVal> PendingNode<TKey, TVal> {
-    pub(crate) fn key(&self) -> &TKey {
-        &self.node.key
-    }
-
     pub(crate) fn status(&self) -> NodeStatus {
         self.status
     }
@@ -70,6 +66,7 @@ impl<TKey, TVal> PendingNode<TKey, TVal> {
         Instant::now() >= self.replace
     }
 
+    #[cfg(test)]
     pub(crate) fn set_ready_at(&mut self, t: Instant) {
         self.replace = t;
     }
@@ -189,11 +186,6 @@ where
     pub(crate) fn as_pending(&self, key: &TKey) -> Option<&PendingNode<TKey, TVal>> {
         self.pending()
             .filter(|p| p.node.key.as_ref() == key.as_ref())
-    }
-
-    /// Returns a reference to a node in the bucket.
-    pub(crate) fn get(&self, key: &TKey) -> Option<&Node<TKey, TVal>> {
-        self.position(key).map(|p| &self.nodes[p.0])
     }
 
     /// Returns an iterator over the nodes in the bucket, together with their status.
@@ -398,22 +390,19 @@ where
         }
     }
 
-    /// Checks whether the given position refers to a connected node.
-    pub(crate) fn is_connected(&self, pos: Position) -> bool {
-        self.status(pos) == NodeStatus::Connected
-    }
-
     /// Gets the number of entries currently in the bucket.
     pub(crate) fn num_entries(&self) -> usize {
         self.nodes.len()
     }
 
     /// Gets the number of entries in the bucket that are considered connected.
+    #[cfg(test)]
     pub(crate) fn num_connected(&self) -> usize {
         self.first_connected_pos.map_or(0, |i| self.nodes.len() - i)
     }
 
     /// Gets the number of entries in the bucket that are considered disconnected.
+    #[cfg(test)]
     pub(crate) fn num_disconnected(&self) -> usize {
         self.nodes.len() - self.num_connected()
     }

--- a/protocols/kad/src/kbucket/entry.rs
+++ b/protocols/kad/src/kbucket/entry.rs
@@ -135,20 +135,6 @@ where
         }
     }
 
-    /// Returns the key of the entry.
-    ///
-    /// Returns `None` if the `Key` used to construct this `Entry` is not a valid
-    /// key for an entry in a bucket, which is the case for the `local_key` of
-    /// the `KBucketsTable` referring to the local node.
-    pub(crate) fn key(&self) -> Option<&TKey> {
-        match self {
-            Entry::Present(entry, _) => Some(entry.key()),
-            Entry::Pending(entry, _) => Some(entry.key()),
-            Entry::Absent(entry) => Some(entry.key()),
-            Entry::SelfEntry => None,
-        }
-    }
-
     /// Returns the value associated with the entry.
     ///
     /// Returns `None` if the entry is absent from any bucket or refers to the
@@ -173,11 +159,6 @@ where
 {
     fn new(bucket: &'a mut KBucket<TKey, TVal>, key: &'a TKey) -> Self {
         PresentEntry(EntryRef { bucket, key })
-    }
-
-    /// Returns the key of the entry.
-    pub(crate) fn key(&self) -> &TKey {
-        self.0.key
     }
 
     /// Returns the value associated with the key.
@@ -218,11 +199,6 @@ where
         PendingEntry(EntryRef { bucket, key })
     }
 
-    /// Returns the key of the entry.
-    pub(crate) fn key(&self) -> &TKey {
-        self.0.key
-    }
-
     /// Returns the value associated with the key.
     pub(crate) fn value(&mut self) -> &mut TVal {
         self.0
@@ -260,11 +236,6 @@ where
 {
     fn new(bucket: &'a mut KBucket<TKey, TVal>, key: &'a TKey) -> Self {
         AbsentEntry(EntryRef { bucket, key })
-    }
-
-    /// Returns the key of the entry.
-    pub(crate) fn key(&self) -> &TKey {
-        self.0.key
     }
 
     /// Attempts to insert the entry into a bucket.

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -33,9 +33,6 @@
 //! existing nodes in the kademlia network cannot obtain the listen addresses
 //! of nodes querying them, and thus will not be able to add them to their routing table.
 
-// TODO: we allow dead_code for now because this library contains a lot of unused code that will
-//       be useful later for record store
-#![allow(dead_code)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod record_priv;

--- a/protocols/kad/src/query.rs
+++ b/protocols/kad/src/query.rs
@@ -326,15 +326,6 @@ impl<TInner> Query<TInner> {
         }
     }
 
-    /// Checks whether the query is currently waiting for a result from `peer`.
-    pub(crate) fn is_waiting(&self, peer: &PeerId) -> bool {
-        match &self.peer_iter {
-            QueryPeerIter::Closest(iter) => iter.is_waiting(peer),
-            QueryPeerIter::ClosestDisjoint(iter) => iter.is_waiting(peer),
-            QueryPeerIter::Fixed(iter) => iter.is_waiting(peer),
-        }
-    }
-
     /// Advances the state of the underlying peer iterator.
     fn next(&mut self, now: Instant) -> PeersIterState<'_> {
         let state = match &mut self.peer_iter {

--- a/protocols/kad/src/query/peers/closest.rs
+++ b/protocols/kad/src/query/peers/closest.rs
@@ -788,6 +788,7 @@ mod tests {
         QuickCheck::new().tests(10).quickcheck(prop as fn(_))
     }
 
+    #[test]
     fn stalled_at_capacity() {
         fn prop(mut iter: ClosestPeersIter) {
             iter.state = State::Stalled;

--- a/protocols/kad/src/query/peers/closest/disjoint.rs
+++ b/protocols/kad/src/query/peers/closest/disjoint.rs
@@ -31,7 +31,6 @@ use std::{
 /// Wraps around a set of [`ClosestPeersIter`], enforcing a disjoint discovery
 /// path per configured parallelism according to the S/Kademlia paper.
 pub(crate) struct ClosestDisjointPeersIter {
-    config: ClosestPeersIterConfig,
     target: KeyBytes,
 
     /// The set of wrapped [`ClosestPeersIter`].
@@ -51,6 +50,7 @@ pub(crate) struct ClosestDisjointPeersIter {
 
 impl ClosestDisjointPeersIter {
     /// Creates a new iterator with a default configuration.
+    #[cfg(test)]
     pub(crate) fn new<I>(target: KeyBytes, known_closest_peers: I) -> Self
     where
         I: IntoIterator<Item = Key<PeerId>>,
@@ -88,7 +88,6 @@ impl ClosestDisjointPeersIter {
         let iters_len = iters.len();
 
         ClosestDisjointPeersIter {
-            config,
             target: target.into(),
             iters,
             iter_order: (0..iters_len)
@@ -188,10 +187,6 @@ impl ClosestDisjointPeersIter {
         }
 
         updated
-    }
-
-    pub(crate) fn is_waiting(&self, peer: &PeerId) -> bool {
-        self.iters.iter().any(|i| i.is_waiting(peer))
     }
 
     pub(crate) fn next(&mut self, now: Instant) -> PeersIterState<'_> {

--- a/protocols/kad/src/query/peers/fixed.rs
+++ b/protocols/kad/src/query/peers/fixed.rs
@@ -115,10 +115,6 @@ impl FixedPeersIter {
         false
     }
 
-    pub(crate) fn is_waiting(&self, peer: &PeerId) -> bool {
-        self.peers.get(peer) == Some(&PeerState::Waiting)
-    }
-
     pub(crate) fn finish(&mut self) {
         if let State::Waiting { .. } = self.state {
             self.state = State::Finished


### PR DESCRIPTION
## Description

We have a fair bit of unused code in `libp2p-kad` that was ignored because we had `#[allow(dead_code)]` at the top of the crate.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
