### PR TITLE
feat(swarm): deprecated `keep_alive_timeout` from `OneShotHandlerConfig`

### DIFF
--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -10,6 +10,8 @@
   Individual protocols should not keep connections alive for longer than necessary.
   Users should use `swarm::Config::idle_connection_timeout` instead.
   See [PR 4656](https://github.com/libp2p/rust-libp2p/pull/4656).
+- Deprecate `keep_alive_timeout` in `OneShotHandlerConfig`.
+  See [PR 4680](https://github.com/libp2p/rust-libp2p/pull/4680).
 
 [PR 4120]: https://github.com/libp2p/rust-libp2p/pull/4120
 

--- a/swarm/src/handler/one_shot.rs
+++ b/swarm/src/handler/one_shot.rs
@@ -233,6 +233,9 @@ where
 #[derive(Debug)]
 pub struct OneShotHandlerConfig {
     /// Keep-alive timeout for idle connections.
+    #[deprecated(
+        note = "Set a global idle connection timeout via `SwarmBuilder::idle_connection_timeout` instead."
+    )]
     pub keep_alive_timeout: Duration,
     /// Timeout for outbound substream upgrades.
     pub outbound_substream_timeout: Duration,
@@ -241,6 +244,7 @@ pub struct OneShotHandlerConfig {
 }
 
 impl Default for OneShotHandlerConfig {
+    #[allow(deprecated)]
     fn default() -> Self {
         OneShotHandlerConfig {
             keep_alive_timeout: Duration::from_secs(10),


### PR DESCRIPTION
## Description
Related: #3844.
Related: #4677

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
