### PR TITLE
fix(kad): re-export `NodeStatus`

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -4,7 +4,7 @@
   See [PR 4547].
 - Fix a bug where we didn't detect a remote peer moving into client-state.
   See [PR 4639](https://github.com/libp2p/rust-libp2p/pull/4639).
-- Re-export NodeStatus
+- Re-export `NodeStatus`.
   See [PR 4645].
 
 [PR 4547]: https://github.com/libp2p/rust-libp2p/pull/4547

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,12 +1,14 @@
 ## 0.44.6 - unreleased
 
-- Rename `Kademlia` symbols to follow naming convention. 
+- Rename `Kademlia` symbols to follow naming convention.
   See [PR 4547].
-
 - Fix a bug where we didn't detect a remote peer moving into client-state.
   See [PR 4639](https://github.com/libp2p/rust-libp2p/pull/4639).
+- Re-export NodeStatus
+  See [PR 4645].
 
 [PR 4547]: https://github.com/libp2p/rust-libp2p/pull/4547
+[PR 4645]: https://github.com/libp2p/rust-libp2p/pull/4645
 
 ## 0.44.5
 - Migrate to `quick-protobuf-codec` crate for codec logic.

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -72,6 +72,7 @@ mod entry;
 #[allow(clippy::assign_op_pattern)]
 mod key;
 
+pub use bucket::NodeStatus;
 pub use entry::*;
 
 use arrayvec::{self, ArrayVec};

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -72,7 +72,9 @@ pub use behaviour::{
 pub use behaviour::{
     Behaviour, BucketInserts, Caching, Config, Event, ProgressStep, Quorum, StoreInserts,
 };
-pub use kbucket::{Distance as KBucketDistance, EntryView, KBucketRef, Key as KBucketKey};
+pub use kbucket::{
+    Distance as KBucketDistance, EntryView, KBucketRef, Key as KBucketKey, NodeStatus,
+};
 pub use protocol::ConnectionType;
 pub use query::QueryId;
 pub use record_priv::{store, Key as RecordKey, ProviderRecord, Record};


### PR DESCRIPTION
## Description

The `EntryView` struct exposes the node status however its type is not public making it impossible to use the status field. This change re-exports `NodeStatus`.

Related: #4108.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
