### PR TITLE
chore: add new header to changelog of each crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,3 +137,6 @@ clippy.used_underscore_binding = "warn"
 clippy.pedantic = "allow"
 clippy.type_complexity = "allow"
 clippy.unnecessary_wraps = "warn"
+
+[workspace.metadata.release]
+pre-release-hook = ["/bin/sh", '-c', '/bin/sh $WORKSPACE_ROOT/scripts/add-changelog-header.sh']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,4 +139,4 @@ clippy.type_complexity = "allow"
 clippy.unnecessary_wraps = "warn"
 
 [workspace.metadata.release]
-pre-release-hook = ["/bin/sh", '-c', '/bin/sh $WORKSPACE_ROOT/scripts/add-changelog-header.sh']
+pre-release-hook = ["/bin/sh", '-c', '/bin/sh $WORKSPACE_ROOT/scripts/add-changelog-header.sh'] # Nested use of shell to expand variables.

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.41.0 - unreleased
+
+
 ## 0.40.1
 
 - Implement `Debug` for `StreamMuxerEvent`.

--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.53.0 - unreleased
+
+
 ## 0.52.4
 
 - Introduce `libp2p::websocket_websys` module behind `websocket-websys` feature flag.

--- a/misc/allow-block-list/CHANGELOG.md
+++ b/misc/allow-block-list/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.0 - unreleased
+
+
 ## 0.2.0 
 
 - Raise MSRV to 1.65.

--- a/misc/connection-limits/CHANGELOG.md
+++ b/misc/connection-limits/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.0 - unreleased
+
+
 ## 0.2.1
 
 - Do not count a connection as established when it is denied by another sibling `NetworkBehaviour`.

--- a/misc/memory-connection-limits/CHANGELOG.md
+++ b/misc/memory-connection-limits/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.0 - unreleased
+
+
 ## 0.1.0
 
 - Initial release.

--- a/misc/metrics/CHANGELOG.md
+++ b/misc/metrics/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.14.0 - unreleased
+
+
 ## 0.13.1
 
 - Enable gossipsub related data-type fields when compiling for wasm.

--- a/muxers/mplex/CHANGELOG.md
+++ b/muxers/mplex/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.41.0 - unreleased
+
+
 ## 0.40.0 
 
 - Raise MSRV to 1.65.

--- a/muxers/yamux/CHANGELOG.md
+++ b/muxers/yamux/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.45.0 - unreleased
+
+
 ## 0.44.1
 
 - Update to `yamux` `v0.12` which brings performance improvements and introduces an ACK backlog of 256 inbound streams.

--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.12.0 - unreleased
+
+
 ## 0.11.0 
 
 - Raise MSRV to 1.65.

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.11.0 - unreleased
+
+
 ## 0.10.0 
 
 - Raise MSRV to 1.65.

--- a/protocols/floodsub/CHANGELOG.md
+++ b/protocols/floodsub/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.44.0 - unreleased
+
+
 ## 0.43.0 
 
 - Raise MSRV to 1.65.

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.46.0 - unreleased
+
+
 ## 0.45.2
 
 - Deprecate `gossipsub::Config::idle_timeout` in favor of `SwarmBuilder::idle_connection_timeout`.

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.44.0 - unreleased
+
+
 ## 0.43.1
 
 - Handle partial push messages.

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.45.0 - unreleased
+
+
 ## 0.44.6
 
 - Rename `Kademlia` symbols to follow naming convention.

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.45.0 - unreleased
+
+
 ## 0.44.0 
 
 - Change `mdns::Event` to hold `Vec` and remove `DiscoveredAddrsIter` and `ExpiredAddrsIter`.

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.44.0 - unreleased
+
+
 ## 0.43.1
 
 - Honor ping interval in case of errors.

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.17.0 - unreleased
+
+
 ## 0.16.2
 
 <!-- Internal changes

--- a/protocols/rendezvous/CHANGELOG.md
+++ b/protocols/rendezvous/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.14.0 - unreleased
+
+
 ## 0.13.1
 - Refresh registration upon a change in external addresses.
   See [PR 4629].

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.26.0 - unreleased
+
+
 ## 0.25.2
 
 - Deprecate `request_response::Config::set_connection_keep_alive` in favor of `SwarmBuilder::idle_connection_timeout`.

--- a/protocols/upnp/CHANGELOG.md
+++ b/protocols/upnp/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.0 - unreleased
+
+
 ## 0.1.1
 
 - Fix high CPU usage due to repeated generation of failure events.

--- a/scripts/add-changelog-header.sh
+++ b/scripts/add-changelog-header.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+header=$(head -n 1 "$CRATE_ROOT/CHANGELOG.md")
+prefix="## $NEW_VERSION"
+
+if [[ $header == $prefix* ]]; then
+  exit
+fi
+
+sed -i "1i ## ${NEW_VERSION} - unreleased\n\n" "$CRATE_ROOT/CHANGELOG.md"

--- a/swarm-derive/CHANGELOG.md
+++ b/swarm-derive/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.34.0 - unreleased
+
+
 ## 0.33.0 
 
 - Raise MSRV to 1.65.

--- a/swarm-test/CHANGELOG.md
+++ b/swarm-test/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.0 - unreleased
+
+
 ## 0.2.0 
 
 - Raise MSRV to 1.65.

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.44.0 - unreleased
+
+
 ## 0.43.6
 
 - Deprecate `libp2p::swarm::SwarmBuilder`.

--- a/transports/deflate/CHANGELOG.md
+++ b/transports/deflate/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.41.0 - unreleased
+
+
 ## 0.40.1
 
 - Deprecate in preparation for removal from the workspace.

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.41.0 - unreleased
+
+
 ## 0.40.1
 
 - Remove `Dns` prefix from types like `TokioDnsConfig` and `DnsConfig` in favor of modules that describe the different variants.

--- a/transports/noise/CHANGELOG.md
+++ b/transports/noise/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.44.0 - unreleased
+
+
 ## 0.43.2
 
 - Update x25519-dalek to 2.0.0.

--- a/transports/plaintext/CHANGELOG.md
+++ b/transports/plaintext/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.41.0 - unreleased
+
+
 ## 0.40.1
 
 - Rename `Plaintext2Config` to `Config` to follow naming conventions across repository.

--- a/transports/pnet/CHANGELOG.md
+++ b/transports/pnet/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.24.0 - unreleased
+
+
 ## 0.23.1
 
 <!-- Interal changes:

--- a/transports/quic/CHANGELOG.md
+++ b/transports/quic/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.10.0 - unreleased
+
+
 ## 0.9.3
 
 - No longer report error when explicit closing of a QUIC endpoint succeeds.

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.41.0 - unreleased
+
+
 ## 0.40.1
 
 - Expose `async_io::TcpStream`.

--- a/transports/tls/CHANGELOG.md
+++ b/transports/tls/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.0 - unreleased
+
+
 ## 0.2.1
 
 - Switch from webpki to rustls-webpki.

--- a/transports/uds/CHANGELOG.md
+++ b/transports/uds/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.40.0 - unreleased
+
+
 ## 0.39.0 
 
 - Raise MSRV to 1.65.

--- a/transports/websocket-websys/CHANGELOG.md
+++ b/transports/websocket-websys/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.0 - unreleased
+
+
 ## 0.2.0
 
 - Add Websys Websocket transport.

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.43.0 - unreleased
+
+
 ## 0.42.1
 
 - Bump `futures-rustls` to `0.24.0`.

--- a/transports/webtransport-websys/CHANGELOG.md
+++ b/transports/webtransport-websys/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.0 - unreleased
+
+
 ## 0.1.0
 
 * Initial implementation of WebTranport transport using web-sys bindings. See [PR 4015].


### PR DESCRIPTION
## Description

Adds a new header with the correct version to each changelog, otherwise the new lint will fail on all of these crates. We also specify a `cargo release` "pre-release-hook" to automate this. All you need to do is run `cargo release hook` for the same crates that you are running `cargo release version` on.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
