### PR TITLE
refactor(relay): keep connection alive while we are using it

### DIFF
--- a/protocols/relay/src/priv_client/handler.rs
+++ b/protocols/relay/src/priv_client/handler.rs
@@ -29,7 +29,6 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use futures::TryFutureExt;
 use futures_bounded::{PushError, Timeout};
 use futures_timer::Delay;
-use instant::Instant;
 use libp2p_core::multiaddr::Protocol;
 use libp2p_core::upgrade::ReadyUpgrade;
 use libp2p_core::Multiaddr;
@@ -122,8 +121,6 @@ pub struct Handler {
             Either<inbound_stop::FatalUpgradeError, outbound_hop::FatalUpgradeError>,
         >,
     >,
-    /// Until when to keep the connection alive.
-    keep_alive: KeepAlive,
 
     /// Queue of events to return when polled.
     queued_events: VecDeque<
@@ -152,10 +149,6 @@ pub struct Handler {
     ///
     /// Contains a [`futures::future::Future`] for each lend out substream that
     /// resolves once the substream is dropped.
-    ///
-    /// Once all substreams are dropped and this handler has no other work,
-    /// [`KeepAlive::Until`] can be set, allowing the connection to be closed
-    /// eventually.
     alive_lend_out_substreams: FuturesUnordered<oneshot::Receiver<void::Void>>,
 
     open_circuit_futs:
@@ -194,7 +187,6 @@ impl Handler {
                 MAX_NUMBER_DENYING_CIRCUIT,
             ),
             send_error_futs: Default::default(),
-            keep_alive: KeepAlive::Yes,
         }
     }
 
@@ -328,7 +320,27 @@ impl ConnectionHandler for Handler {
     }
 
     fn connection_keep_alive(&self) -> KeepAlive {
-        self.keep_alive
+        if self.reservation.is_some() {
+            return KeepAlive::Yes;
+        }
+
+        if !self.alive_lend_out_substreams.is_empty() {
+            return KeepAlive::Yes;
+        }
+
+        if !self.circuit_deny_futs.is_empty() {
+            return KeepAlive::Yes;
+        }
+
+        if !self.open_circuit_futs.is_empty() {
+            return KeepAlive::Yes;
+        }
+
+        if !self.outbound_circuits.is_empty() {
+            return KeepAlive::Yes;
+        }
+
+        KeepAlive::No
     }
 
     fn poll(
@@ -488,25 +500,6 @@ impl ConnectionHandler for Handler {
             }
         }
 
-        // Update keep-alive handling.
-        #[allow(deprecated)]
-        {
-            if matches!(self.reservation, Reservation::None)
-                && self.alive_lend_out_substreams.is_empty()
-                && self.circuit_deny_futs.is_empty()
-            {
-                match self.keep_alive {
-                    KeepAlive::Yes => {
-                        self.keep_alive =
-                            KeepAlive::Until(Instant::now() + Duration::from_secs(10));
-                    }
-                    KeepAlive::Until(_) => {}
-                    KeepAlive::No => panic!("Handler never sets KeepAlive::No."),
-                }
-            } else {
-                self.keep_alive = KeepAlive::Yes;
-            }
-        }
         Poll::Pending
     }
 
@@ -637,6 +630,10 @@ impl Reservation {
         };
 
         Event::ReservationReqAccepted { renewal, limit }
+    }
+
+    fn is_some(&self) -> bool {
+        matches!(self, Self::Accepted { .. } | Self::Renewing { .. })
     }
 
     /// Marks the current reservation as failed.


### PR DESCRIPTION
## Description

Previously, the relay client was applying a 10 second timeout to idle connections. Instead, we now compute the connection keep alive based on whether we are still using the connection.

This makes all tests pass apart from 1: `reuse_connection`. This makes sense as that connection is immediately idle once dialed. To make that test pass, we configure a global idle connection timeout of 1 second.

In a real-world scenario, reusing a connection only applies if the connection is still alive due to other protocols being active.

Related: #3844.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
