### PR TITLE
ci: don't run changelog check on chores and refactor PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,10 @@ jobs:
           test "$PACKAGE_VERSION" = "$SPECIFIED_VERSION"
 
       - name: Ensure manifest and CHANGELOG are properly updated
-        if: github.event_name == 'pull_request'
+        if: >
+          github.event_name == 'pull_request' &&
+          !startsWith(github.event.pull_request.title, 'chore') &&
+          !startsWith(github.event.pull_request.title, 'refactor')
         run: |
           git fetch origin master:master
           ./scripts/ensure-version-bump-and-changelog.sh

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -8,12 +8,6 @@
 
 [PR 4547]: https://github.com/libp2p/rust-libp2p/pull/4547
 
-<!-- Internal changes:
-
-- Fix lints in tests
-
--->
-
 ## 0.44.5
 - Migrate to `quick-protobuf-codec` crate for codec logic.
   See [PR 4501].


### PR DESCRIPTION
## Description

We don't always want to write a changelog entry or bump the version of a crate when we make changes to it. This especially applies to refactorings and other chores. We can automatically detect such PRs based on our conventional commit title.

At the moment, this is not per crate but could be extended in the future. For now, this should be good enough to unblock PRs that are currently stuck on this workflow.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
