### PR TITLE
feat(kad): deprecate `Config::set_connection_idle_timeout`

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -6,9 +6,12 @@
   See [PR 4639](https://github.com/libp2p/rust-libp2p/pull/4639).
 - Re-export `NodeStatus`.
   See [PR 4645].
+- Deprecate `kad::Config::set_connection_idle_timeout` in favor of `SwarmBuilder::idle_connection_timeout`.
+  See [PR 4675].
 
 [PR 4547]: https://github.com/libp2p/rust-libp2p/pull/4547
 [PR 4645]: https://github.com/libp2p/rust-libp2p/pull/4645
+[PR 4675]: https://github.com/libp2p/rust-libp2p/pull/4675
 
 <!-- Internal changes
 

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -43,9 +43,9 @@ use libp2p_swarm::behaviour::{
 };
 use libp2p_swarm::{
     dial_opts::{self, DialOpts},
-    ConnectionDenied, ConnectionId, DialError, ExternalAddresses, ListenAddresses,
-    NetworkBehaviour, NotifyHandler, PollParameters, StreamProtocol, THandler, THandlerInEvent,
-    THandlerOutEvent, ToSwarm,
+    ConnectionDenied, ConnectionHandler, ConnectionId, DialError, ExternalAddresses,
+    ListenAddresses, NetworkBehaviour, NotifyHandler, PollParameters, StreamProtocol, THandler,
+    THandlerInEvent, THandlerOutEvent, ToSwarm,
 };
 use log::{debug, info, warn};
 use smallvec::SmallVec;
@@ -372,6 +372,9 @@ impl Config {
     }
 
     /// Sets the amount of time to keep connections alive when they're idle.
+    #[deprecated(
+        note = "Set a global idle connection timeout via `SwarmBuilder::idle_connection_timeout` instead."
+    )]
     pub fn set_connection_idle_timeout(&mut self, duration: Duration) -> &mut Self {
         self.connection_idle_timeout = duration;
         self
@@ -1903,29 +1906,8 @@ where
             self.address_failed(peer_id, addr);
         }
 
-        // When a connection is established, we don't know yet whether the
-        // remote supports the configured protocol name. Only once a connection
-        // handler reports [`HandlerEvent::ProtocolConfirmed`] do we
-        // update the local routing table.
-
         // Peer's first connection.
         if other_established == 0 {
-            // Queue events for sending pending RPCs to the connected peer.
-            // There can be only one pending RPC for a particular peer and query per definition.
-            for (peer_id, event) in self.queries.iter_mut().filter_map(|q| {
-                q.inner
-                    .pending_rpcs
-                    .iter()
-                    .position(|(p, _)| p == &peer_id)
-                    .map(|p| q.inner.pending_rpcs.remove(p))
-            }) {
-                self.queued_events.push_back(ToSwarm::NotifyHandler {
-                    peer_id,
-                    event,
-                    handler: NotifyHandler::Any,
-                });
-            }
-
             self.connected_peers.insert(peer_id);
         }
     }
@@ -2043,6 +2025,27 @@ where
             self.connected_peers.remove(&peer_id);
         }
     }
+
+    /// Preloads a new [`Handler`] with requests that are waiting to be sent to the newly connected peer.
+    fn preload_new_handler(
+        &mut self,
+        handler: &mut Handler,
+        connection_id: ConnectionId,
+        peer: PeerId,
+    ) {
+        self.connections.insert(connection_id, peer);
+        // Queue events for sending pending RPCs to the connected peer.
+        // There can be only one pending RPC for a particular peer and query per definition.
+        for (_peer_id, event) in self.queries.iter_mut().filter_map(|q| {
+            q.inner
+                .pending_rpcs
+                .iter()
+                .position(|(p, _)| p == &peer)
+                .map(|p| q.inner.pending_rpcs.remove(p))
+        }) {
+            handler.on_behaviour_event(event)
+        }
+    }
 }
 
 /// Exponentially decrease the given duration (base 2).
@@ -2068,16 +2071,17 @@ where
             local_addr: local_addr.clone(),
             send_back_addr: remote_addr.clone(),
         };
-        self.connections.insert(connection_id, peer);
-
-        Ok(Handler::new(
+        let mut handler = Handler::new(
             self.protocol_config.clone(),
             self.connection_idle_timeout,
             connected_point,
             peer,
             self.mode,
             connection_id,
-        ))
+        );
+        self.preload_new_handler(&mut handler, connection_id, peer);
+
+        Ok(handler)
     }
 
     fn handle_established_outbound_connection(
@@ -2091,16 +2095,17 @@ where
             address: addr.clone(),
             role_override,
         };
-        self.connections.insert(connection_id, peer);
-
-        Ok(Handler::new(
+        let mut handler = Handler::new(
             self.protocol_config.clone(),
             self.connection_idle_timeout,
             connected_point,
             peer,
             self.mode,
             connection_id,
-        ))
+        );
+        self.preload_new_handler(&mut handler, connection_id, peer);
+
+        Ok(handler)
     }
 
     fn handle_pending_outbound_connection(


### PR DESCRIPTION
## Description

Related: #3844.
Related: #4659.

## Notes & open questions

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
