### PR TITLE
chore: bump version of `quick-protobuf-codec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "quick-protobuf-codec"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "asynchronous-codec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ multiaddr = "0.18.1"
 multihash = "0.19.1"
 multistream-select = { version = "0.13.0", path = "misc/multistream-select" }
 prometheus-client = "0.22.0"
-quick-protobuf-codec = { version = "0.2.0", path = "misc/quick-protobuf-codec" }
+quick-protobuf-codec = { version = "0.3.0", path = "misc/quick-protobuf-codec" }
 quickcheck = { package = "quickcheck-ext", path = "misc/quickcheck-ext" }
 rw-stream-sink = { version = "0.4.0", path = "misc/rw-stream-sink" }
 unsigned-varint = { version = "0.8.0" }

--- a/misc/quick-protobuf-codec/CHANGELOG.md
+++ b/misc/quick-protobuf-codec/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0
+
+- Update to `asynchronous-codec` `v0.7.0`.
+  See [PR 4636](https://github.com/libp2p/rust-libp2p/pull/4636).
+
 ## 0.2.0 
 
 - Raise MSRV to 1.65.

--- a/misc/quick-protobuf-codec/Cargo.toml
+++ b/misc/quick-protobuf-codec/Cargo.toml
@@ -3,7 +3,7 @@ name = "quick-protobuf-codec"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Asynchronous de-/encoding of Protobuf structs using asynchronous-codec, unsigned-varint and quick-protobuf."
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Max Inden <mail@max-inden.de>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
## Description

The `asynchronous-codec` dependency is exposed in `quick-protobuf-codec`, hence we need to bump the minor version.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
