### PR TITLE
fix(mdns): don't suspend task forever upon reading non-mDNS packet

### DIFF
--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Ensure `Multiaddr` handled and returned by `Behaviour` are `/p2p` terminated.
   See [PR 4596](https://github.com/libp2p/rust-libp2p/pull/4596).
+- Fix a bug in the `Behaviour::poll` method causing missed mdns packets.
+  See [PR 4861](https://github.com/libp2p/rust-libp2p/pull/4861).
 
 ## 0.45.0
 

--- a/protocols/mdns/src/behaviour/iface.rs
+++ b/protocols/mdns/src/behaviour/iface.rs
@@ -312,14 +312,18 @@ where
                 }
                 Poll::Ready(Err(err)) if err.kind() == std::io::ErrorKind::WouldBlock => {
                     // No more bytes available on the socket to read
+                    continue;
                 }
                 Poll::Ready(Err(err)) => {
                     tracing::error!("failed reading datagram: {}", err);
+                    return Poll::Ready(());
                 }
                 Poll::Ready(Ok(Err(err))) => {
                     tracing::debug!("Parsing mdns packet failed: {:?}", err);
+                    continue;
                 }
-                Poll::Ready(Ok(Ok(None))) | Poll::Pending => {}
+                Poll::Ready(Ok(Ok(None))) => continue,
+                Poll::Pending => {}
             }
 
             return Poll::Pending;


### PR DESCRIPTION
## Description

Fixes: #4860.

## Notes & open questions

We are not completely sure if we should loop back again (ie. going through priorities `1`, `2` and `3` all over again) or if we should add another loop around priority `4`. From our understanding of the `poll` implementation, we should loop back at the top but we might be incorrect.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
