### PR TITLE
fix(dns): bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "async-std",
  "async-std-resolver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ libp2p-autonat = { version = "0.12.0", path = "protocols/autonat" }
 libp2p-connection-limits = { version = "0.3.0", path = "misc/connection-limits" }
 libp2p-core = { version = "0.41.1", path = "core" }
 libp2p-dcutr = { version = "0.11.0", path = "protocols/dcutr" }
-libp2p-dns = { version = "0.41.0", path = "transports/dns" }
+libp2p-dns = { version = "0.41.1", path = "transports/dns" }
 libp2p-floodsub = { version = "0.44.0", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.46.0", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.44.0", path = "protocols/identify" }

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 0.41.1 - unreleased
+## 0.41.1
 
-- Add hidden API that removes unnecessary async for `async-std`
-  See [PR 4808](https://github.com/libp2p/rust-libp2p/pull/4808)
+- Add hidden API that removes unnecessary async for `async-std`.
+  See [PR 4808](https://github.com/libp2p/rust-libp2p/pull/4808).
 
 ## 0.41.0
 

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.41.1 - unreleased
+
+- Add hidden API that removes unnecessary async for `async-std`
+  See [PR 4808](https://github.com/libp2p/rust-libp2p/pull/4808)
+
 ## 0.41.0
 
 - Make `tokio::Transport::custom` and `async_std::Transport::custom` constructors infallible.

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-dns"
 edition = "2021"
 rust-version = { workspace = true }
 description = "DNS transport implementation for libp2p"
-version = "0.41.0"
+version = "0.41.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
## Description

After the release of 0.53.1, I noticed that new libp2p-dns was not published. This was because I forgot to increase its version and update its changelog in https://github.com/libp2p/rust-libp2p/pull/4808. 

This affects only users how uses `async-std` and `dns` features together. Sorry about that.
<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
