### PR TITLE
refactor(gossipsub): send more specific messages to `ConnectionHandler`

### DIFF
--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -23,8 +23,10 @@
 use super::*;
 use crate::subscription_filter::WhitelistSubscriptionFilter;
 use crate::transform::{DataTransform, IdentityTransform};
-use crate::{config::Config, config::ConfigBuilder, IdentTopic as Topic, TopicScoreParams};
-use crate::{Rpc, ValidationError};
+use crate::ValidationError;
+use crate::{
+    config::Config, config::ConfigBuilder, types::Rpc, IdentTopic as Topic, TopicScoreParams,
+};
 use async_std::net::Ipv4Addr;
 use byteorder::{BigEndian, ByteOrder};
 use libp2p_core::{ConnectedPoint, Endpoint};

--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -20,7 +20,7 @@
 
 use crate::protocol::{GossipsubCodec, ProtocolConfig};
 use crate::rpc_proto::proto;
-use crate::types::{PeerKind, RawMessage, Rpc};
+use crate::types::{PeerKind, RawMessage, Rpc, RpcOut};
 use crate::ValidationError;
 use asynchronous_codec::Framed;
 use futures::future::Either;
@@ -58,10 +58,11 @@ pub enum HandlerEvent {
 }
 
 /// A message sent from the behaviour to the handler.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum HandlerIn {
     /// A gossipsub message to send.
-    Message(proto::RPC),
+    Message(RpcOut),
     /// The peer has joined the mesh.
     JoinedMesh,
     /// The peer has left the mesh.
@@ -408,7 +409,7 @@ impl ConnectionHandler for Handler {
     fn on_behaviour_event(&mut self, message: HandlerIn) {
         match self {
             Handler::Enabled(handler) => match message {
-                HandlerIn::Message(m) => handler.send_queue.push(m),
+                HandlerIn::Message(m) => handler.send_queue.push(m.into_protobuf()),
                 HandlerIn::JoinedMesh => {
                     handler.in_mesh = true;
                 }

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -518,7 +518,7 @@ impl Decoder for GossipsubCodec {
 mod tests {
     use super::*;
     use crate::config::Config;
-    use crate::{Behaviour, ConfigBuilder};
+    use crate::{types::RpcOut, Behaviour, ConfigBuilder};
     use crate::{IdentTopic as Topic, Version};
     use libp2p_identity::Keypair;
     use quickcheck::*;
@@ -592,12 +592,7 @@ mod tests {
         fn prop(message: Message) {
             let message = message.0;
 
-            let rpc = Rpc {
-                messages: vec![message],
-                subscriptions: vec![],
-                control_msgs: vec![],
-            };
-
+            let rpc = RpcOut::Publish(message.clone());
             let mut codec = GossipsubCodec::new(codec::UviBytes::default(), ValidationMode::Strict);
             let mut buf = BytesMut::new();
             codec.encode(rpc.into_protobuf(), &mut buf).unwrap();
@@ -607,7 +602,7 @@ mod tests {
                 HandlerEvent::Message { mut rpc, .. } => {
                     rpc.messages[0].validated = true;
 
-                    assert_eq!(rpc, rpc);
+                    assert_eq!(vec![message], rpc.messages);
                 }
                 _ => panic!("Must decode a message"),
             }

--- a/protocols/gossipsub/src/types.rs
+++ b/protocols/gossipsub/src/types.rs
@@ -132,6 +132,19 @@ impl RawMessage {
     }
 }
 
+impl From<RawMessage> for proto::Message {
+    fn from(raw: RawMessage) -> Self {
+        proto::Message {
+            from: raw.source.map(|m| m.to_bytes()),
+            data: Some(raw.data),
+            seqno: raw.sequence_number.map(|s| s.to_be_bytes().to_vec()),
+            topic: TopicHash::into_string(raw.topic),
+            signature: raw.signature,
+            key: raw.key,
+        }
+    }
+}
+
 /// The message sent to the user after a [`RawMessage`] has been transformed by a
 /// [`crate::DataTransform`].
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -231,112 +244,6 @@ pub struct Rpc {
     pub control_msgs: Vec<ControlAction>,
 }
 
-impl Rpc {
-    /// Converts the GossipsubRPC into its protobuf format.
-    // A convenience function to avoid explicitly specifying types.
-    pub fn into_protobuf(self) -> proto::RPC {
-        self.into()
-    }
-}
-
-impl From<Rpc> for proto::RPC {
-    /// Converts the RPC into protobuf format.
-    fn from(rpc: Rpc) -> Self {
-        // Messages
-        let mut publish = Vec::new();
-
-        for message in rpc.messages.into_iter() {
-            let message = proto::Message {
-                from: message.source.map(|m| m.to_bytes()),
-                data: Some(message.data),
-                seqno: message.sequence_number.map(|s| s.to_be_bytes().to_vec()),
-                topic: TopicHash::into_string(message.topic),
-                signature: message.signature,
-                key: message.key,
-            };
-
-            publish.push(message);
-        }
-
-        // subscriptions
-        let subscriptions = rpc
-            .subscriptions
-            .into_iter()
-            .map(|sub| proto::SubOpts {
-                subscribe: Some(sub.action == SubscriptionAction::Subscribe),
-                topic_id: Some(sub.topic_hash.into_string()),
-            })
-            .collect::<Vec<_>>();
-
-        // control messages
-        let mut control = proto::ControlMessage {
-            ihave: Vec::new(),
-            iwant: Vec::new(),
-            graft: Vec::new(),
-            prune: Vec::new(),
-        };
-
-        let empty_control_msg = rpc.control_msgs.is_empty();
-
-        for action in rpc.control_msgs {
-            match action {
-                // collect all ihave messages
-                ControlAction::IHave {
-                    topic_hash,
-                    message_ids,
-                } => {
-                    let rpc_ihave = proto::ControlIHave {
-                        topic_id: Some(topic_hash.into_string()),
-                        message_ids: message_ids.into_iter().map(|msg_id| msg_id.0).collect(),
-                    };
-                    control.ihave.push(rpc_ihave);
-                }
-                ControlAction::IWant { message_ids } => {
-                    let rpc_iwant = proto::ControlIWant {
-                        message_ids: message_ids.into_iter().map(|msg_id| msg_id.0).collect(),
-                    };
-                    control.iwant.push(rpc_iwant);
-                }
-                ControlAction::Graft { topic_hash } => {
-                    let rpc_graft = proto::ControlGraft {
-                        topic_id: Some(topic_hash.into_string()),
-                    };
-                    control.graft.push(rpc_graft);
-                }
-                ControlAction::Prune {
-                    topic_hash,
-                    peers,
-                    backoff,
-                } => {
-                    let rpc_prune = proto::ControlPrune {
-                        topic_id: Some(topic_hash.into_string()),
-                        peers: peers
-                            .into_iter()
-                            .map(|info| proto::PeerInfo {
-                                peer_id: info.peer_id.map(|id| id.to_bytes()),
-                                // TODO, see https://github.com/libp2p/specs/pull/217
-                                signed_peer_record: None,
-                            })
-                            .collect(),
-                        backoff,
-                    };
-                    control.prune.push(rpc_prune);
-                }
-            }
-        }
-
-        proto::RPC {
-            subscriptions,
-            publish,
-            control: if empty_control_msg {
-                None
-            } else {
-                Some(control)
-            },
-        }
-    }
-}
-
 impl fmt::Debug for Rpc {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut b = f.debug_struct("GossipsubRpc");
@@ -350,6 +257,134 @@ impl fmt::Debug for Rpc {
             b.field("control_msgs", &self.control_msgs);
         }
         b.finish()
+    }
+}
+
+/// A Gossipsub RPC message sent.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum RpcOut {
+    /// Publish a Gossipsub message on network.
+    Publish(RawMessage),
+    /// Forward a Gossipsub message to the network.
+    Forward(Vec<RawMessage>),
+    /// List of subscriptions.
+    Subscriptions(Vec<Subscription>),
+    /// List of Gossipsub control messages.
+    Control(Vec<ControlAction>),
+}
+
+impl RpcOut {
+    /// Converts the GossipsubRPC into its protobuf format.
+    // A convenience function to avoid explicitly specifying types.
+    pub fn into_protobuf(self) -> proto::RPC {
+        self.into()
+    }
+}
+
+impl From<RpcOut> for proto::RPC {
+    /// Converts the RPC into protobuf format.
+    fn from(rpc: RpcOut) -> Self {
+        match rpc {
+            RpcOut::Publish(message) => proto::RPC {
+                subscriptions: Vec::new(),
+                publish: vec![message.into()],
+                control: None,
+            },
+            RpcOut::Forward(messages) => proto::RPC {
+                publish: messages.into_iter().map(Into::into).collect(),
+                subscriptions: Vec::new(),
+                control: None,
+            },
+            RpcOut::Subscriptions(subscriptions) => {
+                let subscriptions = subscriptions
+                    .into_iter()
+                    .map(|sub| proto::SubOpts {
+                        subscribe: Some(sub.action == SubscriptionAction::Subscribe),
+                        topic_id: Some(sub.topic_hash.into_string()),
+                    })
+                    .collect::<Vec<_>>();
+                proto::RPC {
+                    publish: Vec::new(),
+                    subscriptions,
+                    control: None,
+                }
+            }
+            RpcOut::Control(actions) => {
+                if actions.is_empty() {
+                    return proto::RPC {
+                        publish: Vec::new(),
+                        subscriptions: Vec::new(),
+                        control: None,
+                    };
+                }
+
+                let mut control = proto::ControlMessage {
+                    ihave: Vec::new(),
+                    iwant: Vec::new(),
+                    graft: Vec::new(),
+                    prune: Vec::new(),
+                };
+
+                for action in actions {
+                    match action {
+                        // collect all ihave messages
+                        ControlAction::IHave {
+                            topic_hash,
+                            message_ids,
+                        } => {
+                            let rpc_ihave = proto::ControlIHave {
+                                topic_id: Some(topic_hash.into_string()),
+                                message_ids: message_ids
+                                    .into_iter()
+                                    .map(|msg_id| msg_id.0)
+                                    .collect(),
+                            };
+                            control.ihave.push(rpc_ihave);
+                        }
+                        ControlAction::IWant { message_ids } => {
+                            let rpc_iwant = proto::ControlIWant {
+                                message_ids: message_ids
+                                    .into_iter()
+                                    .map(|msg_id| msg_id.0)
+                                    .collect(),
+                            };
+                            control.iwant.push(rpc_iwant);
+                        }
+                        ControlAction::Graft { topic_hash } => {
+                            let rpc_graft = proto::ControlGraft {
+                                topic_id: Some(topic_hash.into_string()),
+                            };
+                            control.graft.push(rpc_graft);
+                        }
+                        ControlAction::Prune {
+                            topic_hash,
+                            peers,
+                            backoff,
+                        } => {
+                            let rpc_prune = proto::ControlPrune {
+                                topic_id: Some(topic_hash.into_string()),
+                                peers: peers
+                                    .into_iter()
+                                    .map(|info| proto::PeerInfo {
+                                        peer_id: info.peer_id.map(|id| id.to_bytes()),
+                                        // TODO, see https://github.com/libp2p/specs/pull/217
+                                        signed_peer_record: None,
+                                    })
+                                    .collect(),
+                                backoff,
+                            };
+                            control.prune.push(rpc_prune);
+                        }
+                    }
+                }
+
+                proto::RPC {
+                    publish: Vec::new(),
+                    subscriptions: Vec::new(),
+                    control: Some(control),
+                }
+            }
+        }
     }
 }
 

--- a/protocols/gossipsub/src/types.rs
+++ b/protocols/gossipsub/src/types.rs
@@ -266,7 +266,7 @@ pub enum RpcOut {
     /// Publish a Gossipsub message on network.
     Publish(RawMessage),
     /// Forward a Gossipsub message to the network.
-    Forward(Vec<RawMessage>),
+    Forward(RawMessage),
     /// Subscribe a topic.
     Subscribe(TopicHash),
     /// Unsubscribe a topic.
@@ -292,8 +292,8 @@ impl From<RpcOut> for proto::RPC {
                 publish: vec![message.into()],
                 control: None,
             },
-            RpcOut::Forward(messages) => proto::RPC {
-                publish: messages.into_iter().map(Into::into).collect(),
+            RpcOut::Forward(message) => proto::RPC {
+                publish: vec![message.into()],
                 subscriptions: Vec::new(),
                 control: None,
             },


### PR DESCRIPTION
## Description

Previously, the `NetworkBehaviour` constructed a `proto::RPC` type and sent that into an unbounded queue to the `ConnectionHandler`. With such a broad type, the `ConnectionHandler` cannot do any prioritization on which messages to drop if a connection slows down.

To enable a more fine-granular handling of messages, we make the interface between `NetworkBehaviour` and `ConnectionHandler` more specific by introducing an `RpcOut` type that differentiates between `Publish`, `Forward`, `Subscribe`, etc.

Related: #4667.

## Notes & open questions
Max suggested on https://github.com/libp2p/rust-libp2p/issues/4667#issuecomment-1788658203 changing `HandlerIn` but that would imply more changes into the `fragment_message` function and back and forth conversion between `proto::RPC` and its subtypes (using a subtype via `HandlerIn` to then convert to the main `proto::RPC` type when sending it from the `ConnectionHandler`). Adding a `RpcType` to distinguish seemed simpler.

We were also using the `Rpc` type for conversions between `Messages`, `ControlActions`, and `Subscriptions` which can be done from these types directly.

ptal @mxinden @thomaseizinger @divagant-martian @AgeManning 

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
