### PR TITLE
feat: introduce `InflightProtocolDataQueue`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,6 +2956,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-ping",
  "libp2p-plaintext",
+ "libp2p-protocol-utils",
  "libp2p-swarm",
  "libp2p-swarm-test",
  "libp2p-yamux",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3018,6 +3018,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-noise",
+ "libp2p-protocol-utils",
  "libp2p-swarm",
  "libp2p-swarm-test",
  "libp2p-tcp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,6 +2676,7 @@ dependencies = [
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-noise",
+ "libp2p-protocol-utils",
  "libp2p-swarm",
  "libp2p-swarm-test",
  "libp2p-yamux",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,6 +2909,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-protocol-utils"
+version = "0.1.0"
+
+[[package]]
 name = "libp2p-quic"
 version = "0.10.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "misc/memory-connection-limits",
     "misc/metrics",
     "misc/multistream-select",
+    "misc/protocol-utils",
     "misc/quick-protobuf-codec",
     "misc/quickcheck-ext",
     "misc/rw-stream-sink",
@@ -60,8 +61,8 @@ members = [
     "transports/webrtc",
     "transports/webrtc-websys",
     "transports/websocket",
-    "transports/webtransport-websys",
     "transports/websocket-websys",
+    "transports/webtransport-websys",
     "wasm-tests/webtransport-tests",
 ]
 resolver = "2"
@@ -93,6 +94,7 @@ libp2p-perf = { version = "0.3.0", path = "protocols/perf" }
 libp2p-ping = { version = "0.44.0", path = "protocols/ping" }
 libp2p-plaintext = { version = "0.41.0", path = "transports/plaintext" }
 libp2p-pnet = { version = "0.24.0", path = "transports/pnet" }
+libp2p-protocol-utils = { version = "0.1.0", path = "misc/protocol-utils" }
 libp2p-quic = { version = "0.10.1", path = "transports/quic" }
 libp2p-relay = { version = "0.17.1", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.14.0", path = "protocols/rendezvous" }

--- a/misc/protocol-utils/CHANGELOG.md
+++ b/misc/protocol-utils/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 0.1.0 - unreleased
+
+- Initial release, offering `InflightProtocolDataQueue`.
+  See [PR 4834](https://github.com/libp2p/rust-libp2p/pull/4834).

--- a/misc/protocol-utils/Cargo.toml
+++ b/misc/protocol-utils/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "libp2p-protocol-utils"
+version = "0.1.0"
+edition = "2021"
+description = "Utilities for implementing protocols for libp2p, via `NetworkBehaviour` and `ConnectionHandler`."
+rust-version.workspace = true
+license = "MIT"
+repository = "https://github.com/libp2p/rust-libp2p"
+keywords = []
+categories = ["data-structures"]
+publish = false # Temporary until we actually publish it.
+
+[lints]
+workspace = true

--- a/misc/protocol-utils/src/ipd_queue.rs
+++ b/misc/protocol-utils/src/ipd_queue.rs
@@ -28,11 +28,6 @@ impl<D, Req, Res> InflightProtocolDataQueue<D, Req, Res> {
     pub fn enqueue_request(&mut self, request: Req, data: D) {
         self.pending_requests.push_back(request);
         self.data_of_inflight_requests.push_back(data);
-
-        debug_assert_eq!(
-            self.pending_requests.len(),
-            self.data_of_inflight_requests.len()
-        );
     }
 
     /// Submits a response to the queue.
@@ -44,6 +39,11 @@ impl<D, Req, Res> InflightProtocolDataQueue<D, Req, Res> {
             "Expect to not provide more responses than requests were started"
         );
         self.received_responses.push_back(res);
+    }
+
+    /// How many protocols are currently in-flight.
+    pub fn num_inflight(&self) -> usize {
+        self.data_of_inflight_requests.len() - self.received_responses.len()
     }
 
     pub fn next_completed(&mut self) -> Option<(Res, D)> {

--- a/misc/protocol-utils/src/ipd_queue.rs
+++ b/misc/protocol-utils/src/ipd_queue.rs
@@ -1,0 +1,61 @@
+use std::collections::VecDeque;
+
+/// Manages associated data of request-response protocols whilst they are in-flight.
+///
+/// The [`InflightProtocolDataQueue`] ensures that for each in-flight protocol, there is a corresponding piece of associated data.
+/// We process the associated data in a FIFO order based on the incoming responses.
+/// In other words, we assume that requests and their responses are either temporally ordered or it doesn't matter, which piece of data is paired with a particular response.
+pub struct InflightProtocolDataQueue<D, Req, Res> {
+    data_of_inflight_requests: VecDeque<D>,
+    pending_requests: VecDeque<Req>,
+    received_responses: VecDeque<Res>,
+}
+
+impl<D, Req, Res> Default for InflightProtocolDataQueue<D, Req, Res> {
+    fn default() -> Self {
+        Self {
+            pending_requests: Default::default(),
+            received_responses: Default::default(),
+            data_of_inflight_requests: Default::default(),
+        }
+    }
+}
+
+impl<D, Req, Res> InflightProtocolDataQueue<D, Req, Res> {
+    /// Enqueues a new request along-side with the associated data.
+    ///
+    /// The request will be returned again from [`InflightProtocolDataQueue::next_request`].
+    pub fn enqueue_request(&mut self, request: Req, data: D) {
+        self.pending_requests.push_back(request);
+        self.data_of_inflight_requests.push_back(data);
+
+        debug_assert_eq!(
+            self.pending_requests.len(),
+            self.data_of_inflight_requests.len()
+        );
+    }
+
+    /// Submits a response to the queue.
+    ///
+    /// A pair of response and data will be returned from [`InflightProtocolDataQueue::next_completed`].
+    pub fn submit_response(&mut self, res: Res) {
+        debug_assert!(
+            self.data_of_inflight_requests.len() > self.received_responses.len(),
+            "Expect to not provide more responses than requests were started"
+        );
+        self.received_responses.push_back(res);
+    }
+
+    pub fn next_completed(&mut self) -> Option<(Res, D)> {
+        let res = self.received_responses.pop_front()?;
+        let data = self.data_of_inflight_requests.pop_front()?;
+
+        Some((res, data))
+    }
+
+    pub fn next_request(&mut self) -> Option<Req> {
+        let req = self.pending_requests.pop_front()?;
+
+        Some(req)
+    }
+}

--- a/misc/protocol-utils/src/lib.rs
+++ b/misc/protocol-utils/src/lib.rs
@@ -1,0 +1,3 @@
+mod ipd_queue;
+
+pub use ipd_queue::InflightProtocolDataQueue;

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -19,6 +19,7 @@ asynchronous-codec = "0.6"
 futures = "0.3.29"
 libp2p-core = { workspace = true }
 libp2p-swarm = { workspace = true }
+libp2p-protocol-utils = { workspace = true }
 quick-protobuf = "0.8"
 quick-protobuf-codec = { workspace = true }
 libp2p-identity = { workspace = true, features = ["rand"] }

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -40,6 +40,7 @@ use std::marker::PhantomData;
 use std::{convert::TryFrom, time::Duration};
 use std::{io, iter};
 use tracing::debug;
+use void::Void;
 
 /// The protocol name used for negotiating with multistream-select.
 pub(crate) const DEFAULT_PROTO_NAME: StreamProtocol = StreamProtocol::new("/ipfs/kad/1.0.0");
@@ -220,8 +221,8 @@ where
     C: AsyncRead + AsyncWrite + Unpin,
 {
     type Output = KadInStreamSink<C>;
-    type Future = future::Ready<Result<Self::Output, io::Error>>;
-    type Error = io::Error;
+    type Future = future::Ready<Result<Self::Output, Self::Error>>;
+    type Error = Void;
 
     fn upgrade_inbound(self, incoming: C, _: Self::Info) -> Self::Future {
         let codec = Codec::new(self.max_packet_size);
@@ -235,8 +236,8 @@ where
     C: AsyncRead + AsyncWrite + Unpin,
 {
     type Output = KadOutStreamSink<C>;
-    type Future = future::Ready<Result<Self::Output, io::Error>>;
-    type Error = io::Error;
+    type Future = future::Ready<Result<Self::Output, Self::Error>>;
+    type Error = Void;
 
     fn upgrade_outbound(self, incoming: C, _: Self::Info) -> Self::Future {
         let codec = Codec::new(self.max_packet_size);

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -28,6 +28,7 @@ static_assertions = "1"
 thiserror = "1.0"
 tracing = "0.1.37"
 void = "1"
+libp2p-protocol-utils = { workspace = true }
 
 [dev-dependencies]
 libp2p-identity = { workspace = true, features = ["rand"] }

--- a/protocols/relay/src/protocol/outbound_hop.rs
+++ b/protocols/relay/src/protocol/outbound_hop.rs
@@ -47,7 +47,7 @@ pub enum ConnectError {
     #[error("Remote does not support the `{HOP_PROTOCOL_NAME}` protocol")]
     Unsupported,
     #[error("IO error")]
-    Io(#[source] io::Error),
+    Io(#[from] io::Error),
     #[error("Protocol error")]
     Protocol(#[from] ProtocolViolation),
 }
@@ -61,7 +61,7 @@ pub enum ReserveError {
     #[error("Remote does not support the `{HOP_PROTOCOL_NAME}` protocol")]
     Unsupported,
     #[error("IO error")]
-    Io(#[source] io::Error),
+    Io(#[from] io::Error),
     #[error("Protocol error")]
     Protocol(#[from] ProtocolViolation),
 }

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -18,6 +18,7 @@ instant = "0.1.12"
 libp2p-core = { workspace = true }
 libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true }
+libp2p-protocol-utils = { workspace = true }
 rand = "0.8"
 serde = { version = "1.0", optional = true}
 serde_json = { version = "1.0.108", optional = true }


### PR DESCRIPTION
## Description

This PR prototypes what I termed an `InflightProtocolDataQueue`. It is essentially a replacement for `ConnectionHandler::OutboundOpenInfo`, just slightly more generic. In essence, it allows users to submit a request to the queue, together with a piece of data and later submit responses.

Internally, the responses are matched with a pending piece of data and later returned. Assuming the functions are called in the right order (which is an invariant that `libp2p-swarm` should uphold), this frees users from having to worry about tracking state separately.

Resolves: #4510.
Related: #3268.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

Opening this PR for early feedback. In a follow-up PR, I'd then deprecate `InboundOpenInfo` and `OutboundOpenInfo` and point users towards the new `libp2p-protocol-utils` crate and the `InflightProtocolDataQueue`.

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
