### PR TITLE
feat(request-reponse): deprecate `Config::set_connection_keep_alive`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2817,7 +2817,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-perf"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ libp2p-metrics = { version = "0.13.1", path = "misc/metrics" }
 libp2p-mplex = { version = "0.40.0", path = "muxers/mplex" }
 libp2p-muxer-test-harness = { path = "muxers/test-harness" }
 libp2p-noise = { version = "0.43.2", path = "transports/noise" }
-libp2p-perf = { version = "0.2.0", path = "protocols/perf" }
+libp2p-perf = { version = "0.2.1", path = "protocols/perf" }
 libp2p-ping = { version = "0.43.1", path = "protocols/ping" }
 libp2p-plaintext = { version = "0.40.1", path = "transports/plaintext" }
 libp2p-pnet = { version = "0.23.1", path = "transports/pnet" }
@@ -99,7 +99,7 @@ libp2p-quic = { version = "0.9.3", path = "transports/quic" }
 libp2p-relay = { version = "0.16.2", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.13.1", path = "protocols/rendezvous" }
 libp2p-upnp = { version = "0.1.1", path = "protocols/upnp" }
-libp2p-request-response = { version = "0.25.2", path = "protocols/request-response" }
+libp2p-request-response = { version = "0.25.3", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.3", path = "misc/server" }
 libp2p-swarm = { version = "0.43.6", path = "swarm" }
 libp2p-swarm-derive = { version = "0.33.0", path = "swarm-derive" }

--- a/protocols/perf/CHANGELOG.md
+++ b/protocols/perf/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.1 - unreleased
+<!-- Internal changes
+
+- Deprecated `request_response::Config::set_connection_keep_alive`
+
+-->
+
 ## 0.2.0 
 
 - Raise MSRV to 1.65.

--- a/protocols/perf/Cargo.toml
+++ b/protocols/perf/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-perf"
 edition = "2021"
 rust-version = { workspace = true }
 description = "libp2p perf protocol implementation"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Max Inden <mail@max-inden.de>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/perf/src/client.rs
+++ b/protocols/perf/src/client.rs
@@ -59,6 +59,7 @@ pub struct Behaviour {
 impl Default for Behaviour {
     fn default() -> Self {
         let mut req_resp_config = request_response::Config::default();
+        #[allow(deprecated)]
         req_resp_config.set_connection_keep_alive(Duration::from_secs(60 * 5));
         req_resp_config.set_request_timeout(Duration::from_secs(60 * 5));
         Self {

--- a/protocols/perf/src/server.rs
+++ b/protocols/perf/src/server.rs
@@ -38,6 +38,7 @@ pub struct Behaviour {
 impl Default for Behaviour {
     fn default() -> Self {
         let mut req_resp_config = request_response::Config::default();
+        #[allow(deprecated)]
         req_resp_config.set_connection_keep_alive(Duration::from_secs(60 * 5));
         req_resp_config.set_request_timeout(Duration::from_secs(60 * 5));
 

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 0.25.2 - unreleased
+- Deprecate `request_response::Config::set_connection_keep_alive` in favor of `SwarmBuilder::idle_connection_timeout`.
+  See [PR 4678].
+
+[PR 4678]: (https://github.com/libp2p/rust-libp2p/pull/4678)
 
 <!-- Internal changes
 

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-request-response"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Generic Request/Response Protocols"
-version = "0.25.2"
+version = "0.25.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -298,6 +298,9 @@ impl Default for Config {
 
 impl Config {
     /// Sets the keep-alive timeout of idle connections.
+    #[deprecated(
+        note = "Set a global idle connection timeout via `SwarmBuilder::idle_connection_timeout` instead."
+    )]
     pub fn set_connection_keep_alive(&mut self, v: Duration) -> &mut Self {
         self.connection_keep_alive = v;
         self


### PR DESCRIPTION
## Description

Deprecate the `request_reponse::Config::set_connection_keep_alive` function in preparation for removing the `KeepAlive::Until` entirely..
Related: #3844.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
