### PR TITLE
feat: verify expected `PeerId` as part of security handshake

### DIFF
--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -126,6 +126,12 @@ where
     ///
     ///   * I/O upgrade: `C -> (PeerId, D)`.
     ///   * Transport output: `C -> (PeerId, D)`
+    ///
+    /// ## Alternative state
+    ///
+    /// This function is an alternative code path to [`Builder::authenticate`]
+    /// given the supplied upgrade implements `SecurityUpgrade` instead of
+    /// `InboundConnectionUpgrade`/`OutboundConnectionUpgrade`.
     pub fn authenticate2<C, D, U, E>(
         self,
         upgrade: U,
@@ -182,7 +188,7 @@ where
 /// An upgrade that authenticates the remote peer, typically
 /// in the context of negotiating a secure channel.
 ///
-/// Configured through [`Builder::authenticate`].
+/// Configured through [`Builder::authenticate2`].
 #[pin_project::pin_project]
 pub struct Authenticate2<C, U>
 where

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -133,6 +133,7 @@ where
     /// This function is an alternative code path to [`Builder::authenticate`]
     /// given the supplied upgrade implements `SecurityUpgrade` instead of
     /// `InboundConnectionUpgrade`/`OutboundConnectionUpgrade`.
+    #[doc(hidden)]
     pub fn authenticate2<C, D, U, E>(
         self,
         upgrade: U,
@@ -198,6 +199,7 @@ where
 /// in the context of negotiating a secure channel.
 ///
 /// Configured through [`Builder::authenticate2`].
+#[doc(hidden)]
 #[pin_project::pin_project]
 pub struct Authenticate2<C, U>
 where

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -131,8 +131,8 @@ where
     /// ## Alternative state
     ///
     /// This function is an alternative code path to [`Builder::authenticate`]
-    /// given the supplied upgrade implements `SecurityUpgrade` instead of
-    /// `InboundConnectionUpgrade`/`OutboundConnectionUpgrade`.
+    /// given the supplied upgrade implements `InboundConnectionUpgrade`/`OutboundSecurityUpgrade`
+    /// instead of `InboundConnectionUpgrade`/`OutboundConnectionUpgrade`.
     #[doc(hidden)]
     pub fn authenticate2<C, D, U, E>(
         self,

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -115,7 +115,7 @@ where
         ))
     }
 
-    /// Upgrades the transport to perform authentication of the remote
+    /// Upgrades the transport to perform authentication of the remote.
     ///
     /// The supplied upgrade receives the I/O resource `C` and must
     /// produce a pair `(PeerId, D)`, where `D` is a new I/O resource.
@@ -131,8 +131,8 @@ where
     /// ## Alternative state
     ///
     /// This function is an alternative code path to [`Builder::authenticate`]
-    /// given the supplied upgrade implements `InboundConnectionUpgrade`/`OutboundSecurityUpgrade`
-    /// instead of `InboundConnectionUpgrade`/`OutboundConnectionUpgrade`.
+    /// given the supplied upgrade implements [`InboundSecurityUpgrade`]/[`OutboundSecurityUpgrade`]
+    /// instead of [`InboundConnectionUpgrade`]/[`OutboundConnectionUpgrade`].
     #[doc(hidden)]
     pub fn authenticate2<C, D, U, E>(
         self,

--- a/core/src/upgrade.rs
+++ b/core/src/upgrade.rs
@@ -186,12 +186,12 @@ pub trait OutboundSecurityUpgrade<T>: UpgradeInfo {
     /// method is called to start the handshake.
     ///
     /// The `info` is the identifier of the protocol, as produced by `protocol_info`. Security
-    /// transports use the optional `remote_peer_id` parameter on outgoing upgrades to validate the
-    /// expected `PeerId`.
+    /// transports use the optional `expected_peer_id` parameter on outgoing upgrades to validate
+    /// the expected `PeerId`.
     fn secure_outbound(
         self,
         socket: T,
         info: Self::Info,
-        remote_peer_id: Option<PeerId>,
+        expected_peer_id: Option<PeerId>,
     ) -> Self::Future;
 }

--- a/core/src/upgrade.rs
+++ b/core/src/upgrade.rs
@@ -167,10 +167,8 @@ pub trait InboundSecurityUpgrade<T>: UpgradeInfo {
     /// After we have determined that the remote supports one of the protocols we support, this
     /// method is called to start the handshake.
     ///
-    /// The `info` is the identifier of the protocol, as produced by `protocol_info`. Security
-    /// transports use the optional `peer_id` parameter on outgoing upgrades to validate the
-    /// expected `PeerId`.
-    fn secure_inbound(self, socket: T, info: Self::Info, peer_id: Option<PeerId>) -> Self::Future;
+    /// The `info` is the identifier of the protocol, as produced by `protocol_info`.
+    fn secure_inbound(self, socket: T, info: Self::Info) -> Self::Future;
 }
 
 /// Possible security upgrade on an outbound connection

--- a/core/src/upgrade.rs
+++ b/core/src/upgrade.rs
@@ -66,18 +66,20 @@ mod ready;
 mod secure;
 mod select;
 
-pub use self::{
-    denied::DeniedUpgrade, pending::PendingUpgrade, ready::ReadyUpgrade, select::SelectUpgrade,
-};
-pub use crate::Negotiated;
 pub(crate) use apply::{
     apply, apply_inbound, apply_outbound, InboundUpgradeApply, OutboundUpgradeApply,
 };
 pub(crate) use error::UpgradeError;
+pub(crate) use secure::{secure, EitherSecurityFuture};
+
 use futures::future::Future;
 use libp2p_identity::PeerId;
+
+pub use self::{
+    denied::DeniedUpgrade, pending::PendingUpgrade, ready::ReadyUpgrade, select::SelectUpgrade,
+};
+pub use crate::Negotiated;
 pub use multistream_select::{NegotiatedComplete, NegotiationError, ProtocolError, Version};
-pub(crate) use secure::{secure, EitherSecurityFuture};
 
 /// Common trait for upgrades that can be applied on inbound substreams, outbound substreams,
 /// or both.

--- a/core/src/upgrade.rs
+++ b/core/src/upgrade.rs
@@ -162,7 +162,7 @@ pub trait SecurityUpgrade<T>: UpgradeInfo {
     /// Possible error during the handshake.
     type Error;
     /// Future that performs the handshake with the remote.
-    type Future: Future<Output = Result<Self::Output, Self::Error>>;
+    type Future: Future<Output = Result<(PeerId, Self::Output), Self::Error>>;
 
     /// After we have determined that the remote supports one of the protocols we support, this
     /// method is called to start the handshake.

--- a/core/src/upgrade.rs
+++ b/core/src/upgrade.rs
@@ -184,7 +184,12 @@ pub trait OutboundSecurityUpgrade<T>: UpgradeInfo {
     /// method is called to start the handshake.
     ///
     /// The `info` is the identifier of the protocol, as produced by `protocol_info`. Security
-    /// transports use the optional `peer_id` parameter on outgoing upgrades to validate the
+    /// transports use the optional `remote_peer_id` parameter on outgoing upgrades to validate the
     /// expected `PeerId`.
-    fn secure_outbound(self, socket: T, info: Self::Info, peer_id: Option<PeerId>) -> Self::Future;
+    fn secure_outbound(
+        self,
+        socket: T,
+        info: Self::Info,
+        remote_peer_id: Option<PeerId>,
+    ) -> Self::Future;
 }

--- a/core/src/upgrade.rs
+++ b/core/src/upgrade.rs
@@ -168,8 +168,8 @@ pub trait SecurityUpgrade<T>: UpgradeInfo {
     /// method is called to start the handshake.
     ///
     /// The `info` is the identifier of the protocol, as produced by `protocol_info`. Security
-    /// transports use the optional `peer_id` parameter on outgoing upgrades to validate validate
-    /// the expected `PeerId`.
+    /// transports use the optional `peer_id` parameter on outgoing upgrades to validate the
+    /// expected `PeerId`.
     fn upgrade_security(self, socket: T, info: Self::Info, peer_id: Option<PeerId>)
         -> Self::Future;
 }

--- a/core/src/upgrade.rs
+++ b/core/src/upgrade.rs
@@ -77,7 +77,7 @@ pub(crate) use error::UpgradeError;
 use futures::future::Future;
 use libp2p_identity::PeerId;
 pub use multistream_select::{NegotiatedComplete, NegotiationError, ProtocolError, Version};
-pub(crate) use secure::secure;
+pub(crate) use secure::{secure, EitherSecurityFuture};
 
 /// Common trait for upgrades that can be applied on inbound substreams, outbound substreams,
 /// or both.
@@ -155,8 +155,8 @@ pub trait OutboundConnectionUpgrade<T>: UpgradeInfo {
     fn upgrade_outbound(self, socket: T, info: Self::Info) -> Self::Future;
 }
 
-/// Possible security upgrade on a connection
-pub trait SecurityUpgrade<T>: UpgradeInfo {
+/// Possible security upgrade on an inbound connection
+pub trait InboundSecurityUpgrade<T>: UpgradeInfo {
     /// Output after the upgrade has been successfully negotiated and the handshake performed.
     type Output;
     /// Possible error during the handshake.
@@ -170,6 +170,23 @@ pub trait SecurityUpgrade<T>: UpgradeInfo {
     /// The `info` is the identifier of the protocol, as produced by `protocol_info`. Security
     /// transports use the optional `peer_id` parameter on outgoing upgrades to validate the
     /// expected `PeerId`.
-    fn upgrade_security(self, socket: T, info: Self::Info, peer_id: Option<PeerId>)
-        -> Self::Future;
+    fn secure_inbound(self, socket: T, info: Self::Info, peer_id: Option<PeerId>) -> Self::Future;
+}
+
+/// Possible security upgrade on an outbound connection
+pub trait OutboundSecurityUpgrade<T>: UpgradeInfo {
+    /// Output after the upgrade has been successfully negotiated and the handshake performed.
+    type Output;
+    /// Possible error during the handshake.
+    type Error;
+    /// Future that performs the handshake with the remote.
+    type Future: Future<Output = Result<(PeerId, Self::Output), Self::Error>>;
+
+    /// After we have determined that the remote supports one of the protocols we support, this
+    /// method is called to start the handshake.
+    ///
+    /// The `info` is the identifier of the protocol, as produced by `protocol_info`. Security
+    /// transports use the optional `peer_id` parameter on outgoing upgrades to validate the
+    /// expected `PeerId`.
+    fn secure_outbound(self, socket: T, info: Self::Info, peer_id: Option<PeerId>) -> Self::Future;
 }

--- a/core/src/upgrade/secure.rs
+++ b/core/src/upgrade/secure.rs
@@ -90,7 +90,7 @@ where
                 let (info, stream) =
                     multistream_select::listener_select_proto(conn, up.protocol_info()).await?;
                 let name = info.as_ref().to_owned();
-                match up.secure_inbound(stream, info, None).await {
+                match up.secure_inbound(stream, info).await {
                     Ok(x) => {
                         tracing::trace!(up=%name, "Secured inbound stream");
                         Ok(x)

--- a/core/src/upgrade/secure.rs
+++ b/core/src/upgrade/secure.rs
@@ -1,0 +1,88 @@
+//! After a successful protocol negotiation as part of the upgrade process, the `SecurityUpgrade::upgrade_security`
+//! method is called and a [`Future`] that performs a handshake is returned.
+
+use crate::upgrade::{SecurityUpgrade, UpgradeError};
+use crate::{connection::ConnectedPoint, Negotiated};
+use futures::prelude::*;
+
+use libp2p_identity::PeerId;
+use multiaddr::Protocol;
+use multistream_select::Version;
+
+/// Applies a security upgrade to the inbound and outbound direction of a connection or substream.
+pub(crate) async fn secure<C, U>(
+    conn: C,
+    up: U,
+    cp: ConnectedPoint,
+    v: Version,
+) -> Result<U::Output, UpgradeError<U::Error>>
+where
+    C: AsyncRead + AsyncWrite + Unpin,
+    U: SecurityUpgrade<Negotiated<C>>,
+{
+    match cp {
+        ConnectedPoint::Dialer { role_override, .. } if role_override.is_dialer() => {
+            let peer_id = cp
+                .get_remote_address()
+                .iter()
+                .find_map(|protocol| match protocol {
+                    Protocol::P2p(peer_id) => Some(peer_id),
+                    _ => None,
+                })
+                .expect("It should have /p2p as part of the address");
+            secure_outbound(conn, up, Some(peer_id), v).await
+        }
+        _ => secure_inbound(conn, up, None).await,
+    }
+}
+
+/// Tries to perform a security upgrade on an inbound connection or substream.
+async fn secure_inbound<C, U>(
+    conn: C,
+    up: U,
+    peer_id: Option<PeerId>,
+) -> Result<U::Output, UpgradeError<U::Error>>
+where
+    C: AsyncRead + AsyncWrite + Unpin,
+    U: SecurityUpgrade<Negotiated<C>>,
+{
+    let (info, stream) =
+        multistream_select::listener_select_proto(conn, up.protocol_info()).await?;
+    let name = info.as_ref().to_owned();
+    match up.upgrade_security(stream, info, peer_id).await {
+        Ok(x) => {
+            tracing::trace!(up=%name, "Secured inbound stream");
+            Ok(x)
+        }
+        Err(e) => {
+            tracing::trace!(up=%name, "Failed to secure inbound stream");
+            Err(UpgradeError::Apply(e))
+        }
+    }
+}
+
+/// Tries to perform a security upgrade on an outbound connection or substream.
+async fn secure_outbound<C, U>(
+    conn: C,
+    up: U,
+    peer_id: Option<PeerId>,
+    v: Version,
+) -> Result<U::Output, UpgradeError<U::Error>>
+where
+    C: AsyncRead + AsyncWrite + Unpin,
+    U: SecurityUpgrade<Negotiated<C>>,
+{
+    let (info, stream) =
+        multistream_select::dialer_select_proto(conn, up.protocol_info(), v).await?;
+    let name = info.as_ref().to_owned();
+    match up.upgrade_security(stream, info, peer_id).await {
+        Ok(x) => {
+            tracing::trace!(up=%name, "Secured outbound stream");
+            Ok(x)
+        }
+        Err(e) => {
+            tracing::trace!(up=%name, "Failed to secure outbound stream");
+            Err(UpgradeError::Apply(e))
+        }
+    }
+}

--- a/core/src/upgrade/secure.rs
+++ b/core/src/upgrade/secure.rs
@@ -1,5 +1,5 @@
-//! After a successful protocol negotiation as part of the upgrade process, the `InboundConnectionUpgrade::secure_inbound`
-//! or `OutboundSecurityUpgrade::secure_outbound` method is called and a [`Future`] that performs a
+//! After a successful protocol negotiation as part of the upgrade process, the [`InboundSecurityUpgrade::secure_inbound`]
+//! or [`OutboundSecurityUpgrade::secure_outbound`] method is called and a [`Future`] that performs a
 //! handshake is returned.
 
 use std::iter::IntoIterator;

--- a/core/src/upgrade/secure.rs
+++ b/core/src/upgrade/secure.rs
@@ -1,5 +1,6 @@
-//! After a successful protocol negotiation as part of the upgrade process, the `SecurityUpgrade::upgrade_security`
-//! method is called and a [`Future`] that performs a handshake is returned.
+//! After a successful protocol negotiation as part of the upgrade process, the `InboundConnectionUpgrade::secure_inbound`
+//! or `OutboundSecurityUpgrade::secure_outbound` method is called and a [`Future`] that performs a
+//! handshake is returned.
 
 use std::iter::IntoIterator;
 

--- a/core/src/upgrade/secure.rs
+++ b/core/src/upgrade/secure.rs
@@ -1,62 +1,106 @@
 //! After a successful protocol negotiation as part of the upgrade process, the `SecurityUpgrade::upgrade_security`
 //! method is called and a [`Future`] that performs a handshake is returned.
 
-use crate::upgrade::{SecurityUpgrade, UpgradeError};
+use std::iter::IntoIterator;
+
+use crate::upgrade::UpgradeError;
+use crate::UpgradeInfo;
 use crate::{connection::ConnectedPoint, Negotiated};
+use futures::future::{BoxFuture, Either};
 use futures::prelude::*;
 
 use libp2p_identity::PeerId;
 use multiaddr::Protocol;
 use multistream_select::Version;
 
+use super::{InboundSecurityUpgrade, OutboundSecurityUpgrade};
+
+/// An inbound or outbound security upgrade.
+pub(crate) type EitherSecurityFuture<C, U> =
+    Either<InboundSecurityFuture<C, U>, OutboundSecurityFuture<C, U>>;
+
+/// An inbound security upgrade represented by an owned trait object `Future`.
+pub(crate) type InboundSecurityFuture<C, U> = BoxFuture<
+    'static,
+    Result<
+        (PeerId, <U as InboundSecurityUpgrade<Negotiated<C>>>::Output),
+        UpgradeError<<U as InboundSecurityUpgrade<Negotiated<C>>>::Error>,
+    >,
+>;
+
+/// An outbound security upgrade represented by an owned trait object `Future`.
+pub(crate) type OutboundSecurityFuture<C, U> = BoxFuture<
+    'static,
+    Result<
+        (
+            PeerId,
+            <U as OutboundSecurityUpgrade<Negotiated<C>>>::Output,
+        ),
+        UpgradeError<<U as OutboundSecurityUpgrade<Negotiated<C>>>::Error>,
+    >,
+>;
+
 /// Applies a security upgrade to the inbound and outbound direction of a connection or substream.
-pub(crate) async fn secure<C, U>(
+pub(crate) fn secure<C, U>(
     conn: C,
     up: U,
     cp: ConnectedPoint,
     v: Version,
-) -> Result<(PeerId, U::Output), UpgradeError<U::Error>>
+) -> EitherSecurityFuture<C, U>
 where
-    C: AsyncRead + AsyncWrite + Unpin,
-    U: SecurityUpgrade<Negotiated<C>>,
+    C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    U: InboundSecurityUpgrade<Negotiated<C>>
+        + OutboundSecurityUpgrade<Negotiated<C>>
+        + Send
+        + 'static,
+    <U as UpgradeInfo>::Info: Send,
+    <U as InboundSecurityUpgrade<Negotiated<C>>>::Future: Send,
+    <U as OutboundSecurityUpgrade<Negotiated<C>>>::Future: Send,
+    <<U as UpgradeInfo>::InfoIter as IntoIterator>::IntoIter: Send,
 {
     match cp {
-        ConnectedPoint::Dialer { role_override, .. } if role_override.is_dialer() => {
-            let peer_id = cp
-                .get_remote_address()
-                .iter()
-                .find_map(|protocol| match protocol {
-                    Protocol::P2p(peer_id) => Some(peer_id),
-                    _ => None,
-                });
-            let (info, stream) =
-                multistream_select::dialer_select_proto(conn, up.protocol_info(), v).await?;
-            let name = info.as_ref().to_owned();
-            match up.upgrade_security(stream, info, peer_id).await {
-                Ok(x) => {
-                    tracing::trace!(up=%name, "Secured outbound stream");
-                    Ok(x)
-                }
-                Err(e) => {
-                    tracing::trace!(up=%name, "Failed to secure outbound stream");
-                    Err(UpgradeError::Apply(e))
-                }
-            }
-        }
-        _ => {
-            let (info, stream) =
-                multistream_select::listener_select_proto(conn, up.protocol_info()).await?;
-            let name = info.as_ref().to_owned();
-            match up.upgrade_security(stream, info, None).await {
-                Ok(x) => {
-                    tracing::trace!(up=%name, "Secured inbound stream");
-                    Ok(x)
-                }
-                Err(e) => {
-                    tracing::trace!(up=%name, "Failed to secure inbound stream");
-                    Err(UpgradeError::Apply(e))
+        ConnectedPoint::Dialer { role_override, .. } if role_override.is_dialer() => Either::Right(
+            async move {
+                let peer_id = cp
+                    .get_remote_address()
+                    .iter()
+                    .find_map(|protocol| match protocol {
+                        Protocol::P2p(peer_id) => Some(peer_id),
+                        _ => None,
+                    });
+                let (info, stream) =
+                    multistream_select::dialer_select_proto(conn, up.protocol_info(), v).await?;
+                let name = info.as_ref().to_owned();
+                match up.secure_outbound(stream, info, peer_id).await {
+                    Ok(x) => {
+                        tracing::trace!(up=%name, "Secured outbound stream");
+                        Ok(x)
+                    }
+                    Err(e) => {
+                        tracing::trace!(up=%name, "Failed to secure outbound stream");
+                        Err(UpgradeError::Apply(e))
+                    }
                 }
             }
-        }
+            .boxed(),
+        ),
+        _ => Either::Left(
+            async move {
+                let (info, stream) =
+                    multistream_select::listener_select_proto(conn, up.protocol_info()).await?;
+                let name = info.as_ref().to_owned();
+                match up.secure_inbound(stream, info, None).await {
+                    Ok(x) => {
+                        tracing::trace!(up=%name, "Secured inbound stream");
+                        Ok(x)
+                    }
+                    Err(e) => {
+                        tracing::trace!(up=%name, "Failed to secure inbound stream");
+                        Err(UpgradeError::Apply(e))
+                    }
+                }
+            }
+            .boxed(),
+        ),
     }
 }

--- a/transports/noise/src/lib.rs
+++ b/transports/noise/src/lib.rs
@@ -231,7 +231,7 @@ where
     type Error = Error;
     type Future = BoxFuture<'static, Result<(PeerId, Self::Output), Self::Error>>;
 
-    fn secure_inbound(self, socket: T, _: Self::Info, _: Option<PeerId>) -> Self::Future {
+    fn secure_inbound(self, socket: T, _: Self::Info) -> Self::Future {
         async move {
             let mut state = self.into_responder(socket)?;
 

--- a/transports/tls/src/upgrade.rs
+++ b/transports/tls/src/upgrade.rs
@@ -45,10 +45,10 @@ pub enum UpgradeError {
     ClientUpgrade(std::io::Error),
     #[error("Failed to parse certificate")]
     BadCertificate(#[from] certificate::ParseError),
-    #[error("Invalid peer ID (actual {peer_id:?}, remote {remote_peer_id:?})")]
+    #[error("Invalid peer ID (actual {peer_id:?}, expected {expected_peer_id:?})")]
     PeerIdMismatch {
         peer_id: PeerId,
-        remote_peer_id: PeerId,
+        expected_peer_id: PeerId,
     },
 }
 
@@ -66,14 +66,14 @@ impl Config {
         })
     }
 
-    pub(crate) fn with_remote_peer_id(
-        remote_peer_id: Option<PeerId>,
+    pub(crate) fn with_expected_peer_id(
+        expected_peer_id: Option<PeerId>,
     ) -> Result<Self, certificate::GenError> {
         let identity = libp2p_identity::Keypair::generate_ed25519();
 
         Ok(Self {
             server: crate::make_server_config(&identity)?,
-            client: crate::make_client_config(&identity, remote_peer_id)?,
+            client: crate::make_client_config(&identity, expected_peer_id)?,
         })
     }
 }
@@ -148,11 +148,11 @@ where
         mut self,
         socket: C,
         _: Self::Info,
-        remote_peer_id: Option<PeerId>,
+        expected_peer_id: Option<PeerId>,
     ) -> Self::Future {
         async move {
-            // Create new ad-hoc client and server configuration by passing the remote PeerId
-            self = Self::with_remote_peer_id(remote_peer_id)?;
+            // Create new ad-hoc client and server configuration by passing the expected PeerId
+            self = Self::with_expected_peer_id(expected_peer_id)?;
 
             // Spec: In order to keep this flexibility for future versions, clients that only support
             // the version of the handshake defined in this document MUST NOT send any value in the

--- a/transports/tls/src/upgrade.rs
+++ b/transports/tls/src/upgrade.rs
@@ -131,7 +131,7 @@ where
     type Error = UpgradeError;
     type Future = BoxFuture<'static, Result<(PeerId, Self::Output), Self::Error>>;
 
-    fn secure_inbound(self, socket: C, _: Self::Info, _: Option<PeerId>) -> Self::Future {
+    fn secure_inbound(self, socket: C, _: Self::Info) -> Self::Future {
         async move {
             let stream = futures_rustls::TlsAcceptor::from(Arc::new(self.server))
                 .accept(socket)


### PR DESCRIPTION
## Description

During a handshake, certificates should be verified in order to allow the connection attempt to be aborted during the security handshake (by security protocols such as TLS or Noise). This requires being able to verify the peer ID after the handshake. Otherwise, we will have abnormal behaviors, such as aborting after completing the handshake and leaving the peer not knowing what went wrong.

Fixes: #2946.
Related: #4307.
Related: #4726.
Related: #882.

## Tasks

- [x] Introduce the `InboundSecurityUpgrade`/`OutboundSecurityUpgrade` traits that should be implemented by transports such as Noise or TLS.
- [x] Create the `Builder::authenticate2` function to accept an upgrade that implements this traits.
- [x] Implement a state machine in`upgrade::secure` that calls the `InboundSecurityUpgrade`/`OutboundSecurityUpgrade` traits instead of `InboundConnectionUpgrade` / `OutboundConnectionUpgrade`.
- [x] Implement the `InboundSecurityUpgrade`/`OutboundSecurityUpgrade` traits for Noise and TLS transports, repectively.
- [ ] Complete the missing parts.
- [ ] Include unit tests.
- [ ] Make appropriate changes to the docs.

## Notes & open questions

