### PR TITLE
fix(gossipsub): send iwant messages immediately

### DIFF
--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1306,13 +1306,22 @@ where
                 iwant_ids_vec
             );
 
-            Self::control_pool_add(
-                &mut self.control_pool,
-                *peer_id,
-                ControlAction::IWant {
-                    message_ids: iwant_ids_vec,
-                },
-            );
+            if self
+                .send_message(
+                    *peer_id,
+                    Rpc {
+                        subscriptions: Vec::new(),
+                        messages: Vec::new(),
+                        control_msgs: vec![ControlAction::IWant {
+                            message_ids: iwant_ids_vec,
+                        }],
+                    }
+                    .into_protobuf(),
+                )
+                .is_err()
+            {
+                tracing::error!("IHAVE: Failed to send message asking to peer");
+            }
         }
         tracing::trace!(peer=%peer_id, "Completed IHAVE handling for peer");
     }


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

After receiving an IHVE message from another peer, we sometimes need to wait for a heartbeat interval before sending an IWANT message. As a result, the other peer may have cleared the message from the cache, resulting in reducing the other peer's score.

In the implementation of go-libp2p, the IWANT message will be sent in time after receiving the IHAVE message. Therefore this PR will no longer put the message into the control pool but will be sent immediately.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
