### PR TITLE
ci: use dynamic PR base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           ./scripts/ensure-version-bump-and-changelog.sh
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
 
   wasm_tests:
     name: Run all WASM tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           ./scripts/ensure-version-bump-and-changelog.sh
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
 
   wasm_tests:
     name: Run all WASM tests

--- a/scripts/ensure-version-bump-and-changelog.sh
+++ b/scripts/ensure-version-bump-and-changelog.sh
@@ -5,9 +5,9 @@ set -ex;
 MANIFEST_PATH=$(cargo metadata --format-version=1 --no-deps | jq -e -r '.packages[] | select(.name == "'"$CRATE"'") | .manifest_path')
 DIR_TO_CRATE=$(dirname "$MANIFEST_PATH")
 
-MERGE_BASE=$(git merge-base "$HEAD_SHA" master) # Find the merge base. This ensures we only diff what was actually added in the PR.
+MERGE_BASE=$(git merge-base "$HEAD_SHA" "$PR_BASE") # Find the merge base. This ensures we only diff what was actually added in the PR.
 
-SRC_DIFF_TO_MASTER=$(git diff "$HEAD_SHA".."$MERGE_BASE" --name-status -- "$DIR_TO_CRATE/src" "$DIR_TO_CRATE/Cargo.toml")
+SRC_DIFF_TO_BASE=$(git diff "$HEAD_SHA".."$MERGE_BASE" --name-status -- "$DIR_TO_CRATE/src" "$DIR_TO_CRATE/Cargo.toml")
 CHANGELOG_DIFF=$(git diff "$HEAD_SHA".."$MERGE_BASE" --name-only -- "$DIR_TO_CRATE/CHANGELOG.md")
 
 VERSION_IN_CHANGELOG=$(awk -F' ' '/^## [0-9]+\.[0-9]+\.[0-9]+/{print $2; exit}' "$DIR_TO_CRATE/CHANGELOG.md")
@@ -20,7 +20,7 @@ if [[ "$VERSION_IN_CHANGELOG" != "$VERSION_IN_MANIFEST" ]]; then
 fi
 
 # If the source files of this crate weren't touched in this PR, exit early.
-if [ -z "$SRC_DIFF_TO_MASTER" ]; then
+if [ -z "$SRC_DIFF_TO_BASE" ]; then
   exit 0;
 fi
 


### PR DESCRIPTION
## Description

Previously, we would always compare the diff to master. This is wrong because not all PRs go into master. Instead, we now use the correct SHA of the PR base.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
