### PR TITLE
ci: allow opt-out of changelog lint for internal changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,8 @@ jobs:
           !startsWith(github.event.pull_request.title, 'chore') &&
           !startsWith(github.event.pull_request.title, 'refactor') &&
           !startsWith(github.event.pull_request.title, 'deps') &&
-          !startsWith(github.event.pull_request.title, 'docs')
+          !startsWith(github.event.pull_request.title, 'docs') &&
+          !contains(github.event.pull_request.labels.*.name, format('internal:{0}', env.CRATE))
         run: |
           git fetch origin master:master
           ./scripts/ensure-version-bump-and-changelog.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           !startsWith(github.event.pull_request.title, 'refactor') &&
           !startsWith(github.event.pull_request.title, 'deps') &&
           !startsWith(github.event.pull_request.title, 'docs') &&
-          !contains(github.event.pull_request.labels.*.name, format('internal:{0}', env.CRATE))
+          !contains(github.event.pull_request.labels.*.name, 'internal-change')
         run: |
           git fetch origin master:master
           ./scripts/ensure-version-bump-and-changelog.sh

--- a/docs/maintainer-handbook.md
+++ b/docs/maintainer-handbook.md
@@ -26,6 +26,14 @@ Once a PR fulfills all merge requirements (approvals, passing CI, etc), applying
 In case of a trivial code change, maintainers may choose to apply the `trivial` label.
 This will have mergify approve your PR, thus fulfilling all requirements to automatically queue a PR for merging.
 
+## Changelog entries
+
+Our CI checks that each crate which is modified gets a changelog entry.
+Whilst this is a good default safety-wise, it creates a lot of false-positives for changes that are internal and don't need a changelog entry.
+
+For PRs that in the categories `chore`, `deps`, `refactor` and `docs`, this check is disabled automatically.
+Any other PR needs to explicitly disable this check if desired by applying the `internal-change` label.
+
 ## Dependencies
 
 We version our `Cargo.lock` file for better visibility into which dependencies are required for a functional build.


### PR DESCRIPTION
## Description

We introduced a lint in #4620 that ensures the changelog is updated when we touch a certain crate. This however leads to many "false-positives" where a change to the source code is not actually worth mentioning in the changelog.

To opt out of this change, this patch adds a condition to the job that checks for a `internal:$crate` label and if that is applied, it doesn't run the lint.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
