### PR TITLE
feat(quic): allow disabling of path MTU discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-std",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ libp2p-perf = { version = "0.3.0", path = "protocols/perf" }
 libp2p-ping = { version = "0.44.0", path = "protocols/ping" }
 libp2p-plaintext = { version = "0.41.0", path = "transports/plaintext" }
 libp2p-pnet = { version = "0.24.0", path = "transports/pnet" }
-libp2p-quic = { version = "0.10.0", path = "transports/quic" }
+libp2p-quic = { version = "0.10.1", path = "transports/quic" }
 libp2p-relay = { version = "0.17.0", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.14.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.26.0", path = "protocols/request-response" }

--- a/transports/quic/CHANGELOG.md
+++ b/transports/quic/CHANGELOG.md
@@ -1,9 +1,7 @@
 ## 0.10.1 - unreleased
 
-- Allow disabling MTU discovering.
-  See [PR 4823].
-
-[PR 4823]: https://github.com/libp2p/rust-libp2p/pull/4823
+- Allow disabling path MTU discovery.
+  See [PR 4823](https://github.com/libp2p/rust-libp2p/pull/4823).
 
 ## 0.10.0
 

--- a/transports/quic/CHANGELOG.md
+++ b/transports/quic/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.10.1 - unreleased
+
+- Allow disabling MTU discovering.
+  See [PR 4823].
+
+[PR 4823]: https://github.com/libp2p/rust-libp2p/pull/4823
+
 ## 0.10.0
 
 - Improve hole-punch timing.

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-quic"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 rust-version = { workspace = true }

--- a/transports/quic/src/config.rs
+++ b/transports/quic/src/config.rs
@@ -90,11 +90,9 @@ impl Config {
         }
     }
 
-    pub fn path_mtu_discovery_config(
-        mut self,
-        path_mtu_discovery_config: Option<MtuDiscoveryConfig>,
-    ) -> Self {
-        self.path_mtu_discovery_config = path_mtu_discovery_config;
+    /// Disable MTU path discovery (it is enabled by default).
+    pub fn disable_path_mtu_discovery(mut self) -> Self {
+        self.path_mtu_discovery_config = None;
         self
     }
 }

--- a/transports/quic/src/config.rs
+++ b/transports/quic/src/config.rs
@@ -65,7 +65,7 @@ pub struct Config {
     keypair: libp2p_identity::Keypair,
 
     /// Parameters governing MTU discovery. See [`MtuDiscoveryConfig`] for details.
-    path_mtu_discovery_config: Option<MtuDiscoveryConfig>,
+    mtu_discovery_config: Option<MtuDiscoveryConfig>,
 }
 
 impl Config {
@@ -86,13 +86,13 @@ impl Config {
             // Ensure that one stream is not consuming the whole connection.
             max_stream_data: 10_000_000,
             keypair: keypair.clone(),
-            path_mtu_discovery_config: Some(Default::default()),
+            mtu_discovery_config: Some(Default::default()),
         }
     }
 
     /// Disable MTU path discovery (it is enabled by default).
     pub fn disable_path_mtu_discovery(mut self) -> Self {
-        self.path_mtu_discovery_config = None;
+        self.mtu_discovery_config = None;
         self
     }
 }
@@ -118,7 +118,7 @@ impl From<Config> for QuinnConfig {
             support_draft_29,
             handshake_timeout: _,
             keypair,
-            path_mtu_discovery_config,
+            mtu_discovery_config,
         } = config;
         let mut transport = quinn::TransportConfig::default();
         // Disable uni-directional streams.
@@ -131,7 +131,7 @@ impl From<Config> for QuinnConfig {
         transport.allow_spin(false);
         transport.stream_receive_window(max_stream_data.into());
         transport.receive_window(max_connection_data.into());
-        transport.mtu_discovery_config(path_mtu_discovery_config);
+        transport.mtu_discovery_config(mtu_discovery_config);
         let transport = Arc::new(transport);
 
         let mut server_config = quinn::ServerConfig::with_crypto(server_tls_config);


### PR DESCRIPTION
## Description

Path MTU discovery seems to be broken in QUIC right now on Windows and we had to disable it in Subspace.

Related: https://github.com/subspace/subspace/pull/2195.

## Attributions

Co-authored-by: Shamil Gadelshin <shamilgadelshin@gmail.com>

## Notes & open questions

It is following default behavior of quinn and just adds an option to change that if necessary.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
