### PR TITLE
fix(kad): do not insert addresses into Kademlia unless `BucketInserts::OnConnected`

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.45.2 - unreleased
 
+- Do not insert addresses into Kademlia unless `BucketInserts::OnConnected`.
+  See [PR 4884](https://github.com/libp2p/rust-libp2p/pull/4884).
 - Ensure `Multiaddr` handled and returned by `Behaviour` are `/p2p` terminated.
   See [PR 4596](https://github.com/libp2p/rust-libp2p/pull/4596).
 

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -1224,28 +1224,32 @@ where
                 if old_status != new_status {
                     entry.update(new_status)
                 }
-                if let Some(address) = address {
-                    if entry.value().insert(address) {
-                        self.queued_events.push_back(ToSwarm::GenerateEvent(
-                            Event::RoutingUpdated {
-                                peer,
-                                is_new_peer: false,
-                                addresses: entry.value().clone(),
-                                old_peer: None,
-                                bucket_range: self
-                                    .kbuckets
-                                    .bucket(&key)
-                                    .map(|b| b.range())
-                                    .expect("Not kbucket::Entry::SelfEntry."),
-                            },
-                        ))
+                if matches!(self.kbucket_inserts, BucketInserts::OnConnected) {
+                    if let Some(address) = address {
+                        if entry.value().insert(address) {
+                            self.queued_events.push_back(ToSwarm::GenerateEvent(
+                                Event::RoutingUpdated {
+                                    peer,
+                                    is_new_peer: false,
+                                    addresses: entry.value().clone(),
+                                    old_peer: None,
+                                    bucket_range: self
+                                        .kbuckets
+                                        .bucket(&key)
+                                        .map(|b| b.range())
+                                        .expect("Not kbucket::Entry::SelfEntry."),
+                                },
+                            ))
+                        }
                     }
                 }
             }
 
             kbucket::Entry::Pending(mut entry, old_status) => {
-                if let Some(address) = address {
-                    entry.value().insert(address);
+                if matches!(self.kbucket_inserts, BucketInserts::OnConnected) {
+                    if let Some(address) = address {
+                        entry.value().insert(address);
+                    }
                 }
                 if old_status != new_status {
                     entry.update(new_status);


### PR DESCRIPTION
## Description

Fixes: #4882.

## Notes & open questions

None

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
