### PR TITLE
fix(request-response): don't keep duplicate addresses (v0.52 backport)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ libp2p-quic = { version = "0.9.3", path = "transports/quic" }
 libp2p-relay = { version = "0.16.2", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.13.1", path = "protocols/rendezvous" }
 libp2p-upnp = { version = "0.1.1", path = "protocols/upnp" }
-libp2p-request-response = { version = "0.25.2", path = "protocols/request-response" }
+libp2p-request-response = { version = "0.25.3", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.3", path = "misc/server" }
 libp2p-swarm = { version = "0.43.7", path = "swarm" }
 libp2p-swarm-derive = { version = "0.33.0", path = "swarm-derive" }

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.25.3
 
 - Keep peer addresses in `HashSet` instead of `SmallVec` to prevent adding duplicate addresses.
-  See [PR 4700](https://github.com/libp2p/rust-libp2p/pull/4700).
+  See [PR 4724](https://github.com/libp2p/rust-libp2p/pull/4724).
 
 ## 0.25.2
 

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.25.3 - unreleased
+## 0.25.3
 
 - Keep peer addresses in `HashSet` instead of `SmallVec` to prevent adding duplicate addresses.
   See [PR 4700](https://github.com/libp2p/rust-libp2p/pull/4700).

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.25.3 - unreleased
+
+- Keep peer addresses in `HashSet` instead of `SmallVec` to prevent adding duplicate addresses.
+  See [PR 4700](https://github.com/libp2p/rust-libp2p/pull/4700).
+
 ## 0.25.2
 
 - Deprecate `request_response::Config::set_connection_keep_alive` in favor of `SwarmBuilder::idle_connection_timeout`.

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-request-response"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Generic Request/Response Protocols"
-version = "0.25.2"
+version = "0.25.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -746,7 +746,7 @@ where
             addresses.extend(connections.iter().filter_map(|c| c.remote_address.clone()))
         }
         if let Some(more) = self.addresses.get(&peer) {
-            addresses.extend(more.into_iter().cloned());
+            addresses.extend(more.iter().cloned());
         }
 
         Ok(addresses)

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -448,9 +448,6 @@ where
     /// by [`NetworkBehaviour::handle_pending_outbound_connection`].
     ///
     /// Addresses added in this way are only removed by `remove_address`.
-    ///
-    /// Returns true if the address was added, false otherwise (i.e. if the
-    /// address is already in the list).
     pub fn add_address(&mut self, peer: &PeerId, address: Multiaddr) {
         self.addresses.entry(*peer).or_default().insert(address);
     }

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -451,8 +451,8 @@ where
     ///
     /// Returns true if the address was added, false otherwise (i.e. if the
     /// address is already in the list).
-    pub fn add_address(&mut self, peer: &PeerId, address: Multiaddr) -> bool {
-        self.addresses.entry(*peer).or_default().insert(address)
+    pub fn add_address(&mut self, peer: &PeerId, address: Multiaddr) {
+        self.addresses.entry(*peer).or_default().insert(address);
     }
 
     /// Removes an address of a peer previously added via `add_address`.

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -337,7 +337,7 @@ where
     /// reachable addresses, if any.
     connected: HashMap<PeerId, SmallVec<[Connection; 2]>>,
     /// Externally managed addresses via `add_address` and `remove_address`.
-    addresses: HashMap<PeerId, SmallVec<[Multiaddr; 6]>>,
+    addresses: HashMap<PeerId, HashSet<Multiaddr>>,
     /// Requests that have not yet been sent and are waiting for a connection
     /// to be established.
     pending_outbound_requests: HashMap<PeerId, SmallVec<[RequestProtocol<TCodec>; 10]>>,
@@ -452,15 +452,7 @@ where
     /// Returns true if the address was added, false otherwise (i.e. if the
     /// address is already in the list).
     pub fn add_address(&mut self, peer: &PeerId, address: Multiaddr) -> bool {
-        let addrs = self.addresses.entry(*peer).or_default();
-
-        // Add only if address is not already in the list.
-        if addrs.iter().all(|a| *a != address) {
-            addrs.push(address);
-            true
-        } else {
-            false
-        }
+        self.addresses.entry(*peer).or_default().insert(address)
     }
 
     /// Removes an address of a peer previously added via `add_address`.

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -448,8 +448,19 @@ where
     /// by [`NetworkBehaviour::handle_pending_outbound_connection`].
     ///
     /// Addresses added in this way are only removed by `remove_address`.
-    pub fn add_address(&mut self, peer: &PeerId, address: Multiaddr) {
-        self.addresses.entry(*peer).or_default().push(address);
+    ///
+    /// Returns true if the address was added, false otherwise (i.e. if the
+    /// address is already in the list).
+    pub fn add_address(&mut self, peer: &PeerId, address: Multiaddr) -> bool {
+        let addrs = self.addresses.entry(*peer).or_default();
+
+        // Add only if address is not already in the list.
+        if addrs.iter().all(|a| *a != address) {
+            addrs.push(address);
+            true
+        } else {
+            false
+        }
     }
 
     /// Removes an address of a peer previously added via `add_address`.


### PR DESCRIPTION
Backport of #4700 on `v0.52` branch.

- fix: deduplicate autonat add_server addresses
- keep peers in HashSet instead of SmallVec
- change (&HashSet)::into_iter to equivalent iter
