### PR TITLE
feat(quick-protobuf-codec): reduce allocations during encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4371,6 +4371,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "criterion",
+ "futures",
  "quick-protobuf",
  "thiserror",
  "unsigned-varint 0.8.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4370,6 +4370,7 @@ version = "0.2.0"
 dependencies = [
  "asynchronous-codec",
  "bytes",
+ "criterion",
  "quick-protobuf",
  "thiserror",
  "unsigned-varint 0.8.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4366,7 +4366,7 @@ dependencies = [
 
 [[package]]
 name = "quick-protobuf-codec"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "asynchronous-codec",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4373,6 +4373,7 @@ dependencies = [
  "criterion",
  "futures",
  "quick-protobuf",
+ "quickcheck-ext",
  "thiserror",
  "unsigned-varint 0.8.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ multiaddr = "0.18.1"
 multihash = "0.19.1"
 multistream-select = { version = "0.13.0", path = "misc/multistream-select" }
 prometheus-client = "0.22.0"
-quick-protobuf-codec = { version = "0.2.0", path = "misc/quick-protobuf-codec" }
+quick-protobuf-codec = { version = "0.2.1", path = "misc/quick-protobuf-codec" }
 quickcheck = { package = "quickcheck-ext", path = "misc/quickcheck-ext" }
 rw-stream-sink = { version = "0.4.0", path = "misc/rw-stream-sink" }
 unsigned-varint = { version = "0.8.0" }

--- a/misc/quick-protobuf-codec/CHANGELOG.md
+++ b/misc/quick-protobuf-codec/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.1 - unreleased
+## 0.3.1
 
 - Reduce allocations during encoding.
   See [PR 4782](https://github.com/libp2p/rust-libp2p/pull/4782).

--- a/misc/quick-protobuf-codec/CHANGELOG.md
+++ b/misc/quick-protobuf-codec/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.1 - unreleased
+
+- Reduce allocations during encoding.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+
 ## 0.2.0 
 
 - Raise MSRV to 1.65.

--- a/misc/quick-protobuf-codec/CHANGELOG.md
+++ b/misc/quick-protobuf-codec/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.2.1 - unreleased
 
 - Reduce allocations during encoding.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+  See [PR 4782](https://github.com/libp2p/rust-libp2p/pull/4782).
 
 ## 0.2.0 
 

--- a/misc/quick-protobuf-codec/Cargo.toml
+++ b/misc/quick-protobuf-codec/Cargo.toml
@@ -19,6 +19,7 @@ quick-protobuf = "0.8"
 
 [dev-dependencies]
 criterion = "0.5.1"
+futures = "0.3.28"
 
 [[bench]]
 name = "codec"

--- a/misc/quick-protobuf-codec/Cargo.toml
+++ b/misc/quick-protobuf-codec/Cargo.toml
@@ -20,6 +20,7 @@ quick-protobuf = "0.8"
 [dev-dependencies]
 criterion = "0.5.1"
 futures = "0.3.28"
+quickcheck = { workspace = true }
 
 [[bench]]
 name = "codec"

--- a/misc/quick-protobuf-codec/Cargo.toml
+++ b/misc/quick-protobuf-codec/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["asynchronous"]
 asynchronous-codec = { workspace = true }
 bytes = { version = "1" }
 thiserror = "1.0"
-unsigned-varint = { workspace = true, features = ["asynchronous_codec"] }
+unsigned-varint = { workspace = true, features = ["std"] }
 quick-protobuf = "0.8"
 
 [dev-dependencies]

--- a/misc/quick-protobuf-codec/Cargo.toml
+++ b/misc/quick-protobuf-codec/Cargo.toml
@@ -17,6 +17,13 @@ thiserror = "1.0"
 unsigned-varint = { workspace = true, features = ["asynchronous_codec"] }
 quick-protobuf = "0.8"
 
+[dev-dependencies]
+criterion = "0.5.1"
+
+[[bench]]
+name = "codec"
+harness = false
+
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]

--- a/misc/quick-protobuf-codec/Cargo.toml
+++ b/misc/quick-protobuf-codec/Cargo.toml
@@ -3,7 +3,7 @@ name = "quick-protobuf-codec"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Asynchronous de-/encoding of Protobuf structs using asynchronous-codec, unsigned-varint and quick-protobuf."
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Max Inden <mail@max-inden.de>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/misc/quick-protobuf-codec/benches/codec.rs
+++ b/misc/quick-protobuf-codec/benches/codec.rs
@@ -1,0 +1,28 @@
+use asynchronous_codec::Encoder;
+use bytes::BytesMut;
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use quick_protobuf_codec::{proto, Codec};
+
+pub fn benchmark(c: &mut Criterion) {
+    for size in [1000, 10_000, 100_000, 1_000_000, 10_000_000] {
+        c.bench_with_input(BenchmarkId::new("encode", size), &size, |b, i| {
+            b.iter_batched(
+                || {
+                    let mut out = BytesMut::new();
+                    out.reserve(i + 100);
+                    let codec = Codec::<proto::Message>::new(i + 100);
+                    let msg = proto::Message {
+                        data: vec![0; size],
+                    };
+
+                    (codec, out, msg)
+                },
+                |(mut codec, mut out, msg)| codec.encode(msg, &mut out).unwrap(),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/misc/quick-protobuf-codec/src/generated/mod.rs
+++ b/misc/quick-protobuf-codec/src/generated/mod.rs
@@ -1,0 +1,2 @@
+// Automatically generated mod.rs
+pub mod test;

--- a/misc/quick-protobuf-codec/src/generated/test.proto
+++ b/misc/quick-protobuf-codec/src/generated/test.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package test;
+
+message Message {
+    bytes data = 1;
+}

--- a/misc/quick-protobuf-codec/src/generated/test.rs
+++ b/misc/quick-protobuf-codec/src/generated/test.rs
@@ -1,0 +1,47 @@
+// Automatically generated rust module for 'test.proto' file
+
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(unused_imports)]
+#![allow(unknown_lints)]
+#![allow(clippy::all)]
+#![cfg_attr(rustfmt, rustfmt_skip)]
+
+
+use quick_protobuf::{MessageInfo, MessageRead, MessageWrite, BytesReader, Writer, WriterBackend, Result};
+use quick_protobuf::sizeofs::*;
+use super::*;
+
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Debug, Default, PartialEq, Clone)]
+pub struct Message {
+    pub data: Vec<u8>,
+}
+
+impl<'a> MessageRead<'a> for Message {
+    fn from_reader(r: &mut BytesReader, bytes: &'a [u8]) -> Result<Self> {
+        let mut msg = Self::default();
+        while !r.is_eof() {
+            match r.next_tag(bytes) {
+                Ok(10) => msg.data = r.read_bytes(bytes)?.to_owned(),
+                Ok(t) => { r.read_unknown(bytes, t)?; }
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(msg)
+    }
+}
+
+impl MessageWrite for Message {
+    fn get_size(&self) -> usize {
+        0
+        + if self.data.is_empty() { 0 } else { 1 + sizeof_len((&self.data).len()) }
+    }
+
+    fn write_message<W: WriterBackend>(&self, w: &mut Writer<W>) -> Result<()> {
+        if !self.data.is_empty() { w.write_with_tag(10, |w| w.write_bytes(&**&self.data))?; }
+        Ok(())
+    }
+}
+

--- a/misc/quick-protobuf-codec/src/lib.rs
+++ b/misc/quick-protobuf-codec/src/lib.rs
@@ -52,7 +52,7 @@ impl<In: MessageWrite, Out> Encoder for Codec<In, Out> {
 
         let mut written = 0;
 
-        let mut writer = Writer::new(UninitMemoryWriterBackend::new(
+        let mut writer = Writer::new(MaybeUninitWriterBackend::new(
             dst.spare_capacity_mut(),
             &mut written,
         ));
@@ -113,18 +113,18 @@ where
     }
 }
 
-struct UninitMemoryWriterBackend<'a> {
+struct MaybeUninitWriterBackend<'a> {
     memory: &'a mut [MaybeUninit<u8>],
     written: &'a mut usize,
 }
 
-impl<'a> UninitMemoryWriterBackend<'a> {
+impl<'a> MaybeUninitWriterBackend<'a> {
     fn new(memory: &'a mut [MaybeUninit<u8>], written: &'a mut usize) -> Self {
         Self { memory, written }
     }
 }
 
-impl<'a> WriterBackend for UninitMemoryWriterBackend<'a> {
+impl<'a> WriterBackend for MaybeUninitWriterBackend<'a> {
     fn pb_write_u8(&mut self, x: u8) -> quick_protobuf::Result<()> {
         self.pb_write_all(&[x])
     }

--- a/misc/quick-protobuf-codec/src/lib.rs
+++ b/misc/quick-protobuf-codec/src/lib.rs
@@ -217,6 +217,27 @@ mod tests {
     }
 
     #[test]
+    fn empty_bytes_mut_does_not_panic() {
+        let mut codec = Codec::<Dummy>::new(100);
+
+        let mut src = varint_zeroes(100);
+        src.truncate(50);
+
+        let result = codec.decode(&mut src);
+
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn only_partial_message_in_bytes_mut_does_not_panic() {
+        let mut codec = Codec::<Dummy>::new(100);
+
+        let result = codec.decode(&mut BytesMut::new());
+
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
     fn handles_arbitrary_initial_capacity() {
         fn prop(message: proto::Message, initial_capacity: u16) {
             let mut buffer = BytesMut::with_capacity(initial_capacity as usize);

--- a/misc/quick-protobuf-codec/src/lib.rs
+++ b/misc/quick-protobuf-codec/src/lib.rs
@@ -6,6 +6,11 @@ use quick_protobuf::{BytesReader, MessageRead, MessageWrite, Writer};
 use std::marker::PhantomData;
 use unsigned_varint::codec::UviBytes;
 
+mod generated;
+
+#[doc(hidden)] // NOT public API. Do not use.
+pub use generated::test as proto;
+
 /// [`Codec`] implements [`Encoder`] and [`Decoder`], uses [`unsigned_varint`]
 /// to prefix messages with their length and uses [`quick_protobuf`] and a provided
 /// `struct` implementing [`MessageRead`] and [`MessageWrite`] to do the encoding.

--- a/misc/quick-protobuf-codec/src/lib.rs
+++ b/misc/quick-protobuf-codec/src/lib.rs
@@ -110,7 +110,7 @@ where
             return Err(Error(io::Error::new(
                 io::ErrorKind::PermissionDenied,
                 format!(
-                    "message with {len}b exceeds maximum of {}b",
+                    "message with {message_length}b exceeds maximum of {}b",
                     self.max_message_len_bytes
                 ),
             )));

--- a/misc/quick-protobuf-codec/src/lib.rs
+++ b/misc/quick-protobuf-codec/src/lib.rs
@@ -43,6 +43,7 @@ impl<In: MessageWrite, Out> Encoder for Codec<In, Out> {
         let mut uvi_buf = unsigned_varint::encode::usize_buffer();
         let encoded_length = unsigned_varint::encode::usize(message_length, &mut uvi_buf);
 
+        dst.reserve(message_length);
         dst.extend_from_slice(encoded_length);
 
         let mut writer = Writer::new(dst.as_mut());

--- a/misc/quick-protobuf-codec/tests/large_message.rs
+++ b/misc/quick-protobuf-codec/tests/large_message.rs
@@ -1,0 +1,16 @@
+use asynchronous_codec::Encoder;
+use bytes::BytesMut;
+use quick_protobuf_codec::proto;
+use quick_protobuf_codec::Codec;
+
+#[test]
+fn encode_large_message() {
+    let mut codec = Codec::<proto::Message>::new(1_001_000);
+    let mut dst = BytesMut::new();
+    dst.reserve(1_001_000);
+    let message = proto::Message {
+        data: vec![0; 1_000_000],
+    };
+
+    codec.encode(message, &mut dst).unwrap();
+}

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -573,7 +573,7 @@ mod tests {
     #[test]
     /// Test that RPC messages can be encoded and decoded successfully.
     fn encode_decode() {
-        fn prop(message: Message) {
+        fn prop(message: Message, buf_length: u32) {
             let message = message.0;
 
             let rpc = Rpc {
@@ -583,7 +583,7 @@ mod tests {
             };
 
             let mut codec = GossipsubCodec::new(u32::MAX as usize, ValidationMode::Strict);
-            let mut buf = BytesMut::new();
+            let mut buf = BytesMut::with_capacity(buf_length as usize);
             codec.encode(rpc.into_protobuf(), &mut buf).unwrap();
             let decoded_rpc = codec.decode(&mut buf).unwrap().unwrap();
             // mark as validated as its a published message
@@ -597,7 +597,7 @@ mod tests {
             }
         }
 
-        QuickCheck::new().quickcheck(prop as fn(_) -> _)
+        QuickCheck::new().quickcheck(prop as fn(_, _) -> _)
     }
 
     #[test]

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -573,7 +573,7 @@ mod tests {
     #[test]
     /// Test that RPC messages can be encoded and decoded successfully.
     fn encode_decode() {
-        fn prop(message: Message, buf_length: u32) {
+        fn prop(message: Message, buf_length: u16) {
             let message = message.0;
 
             let rpc = Rpc {

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -573,7 +573,7 @@ mod tests {
     #[test]
     /// Test that RPC messages can be encoded and decoded successfully.
     fn encode_decode() {
-        fn prop(message: Message, buf_length: u16) {
+        fn prop(message: Message) {
             let message = message.0;
 
             let rpc = Rpc {
@@ -583,7 +583,7 @@ mod tests {
             };
 
             let mut codec = GossipsubCodec::new(u32::MAX as usize, ValidationMode::Strict);
-            let mut buf = BytesMut::with_capacity(buf_length as usize);
+            let mut buf = BytesMut::new();
             codec.encode(rpc.into_protobuf(), &mut buf).unwrap();
             let decoded_rpc = codec.decode(&mut buf).unwrap().unwrap();
             // mark as validated as its a published message

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -597,7 +597,7 @@ mod tests {
             }
         }
 
-        QuickCheck::new().quickcheck(prop as fn(_, _) -> _)
+        QuickCheck::new().quickcheck(prop as fn(_) -> _)
     }
 
     #[test]


### PR DESCRIPTION
## Description

We can reduce the number of allocations during the encoding of messages by not depending on the `Encoder` implementation of `unsigned-varint` but doing the encoding ourselves.

This allows us to directly plug the `BytesMut` into the `Writer` and directly encode into the target buffer. Previously, we were allocating each message as an additional buffer that got immediately thrown-away again.

Related: #4781.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
