### PR TITLE
fix(relay): close stream once done sending

### DIFF
--- a/protocols/relay/src/protocol/outbound_hop.rs
+++ b/protocols/relay/src/protocol/outbound_hop.rs
@@ -124,6 +124,8 @@ pub(crate) async fn make_reservation(stream: Stream) -> Result<Reservation, Rese
 
     substream.send(msg).await?;
 
+    substream.close().await?;
+
     let proto::HopMessage {
         type_pb,
         peer: _,


### PR DESCRIPTION
## Description

Not explicitly closing a stream can lead to stream resets in the happy path once the stream is dropped. Instead, explicitly close the stream once the local node is done sending data.

Related: #4747.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

@thomaseizinger as discussed in our 1on1. Let's see whether CI goes green.

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
