### PR TITLE
fix(interop-tests): don't hardcode `x86_64` for native

### DIFF
--- a/interop-tests/Dockerfile.native
+++ b/interop-tests/Dockerfile.native
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.5-labs
-FROM lukemathwalker/cargo-chef as chef
+FROM lukemathwalker/cargo-chef:0.1.62-rust-1.73.0 as chef
 WORKDIR /app
 
 FROM chef AS planner

--- a/interop-tests/Dockerfile.native
+++ b/interop-tests/Dockerfile.native
@@ -9,12 +9,13 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 # Build dependencies - this is the caching Docker layer!
-RUN RUSTFLAGS='-C target-feature=+crt-static' cargo chef cook --release --package interop-tests --target x86_64-unknown-linux-gnu --bin native_ping --recipe-path recipe.json
+RUN RUSTFLAGS='-C target-feature=+crt-static' cargo chef cook --release --package interop-tests --target $(rustc -vV | grep host | awk '{print $2}') --bin native_ping --recipe-path recipe.json
 # Build application
 COPY . .
-RUN RUSTFLAGS='-C target-feature=+crt-static' cargo build --release --package interop-tests --target x86_64-unknown-linux-gnu --bin native_ping
+RUN RUSTFLAGS='-C target-feature=+crt-static' cargo build --release --package interop-tests --target $(rustc -vV | grep host | awk '{print $2}') --bin native_ping
+RUN cp /app/target/$(rustc -vV | grep host | awk '{print $2}')/release/native_ping /usr/local/bin/testplan
 
 FROM scratch
-COPY --from=builder /app/target/x86_64-unknown-linux-gnu/release/native_ping /usr/local/bin/testplan
+COPY --from=builder /usr/local/bin/testplan /usr/local/bin/testplan
 ENV RUST_BACKTRACE=1
 ENTRYPOINT ["testplan"]

--- a/interop-tests/Dockerfile.native
+++ b/interop-tests/Dockerfile.native
@@ -1,6 +1,5 @@
 # syntax=docker/dockerfile:1.5-labs
-FROM rust:1.73.0 as chef
-RUN wget -q -O- https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.62/cargo-chef-x86_64-unknown-linux-gnu.tar.gz | tar -zx -C /usr/local/bin
+FROM lukemathwalker/cargo-chef as chef
 WORKDIR /app
 
 FROM chef AS planner


### PR DESCRIPTION
## Description

Remove hard-coded `x86_64` for the native interop tests. The tests couldn't run on arm64 architecture.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
