### PR TITLE
chore(identity): don't inherit rust-version from workspace

### DIFF
--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-identity"
 version = "0.2.8"
 edition = "2021"
 description = "Data structures and algorithms for identifying peers in libp2p."
-rust-version = { workspace = true }
+rust-version = "1.73.0" # MUST NOT inherit from workspace because we don't want to publish breaking changes to `libp2p-identity`.
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
 keywords = ["peer-to-peer", "libp2p", "networking", "cryptography"]


### PR DESCRIPTION
## Description

Another data point in favor of #4742 just popped up. With `libp2p-identity` being part of the workspace, we accidentally published a patch release that bumps the MSRV which is something we normally consider a breaking change.

This PR freezes the MSRV of `libp2p-identity` to avoid this problem in the future. Long-term, we should do #4742 to avoid these kind of mistakes instead of special-casing crates within the repository.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
