### PR TITLE
feat(request-response): Make observed address visible

### DIFF
--- a/protocols/autonat/src/behaviour/as_client.rs
+++ b/protocols/autonat/src/behaviour/as_client.rs
@@ -111,6 +111,7 @@ impl<'a> HandleInnerEvent for AsClient<'a> {
                         request_id,
                         response,
                     },
+                ..
             } => {
                 log::debug!("Outbound dial-back request returned {:?}.", response);
 

--- a/protocols/autonat/src/behaviour/as_server.rs
+++ b/protocols/autonat/src/behaviour/as_server.rs
@@ -106,6 +106,7 @@ impl<'a> HandleInnerEvent for AsServer<'a> {
                         request,
                         channel,
                     },
+                ..
             } => {
                 let probe_id = self.probe_id.next();
                 match self.resolve_inbound_request(peer, request) {

--- a/protocols/rendezvous/src/server.rs
+++ b/protocols/rendezvous/src/server.rs
@@ -174,6 +174,7 @@ impl NetworkBehaviour for Behaviour {
                             libp2p_request_response::Message::Request {
                                 request, channel, ..
                             },
+                        ..
                     }) => {
                         if let Some((event, response)) =
                             handle_request(peer_id, request, &mut self.registrations)
@@ -204,6 +205,7 @@ impl NetworkBehaviour for Behaviour {
                     | ToSwarm::GenerateEvent(libp2p_request_response::Event::Message {
                         peer: _,
                         message: libp2p_request_response::Message::Response { .. },
+                        ..
                     })
                     | ToSwarm::GenerateEvent(libp2p_request_response::Event::OutboundFailure {
                         ..

--- a/protocols/request-response/src/handler.rs
+++ b/protocols/request-response/src/handler.rs
@@ -81,7 +81,7 @@ where
 
     worker_streams: futures_bounded::FuturesMap<RequestId, Result<Event<TCodec>, io::Error>>,
 
-    observed_addr: Arc<Multiaddr>,
+    observed_addr: Multiaddr,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -116,7 +116,7 @@ where
                 substream_timeout,
                 max_concurrent_streams,
             ),
-            observed_addr: Arc::new(observed_addr.clone()),
+            observed_addr: observed_addr.clone(),
         }
     }
 
@@ -270,14 +270,14 @@ where
     /// A request has been received.
     Request {
         request_id: InboundRequestId,
-        observed_addr: Arc<Multiaddr>,
+        observed_addr: Multiaddr,
         request: TCodec::Request,
         sender: oneshot::Sender<TCodec::Response>,
     },
     /// A response has been received.
     Response {
         request_id: OutboundRequestId,
-        observed_addr: Arc<Multiaddr>,
+        observed_addr: Multiaddr,
         response: TCodec::Response,
     },
     /// A response to an inbound request has been sent.

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -131,7 +131,7 @@ pub enum Event<TRequest, TResponse, TChannelResponse = TResponse> {
         /// The peer who sent the message.
         peer: PeerId,
         /// The address that was observed.
-        observed_addr: Arc<Multiaddr>,
+        observed_addr: Multiaddr,
         /// The incoming message.
         message: Message<TRequest, TResponse, TChannelResponse>,
     },

--- a/protocols/request-response/tests/error_reporting.rs
+++ b/protocols/request-response/tests/error_reporting.rs
@@ -493,6 +493,7 @@ async fn wait_request(
                         request,
                         channel,
                     },
+                ..
             }) => {
                 return Ok((peer, request_id, request, channel));
             }

--- a/protocols/request-response/tests/ping.rs
+++ b/protocols/request-response/tests/ping.rs
@@ -112,6 +112,7 @@ async fn ping_protocol() {
                         request_response::Message::Request {
                             request, channel, ..
                         },
+                    ..
                 }) => {
                     assert_eq!(&request, &expected_ping);
                     assert_eq!(&peer, &peer2_id);
@@ -153,6 +154,7 @@ async fn ping_protocol() {
                             request_id,
                             response,
                         },
+                    ..
                 } => {
                     count += 1;
                     assert_eq!(&response, &expected_pong);
@@ -201,7 +203,8 @@ async fn emits_inbound_connection_closed_failure() {
             event = swarm1.select_next_some() => match event {
                 SwarmEvent::Behaviour(request_response::Event::Message {
                     peer,
-                    message: request_response::Message::Request { request, channel, .. }
+                    message: request_response::Message::Request { request, channel, .. },
+                    ..
                 }) => {
                     assert_eq!(&request, &ping);
                     assert_eq!(&peer, &peer2_id);
@@ -266,7 +269,8 @@ async fn emits_inbound_connection_closed_if_channel_is_dropped() {
             event = swarm1.select_next_some() => {
                 if let SwarmEvent::Behaviour(request_response::Event::Message {
                     peer,
-                    message: request_response::Message::Request { request, channel, .. }
+                    message: request_response::Message::Request { request, channel, .. },
+        ..
                 }) = event {
                     assert_eq!(&request, &ping);
                     assert_eq!(&peer, &peer2_id);


### PR DESCRIPTION
## Description

It is now possible to get the observed address in `Event::Message`. This enables use cases where that information is necessary.

Related: https://github.com/libp2p/rust-libp2p/pull/4568#issuecomment-1785454246

## Notes & open questions

This change adds complexity for the request-response protocol, that is originally designed for simple use cases. The only reason this exists is because it makes it easier to implement (and maintain) AutoNATv2. It was not requested by library users and introduces a breaking change.

It should be discussed whether this added complexity is worth it.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
