### PR TITLE
chore(libp2p): add `#[allow(unreachable_pub)]`

### DIFF
--- a/libp2p/src/builder/phase.rs
+++ b/libp2p/src/builder/phase.rs
@@ -34,6 +34,7 @@ use super::SwarmBuilder;
 use libp2p_core::{muxing::StreamMuxerBox, Transport};
 use libp2p_identity::Keypair;
 
+#[allow(unreachable_pub)]
 pub trait IntoSecurityUpgrade<C> {
     type Upgrade;
     type Error;
@@ -75,6 +76,7 @@ where
     }
 }
 
+#[allow(unreachable_pub)]
 pub trait IntoMultiplexerUpgrade<C> {
     type Upgrade;
 

--- a/libp2p/src/builder/select_muxer.rs
+++ b/libp2p/src/builder/select_muxer.rs
@@ -18,6 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+#![allow(unreachable_pub)]
+
 use either::Either;
 use futures::future;
 use libp2p_core::either::EitherFuture;

--- a/libp2p/src/builder/select_security.rs
+++ b/libp2p/src/builder/select_security.rs
@@ -19,6 +19,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+#![allow(unreachable_pub)]
+
 use either::Either;
 use futures::future::MapOk;
 use futures::{future, TryFutureExt};


### PR DESCRIPTION
## Description

In certain feature combinations, these types are not used and thus are flagged as `unreachable_pub`. This PR is a quick fix to unblock CI of other PRs.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
