### PR TITLE
fix(quic): fix address translation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "async-std",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ libp2p-perf = { version = "0.3.0", path = "protocols/perf" }
 libp2p-ping = { version = "0.44.0", path = "protocols/ping" }
 libp2p-plaintext = { version = "0.41.0", path = "transports/plaintext" }
 libp2p-pnet = { version = "0.24.0", path = "transports/pnet" }
-libp2p-quic = { version = "0.10.1", path = "transports/quic" }
+libp2p-quic = { version = "0.10.2", path = "transports/quic" }
 libp2p-relay = { version = "0.17.1", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.14.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.26.0", path = "protocols/request-response" }

--- a/transports/quic/CHANGELOG.md
+++ b/transports/quic/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.2 - unreleased
+
+- Fix address translation.
+  See [PR 4896](https://github.com/libp2p/rust-libp2p/pull/4896).
+
 ## 0.10.1
 
 - Allow disabling path MTU discovery.

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-quic"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 rust-version = { workspace = true }

--- a/transports/quic/src/transport.rs
+++ b/transports/quic/src/transport.rs
@@ -32,6 +32,7 @@ use futures::{prelude::*, stream::SelectAll};
 use if_watch::IfEvent;
 
 use libp2p_core::{
+    address_translation,
     multiaddr::{Multiaddr, Protocol},
     transport::{ListenerId, TransportError, TransportEvent},
     Transport,
@@ -253,7 +254,7 @@ impl<P: Provider> Transport for GenTransport<P> {
         {
             return None;
         }
-        Some(observed.clone())
+        address_translation(listen, observed)
     }
 
     fn dial(&mut self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {


### PR DESCRIPTION
## Description

This fixes address translation for QUIC that was essentially non-existent before.

## Notes & open questions

Test is analogous to corresponding test in TCP protocol implementation. I have added test for both async-std and tokio, even though compiling crate with just tokio feature enabled causes a lot of compilation warnings.

What I'm not sure about is whether old behavior is intentional, but to be it seemed like a bug that caused major issues.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
