### PR TITLE
refactor(kad): use `oneshot`s and `async-await` for outbound streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2719,6 +2719,7 @@ dependencies = [
  "either",
  "fnv",
  "futures",
+ "futures-bounded",
  "futures-timer",
  "instant",
  "libp2p-core",

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -19,6 +19,7 @@ asynchronous-codec = { workspace = true }
 futures = "0.3.29"
 libp2p-core = { workspace = true }
 libp2p-swarm = { workspace = true }
+futures-bounded = { workspace = true }
 quick-protobuf = "0.8"
 quick-protobuf-codec = { workspace = true }
 libp2p-identity = { workspace = true, features = ["rand"] }

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -3173,6 +3173,7 @@ impl QueryInfo {
                         multiaddrs: external_addresses.clone(),
                         connection_ty: crate::protocol::ConnectionType::Connected,
                     },
+                    query_id,
                 },
             },
             QueryInfo::GetRecord { key, .. } => HandlerIn::GetRecord {

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -567,6 +567,7 @@ impl Handler {
             let has_answer = !matches!(msg, KadRequestMsg::AddProvider { .. });
 
             stream.send(msg).await?;
+            stream.close().await?;
 
             if !has_answer {
                 return Ok(None);

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -454,7 +454,7 @@ impl Handler {
             next_connec_unique_id: UniqueConnecId(0),
             inbound_substreams: Default::default(),
             outbound_substreams: futures_bounded::FuturesMap::new(
-                Duration::from_secs(30),
+                Duration::from_secs(10),
                 MAX_NUM_STREAMS,
             ),
             pending_streams: Default::default(),

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -355,7 +355,7 @@ pub enum HandlerIn {
     FindNodeReq {
         /// Identifier of the node.
         key: Vec<u8>,
-        /// Custom user data. Passed back in the out event when the results arrive.
+        /// ID of the query that generated this request.
         query_id: QueryId,
     },
 
@@ -374,7 +374,7 @@ pub enum HandlerIn {
     GetProvidersReq {
         /// Identifier being searched.
         key: record::Key,
-        /// Custom user data. Passed back in the out event when the results arrive.
+        /// ID of the query that generated this request.
         query_id: QueryId,
     },
 
@@ -399,13 +399,15 @@ pub enum HandlerIn {
         key: record::Key,
         /// Known provider for this key.
         provider: KadPeer,
+        /// ID of the query that generated this request.
+        query_id: QueryId,
     },
 
     /// Request to retrieve a record from the DHT.
     GetRecord {
         /// The key of the record.
         key: record::Key,
-        /// Custom data. Passed back in the out event when the results arrive.
+        /// ID of the query that generated this request.
         query_id: QueryId,
     },
 
@@ -422,7 +424,7 @@ pub enum HandlerIn {
     /// Put a value into the dht records.
     PutRecord {
         record: Record,
-        /// Custom data. Passed back in the out event when the results arrive.
+        /// ID of the query that generated this request.
         query_id: QueryId,
     },
 
@@ -648,9 +650,13 @@ impl ConnectionHandler for Handler {
                     provider_peers,
                 },
             ),
-            HandlerIn::AddProvider { key, provider } => {
+            HandlerIn::AddProvider {
+                key,
+                provider,
+                query_id,
+            } => {
                 let msg = KadRequestMsg::AddProvider { key, provider };
-                self.pending_messages.push_back((msg, None));
+                self.pending_messages.push_back((msg, Some(query_id)));
             }
             HandlerIn::GetRecord { key, query_id } => {
                 let msg = KadRequestMsg::GetValue { key };

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -547,7 +547,8 @@ impl Handler {
             });
     }
 
-    fn request_new_stream(&mut self, id: QueryId, msg: KadRequestMsg) {
+    /// Takes the given [`KadRequestMsg`] and composes it into an outbound request-response protocol handshake using a [`oneshot::channel`].
+    fn queue_new_stream(&mut self, id: QueryId, msg: KadRequestMsg) {
         let (sender, receiver) = oneshot::channel();
 
         self.pending_streams.push_back(sender);
@@ -760,7 +761,7 @@ impl ConnectionHandler for Handler {
 
             if (self.outbound_substreams.len() + self.pending_streams.len()) < MAX_NUM_STREAMS {
                 if let Some((msg, id)) = self.pending_messages.pop_front() {
-                    self.request_new_stream(id, msg);
+                    self.queue_new_stream(id, msg);
                     return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
                         protocol: SubstreamProtocol::new(self.protocol_config.clone(), ()),
                     });

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -759,7 +759,7 @@ impl ConnectionHandler for Handler {
                 return Poll::Ready(event);
             }
 
-            if (self.outbound_substreams.len() + self.pending_streams.len()) < MAX_NUM_STREAMS {
+            if self.outbound_substreams.len() < MAX_NUM_STREAMS {
                 if let Some((msg, id)) = self.pending_messages.pop_front() {
                     self.queue_new_stream(id, msg);
                     return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {


### PR DESCRIPTION
## Description

This refactoring addresses several aspects of the current handler implementation:

- Remove the manual state machine for outbound streams in favor of using `async-await`.
- Use `oneshot`s to track the number of requested outbound streams
- Use `futures_bounded::FuturesMap` to track the execution of a stream, thus applying a timeout to the entire request.

Resolves: #3130.
Related: #3268.
Related: #4510.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
