### PR TITLE
chore(autonat, gossipsub, relay, quic): implement latest clippy changes

### DIFF
--- a/protocols/autonat/tests/test_server.rs
+++ b/protocols/autonat/tests/test_server.rs
@@ -305,7 +305,7 @@ async fn test_dial_multiple_addr() {
                 let dial_errors = concurrent_dial_errors.unwrap();
 
                 // The concurrent dial might not be fast enough to produce a dial error.
-                if let Some((addr, _)) = dial_errors.get(0) {
+                if let Some((addr, _)) = dial_errors.first() {
                     assert_eq!(addr, &dial_addresses[0]);
                 }
 

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -3516,7 +3516,7 @@ fn peer_removed_from_mesh(
         .get(&peer_id)
         .expect("To be connected to peer.")
         .connections
-        .get(0)
+        .first()
         .expect("There should be at least one connection to a peer.");
 
     if let Some(topics) = known_topics {

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -1413,7 +1413,7 @@ fn test_explicit_peer_reconnects() {
         .gs_config(config)
         .create_network();
 
-    let peer = others.get(0).unwrap();
+    let peer = others.first().unwrap();
 
     //add peer as explicit peer
     gs.add_explicit_peer(peer);
@@ -1464,7 +1464,7 @@ fn test_handle_graft_explicit_peer() {
         .explicit(1)
         .create_network();
 
-    let peer = peers.get(0).unwrap();
+    let peer = peers.first().unwrap();
 
     gs.handle_graft(peer, topic_hashes.clone());
 

--- a/protocols/relay/src/priv_client.rs
+++ b/protocols/relay/src/priv_client.rs
@@ -302,7 +302,7 @@ impl NetworkBehaviour for Behaviour {
                 match self
                     .directly_connected_peers
                     .get(&relay_peer_id)
-                    .and_then(|cs| cs.get(0))
+                    .and_then(|cs| cs.first())
                 {
                     Some(connection_id) => ToSwarm::NotifyHandler {
                         peer_id: relay_peer_id,
@@ -332,7 +332,7 @@ impl NetworkBehaviour for Behaviour {
                 match self
                     .directly_connected_peers
                     .get(&relay_peer_id)
-                    .and_then(|cs| cs.get(0))
+                    .and_then(|cs| cs.first())
                 {
                     Some(connection_id) => ToSwarm::NotifyHandler {
                         peer_id: relay_peer_id,

--- a/transports/quic/src/connection/connecting.rs
+++ b/transports/quic/src/connection/connecting.rs
@@ -58,7 +58,7 @@ impl Connecting {
         let certificates: Box<Vec<rustls::Certificate>> =
             identity.downcast().expect("we rely on rustls feature; qed");
         let end_entity = certificates
-            .get(0)
+            .first()
             .expect("there should be exactly one certificate; qed");
         let p2p_cert = libp2p_tls::certificate::parse(end_entity)
             .expect("the certificate was validated during TLS handshake; qed");


### PR DESCRIPTION
## Description

I implemented the latest clippy suggestions (again). With those changes the CI won't fail when these lints are merged.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
