### PR TITLE
feat(websocket-websys): add support for different WASM environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket-websys"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ libp2p-webrtc = { version = "0.6.1-alpha", path = "transports/webrtc" }
 libp2p-webrtc-utils = { version = "0.1.0", path = "misc/webrtc-utils" }
 libp2p-webrtc-websys = { version = "0.2.0-alpha", path = "transports/webrtc-websys" }
 libp2p-websocket = { version = "0.43.0", path = "transports/websocket" }
-libp2p-websocket-websys = { version = "0.3.0", path = "transports/websocket-websys" }
+libp2p-websocket-websys = { version = "0.3.1", path = "transports/websocket-websys" }
 libp2p-webtransport-websys = { version = "0.2.0", path = "transports/webtransport-websys" }
 libp2p-yamux = { version = "0.45.0", path = "muxers/yamux" }
 multiaddr = "0.18.1"

--- a/transports/websocket-websys/CHANGELOG.md
+++ b/transports/websocket-websys/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.1
+
+- Add support for different WASM environments by introducing a `WebContext` that
+  detects and abstracts the `Window` vs the `WorkerGlobalScope` API.
+  See [PR 4889](https://github.com/libp2p/rust-libp2p/pull/4889).
+
 ## 0.3.0
 
 

--- a/transports/websocket-websys/Cargo.toml
+++ b/transports/websocket-websys/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-websocket-websys"
 edition = "2021"
 rust-version = "1.60.0"
 description = "WebSocket for libp2p under WASM environment"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Vince Vasta <vince.vasta@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -20,7 +20,7 @@ parking_lot = "0.12.1"
 send_wrapper = "0.6.0"
 thiserror = "1.0.50"
 wasm-bindgen = "0.2.88"
-web-sys = { version = "0.3.65", features = ["BinaryType", "CloseEvent", "MessageEvent", "WebSocket", "Window"] }
+web-sys = { version = "0.3.65", features = ["BinaryType", "CloseEvent", "MessageEvent", "WebSocket", "Window", "WorkerGlobalScope"] }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/transports/websocket-websys/src/lib.rs
+++ b/transports/websocket-websys/src/lib.rs
@@ -20,6 +20,8 @@
 
 //! Libp2p websocket transports built on [web-sys](https://rustwasm.github.io/wasm-bindgen/web-sys/index.html).
 
+mod web_context;
+
 use bytes::BytesMut;
 use futures::task::AtomicWaker;
 use futures::{future::Ready, io, prelude::*};
@@ -35,7 +37,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::{pin::Pin, task::Context, task::Poll};
 use wasm_bindgen::{prelude::*, JsCast};
-use web_sys::{window, CloseEvent, Event, MessageEvent, WebSocket};
+use web_sys::{CloseEvent, Event, MessageEvent, WebSocket};
+
+use crate::web_context::WebContext;
 
 /// A Websocket transport that can be used in a wasm environment.
 ///
@@ -300,8 +304,8 @@ impl Connection {
                 }
             }
         });
-        let buffered_amount_low_interval = window()
-            .expect("to have a window")
+        let buffered_amount_low_interval = WebContext::new()
+            .expect("to have a window or worker context")
             .set_interval_with_callback_and_timeout_and_arguments(
                 on_buffered_amount_low_closure.as_ref().unchecked_ref(),
                 100, // Chosen arbitrarily and likely worth tuning. Due to low impact of the /ws transport, no further effort was invested at the time.
@@ -439,8 +443,8 @@ impl Drop for Connection {
                 .close_with_code_and_reason(GO_AWAY_STATUS_CODE, "connection dropped");
         }
 
-        window()
-            .expect("to have a window")
-            .clear_interval_with_handle(self.inner.buffered_amount_low_interval)
+        WebContext::new()
+            .expect("to have a window or worker context")
+            .clear_interval_with_handle(self.inner.buffered_amount_low_interval);
     }
 }

--- a/transports/websocket-websys/src/web_context.rs
+++ b/transports/websocket-websys/src/web_context.rs
@@ -1,0 +1,57 @@
+use wasm_bindgen::{prelude::*, JsCast};
+use web_sys::window;
+
+/// Web context that abstract the window vs web worker API
+#[derive(Debug)]
+pub(crate) enum WebContext {
+    Window(web_sys::Window),
+    Worker(web_sys::WorkerGlobalScope),
+}
+
+impl WebContext {
+    pub(crate) fn new() -> Option<Self> {
+        match window() {
+            Some(window) => Some(Self::Window(window)),
+            None => {
+                #[wasm_bindgen]
+                extern "C" {
+                    type Global;
+
+                    #[wasm_bindgen(method, getter, js_name = WorkerGlobalScope)]
+                    fn worker(this: &Global) -> JsValue;
+                }
+                let global: Global = js_sys::global().unchecked_into();
+                if !global.worker().is_undefined() {
+                    Some(Self::Worker(global.unchecked_into()))
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    /// The `setInterval()` method.
+    pub(crate) fn set_interval_with_callback_and_timeout_and_arguments(
+        &self,
+        handler: &::js_sys::Function,
+        timeout: i32,
+        arguments: &::js_sys::Array,
+    ) -> Result<i32, JsValue> {
+        match self {
+            WebContext::Window(w) => {
+                w.set_interval_with_callback_and_timeout_and_arguments(handler, timeout, arguments)
+            }
+            WebContext::Worker(w) => {
+                w.set_interval_with_callback_and_timeout_and_arguments(handler, timeout, arguments)
+            }
+        }
+    }
+
+    /// The `clearInterval()` method.
+    pub(crate) fn clear_interval_with_handle(&self, handle: i32) {
+        match self {
+            WebContext::Window(w) => w.clear_interval_with_handle(handle),
+            WebContext::Worker(w) => w.clear_interval_with_handle(handle),
+        }
+    }
+}


### PR DESCRIPTION
## Description

We introduce a `WebContext` `enum` that abstracts and detects the `Window` vs the `WorkerGlobalScope` API.

Related: https://github.com/rustwasm/wasm-bindgen/issues/1046.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] A changelog entry has been made in the appropriate crates
