### PR TITLE
refactor(dcutr): simplify public API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2498,6 +2498,7 @@ dependencies = [
  "either",
  "env_logger 0.10.0",
  "futures",
+ "futures-bounded",
  "futures-timer",
  "instant",
  "libp2p-core",

--- a/hole-punching-tests/src/main.rs
+++ b/hole-punching-tests/src/main.rs
@@ -104,8 +104,7 @@ async fn main() -> Result<()> {
             (
                 SwarmEvent::Behaviour(BehaviourEvent::Dcutr(dcutr::Event {
                     remote_peer_id,
-                    connection_id,
-                    result: Ok(()),
+                    result: Ok(connection_id),
                 })),
                 _,
             ) => {

--- a/hole-punching-tests/src/main.rs
+++ b/hole-punching-tests/src/main.rs
@@ -102,12 +102,11 @@ async fn main() -> Result<()> {
                     .await?;
             }
             (
-                SwarmEvent::Behaviour(BehaviourEvent::Dcutr(
-                    dcutr::Event::DirectConnectionUpgradeSucceeded {
-                        remote_peer_id,
-                        connection_id,
-                    },
-                )),
+                SwarmEvent::Behaviour(BehaviourEvent::Dcutr(dcutr::Event {
+                    remote_peer_id,
+                    connection_id,
+                    result: Ok(()),
+                })),
                 _,
             ) => {
                 log::info!("Successfully hole-punched to {remote_peer_id}");
@@ -127,13 +126,11 @@ async fn main() -> Result<()> {
                 return Ok(());
             }
             (
-                SwarmEvent::Behaviour(BehaviourEvent::Dcutr(
-                    dcutr::Event::DirectConnectionUpgradeFailed {
-                        remote_peer_id,
-                        error,
-                        ..
-                    },
-                )),
+                SwarmEvent::Behaviour(BehaviourEvent::Dcutr(dcutr::Event {
+                    remote_peer_id,
+                    result: Err(error),
+                    ..
+                })),
                 _,
             ) => {
                 log::info!("Failed to hole-punched to {remote_peer_id}");

--- a/libp2p/src/tutorials/hole_punching.rs
+++ b/libp2p/src/tutorials/hole_punching.rs
@@ -166,18 +166,9 @@
 //!    [2022-01-30T12:54:10Z INFO  client] Established connection to PeerId("12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X") via Dialer { address: "/ip4/$RELAY_PEER_ID/tcp/4001/p2p/12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN/p2p-circuit/p2p/12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X", role_override: Dialer }
 //!    ```
 //!
-//! 2. The listening client initiating a direct connection upgrade for the new relayed connection.
-//!    Reported by [`dcutr`](crate::dcutr) through
-//!    [`Event::RemoteInitiatedDirectConnectionUpgrade`](crate::dcutr::Event::RemoteInitiatedDirectConnectionUpgrade).
+//! 2. The direct connection upgrade, also known as hole punch, succeeding.
+//!    Reported by [`dcutr`](crate::dcutr) through [`Event`](crate::dcutr::Event) containing [`Result::Ok`] with the [`ConnectionId`](libp2p_swarm::ConnectionId) of the new direct connection.
 //!
 //!    ``` ignore
-//!    [2022-01-30T12:54:11Z INFO  client] RemoteInitiatedDirectConnectionUpgrade { remote_peer_id: PeerId("12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X"), remote_relayed_addr: "/ip4/$RELAY_PEER_ID/tcp/4001/p2p/12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN/p2p-circuit/p2p/12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X" }
-//!    ```
-//!
-//! 3. The direct connection upgrade, also known as hole punch, succeeding. Reported by
-//!    [`dcutr`](crate::dcutr) through
-//!    [`Event::RemoteInitiatedDirectConnectionUpgrade`](crate::dcutr::Event::DirectConnectionUpgradeSucceeded).
-//!
-//!    ``` ignore
-//!    [2022-01-30T12:54:11Z INFO  client] DirectConnectionUpgradeSucceeded { remote_peer_id: PeerId("12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X") }
+//!    [2022-01-30T12:54:11Z INFO  client] Event { remote_peer_id: PeerId("12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X"), result: Ok(2) }
 //!    ```

--- a/misc/metrics/src/dcutr.rs
+++ b/misc/metrics/src/dcutr.rs
@@ -58,12 +58,10 @@ impl From<&libp2p_dcutr::Event> for EventType {
         match event {
             libp2p_dcutr::Event {
                 remote_peer_id: _,
-                connection_id: _,
-                result: Ok(()),
+                result: Ok(_),
             } => EventType::DirectConnectionUpgradeSucceeded,
             libp2p_dcutr::Event {
                 remote_peer_id: _,
-                connection_id: _,
                 result: Err(_),
             } => EventType::DirectConnectionUpgradeFailed,
         }

--- a/misc/metrics/src/dcutr.rs
+++ b/misc/metrics/src/dcutr.rs
@@ -56,14 +56,15 @@ enum EventType {
 impl From<&libp2p_dcutr::Event> for EventType {
     fn from(event: &libp2p_dcutr::Event) -> Self {
         match event {
-            libp2p_dcutr::Event::DirectConnectionUpgradeSucceeded {
+            libp2p_dcutr::Event {
                 remote_peer_id: _,
                 connection_id: _,
+                result: Ok(()),
             } => EventType::DirectConnectionUpgradeSucceeded,
-            libp2p_dcutr::Event::DirectConnectionUpgradeFailed {
+            libp2p_dcutr::Event {
                 remote_peer_id: _,
                 connection_id: _,
-                error: _,
+                result: Err(_),
             } => EventType::DirectConnectionUpgradeFailed,
         }
     }

--- a/misc/metrics/src/dcutr.rs
+++ b/misc/metrics/src/dcutr.rs
@@ -49,8 +49,6 @@ struct EventLabels {
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelValue)]
 enum EventType {
-    InitiateDirectConnectionUpgrade,
-    RemoteInitiatedDirectConnectionUpgrade,
     DirectConnectionUpgradeSucceeded,
     DirectConnectionUpgradeFailed,
 }
@@ -58,14 +56,6 @@ enum EventType {
 impl From<&libp2p_dcutr::Event> for EventType {
     fn from(event: &libp2p_dcutr::Event) -> Self {
         match event {
-            libp2p_dcutr::Event::InitiatedDirectConnectionUpgrade {
-                remote_peer_id: _,
-                local_relayed_addr: _,
-            } => EventType::InitiateDirectConnectionUpgrade,
-            libp2p_dcutr::Event::RemoteInitiatedDirectConnectionUpgrade {
-                remote_peer_id: _,
-                remote_relayed_addr: _,
-            } => EventType::RemoteInitiatedDirectConnectionUpgrade,
             libp2p_dcutr::Event::DirectConnectionUpgradeSucceeded {
                 remote_peer_id: _,
                 connection_id: _,

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -1,10 +1,7 @@
 ## 0.11.0 - unreleased
 
 - Add `ConnectionId` to `Event::DirectConnectionUpgradeSucceeded` and `Event::DirectConnectionUpgradeFailed`.
-  See [PR 4558].
-
-[PR 4558]: https://github.com/libp2p/rust-libp2p/pull/4558
-
+  See [PR 4558](https://github.com/libp2p/rust-libp2p/pull/4558).
 - Exchange address _candidates_ instead of external addresses in `CONNECT`.
   If hole-punching wasn't working properly for you until now, this might be the reason why.
   See [PR 4624](https://github.com/libp2p/rust-libp2p/pull/4624).

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Exchange address _candidates_ instead of external addresses in `CONNECT`.
   If hole-punching wasn't working properly for you until now, this might be the reason why.
   See [PR 4624](https://github.com/libp2p/rust-libp2p/pull/4624).
+- Simplify public API.
+  We now only emit a single event: whether the hole-punch was successful or not.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
 
 ## 0.10.0 
 

--- a/protocols/dcutr/Cargo.toml
+++ b/protocols/dcutr/Cargo.toml
@@ -25,6 +25,7 @@ quick-protobuf-codec = { workspace = true }
 thiserror = "1.0"
 void = "1"
 lru = "0.11.1"
+futures-bounded = { workspace = true }
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }

--- a/protocols/dcutr/src/behaviour.rs
+++ b/protocols/dcutr/src/behaviour.rs
@@ -46,8 +46,7 @@ pub(crate) const MAX_NUMBER_OF_UPGRADE_ATTEMPTS: u8 = 3;
 #[derive(Debug)]
 pub struct Event {
     pub remote_peer_id: PeerId,
-    pub connection_id: ConnectionId,
-    pub result: Result<(), Error>,
+    pub result: Result<ConnectionId, Error>,
 }
 
 #[derive(Debug, Error)]
@@ -128,7 +127,6 @@ impl Behaviour {
         } else {
             self.queued_events.extend([ToSwarm::GenerateEvent(Event {
                 remote_peer_id: peer_id,
-                connection_id: failed_direct_connection,
                 result: Err(Error {
                     attempts: MAX_NUMBER_OF_UPGRADE_ATTEMPTS,
                 }),
@@ -234,8 +232,7 @@ impl NetworkBehaviour for Behaviour {
 
             self.queued_events.extend([ToSwarm::GenerateEvent(Event {
                 remote_peer_id: peer,
-                connection_id,
-                result: Ok(()),
+                result: Ok(connection_id),
             })]);
         }
 

--- a/protocols/dcutr/src/behaviour.rs
+++ b/protocols/dcutr/src/behaviour.rs
@@ -58,8 +58,8 @@ pub enum Event {
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Failed to dial peer.")]
-    Dial,
+    #[error("Failed to hole-punch after {MAX_NUMBER_OF_UPGRADE_ATTEMPTS}")]
+    AttemptsExceeded,
     #[error("Outbound handshake failed: {0}.")]
     Outbound(protocol::outbound::Error),
     #[error("Inbound handshake failed: {0}.")]
@@ -140,7 +140,7 @@ impl Behaviour {
                 Event::DirectConnectionUpgradeFailed {
                     remote_peer_id: peer_id,
                     connection_id: failed_direct_connection,
-                    error: Error::Dial,
+                    error: Error::AttemptsExceeded,
                 },
             )]);
         }

--- a/protocols/dcutr/src/behaviour.rs
+++ b/protocols/dcutr/src/behaviour.rs
@@ -45,14 +45,6 @@ pub(crate) const MAX_NUMBER_OF_UPGRADE_ATTEMPTS: u8 = 3;
 /// The events produced by the [`Behaviour`].
 #[derive(Debug)]
 pub enum Event {
-    // InitiatedDirectConnectionUpgrade {
-    //     remote_peer_id: PeerId,
-    //     local_relayed_addr: Multiaddr,
-    // },
-    // RemoteInitiatedDirectConnectionUpgrade {
-    //     remote_peer_id: PeerId,
-    //     remote_relayed_addr: Multiaddr,
-    // },
     DirectConnectionUpgradeSucceeded {
         remote_peer_id: PeerId,
         connection_id: ConnectionId,

--- a/protocols/dcutr/src/handler/relayed.rs
+++ b/protocols/dcutr/src/handler/relayed.rs
@@ -40,6 +40,7 @@ use std::collections::VecDeque;
 use std::io;
 use std::task::{Context, Poll};
 use std::time::Duration;
+use void::Void;
 
 #[derive(Debug)]
 pub enum Command {
@@ -181,8 +182,7 @@ impl Handler {
 impl ConnectionHandler for Handler {
     type FromBehaviour = Command;
     type ToBehaviour = Event;
-    type Error =
-        StreamUpgradeError<Either<inbound::ProtocolViolation, outbound::ProtocolViolation>>;
+    type Error = Void;
     type InboundProtocol = Either<ReadyUpgrade<StreamProtocol>, DeniedUpgrade>;
     type OutboundProtocol = ReadyUpgrade<StreamProtocol>;
     type OutboundOpenInfo = ();

--- a/protocols/dcutr/src/handler/relayed.rs
+++ b/protocols/dcutr/src/handler/relayed.rs
@@ -21,22 +21,25 @@
 //! [`ConnectionHandler`] handling relayed connection potentially upgraded to a direct connection.
 
 use crate::behaviour::MAX_NUMBER_OF_UPGRADE_ATTEMPTS;
-use crate::protocol;
+use crate::{protocol, PROTOCOL_NAME};
 use either::Either;
 use futures::future;
-use futures::future::{BoxFuture, FutureExt};
 use libp2p_core::multiaddr::Multiaddr;
-use libp2p_core::upgrade::DeniedUpgrade;
+use libp2p_core::upgrade::{DeniedUpgrade, ReadyUpgrade};
 use libp2p_core::ConnectedPoint;
 use libp2p_swarm::handler::{
     ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
     ListenUpgradeError,
 };
 use libp2p_swarm::{
-    ConnectionHandler, ConnectionHandlerEvent, StreamUpgradeError, SubstreamProtocol,
+    ConnectionHandler, ConnectionHandlerEvent, StreamProtocol, StreamUpgradeError,
+    SubstreamProtocol,
 };
+use protocol::{inbound, outbound};
 use std::collections::VecDeque;
+use std::io;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 #[derive(Debug)]
 pub enum Command {
@@ -45,26 +48,14 @@ pub enum Command {
 
 #[derive(Debug)]
 pub enum Event {
-    InboundConnectRequest {
-        remote_addr: Multiaddr,
-    },
-    InboundConnectNegotiated(Vec<Multiaddr>),
-    OutboundNegotiationFailed {
-        error: StreamUpgradeError<void::Void>,
-    },
-    OutboundConnectNegotiated {
-        remote_addrs: Vec<Multiaddr>,
-    },
+    InboundConnectNegotiated { remote_addrs: Vec<Multiaddr> },
+    InboundConnectFailed { error: inbound::Error },
+    OutboundConnectNegotiated { remote_addrs: Vec<Multiaddr> },
+    OutboundConnectFailed { error: outbound::Error },
 }
 
 pub struct Handler {
     endpoint: ConnectedPoint,
-    /// A pending fatal error that results in the connection being closed.
-    pending_error: Option<
-        StreamUpgradeError<
-            Either<protocol::inbound::UpgradeError, protocol::outbound::UpgradeError>,
-        >,
-    >,
     /// Queue of events to return when polled.
     queued_events: VecDeque<
         ConnectionHandlerEvent<
@@ -74,9 +65,12 @@ pub struct Handler {
             <Self as ConnectionHandler>::Error,
         >,
     >,
-    /// Inbound connect, accepted by the behaviour, pending completion.
-    inbound_connect:
-        Option<BoxFuture<'static, Result<Vec<Multiaddr>, protocol::inbound::UpgradeError>>>,
+
+    // Inbound DCUtR handshakes
+    inbound_stream: futures_bounded::FuturesSet<Result<Vec<Multiaddr>, inbound::Error>>,
+
+    // Outbound DCUtR handshake.
+    outbound_stream: futures_bounded::FuturesSet<Result<Vec<Multiaddr>, outbound::Error>>,
 
     /// The addresses we will send to the other party for hole-punching attempts.
     holepunch_candidates: Vec<Multiaddr>,
@@ -88,9 +82,9 @@ impl Handler {
     pub fn new(endpoint: ConnectedPoint, holepunch_candidates: Vec<Multiaddr>) -> Self {
         Self {
             endpoint,
-            pending_error: Default::default(),
             queued_events: Default::default(),
-            inbound_connect: Default::default(),
+            inbound_stream: futures_bounded::FuturesSet::new(Duration::from_secs(10), 1),
+            outbound_stream: futures_bounded::FuturesSet::new(Duration::from_secs(10), 1),
             holepunch_candidates,
             attempts: 0,
         }
@@ -106,29 +100,19 @@ impl Handler {
         >,
     ) {
         match output {
-            future::Either::Left(inbound_connect) => {
+            future::Either::Left(stream) => {
                 if self
-                    .inbound_connect
-                    .replace(
-                        inbound_connect
-                            .accept(self.holepunch_candidates.clone())
-                            .boxed(),
-                    )
-                    .is_some()
+                    .inbound_stream
+                    .try_push(inbound::handshake(
+                        stream,
+                        self.holepunch_candidates.clone(),
+                    ))
+                    .is_err()
                 {
                     log::warn!(
-                        "New inbound connect stream while still upgrading previous one. \
-                         Replacing previous with new.",
+                        "New inbound connect stream while still upgrading previous one. Replacing previous with new.",
                     );
                 }
-                let remote_addr = match &self.endpoint {
-                    ConnectedPoint::Dialer { address, role_override: _ } => address.clone(),
-                    ConnectedPoint::Listener { ..} => unreachable!("`<Handler as ConnectionHandler>::listen_protocol` denies all incoming substreams as a listener."),
-                };
-                self.queued_events
-                    .push_back(ConnectionHandlerEvent::NotifyBehaviour(
-                        Event::InboundConnectRequest { remote_addr },
-                    ));
                 self.attempts += 1;
             }
             // A connection listener denies all incoming substreams, thus none can ever be fully negotiated.
@@ -139,8 +123,7 @@ impl Handler {
     fn on_fully_negotiated_outbound(
         &mut self,
         FullyNegotiatedOutbound {
-            protocol: protocol::outbound::Connect { obs_addrs },
-            ..
+            protocol: stream, ..
         }: FullyNegotiatedOutbound<
             <Self as ConnectionHandler>::OutboundProtocol,
             <Self as ConnectionHandler>::OutboundOpenInfo,
@@ -150,12 +133,18 @@ impl Handler {
             self.endpoint.is_listener(),
             "A connection dialer never initiates a connection upgrade."
         );
-        self.queued_events
-            .push_back(ConnectionHandlerEvent::NotifyBehaviour(
-                Event::OutboundConnectNegotiated {
-                    remote_addrs: obs_addrs,
-                },
-            ));
+        if self
+            .outbound_stream
+            .try_push(outbound::handshake(
+                stream,
+                self.holepunch_candidates.clone(),
+            ))
+            .is_err()
+        {
+            log::warn!(
+                "New outbound connect stream while still upgrading previous one. Replacing previous with new.",
+            );
+        }
     }
 
     fn on_listen_upgrade_error(
@@ -165,10 +154,7 @@ impl Handler {
             <Self as ConnectionHandler>::InboundProtocol,
         >,
     ) {
-        self.pending_error = Some(StreamUpgradeError::Apply(match error {
-            Either::Left(e) => Either::Left(e),
-            Either::Right(v) => void::unreachable(v),
-        }));
+        void::unreachable(error.into_inner());
     }
 
     fn on_dial_upgrade_error(
@@ -178,50 +164,34 @@ impl Handler {
             <Self as ConnectionHandler>::OutboundProtocol,
         >,
     ) {
-        match error {
-            StreamUpgradeError::Timeout => {
-                self.queued_events
-                    .push_back(ConnectionHandlerEvent::NotifyBehaviour(
-                        Event::OutboundNegotiationFailed {
-                            error: StreamUpgradeError::Timeout,
-                        },
-                    ));
-            }
-            StreamUpgradeError::NegotiationFailed => {
-                // The remote merely doesn't support the DCUtR protocol.
-                // This is no reason to close the connection, which may
-                // successfully communicate with other protocols already.
-                self.queued_events
-                    .push_back(ConnectionHandlerEvent::NotifyBehaviour(
-                        Event::OutboundNegotiationFailed {
-                            error: StreamUpgradeError::NegotiationFailed,
-                        },
-                    ));
-            }
-            _ => {
-                // Anything else is considered a fatal error or misbehaviour of
-                // the remote peer and results in closing the connection.
-                self.pending_error = Some(error.map_upgrade_err(Either::Right));
-            }
-        }
+        let error = match error {
+            StreamUpgradeError::Apply(v) => void::unreachable(v),
+            StreamUpgradeError::NegotiationFailed => outbound::Error::Unsupported,
+            StreamUpgradeError::Io(e) => outbound::Error::Io(e),
+            StreamUpgradeError::Timeout => outbound::Error::Io(io::ErrorKind::TimedOut.into()),
+        };
+
+        self.queued_events
+            .push_back(ConnectionHandlerEvent::NotifyBehaviour(
+                Event::OutboundConnectFailed { error },
+            ))
     }
 }
 
 impl ConnectionHandler for Handler {
     type FromBehaviour = Command;
     type ToBehaviour = Event;
-    type Error = StreamUpgradeError<
-        Either<protocol::inbound::UpgradeError, protocol::outbound::UpgradeError>,
-    >;
-    type InboundProtocol = Either<protocol::inbound::Upgrade, DeniedUpgrade>;
-    type OutboundProtocol = protocol::outbound::Upgrade;
+    type Error =
+        StreamUpgradeError<Either<inbound::ProtocolViolation, outbound::ProtocolViolation>>;
+    type InboundProtocol = Either<ReadyUpgrade<StreamProtocol>, DeniedUpgrade>;
+    type OutboundProtocol = ReadyUpgrade<StreamProtocol>;
     type OutboundOpenInfo = ();
     type InboundOpenInfo = ();
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
         match self.endpoint {
             ConnectedPoint::Dialer { .. } => {
-                SubstreamProtocol::new(Either::Left(protocol::inbound::Upgrade {}), ())
+                SubstreamProtocol::new(Either::Left(ReadyUpgrade::new(PROTOCOL_NAME)), ())
             }
             ConnectedPoint::Listener { .. } => {
                 // By the protocol specification the listening side of a relayed connection
@@ -239,10 +209,7 @@ impl ConnectionHandler for Handler {
             Command::Connect => {
                 self.queued_events
                     .push_back(ConnectionHandlerEvent::OutboundSubstreamRequest {
-                        protocol: SubstreamProtocol::new(
-                            protocol::outbound::Upgrade::new(self.holepunch_candidates.clone()),
-                            (),
-                        ),
+                        protocol: SubstreamProtocol::new(ReadyUpgrade::new(PROTOCOL_NAME), ()),
                     });
                 self.attempts += 1;
             }
@@ -268,31 +235,55 @@ impl ConnectionHandler for Handler {
             Self::Error,
         >,
     > {
-        // Check for a pending (fatal) error.
-        if let Some(err) = self.pending_error.take() {
-            // The handler will not be polled again by the `Swarm`.
-            return Poll::Ready(ConnectionHandlerEvent::Close(err));
-        }
-
         // Return queued events.
         if let Some(event) = self.queued_events.pop_front() {
             return Poll::Ready(event);
         }
 
-        if let Some(Poll::Ready(result)) = self.inbound_connect.as_mut().map(|f| f.poll_unpin(cx)) {
-            self.inbound_connect = None;
-            match result {
-                Ok(addresses) => {
-                    return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
-                        Event::InboundConnectNegotiated(addresses),
-                    ));
-                }
-                Err(e) => {
-                    return Poll::Ready(ConnectionHandlerEvent::Close(StreamUpgradeError::Apply(
-                        Either::Left(e),
-                    )))
-                }
+        match self.inbound_stream.poll_unpin(cx) {
+            Poll::Ready(Ok(Ok(addresses))) => {
+                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
+                    Event::InboundConnectNegotiated {
+                        remote_addrs: addresses,
+                    },
+                ))
             }
+            Poll::Ready(Ok(Err(error))) => {
+                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
+                    Event::InboundConnectFailed { error },
+                ))
+            }
+            Poll::Ready(Err(futures_bounded::Timeout { .. })) => {
+                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
+                    Event::InboundConnectFailed {
+                        error: inbound::Error::Io(io::ErrorKind::TimedOut.into()),
+                    },
+                ))
+            }
+            Poll::Pending => {}
+        }
+
+        match self.outbound_stream.poll_unpin(cx) {
+            Poll::Ready(Ok(Ok(addresses))) => {
+                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
+                    Event::OutboundConnectNegotiated {
+                        remote_addrs: addresses,
+                    },
+                ))
+            }
+            Poll::Ready(Ok(Err(error))) => {
+                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
+                    Event::OutboundConnectFailed { error },
+                ))
+            }
+            Poll::Ready(Err(futures_bounded::Timeout { .. })) => {
+                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
+                    Event::OutboundConnectFailed {
+                        error: outbound::Error::Io(io::ErrorKind::TimedOut.into()),
+                    },
+                ))
+            }
+            Poll::Pending => {}
         }
 
         Poll::Pending

--- a/protocols/dcutr/src/lib.rs
+++ b/protocols/dcutr/src/lib.rs
@@ -36,8 +36,8 @@ mod proto {
 pub use behaviour::{Behaviour, Error, Event};
 pub use protocol::PROTOCOL_NAME;
 pub mod inbound {
-    pub use crate::protocol::inbound::UpgradeError;
+    pub use crate::protocol::inbound::ProtocolViolation;
 }
 pub mod outbound {
-    pub use crate::protocol::outbound::UpgradeError;
+    pub use crate::protocol::outbound::ProtocolViolation;
 }

--- a/protocols/dcutr/src/protocol/inbound.rs
+++ b/protocols/dcutr/src/protocol/inbound.rs
@@ -41,29 +41,29 @@ pub(crate) async fn handshake(
         .await
         .ok_or(io::Error::from(io::ErrorKind::UnexpectedEof))??;
 
-    let obs_addrs = if ObsAddrs.is_empty() {
+    if ObsAddrs.is_empty() {
         return Err(Error::Protocol(ProtocolViolation::NoAddresses));
-    } else {
-        ObsAddrs
-            .into_iter()
-            .filter_map(|a| match Multiaddr::try_from(a.to_vec()) {
-                Ok(a) => Some(a),
-                Err(e) => {
-                    log::debug!("Unable to parse multiaddr: {e}");
-                    None
-                }
-            })
-            // Filter out relayed addresses.
-            .filter(|a| {
-                if a.iter().any(|p| p == Protocol::P2pCircuit) {
-                    log::debug!("Dropping relayed address {a}");
-                    false
-                } else {
-                    true
-                }
-            })
-            .collect::<Vec<Multiaddr>>()
     };
+
+    let obs_addrs = ObsAddrs
+        .into_iter()
+        .filter_map(|a| match Multiaddr::try_from(a.to_vec()) {
+            Ok(a) => Some(a),
+            Err(e) => {
+                log::debug!("Unable to parse multiaddr: {e}");
+                None
+            }
+        })
+        // Filter out relayed addresses.
+        .filter(|a| {
+            if a.iter().any(|p| p == Protocol::P2pCircuit) {
+                log::debug!("Dropping relayed address {a}");
+                false
+            } else {
+                true
+            }
+        })
+        .collect();
 
     match type_pb {
         proto::Type::CONNECT => {}

--- a/protocols/dcutr/src/protocol/inbound.rs
+++ b/protocols/dcutr/src/protocol/inbound.rs
@@ -88,7 +88,7 @@ pub(crate) async fn handshake(
 }
 
 #[derive(Debug, Error)]
-pub(crate) enum Error {
+pub enum Error {
     #[error("IO error")]
     Io(#[from] io::Error),
     #[error("Protocol error")]

--- a/protocols/dcutr/src/protocol/inbound.rs
+++ b/protocols/dcutr/src/protocol/inbound.rs
@@ -88,7 +88,7 @@ pub(crate) async fn handshake(
 }
 
 #[derive(Debug, Error)]
-pub enum Error {
+pub(crate) enum Error {
     #[error("IO error")]
     Io(#[from] io::Error),
     #[error("Protocol error")]

--- a/protocols/dcutr/src/protocol/inbound.rs
+++ b/protocols/dcutr/src/protocol/inbound.rs
@@ -65,9 +65,8 @@ pub(crate) async fn handshake(
         })
         .collect();
 
-    match type_pb {
-        proto::Type::CONNECT => {}
-        proto::Type::SYNC => return Err(Error::Protocol(ProtocolViolation::UnexpectedTypeSync)),
+    if !matches!(type_pb, proto::Type::CONNECT) {
+        return Err(Error::Protocol(ProtocolViolation::UnexpectedTypeSync));
     }
 
     let msg = proto::HolePunch {
@@ -81,11 +80,8 @@ pub(crate) async fn handshake(
         .await
         .ok_or(io::Error::from(io::ErrorKind::UnexpectedEof))??;
 
-    match type_pb {
-        proto::Type::CONNECT => {
-            return Err(Error::Protocol(ProtocolViolation::UnexpectedTypeConnect))
-        }
-        proto::Type::SYNC => {}
+    if !matches!(type_pb, proto::Type::SYNC) {
+        return Err(Error::Protocol(ProtocolViolation::UnexpectedTypeConnect));
     }
 
     Ok(obs_addrs)

--- a/protocols/dcutr/src/protocol/outbound.rs
+++ b/protocols/dcutr/src/protocol/outbound.rs
@@ -19,115 +19,103 @@
 // DEALINGS IN THE SOFTWARE.
 
 use crate::proto;
+use crate::PROTOCOL_NAME;
 use asynchronous_codec::Framed;
-use futures::{future::BoxFuture, prelude::*};
+use futures::prelude::*;
 use futures_timer::Delay;
 use instant::Instant;
-use libp2p_core::{multiaddr::Protocol, upgrade, Multiaddr};
-use libp2p_swarm::{Stream, StreamProtocol};
+use libp2p_core::{multiaddr::Protocol, Multiaddr};
+use libp2p_swarm::Stream;
 use std::convert::TryFrom;
-use std::iter;
+use std::io;
 use thiserror::Error;
 
-pub struct Upgrade {
-    obs_addrs: Vec<Multiaddr>,
-}
+pub(crate) async fn handshake(
+    stream: Stream,
+    candidates: Vec<Multiaddr>,
+) -> Result<Vec<Multiaddr>, Error> {
+    let mut stream = Framed::new(
+        stream,
+        quick_protobuf_codec::Codec::new(super::MAX_MESSAGE_SIZE_BYTES),
+    );
 
-impl upgrade::UpgradeInfo for Upgrade {
-    type Info = StreamProtocol;
-    type InfoIter = iter::Once<Self::Info>;
+    let msg = proto::HolePunch {
+        type_pb: proto::Type::CONNECT,
+        ObsAddrs: candidates.into_iter().map(|a| a.to_vec()).collect(),
+    };
 
-    fn protocol_info(&self) -> Self::InfoIter {
-        iter::once(super::PROTOCOL_NAME)
+    stream.send(msg).await?;
+
+    let sent_time = Instant::now();
+
+    let proto::HolePunch { type_pb, ObsAddrs } = stream
+        .next()
+        .await
+        .ok_or(io::Error::from(io::ErrorKind::UnexpectedEof))??;
+
+    let rtt = sent_time.elapsed();
+
+    match type_pb {
+        proto::Type::CONNECT => {}
+        proto::Type::SYNC => return Err(Error::Protocol(ProtocolViolation::UnexpectedTypeSync)),
     }
-}
 
-impl Upgrade {
-    pub fn new(obs_addrs: Vec<Multiaddr>) -> Self {
-        Self { obs_addrs }
-    }
-}
+    let obs_addrs = if ObsAddrs.is_empty() {
+        return Err(Error::Protocol(ProtocolViolation::NoAddresses));
+    } else {
+        ObsAddrs
+            .into_iter()
+            .filter_map(|a| match Multiaddr::try_from(a.to_vec()) {
+                Ok(a) => Some(a),
+                Err(e) => {
+                    log::debug!("Unable to parse multiaddr: {e}");
+                    None
+                }
+            })
+            // Filter out relayed addresses.
+            .filter(|a| {
+                if a.iter().any(|p| p == Protocol::P2pCircuit) {
+                    log::debug!("Dropping relayed address {a}");
+                    false
+                } else {
+                    true
+                }
+            })
+            .collect::<Vec<Multiaddr>>()
+    };
 
-impl upgrade::OutboundUpgrade<Stream> for Upgrade {
-    type Output = Connect;
-    type Error = UpgradeError;
-    type Future = BoxFuture<'static, Result<Self::Output, Self::Error>>;
+    let msg = proto::HolePunch {
+        type_pb: proto::Type::SYNC,
+        ObsAddrs: vec![],
+    };
 
-    fn upgrade_outbound(self, substream: Stream, _: Self::Info) -> Self::Future {
-        let mut substream = Framed::new(
-            substream,
-            quick_protobuf_codec::Codec::new(super::MAX_MESSAGE_SIZE_BYTES),
-        );
+    stream.send(msg).await?;
 
-        let msg = proto::HolePunch {
-            type_pb: proto::Type::CONNECT,
-            ObsAddrs: self.obs_addrs.into_iter().map(|a| a.to_vec()).collect(),
-        };
+    Delay::new(rtt / 2).await;
 
-        async move {
-            substream.send(msg).await?;
-
-            let sent_time = Instant::now();
-
-            let proto::HolePunch { type_pb, ObsAddrs } =
-                substream.next().await.ok_or(UpgradeError::StreamClosed)??;
-
-            let rtt = sent_time.elapsed();
-
-            match type_pb {
-                proto::Type::CONNECT => {}
-                proto::Type::SYNC => return Err(UpgradeError::UnexpectedTypeSync),
-            }
-
-            let obs_addrs = if ObsAddrs.is_empty() {
-                return Err(UpgradeError::NoAddresses);
-            } else {
-                ObsAddrs
-                    .into_iter()
-                    .filter_map(|a| match Multiaddr::try_from(a.to_vec()) {
-                        Ok(a) => Some(a),
-                        Err(e) => {
-                            log::debug!("Unable to parse multiaddr: {e}");
-                            None
-                        }
-                    })
-                    // Filter out relayed addresses.
-                    .filter(|a| {
-                        if a.iter().any(|p| p == Protocol::P2pCircuit) {
-                            log::debug!("Dropping relayed address {a}");
-                            false
-                        } else {
-                            true
-                        }
-                    })
-                    .collect::<Vec<Multiaddr>>()
-            };
-
-            let msg = proto::HolePunch {
-                type_pb: proto::Type::SYNC,
-                ObsAddrs: vec![],
-            };
-
-            substream.send(msg).await?;
-
-            Delay::new(rtt / 2).await;
-
-            Ok(Connect { obs_addrs })
-        }
-        .boxed()
-    }
-}
-
-pub struct Connect {
-    pub obs_addrs: Vec<Multiaddr>,
+    Ok(obs_addrs)
 }
 
 #[derive(Debug, Error)]
-pub enum UpgradeError {
+pub enum Error {
+    #[error("IO error")]
+    Io(#[from] io::Error),
+    #[error("Remote does not support the `{PROTOCOL_NAME}` protocol")]
+    Unsupported,
+    #[error("Protocol error")]
+    Protocol(#[from] ProtocolViolation),
+}
+
+impl From<quick_protobuf_codec::Error> for Error {
+    fn from(e: quick_protobuf_codec::Error) -> Self {
+        Error::Protocol(ProtocolViolation::Codec(e))
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ProtocolViolation {
     #[error(transparent)]
     Codec(#[from] quick_protobuf_codec::Error),
-    #[error("Stream closed")]
-    StreamClosed,
     #[error("Expected 'status' field to be set.")]
     MissingStatusField,
     #[error("Expected 'reservation' field to be set.")]

--- a/protocols/dcutr/src/protocol/outbound.rs
+++ b/protocols/dcutr/src/protocol/outbound.rs
@@ -60,29 +60,29 @@ pub(crate) async fn handshake(
         proto::Type::SYNC => return Err(Error::Protocol(ProtocolViolation::UnexpectedTypeSync)),
     }
 
-    let obs_addrs = if ObsAddrs.is_empty() {
+    if ObsAddrs.is_empty() {
         return Err(Error::Protocol(ProtocolViolation::NoAddresses));
-    } else {
-        ObsAddrs
-            .into_iter()
-            .filter_map(|a| match Multiaddr::try_from(a.to_vec()) {
-                Ok(a) => Some(a),
-                Err(e) => {
-                    log::debug!("Unable to parse multiaddr: {e}");
-                    None
-                }
-            })
-            // Filter out relayed addresses.
-            .filter(|a| {
-                if a.iter().any(|p| p == Protocol::P2pCircuit) {
-                    log::debug!("Dropping relayed address {a}");
-                    false
-                } else {
-                    true
-                }
-            })
-            .collect::<Vec<Multiaddr>>()
-    };
+    }
+
+    let obs_addrs = ObsAddrs
+        .into_iter()
+        .filter_map(|a| match Multiaddr::try_from(a.to_vec()) {
+            Ok(a) => Some(a),
+            Err(e) => {
+                log::debug!("Unable to parse multiaddr: {e}");
+                None
+            }
+        })
+        // Filter out relayed addresses.
+        .filter(|a| {
+            if a.iter().any(|p| p == Protocol::P2pCircuit) {
+                log::debug!("Dropping relayed address {a}");
+                false
+            } else {
+                true
+            }
+        })
+        .collect();
 
     let msg = proto::HolePunch {
         type_pb: proto::Type::SYNC,

--- a/protocols/dcutr/src/protocol/outbound.rs
+++ b/protocols/dcutr/src/protocol/outbound.rs
@@ -55,9 +55,8 @@ pub(crate) async fn handshake(
 
     let rtt = sent_time.elapsed();
 
-    match type_pb {
-        proto::Type::CONNECT => {}
-        proto::Type::SYNC => return Err(Error::Protocol(ProtocolViolation::UnexpectedTypeSync)),
+    if !matches!(type_pb, proto::Type::CONNECT) {
+        return Err(Error::Protocol(ProtocolViolation::UnexpectedTypeSync));
     }
 
     if ObsAddrs.is_empty() {

--- a/protocols/dcutr/tests/lib.rs
+++ b/protocols/dcutr/tests/lib.rs
@@ -90,9 +90,11 @@ async fn connect() {
 
     let reported_conn_id = src
         .wait(move |e| match e {
-            SwarmEvent::Behaviour(ClientEvent::Dcutr(
-                dcutr::Event::DirectConnectionUpgradeSucceeded { connection_id, .. },
-            )) => Some(connection_id),
+            SwarmEvent::Behaviour(ClientEvent::Dcutr(dcutr::Event {
+                connection_id,
+                result: Ok(()),
+                ..
+            })) => Some(connection_id),
             _ => None,
         })
         .await;

--- a/protocols/dcutr/tests/lib.rs
+++ b/protocols/dcutr/tests/lib.rs
@@ -75,26 +75,6 @@ async fn connect() {
 
     src.dial_and_wait(dst_relayed_addr.clone()).await;
 
-    loop {
-        match src
-            .next_swarm_event()
-            .await
-            .try_into_behaviour_event()
-            .unwrap()
-        {
-            ClientEvent::Dcutr(dcutr::Event::RemoteInitiatedDirectConnectionUpgrade {
-                remote_peer_id,
-                remote_relayed_addr,
-            }) => {
-                if remote_peer_id == dst_peer_id && remote_relayed_addr == dst_relayed_addr {
-                    break;
-                }
-            }
-            ClientEvent::Identify(_) => {}
-            other => panic!("Unexpected event: {other:?}."),
-        }
-    }
-
     let dst_addr = dst_tcp_addr.with(Protocol::P2p(dst_peer_id));
 
     let established_conn_id = src

--- a/protocols/dcutr/tests/lib.rs
+++ b/protocols/dcutr/tests/lib.rs
@@ -91,8 +91,7 @@ async fn connect() {
     let reported_conn_id = src
         .wait(move |e| match e {
             SwarmEvent::Behaviour(ClientEvent::Dcutr(dcutr::Event {
-                connection_id,
-                result: Ok(()),
+                result: Ok(connection_id),
                 ..
             })) => Some(connection_id),
             _ => None,


### PR DESCRIPTION
## Description

We refactor the `libp2p-dcutr` API to only emit a single event: whether the hole-punch was successful or not. All other intermediate events are removed. Hole-punching is something that we try to do automatically as soon as we are connected to a peer over a relayed connection. The lack of explicit user intent means any event we emit is at best informational and not a "response" that the user would wait for.

Thus, I chose to not expose the details of why the hole-punch failed but return an opaque error.

Lastly, this PR also removes the usage of `ConnectionHandlerEvent::Close`. Just because something went wrong during the DCUtR handshake, doesn't mean we should close the relayed connection.

Related: #3591.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
