### PR TITLE
chore: fix wrong or missing span names for `NetworkBehaviour::poll`

### DIFF
--- a/protocols/autonat/src/behaviour.rs
+++ b/protocols/autonat/src/behaviour.rs
@@ -435,7 +435,7 @@ impl NetworkBehaviour for Behaviour {
         <request_response::Behaviour<AutoNatCodec> as NetworkBehaviour>::ConnectionHandler;
     type ToSwarm = Event;
 
-    #[tracing::instrument(level = "trace", name = "ConnectionHandler::poll", skip(self, cx))]
+    #[tracing::instrument(level = "trace", name = "NetworkBehaviour::poll", skip(self, cx))]
     fn poll(
         &mut self,
         cx: &mut Context<'_>,

--- a/protocols/dcutr/src/behaviour.rs
+++ b/protocols/dcutr/src/behaviour.rs
@@ -322,6 +322,7 @@ impl NetworkBehaviour for Behaviour {
         };
     }
 
+    #[tracing::instrument(level = "trace", name = "NetworkBehaviour::poll", skip(self))]
     fn poll(&mut self, _: &mut Context<'_>) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         if let Some(event) = self.queued_events.pop_front() {
             return Poll::Ready(event);

--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -474,6 +474,7 @@ impl NetworkBehaviour for Floodsub {
         }
     }
 
+    #[tracing::instrument(level = "trace", name = "NetworkBehaviour::poll", skip(self))]
     fn poll(&mut self, _: &mut Context<'_>) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         if let Some(event) = self.events.pop_front() {
             return Poll::Ready(event);

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -3426,7 +3426,7 @@ where
         }
     }
 
-    #[tracing::instrument(level = "trace", name = "ConnectionHandler::poll", skip(self, cx))]
+    #[tracing::instrument(level = "trace", name = "NetworkBehaviour::poll", skip(self, cx))]
     fn poll(
         &mut self,
         cx: &mut Context<'_>,

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -2413,7 +2413,7 @@ where
         };
     }
 
-    #[tracing::instrument(level = "trace", name = "ConnectionHandler::poll", skip(self, cx))]
+    #[tracing::instrument(level = "trace", name = "NetworkBehaviour::poll", skip(self, cx))]
     fn poll(
         &mut self,
         cx: &mut Context<'_>,

--- a/protocols/mdns/src/behaviour.rs
+++ b/protocols/mdns/src/behaviour.rs
@@ -282,7 +282,7 @@ where
             .on_swarm_event(&event);
     }
 
-    #[tracing::instrument(level = "trace", name = "ConnectionHandler::poll", skip(self, cx))]
+    #[tracing::instrument(level = "trace", name = "NetworkBehaviour::poll", skip(self, cx))]
     fn poll(
         &mut self,
         cx: &mut Context<'_>,

--- a/protocols/perf/src/client/behaviour.rs
+++ b/protocols/perf/src/client/behaviour.rs
@@ -135,11 +135,8 @@ impl NetworkBehaviour for Behaviour {
             .push_back(ToSwarm::GenerateEvent(Event { id, result }));
     }
 
-    #[tracing::instrument(level = "trace", name = "ConnectionHandler::poll", skip(self, _cx))]
-    fn poll(
-        &mut self,
-        _cx: &mut Context<'_>,
-    ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+    #[tracing::instrument(level = "trace", name = "NetworkBehaviour::poll", skip(self))]
+    fn poll(&mut self, _: &mut Context<'_>) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         if let Some(event) = self.queued_events.pop_front() {
             return Poll::Ready(event);
         }

--- a/protocols/perf/src/server/behaviour.rs
+++ b/protocols/perf/src/server/behaviour.rs
@@ -89,11 +89,8 @@ impl NetworkBehaviour for Behaviour {
         }))
     }
 
-    #[tracing::instrument(level = "trace", name = "ConnectionHandler::poll", skip(self, _cx))]
-    fn poll(
-        &mut self,
-        _cx: &mut Context<'_>,
-    ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+    #[tracing::instrument(level = "trace", name = "NetworkBehaviour::poll", skip(self))]
+    fn poll(&mut self, _: &mut Context<'_>) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         if let Some(event) = self.queued_events.pop_front() {
             return Poll::Ready(event);
         }

--- a/protocols/relay/src/behaviour.rs
+++ b/protocols/relay/src/behaviour.rs
@@ -693,11 +693,8 @@ impl NetworkBehaviour for Behaviour {
         }
     }
 
-    #[tracing::instrument(level = "trace", name = "ConnectionHandler::poll", skip(self, _cx))]
-    fn poll(
-        &mut self,
-        _cx: &mut Context<'_>,
-    ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+    #[tracing::instrument(level = "trace", name = "NetworkBehaviour::poll", skip(self))]
+    fn poll(&mut self, _: &mut Context<'_>) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         if let Some(to_swarm) = self.queued_actions.pop_front() {
             return Poll::Ready(to_swarm);
         }

--- a/protocols/relay/src/priv_client.rs
+++ b/protocols/relay/src/priv_client.rs
@@ -239,6 +239,7 @@ impl NetworkBehaviour for Behaviour {
         self.queued_actions.push_back(ToSwarm::GenerateEvent(event))
     }
 
+    #[tracing::instrument(level = "trace", name = "NetworkBehaviour::poll", skip(self, cx))]
     fn poll(
         &mut self,
         cx: &mut Context<'_>,

--- a/protocols/rendezvous/src/client.rs
+++ b/protocols/rendezvous/src/client.rs
@@ -238,6 +238,7 @@ impl NetworkBehaviour for Behaviour {
         }
     }
 
+    #[tracing::instrument(level = "trace", name = "NetworkBehaviour::poll", skip(self, cx))]
     fn poll(
         &mut self,
         cx: &mut Context<'_>,

--- a/protocols/rendezvous/src/server.rs
+++ b/protocols/rendezvous/src/server.rs
@@ -155,6 +155,7 @@ impl NetworkBehaviour for Behaviour {
             .on_connection_handler_event(peer_id, connection, event);
     }
 
+    #[tracing::instrument(level = "trace", name = "NetworkBehaviour::poll", skip(self, cx))]
     fn poll(
         &mut self,
         cx: &mut Context<'_>,

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -955,6 +955,7 @@ where
         }
     }
 
+    #[tracing::instrument(level = "trace", name = "NetworkBehaviour::poll", skip(self))]
     fn poll(&mut self, _: &mut Context<'_>) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         if let Some(ev) = self.pending_events.pop_front() {
             return Poll::Ready(ev);

--- a/protocols/upnp/src/behaviour.rs
+++ b/protocols/upnp/src/behaviour.rs
@@ -364,7 +364,7 @@ impl NetworkBehaviour for Behaviour {
         void::unreachable(event)
     }
 
-    #[tracing::instrument(level = "trace", name = "ConnectionHandler::poll", skip(self, cx))]
+    #[tracing::instrument(level = "trace", name = "NetworkBehaviour::poll", skip(self, cx))]
     fn poll(
         &mut self,
         cx: &mut Context<'_>,


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
