### PR TITLE
fix(futures-bounded): register replaced `Stream`s/`Future`s as ready

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,6 +1535,7 @@ dependencies = [
 name = "futures-bounded"
 version = "0.2.1"
 dependencies = [
+ "futures",
  "futures-timer",
  "futures-util",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "futures-bounded"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "futures",
  "futures-timer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ resolver = "2"
 rust-version = "1.73.0"
 
 [workspace.dependencies]
-futures-bounded = { version = "0.2.1", path = "misc/futures-bounded" }
+futures-bounded = { version = "0.2.2", path = "misc/futures-bounded" }
 libp2p = { version = "0.53.0", path = "libp2p" }
 libp2p-allow-block-list = { version = "0.3.0", path = "misc/allow-block-list" }
 libp2p-autonat = { version = "0.12.0", path = "protocols/autonat" }

--- a/misc/futures-bounded/CHANGELOG.md
+++ b/misc/futures-bounded/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.2
+
+- Fix an issue where `{Futures,Stream}Map` returns `Poll::Pending` despite being ready after an item has been replaced as part of `try_push`.
+  See [PR 4865](https://github.com/libp2p/rust-lib2pp/pulls/4865). 
+
 ## 0.2.1
 
 - Add `.len()` getter to `FuturesMap`, `FuturesSet`, `StreamMap` and `StreamSet`.

--- a/misc/futures-bounded/Cargo.toml
+++ b/misc/futures-bounded/Cargo.toml
@@ -17,7 +17,7 @@ futures-util = { version = "0.3.29" }
 futures-timer = "3.0.2"
 
 [dev-dependencies]
-tokio = { version = "1.33.0", features = ["macros", "rt"] }
+tokio = { version = "1.33.0", features = ["macros", "rt", "sync"] }
 
 [lints]
 workspace = true

--- a/misc/futures-bounded/Cargo.toml
+++ b/misc/futures-bounded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-bounded"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version.workspace = true
 license = "MIT"

--- a/misc/futures-bounded/Cargo.toml
+++ b/misc/futures-bounded/Cargo.toml
@@ -18,6 +18,7 @@ futures-timer = "3.0.2"
 
 [dev-dependencies]
 tokio = { version = "1.33.0", features = ["macros", "rt", "sync"] }
+futures = "0.3.28"
 
 [lints]
 workspace = true

--- a/misc/futures-bounded/src/futures_set.rs
+++ b/misc/futures-bounded/src/futures_set.rs
@@ -23,7 +23,10 @@ impl<O> FuturesSet<O> {
     }
 }
 
-impl<O> FuturesSet<O> {
+impl<O> FuturesSet<O>
+where
+    O: 'static,
+{
     /// Push a future into the list.
     ///
     /// This method adds the given future to the list.


### PR DESCRIPTION
## Description

Currently, when a `Stream` or `Future` is replaced with a new one, it might happen that we miss a task wake-up and thus the task polling `FuturesMap` or `StreamMap` is never called again. This can be fixed by first removing the old `Stream`/`Future` and properly adding a new one via `.push`. The inner `SelectAll` calls a waker in that case which allows the outer task to continue.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
