### PR TITLE
fix(quic): delete flaky `dial_failure` test

### DIFF
--- a/transports/quic/tests/smoke.rs
+++ b/transports/quic/tests/smoke.rs
@@ -39,24 +39,6 @@ async fn async_std_smoke() {
     smoke::<quic::async_std::Provider>().await
 }
 
-#[cfg(feature = "async-std")]
-#[async_std::test]
-async fn dial_failure() {
-    let _ = env_logger::try_init();
-    let mut a = create_default_transport::<quic::async_std::Provider>().1;
-    let mut b = create_default_transport::<quic::async_std::Provider>().1;
-
-    let addr = start_listening(&mut a, "/ip4/127.0.0.1/udp/0/quic-v1").await;
-    drop(a); // stop a so b can never reach it
-
-    match dial(&mut b, addr).await {
-        Ok(_) => panic!("Expected dial to fail"),
-        Err(error) => {
-            assert_eq!("Handshake with the remote timed out.", error.to_string())
-        }
-    };
-}
-
 #[cfg(feature = "tokio")]
 #[tokio::test]
 async fn endpoint_reuse() {


### PR DESCRIPTION
## Description

This test is sometimes flaky. Instead of fixing it, I am proposing to delete it because it doesn't test anything meaningful. Dialing a non-existent transport should fail? Yes probably. Should we test that dropping a value destroys the relevant tasks? I don't think so. That is covered by Rust's ownership rules.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

Sleeping here isn't a very clean solution. Happy to

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
