### PR TITLE
fix(request-response): cleanup connected on dial/listen failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "async-std",

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- Remove failed connections from internal state. Fixes [Issue
+    4773](https://github.com/libp2p/rust-libp2p/issues/4773).
+    See [PR 4777](https://github.com/libp2p/rust-libp2p/pull/4777)
+
 ## 0.26.0
 
 - Remove `request_response::Config::set_connection_keep_alive` in favor of `SwarmBuilder::idle_connection_timeout`.

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,8 +1,7 @@
-## Unreleased
+## 0.26.1 - unreleased
 
-- Remove failed connections from internal state. Fixes [Issue
-    4773](https://github.com/libp2p/rust-libp2p/issues/4773).
-    See [PR 4777](https://github.com/libp2p/rust-libp2p/pull/4777)
+- Correctly update internal state for failed connections.
+  See [PR 4777](https://github.com/libp2p/rust-libp2p/pull/4777)
 
 ## 0.26.0
 

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-request-response"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Generic Request/Response Protocols"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
## Description

It is possible for dial and listen failures to be sent even after `handle_established_*_connection` methods are called on behaviours. Therefore we need to clean up any state about those failed connections.

Prior to this change the state would get out of sync and cause a debug_assert_eq panic.

Fixes: #4773.

## Notes & open questions

The tests do not pass locally yet. But I would like feedback on the approach before tracking down the failing test.


## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
