### PR TITLE
feat(gossipsub): deprecate `Config::idle_timeout`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.45.1"
+version = "0.45.2"
 dependencies = [
  "async-std",
  "asynchronous-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ libp2p-dcutr = { version = "0.10.0", path = "protocols/dcutr" }
 libp2p-deflate = { version = "0.40.1", path = "transports/deflate" }
 libp2p-dns = { version = "0.40.1", path = "transports/dns" }
 libp2p-floodsub = { version = "0.43.0", path = "protocols/floodsub" }
-libp2p-gossipsub = { version = "0.45.1", path = "protocols/gossipsub" }
+libp2p-gossipsub = { version = "0.45.2", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.43.1", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.5" }
 libp2p-kad = { version = "0.44.6", path = "protocols/kad" }

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.45.2 - unreleased
+
+- Deprecate `gossipsub::Config::idle_timeout` in favor of `SwarmBuilder::idle_connection_timeout`.
+  See [PR 4648].
+
+[PR 4648]: (https://github.com/libp2p/rust-libp2p/pull/4648)
+
 ## 0.45.1
 
 - Add getter function to obtain `TopicScoreParams`.

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-gossipsub"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Gossipsub protocol for libp2p"
-version = "0.45.1"
+version = "0.45.2"
 authors = ["Age Manning <Age@AgeManning.com>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -3305,6 +3305,7 @@ where
     type ConnectionHandler = Handler;
     type ToSwarm = Event;
 
+    #[allow(deprecated)]
     fn handle_established_inbound_connection(
         &mut self,
         _: ConnectionId,
@@ -3318,6 +3319,7 @@ where
         ))
     }
 
+    #[allow(deprecated)]
     fn handle_established_outbound_connection(
         &mut self,
         _: ConnectionId,

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -189,6 +189,7 @@ impl Config {
     #[deprecated(
         note = "Set a global idle connection timeout via `SwarmBuilder::idle_connection_timeout` instead."
     )]
+    #[allow(deprecated)]
     pub fn idle_timeout(&self) -> Duration {
         self.idle_timeout
     }

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -189,7 +189,6 @@ impl Config {
     #[deprecated(
         note = "Set a global idle connection timeout via `SwarmBuilder::idle_connection_timeout` instead."
     )]
-    #[allow(deprecated)]
     pub fn idle_timeout(&self) -> Duration {
         self.idle_timeout
     }

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -186,6 +186,9 @@ impl Config {
     /// The time a connection is maintained to a peer without being in the mesh and without
     /// send/receiving a message from. Connections that idle beyond this timeout are disconnected.
     /// Default is 120 seconds.
+    #[deprecated(
+        note = "Set a global idle connection timeout via `SwarmBuilder::idle_connection_timeout` instead."
+    )]
     pub fn idle_timeout(&self) -> Duration {
         self.idle_timeout
     }


### PR DESCRIPTION
## Description

Deprecate the `Config::idle_timeout` function in preparation for removing the `KeepAlive::Until` entirely.

Related: #3844.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
