### PR TITLE
chore(*): Run rustfmt 1.7.0 and clippy 0.1.76

### DIFF
--- a/core/src/signed_envelope.rs
+++ b/core/src/signed_envelope.rs
@@ -120,14 +120,15 @@ fn signature_payload(domain_separation: String, payload_type: &[u8], payload: &[
     let mut payload_length_buffer = usize_buffer();
     let payload_length = unsigned_varint::encode::usize(payload.len(), &mut payload_length_buffer);
 
-    let mut buffer = Vec::with_capacity(
-        domain_sep_length.len()
-            + domain_separation.len()
-            + payload_type_length.len()
-            + payload_type.len()
-            + payload_length.len()
-            + payload.len(),
-    );
+    let mut buffer =
+        Vec::with_capacity(
+            domain_sep_length.len()
+                + domain_separation.len()
+                + payload_type_length.len()
+                + payload_type.len()
+                + payload_length.len()
+                + payload.len(),
+        );
 
     buffer.extend_from_slice(domain_sep_length);
     buffer.extend_from_slice(domain_separation.as_bytes());

--- a/examples/autonat/src/bin/autonat_client.rs
+++ b/examples/autonat/src/bin/autonat_client.rs
@@ -91,10 +91,9 @@ struct Behaviour {
 impl Behaviour {
     fn new(local_public_key: identity::PublicKey) -> Self {
         Self {
-            identify: identify::Behaviour::new(identify::Config::new(
-                "/ipfs/0.1.0".into(),
-                local_public_key.clone(),
-            )),
+            identify: identify::Behaviour::new(
+                identify::Config::new("/ipfs/0.1.0".into(), local_public_key.clone())
+            ),
             auto_nat: autonat::Behaviour::new(
                 local_public_key.to_peer_id(),
                 autonat::Config {

--- a/examples/autonat/src/bin/autonat_server.rs
+++ b/examples/autonat/src/bin/autonat_server.rs
@@ -78,10 +78,9 @@ struct Behaviour {
 impl Behaviour {
     fn new(local_public_key: identity::PublicKey) -> Self {
         Self {
-            identify: identify::Behaviour::new(identify::Config::new(
-                "/ipfs/0.1.0".into(),
-                local_public_key.clone(),
-            )),
+            identify: identify::Behaviour::new(
+                identify::Config::new("/ipfs/0.1.0".into(), local_public_key.clone())
+            ),
             auto_nat: autonat::Behaviour::new(
                 local_public_key.to_peer_id(),
                 autonat::Config {

--- a/examples/browser-webrtc/src/lib.rs
+++ b/examples/browser-webrtc/src/lib.rs
@@ -18,14 +18,15 @@ pub async fn run(libp2p_endpoint: String) -> Result<(), JsError> {
     let body = Body::from_current_window()?;
     body.append_p("Let's ping the WebRTC Server!")?;
 
-    let mut swarm = libp2p::SwarmBuilder::with_new_identity()
-        .with_wasm_bindgen()
-        .with_other_transport(|key| {
-            webrtc_websys::Transport::new(webrtc_websys::Config::new(&key))
-        })?
-        .with_behaviour(|_| ping::Behaviour::new(ping::Config::new()))?
-        .with_swarm_config(|c| c.with_idle_connection_timeout(Duration::from_secs(5)))
-        .build();
+    let mut swarm =
+        libp2p::SwarmBuilder::with_new_identity()
+            .with_wasm_bindgen()
+            .with_other_transport(
+                |key| webrtc_websys::Transport::new(webrtc_websys::Config::new(&key))
+            )?
+            .with_behaviour(|_| ping::Behaviour::new(ping::Config::new()))?
+            .with_swarm_config(|c| c.with_idle_connection_timeout(Duration::from_secs(5)))
+            .build();
 
     let addr = libp2p_endpoint.parse::<Multiaddr>()?;
     tracing::info!("Dialing {addr}");

--- a/examples/browser-webrtc/src/main.rs
+++ b/examples/browser-webrtc/src/main.rs
@@ -49,23 +49,24 @@ async fn main() -> anyhow::Result<()> {
 
     swarm.listen_on(address_webrtc.clone())?;
 
-    let address = loop {
-        if let SwarmEvent::NewListenAddr { address, .. } = swarm.select_next_some().await {
-            if address
-                .iter()
-                .any(|e| e == Protocol::Ip4(Ipv4Addr::LOCALHOST))
-            {
-                tracing::debug!(
-                    "Ignoring localhost address to make sure the example works in Firefox"
-                );
-                continue;
+    let address =
+        loop {
+            if let SwarmEvent::NewListenAddr { address, .. } = swarm.select_next_some().await {
+                if address
+                    .iter()
+                    .any(|e| e == Protocol::Ip4(Ipv4Addr::LOCALHOST))
+                {
+                    tracing::debug!(
+                        "Ignoring localhost address to make sure the example works in Firefox"
+                    );
+                    continue;
+                }
+
+                tracing::info!(%address, "Listening");
+
+                break address;
             }
-
-            tracing::info!(%address, "Listening");
-
-            break address;
-        }
-    };
+        };
 
     let addr = address.with(Protocol::P2p(*swarm.local_peer_id()));
 

--- a/examples/dcutr/src/main.rs
+++ b/examples/dcutr/src/main.rs
@@ -148,9 +148,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 SwarmEvent::Dialing { .. } => {}
                 SwarmEvent::ConnectionEstablished { .. } => {}
                 SwarmEvent::Behaviour(BehaviourEvent::Ping(_)) => {}
-                SwarmEvent::Behaviour(BehaviourEvent::Identify(identify::Event::Sent {
-                    ..
-                })) => {
+                SwarmEvent::Behaviour(BehaviourEvent::Identify(identify::Event::Sent { .. })) => {
                     tracing::info!("Told relay its public address");
                     told_relay_observed_addr = true;
                 }
@@ -193,9 +191,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 SwarmEvent::NewListenAddr { address, .. } => {
                     tracing::info!(%address, "Listening on address");
                 }
-                SwarmEvent::Behaviour(BehaviourEvent::RelayClient(
-                    relay::client::Event::ReservationReqAccepted { .. },
-                )) => {
+                SwarmEvent::Behaviour(
+                    BehaviourEvent::RelayClient(relay::client::Event::ReservationReqAccepted { .. })
+                ) => {
                     assert!(opts.mode == Mode::Listen);
                     tracing::info!("Relay accepted our reservation request");
                 }

--- a/examples/file-sharing/src/network.rs
+++ b/examples/file-sharing/src/network.rs
@@ -247,16 +247,16 @@ impl EventLoop {
             SwarmEvent::Behaviour(BehaviourEvent::Kademlia(
                 kad::Event::OutboundQueryProgressed {
                     result:
-                        kad::QueryResult::GetProviders(Ok(
-                            kad::GetProvidersOk::FinishedWithNoAdditionalRecord { .. },
-                        )),
+                        kad::QueryResult::GetProviders(
+                            Ok(kad::GetProvidersOk::FinishedWithNoAdditionalRecord { .. })
+                        ),
                     ..
                 },
             )) => {}
             SwarmEvent::Behaviour(BehaviourEvent::Kademlia(_)) => {}
-            SwarmEvent::Behaviour(BehaviourEvent::RequestResponse(
-                request_response::Event::Message { message, .. },
-            )) => match message {
+            SwarmEvent::Behaviour(
+                BehaviourEvent::RequestResponse(request_response::Event::Message { message, .. })
+            ) => match message {
                 request_response::Message::Request {
                     request, channel, ..
                 } => {
@@ -290,9 +290,9 @@ impl EventLoop {
                     .expect("Request to still be pending.")
                     .send(Err(Box::new(error)));
             }
-            SwarmEvent::Behaviour(BehaviourEvent::RequestResponse(
-                request_response::Event::ResponseSent { .. },
-            )) => {}
+            SwarmEvent::Behaviour(
+                BehaviourEvent::RequestResponse(request_response::Event::ResponseSent { .. })
+            ) => {}
             SwarmEvent::NewListenAddr { address, .. } => {
                 let local_peer_id = *self.swarm.local_peer_id();
                 eprintln!(

--- a/examples/identify/src/main.rs
+++ b/examples/identify/src/main.rs
@@ -31,20 +31,21 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
 
-    let mut swarm = libp2p::SwarmBuilder::with_new_identity()
-        .with_async_std()
-        .with_tcp(
-            tcp::Config::default(),
-            noise::Config::new,
-            yamux::Config::default,
-        )?
-        .with_behaviour(|key| {
-            identify::Behaviour::new(identify::Config::new(
-                "/ipfs/id/1.0.0".to_string(),
-                key.public(),
-            ))
-        })?
-        .build();
+    let mut swarm =
+        libp2p::SwarmBuilder::with_new_identity()
+            .with_async_std()
+            .with_tcp(
+                tcp::Config::default(),
+                noise::Config::new,
+                yamux::Config::default,
+            )?
+            .with_behaviour(|key| {
+                identify::Behaviour::new(identify::Config::new(
+                    "/ipfs/id/1.0.0".to_string(),
+                    key.public(),
+                ))
+            })?
+            .build();
 
     // Tell the swarm to listen on all interfaces and a random, OS-assigned
     // port.

--- a/examples/ipfs-kad/src/main.rs
+++ b/examples/ipfs-kad/src/main.rs
@@ -119,9 +119,7 @@ async fn main() -> Result<()> {
             }
             SwarmEvent::Behaviour(kad::Event::OutboundQueryProgressed {
                 result:
-                    kad::QueryResult::GetClosestPeers(Err(kad::GetClosestPeersError::Timeout {
-                        ..
-                    })),
+                    kad::QueryResult::GetClosestPeers(Err(kad::GetClosestPeersError::Timeout { .. })),
                 ..
             }) => {
                 bail!("Query for closest peers timed out")

--- a/examples/metrics/src/main.rs
+++ b/examples/metrics/src/main.rs
@@ -88,10 +88,8 @@ fn setup_tracing() -> Result<(), Box<dyn Error>> {
         .tracing()
         .with_exporter(opentelemetry_otlp::new_exporter().tonic())
         .with_trace_config(
-            sdk::trace::Config::default().with_resource(sdk::Resource::new(vec![KeyValue::new(
-                "service.name",
-                "libp2p",
-            )])),
+            sdk::trace::Config::default()
+                .with_resource(sdk::Resource::new(vec![KeyValue::new("service.name", "libp2p")])),
         )
         .install_batch(opentelemetry::runtime::Tokio)?;
 
@@ -118,10 +116,9 @@ impl Behaviour {
     fn new(local_pub_key: identity::PublicKey) -> Self {
         Self {
             ping: ping::Behaviour::default(),
-            identify: identify::Behaviour::new(identify::Config::new(
-                "/ipfs/0.1.0".into(),
-                local_pub_key,
-            )),
+            identify: identify::Behaviour::new(
+                identify::Config::new("/ipfs/0.1.0".into(), local_pub_key)
+            ),
         }
     }
 }

--- a/examples/rendezvous/src/bin/rzv-identify.rs
+++ b/examples/rendezvous/src/bin/rzv-identify.rs
@@ -75,9 +75,7 @@ async fn main() {
                 tracing::error!("Lost connection to rendezvous point {}", error);
             }
             // once `/identify` did its job, we know our external address and can register
-            SwarmEvent::Behaviour(MyBehaviourEvent::Identify(identify::Event::Received {
-                ..
-            })) => {
+            SwarmEvent::Behaviour(MyBehaviourEvent::Identify(identify::Event::Received { .. })) => {
                 if let Err(error) = swarm.behaviour_mut().rendezvous.register(
                     rendezvous::Namespace::from_static("rendezvous"),
                     rendezvous_point,

--- a/hole-punching-tests/src/main.rs
+++ b/hole-punching-tests/src/main.rs
@@ -98,9 +98,9 @@ async fn main() -> Result<()> {
             id,
         ) {
             (
-                SwarmEvent::Behaviour(BehaviourEvent::RelayClient(
-                    relay::client::Event::ReservationReqAccepted { .. },
-                )),
+                SwarmEvent::Behaviour(
+                    BehaviourEvent::RelayClient(relay::client::Event::ReservationReqAccepted { .. })
+                ),
                 _,
                 _,
             ) => {
@@ -237,27 +237,28 @@ async fn client_setup(
     relay_addr: Multiaddr,
     mode: Mode,
 ) -> Result<Either<ListenerId, ConnectionId>> {
-    let either = match mode {
-        Mode::Listen => {
-            let id = swarm.listen_on(relay_addr.with(Protocol::P2pCircuit))?;
+    let either =
+        match mode {
+            Mode::Listen => {
+                let id = swarm.listen_on(relay_addr.with(Protocol::P2pCircuit))?;
 
-            Either::Left(id)
-        }
-        Mode::Dial => {
-            let remote_peer_id = redis.pop(LISTEN_CLIENT_PEER_ID).await?;
+                Either::Left(id)
+            }
+            Mode::Dial => {
+                let remote_peer_id = redis.pop(LISTEN_CLIENT_PEER_ID).await?;
 
-            let opts = DialOpts::from(
-                relay_addr
-                    .with(Protocol::P2pCircuit)
-                    .with(Protocol::P2p(remote_peer_id)),
-            );
-            let id = opts.connection_id();
+                let opts = DialOpts::from(
+                    relay_addr
+                        .with(Protocol::P2pCircuit)
+                        .with(Protocol::P2p(remote_peer_id)),
+                );
+                let id = opts.connection_id();
 
-            swarm.dial(opts)?;
+                swarm.dial(opts)?;
 
-            Either::Right(id)
-        }
-    };
+                Either::Right(id)
+            }
+        };
 
     Ok(either)
 }
@@ -332,10 +333,7 @@ impl FromStr for TransportProtocol {
         match mode {
             "tcp" => Ok(TransportProtocol::Tcp),
             "quic" => Ok(TransportProtocol::Quic),
-            _ => Err(io::Error::new(
-                io::ErrorKind::Other,
-                "Expected either 'tcp' or 'quic'",
-            )),
+            _ => Err(io::Error::new(io::ErrorKind::Other, "Expected either 'tcp' or 'quic'")),
         }
     }
 }
@@ -352,10 +350,7 @@ impl FromStr for Mode {
         match mode {
             "dial" => Ok(Mode::Dial),
             "listen" => Ok(Mode::Listen),
-            _ => Err(io::Error::new(
-                io::ErrorKind::Other,
-                "Expected either 'dial' or 'listen'",
-            )),
+            _ => Err(io::Error::new(io::ErrorKind::Other, "Expected either 'dial' or 'listen'")),
         }
     }
 }

--- a/identity/src/keypair.rs
+++ b/identity/src/keypair.rs
@@ -170,9 +170,9 @@ impl Keypair {
     #[cfg(feature = "ed25519")]
     pub fn ed25519_from_bytes(bytes: impl AsMut<[u8]>) -> Result<Keypair, DecodingError> {
         Ok(Keypair {
-            keypair: KeyPairInner::Ed25519(ed25519::Keypair::from(
-                ed25519::SecretKey::try_from_bytes(bytes)?,
-            )),
+            keypair: KeyPairInner::Ed25519(
+                ed25519::Keypair::from(ed25519::SecretKey::try_from_bytes(bytes)?)
+            ),
         })
     }
 
@@ -665,11 +665,13 @@ impl TryFrom<proto::PublicKey> for PublicKey {
     fn try_from(pubkey: proto::PublicKey) -> Result<Self, Self::Error> {
         match pubkey.Type {
             #[cfg(feature = "ed25519")]
-            proto::KeyType::Ed25519 => Ok(ed25519::PublicKey::try_from_bytes(&pubkey.Data).map(
-                |kp| PublicKey {
-                    publickey: PublicKeyInner::Ed25519(kp),
-                },
-            )?),
+            proto::KeyType::Ed25519 => {
+                Ok(
+                    ed25519::PublicKey::try_from_bytes(&pubkey.Data).map(|kp| PublicKey {
+                        publickey: PublicKeyInner::Ed25519(kp),
+                    })?,
+                )
+            }
             #[cfg(not(feature = "ed25519"))]
             proto::KeyType::Ed25519 => {
                 tracing::debug!("support for ed25519 was disabled at compile-time");
@@ -699,11 +701,13 @@ impl TryFrom<proto::PublicKey> for PublicKey {
                 Err(DecodingError::missing_feature("secp256k1"))
             }
             #[cfg(feature = "ecdsa")]
-            proto::KeyType::ECDSA => Ok(ecdsa::PublicKey::try_decode_der(&pubkey.Data).map(
-                |kp| PublicKey {
-                    publickey: PublicKeyInner::Ecdsa(kp),
-                },
-            )?),
+            proto::KeyType::ECDSA => {
+                Ok(
+                    ecdsa::PublicKey::try_decode_der(&pubkey.Data).map(|kp| PublicKey {
+                        publickey: PublicKeyInner::Ecdsa(kp),
+                    })?,
+                )
+            }
             #[cfg(not(feature = "ecdsa"))]
             proto::KeyType::ECDSA => {
                 tracing::debug!("support for ECDSA was disabled at compile-time");

--- a/identity/src/lib.rs
+++ b/identity/src/lib.rs
@@ -86,10 +86,12 @@ impl From<&PublicKey> for proto::PublicKey {
     fn from(key: &PublicKey) -> Self {
         match &key.publickey {
             #[cfg(feature = "ed25519")]
-            keypair::PublicKeyInner::Ed25519(key) => proto::PublicKey {
-                Type: proto::KeyType::Ed25519,
-                Data: key.to_bytes().to_vec(),
-            },
+            keypair::PublicKeyInner::Ed25519(key) => {
+                proto::PublicKey {
+                    Type: proto::KeyType::Ed25519,
+                    Data: key.to_bytes().to_vec(),
+                }
+            }
             #[cfg(all(feature = "rsa", not(target_arch = "wasm32")))]
             keypair::PublicKeyInner::Rsa(key) => proto::PublicKey {
                 Type: proto::KeyType::RSA,

--- a/identity/src/rsa.rs
+++ b/identity/src/rsa.rs
@@ -269,9 +269,9 @@ impl DerEncodable for Asn1SubjectPublicKey {
 impl DerDecodable<'_> for Asn1SubjectPublicKey {
     fn load(object: DerObject<'_>) -> Result<Self, Asn1DerError> {
         if object.tag() != 3 {
-            return Err(Asn1DerError::new(Asn1DerErrorVariant::InvalidData(
-                "DER object tag is not the bit string tag.",
-            )));
+            return Err(Asn1DerError::new(
+                Asn1DerErrorVariant::InvalidData("DER object tag is not the bit string tag.")
+            ));
         }
 
         let pk_der: Vec<u8> = object.value().iter().skip(1).cloned().collect();

--- a/interop-tests/src/arch.rs
+++ b/interop-tests/src/arch.rs
@@ -167,9 +167,7 @@ pub(crate) mod native {
 
     impl RedisClient {
         pub(crate) fn new(redis_addr: &str) -> Result<Self> {
-            Ok(Self(
-                redis::Client::open(redis_addr).context("Could not connect to redis")?,
-            ))
+            Ok(Self(redis::Client::open(redis_addr).context("Could not connect to redis")?))
         }
 
         pub(crate) async fn blpop(&self, key: &str, timeout: u64) -> Result<Vec<String>> {
@@ -222,9 +220,9 @@ pub(crate) mod wasm {
                 libp2p::SwarmBuilder::with_new_identity()
                     .with_wasm_bindgen()
                     .with_other_transport(|local_key| {
-                        webtransport_websys::Transport::new(webtransport_websys::Config::new(
-                            &local_key,
-                        ))
+                        webtransport_websys::Transport::new(
+                            webtransport_websys::Config::new(&local_key)
+                        )
                     })?
                     .with_behaviour(behaviour_constructor)?
                     .with_swarm_config(|c| c.with_idle_connection_timeout(Duration::from_secs(5)))
@@ -288,16 +286,17 @@ pub(crate) mod wasm {
         }
 
         pub(crate) async fn blpop(&self, key: &str, timeout: u64) -> Result<Vec<String>> {
-            let res = reqwest::Client::new()
-                .post(&format!("http://{}/blpop", self.0))
-                .json(&BlpopRequest {
-                    key: key.to_owned(),
-                    timeout,
-                })
-                .send()
-                .await?
-                .json()
-                .await?;
+            let res =
+                reqwest::Client::new()
+                    .post(&format!("http://{}/blpop", self.0))
+                    .json(&BlpopRequest {
+                        key: key.to_owned(),
+                        timeout,
+                    })
+                    .send()
+                    .await?
+                    .json()
+                    .await?;
             Ok(res)
         }
 

--- a/interop-tests/src/bin/native_ping.rs
+++ b/interop-tests/src/bin/native_ping.rs
@@ -6,16 +6,17 @@ mod config;
 async fn main() -> Result<()> {
     let config = config::Config::from_env()?;
 
-    let report = interop_tests::run_test(
-        &config.transport,
-        &config.ip,
-        config.is_dialer,
-        config.test_timeout,
-        &config.redis_addr,
-        config.sec_protocol,
-        config.muxer,
-    )
-    .await?;
+    let report =
+        interop_tests::run_test(
+            &config.transport,
+            &config.ip,
+            config.is_dialer,
+            config.test_timeout,
+            &config.redis_addr,
+            config.sec_protocol,
+            config.muxer,
+        )
+        .await?;
 
     println!("{}", serde_json::to_string(&report)?);
 

--- a/interop-tests/src/bin/wasm_ping.rs
+++ b/interop-tests/src/bin/wasm_ping.rs
@@ -108,10 +108,11 @@ async fn open_in_browser() -> Result<(Child, WebDriver)> {
     } else {
         "chromedriver"
     };
-    let mut chrome = tokio::process::Command::new(chromedriver)
-        .arg("--port=45782")
-        .stdout(Stdio::piped())
-        .spawn()?;
+    let mut chrome =
+        tokio::process::Command::new(chromedriver)
+            .arg("--port=45782")
+            .stdout(Stdio::piped())
+            .spawn()?;
     // read driver's stdout
     let driver_out = chrome
         .stdout

--- a/interop-tests/src/lib.rs
+++ b/interop-tests/src/lib.rs
@@ -26,20 +26,22 @@ pub async fn run_test(
 
     let test_timeout = Duration::from_secs(test_timeout_seconds);
     let transport = transport.parse().context("Couldn't parse transport")?;
-    let sec_protocol = sec_protocol
-        .map(|sec_protocol| {
-            sec_protocol
-                .parse()
-                .context("Couldn't parse security protocol")
-        })
-        .transpose()?;
-    let muxer = muxer
-        .map(|sec_protocol| {
-            sec_protocol
-                .parse()
-                .context("Couldn't parse muxer protocol")
-        })
-        .transpose()?;
+    let sec_protocol =
+        sec_protocol
+            .map(|sec_protocol| {
+                sec_protocol
+                    .parse()
+                    .context("Couldn't parse security protocol")
+            })
+            .transpose()?;
+    let muxer =
+        muxer
+            .map(|sec_protocol| {
+                sec_protocol
+                    .parse()
+                    .context("Couldn't parse muxer protocol")
+            })
+            .transpose()?;
 
     let redis_client = RedisClient::new(redis_addr).context("Could not connect to redis")?;
 
@@ -51,11 +53,12 @@ pub async fn run_test(
 
     // See https://github.com/libp2p/rust-libp2p/issues/4071.
     #[cfg(not(target_arch = "wasm32"))]
-    let maybe_id = if transport == Transport::WebRtcDirect {
-        Some(swarm.listen_on(local_addr.parse()?)?)
-    } else {
-        None
-    };
+    let maybe_id =
+        if transport == Transport::WebRtcDirect {
+            Some(swarm.listen_on(local_addr.parse()?)?)
+        } else {
+            None
+        };
     #[cfg(target_arch = "wasm32")]
     let maybe_id = None;
 
@@ -76,16 +79,17 @@ pub async fn run_test(
             swarm.dial(other.parse::<Multiaddr>()?)?;
             tracing::info!(listener=%other, "Test instance, dialing multiaddress");
 
-            let rtt = loop {
-                if let Some(SwarmEvent::Behaviour(BehaviourEvent::Ping(ping::Event {
-                    result: Ok(rtt),
-                    ..
-                }))) = swarm.next().await
-                {
-                    tracing::info!(?rtt, "Ping successful");
-                    break rtt.as_micros() as f32 / 1000.;
-                }
-            };
+            let rtt =
+                loop {
+                    if let Some(SwarmEvent::Behaviour(BehaviourEvent::Ping(ping::Event {
+                        result: Ok(rtt),
+                        ..
+                    }))) = swarm.next().await
+                    {
+                        tracing::info!(?rtt, "Ping successful");
+                        break rtt.as_micros() as f32 / 1000.;
+                    }
+                };
 
             let handshake_plus_ping = handshake_start.elapsed().as_micros() as f32 / 1000.;
             Ok(Report {
@@ -96,10 +100,11 @@ pub async fn run_test(
         false => {
             // Listen if we haven't done so already.
             // This is a hack until https://github.com/libp2p/rust-libp2p/issues/4071 is fixed at which point we can do this unconditionally here.
-            let id = match maybe_id {
-                None => swarm.listen_on(local_addr.parse()?)?,
-                Some(id) => id,
-            };
+            let id =
+                match maybe_id {
+                    None => swarm.listen_on(local_addr.parse()?)?,
+                    Some(id) => id,
+                };
 
             tracing::info!(
                 address=%local_addr,
@@ -154,16 +159,17 @@ pub async fn run_test_wasm(
     sec_protocol: Option<String>,
     muxer: Option<String>,
 ) -> Result<(), JsValue> {
-    let result = run_test(
-        transport,
-        ip,
-        is_dialer,
-        test_timeout_secs,
-        base_url,
-        sec_protocol,
-        muxer,
-    )
-    .await;
+    let result =
+        run_test(
+            transport,
+            ip,
+            is_dialer,
+            test_timeout_secs,
+            base_url,
+            sec_protocol,
+            muxer,
+        )
+        .await;
     tracing::info!(?result, "Sending test result");
     reqwest::Client::new()
         .post(&format!("http://{}/results", base_url))
@@ -266,9 +272,8 @@ pub(crate) fn build_behaviour(key: &Keypair) -> Behaviour {
     Behaviour {
         ping: ping::Behaviour::new(ping::Config::new().with_interval(Duration::from_secs(1))),
         // Need to include identify until https://github.com/status-im/nim-libp2p/issues/924 is resolved.
-        identify: identify::Behaviour::new(identify::Config::new(
-            "/interop-tests".to_owned(),
-            key.public(),
-        )),
+        identify: identify::Behaviour::new(
+            identify::Config::new("/interop-tests".to_owned(), key.public())
+        ),
     }
 }

--- a/libp2p/src/builder.rs
+++ b/libp2p/src/builder.rs
@@ -122,12 +122,13 @@ mod tests {
     #[test]
     #[cfg(all(feature = "tokio", feature = "quic"))]
     fn quic() {
-        let _ = SwarmBuilder::with_new_identity()
-            .with_tokio()
-            .with_quic()
-            .with_behaviour(|_| libp2p_swarm::dummy::Behaviour)
-            .unwrap()
-            .build();
+        let _ =
+            SwarmBuilder::with_new_identity()
+                .with_tokio()
+                .with_quic()
+                .with_behaviour(|_| libp2p_swarm::dummy::Behaviour)
+                .unwrap()
+                .build();
     }
 
     #[test]

--- a/libp2p/src/builder/phase/quic.rs
+++ b/libp2p/src/builder/phase/quic.rs
@@ -40,9 +40,9 @@ macro_rules! impl_quic_builder {
                             .phase
                             .transport
                             .or_transport(
-                                libp2p_quic::$quic::Transport::new(constructor(
-                                    libp2p_quic::Config::new(&self.keypair),
-                                ))
+                                libp2p_quic::$quic::Transport::new(
+                                    constructor(libp2p_quic::Config::new(&self.keypair))
+                                )
                                 .map(|(peer_id, muxer), _| {
                                     (peer_id, libp2p_core::muxing::StreamMuxerBox::new(muxer))
                                 }),

--- a/libp2p/src/builder/phase/websocket.rs
+++ b/libp2p/src/builder/phase/websocket.rs
@@ -116,9 +116,9 @@ macro_rules! impl_websocket_builder {
 impl_websocket_builder!(
     "async-std",
     super::provider::AsyncStd,
-    libp2p_dns::async_std::Transport::system(libp2p_tcp::async_io::Transport::new(
-        libp2p_tcp::Config::default(),
-    )),
+    libp2p_dns::async_std::Transport::system(
+        libp2p_tcp::async_io::Transport::new(libp2p_tcp::Config::default(),)
+    ),
     rw_stream_sink::RwStreamSink<
         libp2p_websocket::BytesConnection<libp2p_tcp::async_io::TcpStream>,
     >

--- a/misc/connection-limits/src/lib.rs
+++ b/misc/connection-limits/src/lib.rs
@@ -428,16 +428,18 @@ mod tests {
     #[test]
     fn max_established_incoming() {
         fn prop(Limit(limit): Limit) {
-            let mut swarm1 = Swarm::new_ephemeral(|_| {
-                Behaviour::new(
-                    ConnectionLimits::default().with_max_established_incoming(Some(limit)),
-                )
-            });
-            let mut swarm2 = Swarm::new_ephemeral(|_| {
-                Behaviour::new(
-                    ConnectionLimits::default().with_max_established_incoming(Some(limit)),
-                )
-            });
+            let mut swarm1 =
+                Swarm::new_ephemeral(|_| {
+                    Behaviour::new(
+                        ConnectionLimits::default().with_max_established_incoming(Some(limit)),
+                    )
+                });
+            let mut swarm2 =
+                Swarm::new_ephemeral(|_| {
+                    Behaviour::new(
+                        ConnectionLimits::default().with_max_established_incoming(Some(limit)),
+                    )
+                });
 
             async_std::task::block_on(async {
                 let (listen_addr, _) = swarm1.listen().with_memory_addr_external().await;
@@ -485,9 +487,9 @@ mod tests {
     /// ([`SwarmEvent::ConnectionEstablished`]) can the connection be seen as established.
     #[test]
     fn support_other_behaviour_denying_connection() {
-        let mut swarm1 = Swarm::new_ephemeral(|_| {
-            Behaviour::new_with_connection_denier(ConnectionLimits::default())
-        });
+        let mut swarm1 = Swarm::new_ephemeral(
+            |_| Behaviour::new_with_connection_denier(ConnectionLimits::default())
+        );
         let mut swarm2 = Swarm::new_ephemeral(|_| Behaviour::new(ConnectionLimits::default()));
 
         async_std::task::block_on(async {
@@ -497,15 +499,16 @@ mod tests {
             async_std::task::spawn(swarm2.loop_on_next());
 
             // Wait for the ConnectionDenier of swarm1 to deny the established connection.
-            let cause = swarm1
-                .wait(|event| match event {
-                    SwarmEvent::IncomingConnectionError {
-                        error: ListenError::Denied { cause },
-                        ..
-                    } => Some(cause),
-                    _ => None,
-                })
-                .await;
+            let cause =
+                swarm1
+                    .wait(|event| match event {
+                        SwarmEvent::IncomingConnectionError {
+                            error: ListenError::Denied { cause },
+                            ..
+                        } => Some(cause),
+                        _ => None,
+                    })
+                    .await;
 
             cause.downcast::<std::io::Error>().unwrap();
 
@@ -556,10 +559,9 @@ mod tests {
             _local_addr: &Multiaddr,
             _remote_addr: &Multiaddr,
         ) -> Result<THandler<Self>, ConnectionDenied> {
-            Err(ConnectionDenied::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "ConnectionDenier",
-            )))
+            Err(ConnectionDenied::new(
+                std::io::Error::new(std::io::ErrorKind::Other, "ConnectionDenier")
+            ))
         }
 
         fn handle_established_outbound_connection(
@@ -569,10 +571,9 @@ mod tests {
             _addr: &Multiaddr,
             _role_override: Endpoint,
         ) -> Result<THandler<Self>, ConnectionDenied> {
-            Err(ConnectionDenied::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "ConnectionDenier",
-            )))
+            Err(ConnectionDenied::new(
+                std::io::Error::new(std::io::ErrorKind::Other, "ConnectionDenier")
+            ))
         }
 
         fn on_swarm_event(&mut self, _event: FromSwarm) {}

--- a/misc/futures-bounded/src/stream_map.rs
+++ b/misc/futures-bounded/src/stream_map.rs
@@ -228,9 +228,8 @@ mod tests {
         Delay::new(Duration::from_millis(150)).await;
         poll_fn(|cx| streams.poll_next_unpin(cx)).await;
 
-        let poll = streams.poll_next_unpin(&mut Context::from_waker(
-            futures_util::task::noop_waker_ref(),
-        ));
+        let poll =
+            streams.poll_next_unpin(&mut Context::from_waker(futures_util::task::noop_waker_ref()));
         assert!(poll.is_pending())
     }
 
@@ -245,9 +244,8 @@ mod tests {
             assert!(cancelled_stream.is_some());
         }
 
-        let poll = streams.poll_next_unpin(&mut Context::from_waker(
-            futures_util::task::noop_waker_ref(),
-        ));
+        let poll =
+            streams.poll_next_unpin(&mut Context::from_waker(futures_util::task::noop_waker_ref()));
 
         assert!(poll.is_pending());
         assert_eq!(

--- a/misc/keygen/src/main.rs
+++ b/misc/keygen/src/main.rs
@@ -54,9 +54,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         Command::From { config } => {
             let config = Zeroizing::new(config::Config::from_file(config.as_ref())?);
 
-            let keypair = identity::Keypair::from_protobuf_encoding(&Zeroizing::new(
-                BASE64_STANDARD.decode(config.identity.priv_key.as_bytes())?,
-            ))?;
+            let keypair = identity::Keypair::from_protobuf_encoding(
+                &Zeroizing::new(BASE64_STANDARD.decode(config.identity.priv_key.as_bytes())?)
+            )?;
 
             let peer_id = keypair.public().into();
             assert_eq!(

--- a/misc/metrics/src/bandwidth.rs
+++ b/misc/metrics/src/bandwidth.rs
@@ -86,12 +86,9 @@ where
 
     fn dial(&mut self, addr: Multiaddr) -> Result<Self::Dial, TransportError<Self::Error>> {
         let metrics = ConnectionMetrics::from_family_and_addr(&self.metrics, &addr);
-        Ok(self
-            .transport
-            .dial(addr.clone())?
-            .map_ok(Box::new(|(peer_id, stream_muxer)| {
-                (peer_id, Muxer::new(stream_muxer, metrics))
-            })))
+        Ok(self.transport.dial(addr.clone())?.map_ok(
+            Box::new(|(peer_id, stream_muxer)| (peer_id, Muxer::new(stream_muxer, metrics)))
+        ))
     }
 
     fn dial_as_listener(
@@ -99,12 +96,9 @@ where
         addr: Multiaddr,
     ) -> Result<Self::Dial, TransportError<Self::Error>> {
         let metrics = ConnectionMetrics::from_family_and_addr(&self.metrics, &addr);
-        Ok(self
-            .transport
-            .dial_as_listener(addr.clone())?
-            .map_ok(Box::new(|(peer_id, stream_muxer)| {
-                (peer_id, Muxer::new(stream_muxer, metrics))
-            })))
+        Ok(self.transport.dial_as_listener(addr.clone())?.map_ok(
+            Box::new(|(peer_id, stream_muxer)| (peer_id, Muxer::new(stream_muxer, metrics)))
+        ))
     }
 
     fn address_translation(&self, server: &Multiaddr, observed: &Multiaddr) -> Option<Multiaddr> {
@@ -127,9 +121,9 @@ where
                     ConnectionMetrics::from_family_and_addr(this.metrics, &send_back_addr);
                 Poll::Ready(TransportEvent::Incoming {
                     listener_id,
-                    upgrade: upgrade.map_ok(Box::new(|(peer_id, stream_muxer)| {
-                        (peer_id, Muxer::new(stream_muxer, metrics))
-                    })),
+                    upgrade: upgrade.map_ok(Box::new(
+                        |(peer_id, stream_muxer)| (peer_id, Muxer::new(stream_muxer, metrics))
+                    )),
                     local_addr,
                     send_back_addr,
                 })
@@ -162,13 +156,14 @@ impl ConnectionMetrics {
             m.clone()
         };
         // Additional scope to make sure to drop the lock guard from `get_or_create`.
-        let inbound = {
-            let m = family.get_or_create(&Labels {
-                protocols,
-                direction: Direction::Inbound,
-            });
-            m.clone()
-        };
+        let inbound =
+            {
+                let m = family.get_or_create(&Labels {
+                    protocols,
+                    direction: Direction::Inbound,
+                });
+                m.clone()
+            };
         ConnectionMetrics { outbound, inbound }
     }
 }

--- a/misc/metrics/src/kad.rs
+++ b/misc/metrics/src/kad.rs
@@ -190,24 +190,24 @@ impl super::Recorder<libp2p_kad::Event> for Metrics {
                                 .inc();
                         }
                     },
-                    libp2p_kad::QueryResult::GetClosestPeers(result) => match result {
-                        Ok(ok) => self
-                            .query_result_get_closest_peers_ok
-                            .observe(ok.peers.len() as f64),
-                        Err(error) => {
-                            self.query_result_get_closest_peers_error
-                                .get_or_create(&error.into())
-                                .inc();
+                    libp2p_kad::QueryResult::GetClosestPeers(result) => {
+                        match result {
+                            Ok(ok) => self
+                                .query_result_get_closest_peers_ok
+                                .observe(ok.peers.len() as f64),
+                            Err(error) => {
+                                self.query_result_get_closest_peers_error
+                                    .get_or_create(&error.into())
+                                    .inc();
+                            }
                         }
-                    },
+                    }
                     libp2p_kad::QueryResult::GetProviders(result) => match result {
                         Ok(libp2p_kad::GetProvidersOk::FoundProviders { providers, .. }) => {
                             self.query_result_get_providers_ok
                                 .observe(providers.len() as f64);
                         }
-                        Ok(libp2p_kad::GetProvidersOk::FinishedWithNoAdditionalRecord {
-                            ..
-                        }) => {}
+                        Ok(libp2p_kad::GetProvidersOk::FinishedWithNoAdditionalRecord { .. }) => {}
                         Err(error) => {
                             self.query_result_get_providers_error
                                 .get_or_create(&error.into())

--- a/misc/multistream-select/src/protocol.rs
+++ b/misc/multistream-select/src/protocol.rs
@@ -394,14 +394,15 @@ fn poll_stream<S>(
 where
     S: Stream<Item = Result<Bytes, io::Error>>,
 {
-    let msg = if let Some(msg) = ready!(stream.poll_next(cx)?) {
-        match Message::decode(msg) {
-            Ok(m) => m,
-            Err(err) => return Poll::Ready(Some(Err(err))),
-        }
-    } else {
-        return Poll::Ready(None);
-    };
+    let msg =
+        if let Some(msg) = ready!(stream.poll_next(cx)?) {
+            match Message::decode(msg) {
+                Ok(m) => m,
+                Err(err) => return Poll::Ready(Some(Err(err))),
+            }
+        } else {
+            return Poll::Ready(None);
+        };
 
     tracing::trace!(message=?msg, "Received message");
 

--- a/misc/server/src/behaviour.rs
+++ b/misc/server/src/behaviour.rs
@@ -37,11 +37,12 @@ impl Behaviour {
             // TODO: Replace hack with option to disable both.
             kademlia_config.set_record_ttl(Some(Duration::from_secs(0)));
             kademlia_config.set_provider_record_ttl(Some(Duration::from_secs(0)));
-            let mut kademlia = kad::Behaviour::with_config(
-                pub_key.to_peer_id(),
-                kad::store::MemoryStore::new(pub_key.to_peer_id()),
-                kademlia_config,
-            );
+            let mut kademlia =
+                kad::Behaviour::with_config(
+                    pub_key.to_peer_id(),
+                    kad::store::MemoryStore::new(pub_key.to_peer_id()),
+                    kademlia_config,
+                );
             let bootaddr = Multiaddr::from_str("/dnsaddr/bootstrap.libp2p.io").unwrap();
             for peer in &BOOTNODES {
                 kademlia.add_address(&PeerId::from_str(peer).unwrap(), bootaddr.clone());

--- a/misc/server/src/http_service.rs
+++ b/misc/server/src/http_service.rs
@@ -70,10 +70,7 @@ impl MetricService {
     fn respond_with_404_not_found(&mut self) -> Response<String> {
         Response::builder()
             .status(StatusCode::NOT_FOUND)
-            .body(format!(
-                "Not found try localhost:[port]/{}",
-                self.metrics_path
-            ))
+            .body(format!("Not found try localhost:[port]/{}", self.metrics_path))
             .unwrap()
     }
 }

--- a/misc/server/src/main.rs
+++ b/misc/server/src/main.rs
@@ -57,21 +57,22 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let mut metric_registry = Registry::default();
 
-    let local_keypair = {
-        let keypair = identity::Keypair::from_protobuf_encoding(&Zeroizing::new(
-            base64::engine::general_purpose::STANDARD
-                .decode(config.identity.priv_key.as_bytes())?,
-        ))?;
+    let local_keypair =
+        {
+            let keypair = identity::Keypair::from_protobuf_encoding(&Zeroizing::new(
+                base64::engine::general_purpose::STANDARD
+                    .decode(config.identity.priv_key.as_bytes())?,
+            ))?;
 
-        let peer_id = keypair.public().into();
-        assert_eq!(
+            let peer_id = keypair.public().into();
+            assert_eq!(
             PeerId::from_str(&config.identity.peer_id)?,
             peer_id,
             "Expect peer id derived from private key and peer id retrieved from config to match."
         );
 
-        keypair
-    };
+            keypair
+        };
 
     let mut swarm = libp2p::SwarmBuilder::with_existing_identity(local_keypair)
         .with_tokio()
@@ -83,9 +84,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with_quic()
         .with_dns()?
         .with_bandwidth_metrics(&mut metric_registry)
-        .with_behaviour(|key| {
-            behaviour::Behaviour::new(key.public(), opt.enable_kademlia, opt.enable_autonat)
-        })?
+        .with_behaviour(
+            |key| behaviour::Behaviour::new(key.public(), opt.enable_kademlia, opt.enable_autonat)
+        )?
         .build();
 
     if config.addresses.swarm.is_empty() {

--- a/misc/webrtc-utils/src/noise.rs
+++ b/misc/webrtc-utils/src/noise.rs
@@ -92,12 +92,12 @@ mod tests {
 
     #[test]
     fn noise_prologue_tests() {
-        let a = Fingerprint::raw(hex!(
-            "3e79af40d6059617a0d83b83a52ce73b0c1f37a72c6043ad2969e2351bdca870"
-        ));
-        let b = Fingerprint::raw(hex!(
-            "30fc9f469c207419dfdd0aab5f27a86c973c94e40548db9375cca2e915973b99"
-        ));
+        let a = Fingerprint::raw(
+            hex!("3e79af40d6059617a0d83b83a52ce73b0c1f37a72c6043ad2969e2351bdca870")
+        );
+        let b = Fingerprint::raw(
+            hex!("30fc9f469c207419dfdd0aab5f27a86c973c94e40548db9375cca2e915973b99")
+        );
 
         let prologue1 = noise_prologue(a, b);
         let prologue2 = noise_prologue(b, a);

--- a/misc/webrtc-utils/src/sdp.rs
+++ b/misc/webrtc-utils/src/sdp.rs
@@ -27,12 +27,13 @@ use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 
 pub fn answer(addr: SocketAddr, server_fingerprint: Fingerprint, client_ufrag: &str) -> String {
-    let answer = render_description(
-        SERVER_SESSION_DESCRIPTION,
-        addr,
-        server_fingerprint,
-        client_ufrag,
-    );
+    let answer =
+        render_description(
+            SERVER_SESSION_DESCRIPTION,
+            addr,
+            server_fingerprint,
+            client_ufrag,
+        );
 
     tracing::trace!(%answer, "Created SDP answer");
 

--- a/muxers/mplex/benches/split_send_size.rs
+++ b/muxers/mplex/benches/split_send_size.rs
@@ -40,16 +40,17 @@ use tracing_subscriber::EnvFilter;
 type BenchTransport = transport::Boxed<(PeerId, muxing::StreamMuxerBox)>;
 
 /// The sizes (in bytes) used for the `split_send_size` configuration.
-const BENCH_SIZES: [usize; 8] = [
-    256,
-    512,
-    1024,
-    8 * 1024,
-    16 * 1024,
-    64 * 1024,
-    256 * 1024,
-    1024 * 1024,
-];
+const BENCH_SIZES: [usize; 8] =
+    [
+        256,
+        512,
+        1024,
+        8 * 1024,
+        16 * 1024,
+        64 * 1024,
+        256 * 1024,
+        1024 * 1024,
+    ];
 
 fn prepare(c: &mut Criterion) {
     let _ = tracing_subscriber::fmt()
@@ -174,9 +175,7 @@ fn tcp_transport(split_send_size: usize) -> BenchTransport {
 
     libp2p_tcp::async_io::Transport::new(libp2p_tcp::Config::default().nodelay(true))
         .upgrade(upgrade::Version::V1)
-        .authenticate(plaintext::Config::new(
-            &identity::Keypair::generate_ed25519(),
-        ))
+        .authenticate(plaintext::Config::new(&identity::Keypair::generate_ed25519()))
         .multiplex(mplex)
         .timeout(Duration::from_secs(5))
         .boxed()
@@ -188,9 +187,7 @@ fn mem_transport(split_send_size: usize) -> BenchTransport {
 
     transport::MemoryTransport::default()
         .upgrade(upgrade::Version::V1)
-        .authenticate(plaintext::Config::new(
-            &identity::Keypair::generate_ed25519(),
-        ))
+        .authenticate(plaintext::Config::new(&identity::Keypair::generate_ed25519()))
         .multiplex(mplex)
         .timeout(Duration::from_secs(5))
         .boxed()

--- a/muxers/mplex/src/io.rs
+++ b/muxers/mplex/src/io.rs
@@ -224,7 +224,7 @@ where
             // yield to give the current task a chance to read
             // from the respective substreams.
             if num_buffered == self.config.max_buffer_len {
-                cx.waker().clone().wake();
+                cx.waker().wake_by_ref();
                 return Poll::Pending;
             }
 
@@ -456,7 +456,7 @@ where
             // next frame for `id`, yield to give the current task
             // a chance to read from the other substream(s).
             if num_buffered == self.config.max_buffer_len {
-                cx.waker().clone().wake();
+                cx.waker().wake_by_ref();
                 return Poll::Pending;
             }
 
@@ -663,7 +663,7 @@ where
                     connection=%self.id,
                     "No task to read from blocked stream. Waking current task."
                 );
-                cx.waker().clone().wake();
+                cx.waker().wake_by_ref();
             } else if let Some(id) = stream_id {
                 // We woke some other task, but are still interested in
                 // reading `Data` frames from the current stream when unblocked.

--- a/muxers/mplex/src/io.rs
+++ b/muxers/mplex/src/io.rs
@@ -894,10 +894,7 @@ where
     /// has not been reached.
     fn check_max_pending_frames(&mut self) -> io::Result<()> {
         if self.pending_frames.len() >= self.config.max_substreams + EXTRA_PENDING_FRAMES {
-            return self.on_error(io::Error::new(
-                io::ErrorKind::Other,
-                "Too many pending frames.",
-            ));
+            return self.on_error(io::Error::new(io::ErrorKind::Other, "Too many pending frames."));
         }
         Ok(())
     }
@@ -1257,11 +1254,12 @@ mod tests {
             }
 
             // Setup the multiplexed connection.
-            let conn = Connection {
-                r_buf,
-                w_buf: BytesMut::new(),
-                eof: false,
-            };
+            let conn =
+                Connection {
+                    r_buf,
+                    w_buf: BytesMut::new(),
+                    eof: false,
+                };
             let mut m = Multiplexed::new(conn, cfg.clone());
 
             task::block_on(future::poll_fn(move |cx| {

--- a/muxers/mplex/tests/compliance.rs
+++ b/muxers/mplex/tests/compliance.rs
@@ -2,18 +2,24 @@ use libp2p_mplex::MplexConfig;
 
 #[async_std::test]
 async fn close_implies_flush() {
-    let (alice, bob) =
-        libp2p_muxer_test_harness::connected_muxers_on_memory_ring_buffer::<MplexConfig, _, _>()
-            .await;
+    let (alice, bob) = libp2p_muxer_test_harness::connected_muxers_on_memory_ring_buffer::<
+        MplexConfig,
+        _,
+        _,
+    >()
+    .await;
 
     libp2p_muxer_test_harness::close_implies_flush(alice, bob).await;
 }
 
 #[async_std::test]
 async fn read_after_close() {
-    let (alice, bob) =
-        libp2p_muxer_test_harness::connected_muxers_on_memory_ring_buffer::<MplexConfig, _, _>()
-            .await;
+    let (alice, bob) = libp2p_muxer_test_harness::connected_muxers_on_memory_ring_buffer::<
+        MplexConfig,
+        _,
+        _,
+    >()
+    .await;
 
     libp2p_muxer_test_harness::read_after_close(alice, bob).await;
 }

--- a/protocols/autonat/src/behaviour.rs
+++ b/protocols/autonat/src/behaviour.rs
@@ -328,12 +328,13 @@ impl Behaviour {
     ) {
         let connections = self.connected.entry(peer).or_default();
         let addr = endpoint.get_remote_address();
-        let observed_addr =
-            if !endpoint.is_relayed() && (!self.config.only_global_ips || addr.is_global_ip()) {
-                Some(addr.clone())
-            } else {
-                None
-            };
+        let observed_addr = if !endpoint.is_relayed()
+            && (!self.config.only_global_ips || addr.is_global_ip())
+        {
+            Some(addr.clone())
+        } else {
+            None
+        };
         connections.insert(conn, observed_addr);
 
         match endpoint {
@@ -420,12 +421,13 @@ impl Behaviour {
         }
         let connections = self.connected.get_mut(&peer).expect("Peer is connected.");
         let addr = new.get_remote_address();
-        let observed_addr =
-            if !new.is_relayed() && (!self.config.only_global_ips || addr.is_global_ip()) {
-                Some(addr.clone())
-            } else {
-                None
-            };
+        let observed_addr = if !new.is_relayed()
+            && (!self.config.only_global_ips || addr.is_global_ip())
+        {
+            Some(addr.clone())
+        } else {
+            None
+        };
         connections.insert(conn, observed_addr);
     }
 }
@@ -563,11 +565,9 @@ impl NetworkBehaviour for Behaviour {
                 self.as_client().on_new_address();
             }
             FromSwarm::ExpiredListenAddr(ExpiredListenAddr { listener_id, addr }) => {
-                self.inner
-                    .on_swarm_event(FromSwarm::ExpiredListenAddr(ExpiredListenAddr {
-                        listener_id,
-                        addr,
-                    }));
+                self.inner.on_swarm_event(
+                    FromSwarm::ExpiredListenAddr(ExpiredListenAddr { listener_id, addr })
+                );
                 self.as_client().on_expired_address(addr);
             }
             FromSwarm::ExternalAddrExpired(ExternalAddrExpired { addr }) => {
@@ -576,10 +576,9 @@ impl NetworkBehaviour for Behaviour {
                 self.as_client().on_expired_address(addr);
             }
             FromSwarm::NewExternalAddrCandidate(NewExternalAddrCandidate { addr }) => {
-                self.inner
-                    .on_swarm_event(FromSwarm::NewExternalAddrCandidate(
-                        NewExternalAddrCandidate { addr },
-                    ));
+                self.inner.on_swarm_event(
+                    FromSwarm::NewExternalAddrCandidate(NewExternalAddrCandidate { addr })
+                );
                 self.probe_address(addr.to_owned());
             }
             listen_failure @ FromSwarm::ListenFailure(_) => {

--- a/protocols/autonat/src/behaviour/as_client.rs
+++ b/protocols/autonat/src/behaviour/as_client.rs
@@ -244,9 +244,9 @@ impl<'a> AsClient<'a> {
     // Select a random server for the probe.
     fn random_server(&mut self) -> Option<PeerId> {
         // Update list of throttled servers.
-        let i = self.throttled_servers.partition_point(|(_, time)| {
-            *time + self.config.throttle_server_period < Instant::now()
-        });
+        let i = self.throttled_servers.partition_point(
+            |(_, time)| *time + self.config.throttle_server_period < Instant::now()
+        );
         self.throttled_servers.drain(..i);
 
         let mut servers: Vec<&PeerId> = self.servers.iter().collect();
@@ -281,13 +281,14 @@ impl<'a> AsClient<'a> {
 
         let server = self.random_server().ok_or(OutboundProbeError::NoServer)?;
 
-        let request_id = self.inner.send_request(
-            &server,
-            DialRequest {
-                peer_id: self.local_peer_id,
-                addresses,
-            },
-        );
+        let request_id =
+            self.inner.send_request(
+                &server,
+                DialRequest {
+                    peer_id: self.local_peer_id,
+                    addresses,
+                },
+            );
         self.throttled_servers.push((server, Instant::now()));
         tracing::debug!(peer=%server, "Send dial-back request to peer");
         self.ongoing_outbound.insert(request_id, probe_id);

--- a/protocols/autonat/src/behaviour/as_server.rs
+++ b/protocols/autonat/src/behaviour/as_server.rs
@@ -239,10 +239,12 @@ impl<'a> AsServer<'a> {
                 "Dial-back to peer failed with error {:?}",
                 error
             ),
-            None => tracing::debug!(
-                "Dial-back to non existent peer failed with error {:?}",
-                error
-            ),
+            None => {
+                tracing::debug!(
+                    "Dial-back to non existent peer failed with error {:?}",
+                    error
+                )
+            }
         };
 
         let response_error = ResponseError::DialError;
@@ -266,9 +268,9 @@ impl<'a> AsServer<'a> {
         request: DialRequest,
     ) -> Result<Vec<Multiaddr>, (String, ResponseError)> {
         // Update list of throttled clients.
-        let i = self.throttled_clients.partition_point(|(_, time)| {
-            *time + self.config.throttle_clients_period < Instant::now()
-        });
+        let i = self.throttled_clients.partition_point(
+            |(_, time)| *time + self.config.throttle_clients_period < Instant::now()
+        );
         self.throttled_clients.drain(..i);
 
         if request.peer_id != sender {

--- a/protocols/autonat/src/protocol.rs
+++ b/protocols/autonat/src/protocol.rs
@@ -137,16 +137,17 @@ impl DialRequest {
                 .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid peer id"))?
         };
 
-        let addrs = addrs
-            .into_iter()
-            .filter_map(|a| match Multiaddr::try_from(a.to_vec()) {
-                Ok(a) => Some(a),
-                Err(e) => {
-                    tracing::debug!("Unable to parse multiaddr: {e}");
-                    None
-                }
-            })
-            .collect();
+        let addrs =
+            addrs
+                .into_iter()
+                .filter_map(|a| match Multiaddr::try_from(a.to_vec()) {
+                    Ok(a) => Some(a),
+                    Err(e) => {
+                        tracing::debug!("Unable to parse multiaddr: {e}");
+                        None
+                    }
+                })
+                .collect();
         Ok(Self {
             peer_id,
             addresses: addrs,
@@ -257,18 +258,19 @@ impl DialResponse {
     }
 
     pub fn into_proto(self) -> proto::Message {
-        let dial_response = match self.result {
-            Ok(addr) => proto::DialResponse {
-                status: Some(proto::ResponseStatus::OK),
-                statusText: self.status_text,
-                addr: Some(addr.to_vec()),
-            },
-            Err(error) => proto::DialResponse {
-                status: Some(error.into()),
-                statusText: self.status_text,
-                addr: None,
-            },
-        };
+        let dial_response =
+            match self.result {
+                Ok(addr) => proto::DialResponse {
+                    status: Some(proto::ResponseStatus::OK),
+                    statusText: self.status_text,
+                    addr: Some(addr.to_vec()),
+                },
+                Err(error) => proto::DialResponse {
+                    status: Some(error.into()),
+                    statusText: self.status_text,
+                    addr: None,
+                },
+            };
 
         proto::Message {
             type_pb: Some(proto::MessageType::DIAL_RESPONSE),
@@ -298,10 +300,11 @@ mod tests {
 
     #[test]
     fn test_response_ok_encode_decode() {
-        let response = DialResponse {
-            result: Ok("/ip4/8.8.8.8/tcp/30333".parse().unwrap()),
-            status_text: None,
-        };
+        let response =
+            DialResponse {
+                result: Ok("/ip4/8.8.8.8/tcp/30333".parse().unwrap()),
+                status_text: None,
+            };
         let proto = response.clone().into_proto();
         let response2 = DialResponse::from_proto(proto).unwrap();
         assert_eq!(response, response2);
@@ -323,11 +326,12 @@ mod tests {
         let valid_multiaddr: Multiaddr = "/ip6/2001:db8::/tcp/1234".parse().unwrap();
         let valid_multiaddr_bytes = valid_multiaddr.to_vec();
 
-        let invalid_multiaddr = {
-            let a = vec![255; 8];
-            assert!(Multiaddr::try_from(a.clone()).is_err());
-            a
-        };
+        let invalid_multiaddr =
+            {
+                let a = vec![255; 8];
+                assert!(Multiaddr::try_from(a.clone()).is_err());
+                a
+            };
 
         let msg = proto::Message {
             type_pb: Some(proto::MessageType::DIAL),

--- a/protocols/autonat/tests/test_server.rs
+++ b/protocols/autonat/tests/test_server.rs
@@ -168,10 +168,7 @@ async fn test_dial_error() {
         }) => {
             assert_eq!(probe_id, request_probe_id);
             assert_eq!(peer, client_id);
-            assert!(matches!(
-                error,
-                InboundProbeError::Response(ResponseError::DialError)
-            ));
+            assert!(matches!(error, InboundProbeError::Response(ResponseError::DialError)));
         }
         other => panic!("Unexpected behaviour event: {other:?}."),
     }

--- a/protocols/dcutr/src/handler/relayed.rs
+++ b/protocols/dcutr/src/handler/relayed.rs
@@ -134,10 +134,7 @@ impl Handler {
         );
         if self
             .outbound_stream
-            .try_push(outbound::handshake(
-                stream,
-                self.holepunch_candidates.clone(),
-            ))
+            .try_push(outbound::handshake(stream, self.holepunch_candidates.clone()))
             .is_err()
         {
             tracing::warn!(
@@ -170,10 +167,9 @@ impl Handler {
             StreamUpgradeError::Timeout => outbound::Error::Io(io::ErrorKind::TimedOut.into()),
         };
 
-        self.queued_events
-            .push_back(ConnectionHandlerEvent::NotifyBehaviour(
-                Event::OutboundConnectFailed { error },
-            ))
+        self.queued_events.push_back(
+            ConnectionHandlerEvent::NotifyBehaviour(Event::OutboundConnectFailed { error })
+        )
     }
 }
 
@@ -242,9 +238,9 @@ impl ConnectionHandler for Handler {
                 ))
             }
             Poll::Ready(Ok(Err(error))) => {
-                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
-                    Event::InboundConnectFailed { error },
-                ))
+                return Poll::Ready(
+                    ConnectionHandlerEvent::NotifyBehaviour(Event::InboundConnectFailed { error })
+                )
             }
             Poll::Ready(Err(futures_bounded::Timeout { .. })) => {
                 return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
@@ -265,9 +261,9 @@ impl ConnectionHandler for Handler {
                 ))
             }
             Poll::Ready(Ok(Err(error))) => {
-                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
-                    Event::OutboundConnectFailed { error },
-                ))
+                return Poll::Ready(
+                    ConnectionHandlerEvent::NotifyBehaviour(Event::OutboundConnectFailed { error })
+                )
             }
             Poll::Ready(Err(futures_bounded::Timeout { .. })) => {
                 return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(

--- a/protocols/dcutr/tests/lib.rs
+++ b/protocols/dcutr/tests/lib.rs
@@ -110,10 +110,9 @@ fn build_relay() -> Swarm<Relay> {
                     ..Default::default()
                 },
             ),
-            identify: identify::Behaviour::new(identify::Config::new(
-                "/relay".to_owned(),
-                identity.public(),
-            )),
+            identify: identify::Behaviour::new(
+                identify::Config::new("/relay".to_owned(), identity.public())
+            ),
         }
     })
 }
@@ -144,10 +143,9 @@ fn build_client() -> Swarm<Client> {
         Client {
             relay: behaviour,
             dcutr: dcutr::Behaviour::new(local_peer_id),
-            identify: identify::Behaviour::new(identify::Config::new(
-                "/client".to_owned(),
-                local_key.public(),
-            )),
+            identify: identify::Behaviour::new(
+                identify::Config::new("/client".to_owned(), local_key.public())
+            ),
         },
         local_peer_id,
         Config::with_async_std_executor(),

--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -230,9 +230,7 @@ impl Floodsub {
             }
             if self.config.subscribe_local_messages {
                 self.events
-                    .push_back(ToSwarm::GenerateEvent(FloodsubEvent::Message(
-                        message.clone(),
-                    )));
+                    .push_back(ToSwarm::GenerateEvent(FloodsubEvent::Message(message.clone())));
             }
         }
         // Don't publish the message if we have to check subscriptions

--- a/protocols/gossipsub/src/backoff.rs
+++ b/protocols/gossipsub/src/backoff.rs
@@ -151,10 +151,11 @@ impl BackoffStorage {
             let slack = self.heartbeat_interval * self.backoff_slack;
             let now = Instant::now();
             s.retain(|(topic, peer)| {
-                let keep = match Self::get_backoff_time_from_backoffs(backoffs, topic, peer) {
-                    Some(backoff_time) => backoff_time + slack > now,
-                    None => false,
-                };
+                let keep =
+                    match Self::get_backoff_time_from_backoffs(backoffs, topic, peer) {
+                        Some(backoff_time) => backoff_time + slack > now,
+                        None => false,
+                    };
                 if !keep {
                     //remove from backoffs
                     if let Entry::Occupied(mut m) = backoffs.entry(topic.clone()) {

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -536,15 +536,16 @@ where
         // send subscription request to all peers
         let peer_list = self.peer_topics.keys().cloned().collect::<Vec<_>>();
         if !peer_list.is_empty() {
-            let event = Rpc {
-                messages: Vec::new(),
-                subscriptions: vec![Subscription {
-                    topic_hash: topic_hash.clone(),
-                    action: SubscriptionAction::Subscribe,
-                }],
-                control_msgs: Vec::new(),
-            }
-            .into_protobuf();
+            let event =
+                Rpc {
+                    messages: Vec::new(),
+                    subscriptions: vec![Subscription {
+                        topic_hash: topic_hash.clone(),
+                        action: SubscriptionAction::Subscribe,
+                    }],
+                    control_msgs: Vec::new(),
+                }
+                .into_protobuf();
 
             for peer in peer_list {
                 tracing::debug!(%peer, "Sending SUBSCRIBE to peer");
@@ -576,15 +577,16 @@ where
         // announce to all peers
         let peer_list = self.peer_topics.keys().cloned().collect::<Vec<_>>();
         if !peer_list.is_empty() {
-            let event = Rpc {
-                messages: Vec::new(),
-                subscriptions: vec![Subscription {
-                    topic_hash: topic_hash.clone(),
-                    action: SubscriptionAction::Unsubscribe,
-                }],
-                control_msgs: Vec::new(),
-            }
-            .into_protobuf();
+            let event =
+                Rpc {
+                    messages: Vec::new(),
+                    subscriptions: vec![Subscription {
+                        topic_hash: topic_hash.clone(),
+                        action: SubscriptionAction::Unsubscribe,
+                    }],
+                    control_msgs: Vec::new(),
+                }
+                .into_protobuf();
 
             for peer in peer_list {
                 tracing::debug!(%peer, "Sending UNSUBSCRIBE to peer");
@@ -1360,12 +1362,13 @@ where
                 .map(|message| message.topic.clone())
                 .collect::<HashSet<TopicHash>>();
 
-            let message = Rpc {
-                subscriptions: Vec::new(),
-                messages: message_list,
-                control_msgs: Vec::new(),
-            }
-            .into_protobuf();
+            let message =
+                Rpc {
+                    subscriptions: Vec::new(),
+                    messages: message_list,
+                    control_msgs: Vec::new(),
+                }
+                .into_protobuf();
 
             let msg_bytes = message.get_size();
 
@@ -2506,12 +2509,13 @@ where
             }
 
             // dynamic number of peers to gossip based on `gossip_factor` with minimum `gossip_lazy`
-            let n_map = |m| {
-                max(
-                    self.config.gossip_lazy(),
-                    (self.config.gossip_factor() * m as f64) as usize,
-                )
-            };
+            let n_map =
+                |m| {
+                    max(
+                        self.config.gossip_lazy(),
+                        (self.config.gossip_factor() * m as f64) as usize,
+                    )
+                };
             // get gossip_lazy random peers
             let to_msg_peers = get_random_peers_dynamic(
                 &self.topic_peers,
@@ -2578,12 +2582,13 @@ where
                     &self.connected_peers,
                 );
             }
-            let mut control_msgs: Vec<ControlAction> = topics
-                .iter()
-                .map(|topic_hash| ControlAction::Graft {
-                    topic_hash: topic_hash.clone(),
-                })
-                .collect();
+            let mut control_msgs: Vec<ControlAction> =
+                topics
+                    .iter()
+                    .map(|topic_hash| ControlAction::Graft {
+                        topic_hash: topic_hash.clone(),
+                    })
+                    .collect();
 
             // If there are prunes associated with the same peer add them.
             // NOTE: In this case a peer has been added to a topic mesh, and removed from another.
@@ -2718,12 +2723,13 @@ where
 
         // forward the message to peers
         if !recipient_peers.is_empty() {
-            let event = Rpc {
-                subscriptions: Vec::new(),
-                messages: vec![message.clone()],
-                control_msgs: Vec::new(),
-            }
-            .into_protobuf();
+            let event =
+                Rpc {
+                    subscriptions: Vec::new(),
+                    messages: vec![message.clone()],
+                    control_msgs: Vec::new(),
+                }
+                .into_protobuf();
 
             let msg_bytes = event.get_size();
             for peer in recipient_peers.iter() {
@@ -2890,11 +2896,12 @@ where
             return Ok(vec![rpc]);
         }
 
-        let new_rpc = proto::RPC {
-            subscriptions: Vec::new(),
-            publish: Vec::new(),
-            control: None,
-        };
+        let new_rpc =
+            proto::RPC {
+                subscriptions: Vec::new(),
+                publish: Vec::new(),
+                control: None,
+            };
 
         let mut rpc_list = vec![new_rpc.clone()];
 
@@ -3469,14 +3476,15 @@ fn peer_added_to_mesh(
     connections: &HashMap<PeerId, PeerConnections>,
 ) {
     // Ensure there is an active connection
-    let connection_id = {
-        let conn = connections.get(&peer_id).expect("To be connected to peer.");
-        assert!(
-            !conn.connections.is_empty(),
-            "Must have at least one connection"
-        );
-        conn.connections[0]
-    };
+    let connection_id =
+        {
+            let conn = connections.get(&peer_id).expect("To be connected to peer.");
+            assert!(
+                !conn.connections.is_empty(),
+                "Must have at least one connection"
+            );
+            conn.connections[0]
+        };
 
     if let Some(topics) = known_topics {
         for topic in topics {
@@ -3717,11 +3725,12 @@ mod local_test {
     /// Tests RPC message fragmentation
     fn test_message_fragmentation_deterministic() {
         let max_transmit_size = 500;
-        let config = crate::config::ConfigBuilder::default()
-            .max_transmit_size(max_transmit_size)
-            .validation_mode(ValidationMode::Permissive)
-            .build()
-            .unwrap();
+        let config =
+            crate::config::ConfigBuilder::default()
+                .max_transmit_size(max_transmit_size)
+                .validation_mode(ValidationMode::Permissive)
+                .build()
+                .unwrap();
         let gs: Behaviour = Behaviour::new(MessageAuthenticity::RandomAuthor, config).unwrap();
 
         // Message under the limit should be fine.

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -59,14 +59,15 @@ where
     pub(crate) fn create_network(self) -> (Behaviour<D, F>, Vec<PeerId>, Vec<TopicHash>) {
         let keypair = libp2p_identity::Keypair::generate_ed25519();
         // create a gossipsub struct
-        let mut gs: Behaviour<D, F> = Behaviour::new_with_subscription_filter_and_transform(
-            MessageAuthenticity::Signed(keypair),
-            self.gs_config,
-            None,
-            self.subscription_filter,
-            self.data_transform,
-        )
-        .unwrap();
+        let mut gs: Behaviour<D, F> =
+            Behaviour::new_with_subscription_filter_and_transform(
+                MessageAuthenticity::Signed(keypair),
+                self.gs_config,
+                None,
+                self.subscription_filter,
+                self.data_transform,
+            )
+            .unwrap();
 
         if let Some((scoring_params, scoring_thresholds)) = self.scoring {
             gs.with_peer_score(scoring_params, scoring_thresholds)
@@ -256,11 +257,12 @@ where
     F: TopicSubscriptionFilter + Clone + Default + Send + 'static,
 {
     if let Some(peer_connections) = gs.connected_peers.get(peer_id) {
-        let fake_endpoint = ConnectedPoint::Dialer {
-            address: Multiaddr::empty(),
-            role_override: Endpoint::Dialer,
-        }; // this is not relevant
-           // peer_connections.connections should never be empty.
+        let fake_endpoint =
+            ConnectedPoint::Dialer {
+                address: Multiaddr::empty(),
+                role_override: Endpoint::Dialer,
+            }; // this is not relevant
+               // peer_connections.connections should never be empty.
 
         let mut active_connections = peer_connections.connections.len();
         for connection_id in peer_connections.connections.clone() {
@@ -387,11 +389,12 @@ fn test_subscribe() {
     // - run JOIN(topic)
 
     let subscribe_topic = vec![String::from("test_subscribe")];
-    let (gs, _, topic_hashes) = inject_nodes1()
-        .peer_no(20)
-        .topics(subscribe_topic)
-        .to_subscribe(true)
-        .create_network();
+    let (gs, _, topic_hashes) =
+        inject_nodes1()
+            .peer_no(20)
+            .topics(subscribe_topic)
+            .to_subscribe(true)
+            .create_network();
 
     assert!(
         gs.mesh.get(&topic_hashes[0]).is_some(),
@@ -439,11 +442,12 @@ fn test_unsubscribe() {
         .collect::<Vec<Topic>>();
 
     // subscribe to topic_strings
-    let (mut gs, _, topic_hashes) = inject_nodes1()
-        .peer_no(20)
-        .topics(topic_strings)
-        .to_subscribe(true)
-        .create_network();
+    let (mut gs, _, topic_hashes) =
+        inject_nodes1()
+            .peer_no(20)
+            .topics(topic_strings)
+            .to_subscribe(true)
+            .create_network();
 
     for topic_hash in &topic_hashes {
         assert!(
@@ -518,11 +522,12 @@ fn test_join() {
         .map(|t| Topic::new(t.clone()))
         .collect::<Vec<Topic>>();
 
-    let (mut gs, _, topic_hashes) = inject_nodes1()
-        .peer_no(20)
-        .topics(topic_strings)
-        .to_subscribe(true)
-        .create_network();
+    let (mut gs, _, topic_hashes) =
+        inject_nodes1()
+            .peer_no(20)
+            .topics(topic_strings)
+            .to_subscribe(true)
+            .create_network();
 
     // unsubscribe, then call join to invoke functionality
     assert!(
@@ -951,18 +956,19 @@ fn test_get_random_peers() {
     gs.topic_peers
         .insert(topic_hash.clone(), peers.iter().cloned().collect());
 
-    gs.connected_peers = peers
-        .iter()
-        .map(|p| {
-            (
-                *p,
-                PeerConnections {
-                    kind: PeerKind::Gossipsubv1_1,
-                    connections: vec![ConnectionId::new_unchecked(0)],
-                },
-            )
-        })
-        .collect();
+    gs.connected_peers =
+        peers
+            .iter()
+            .map(|p| {
+                (
+                    *p,
+                    PeerConnections {
+                        kind: PeerKind::Gossipsubv1_1,
+                        connections: vec![ConnectionId::new_unchecked(0)],
+                    },
+                )
+            })
+            .collect();
 
     let random_peers =
         get_random_peers(&gs.topic_peers, &gs.connected_peers, &topic_hash, 5, |_| {
@@ -1013,11 +1019,12 @@ fn test_get_random_peers() {
 /// Tests that the correct message is sent when a peer asks for a message in our cache.
 #[test]
 fn test_handle_iwant_msg_cached() {
-    let (mut gs, peers, _) = inject_nodes1()
-        .peer_no(20)
-        .topics(Vec::new())
-        .to_subscribe(true)
-        .create_network();
+    let (mut gs, peers, _) =
+        inject_nodes1()
+            .peer_no(20)
+            .topics(Vec::new())
+            .to_subscribe(true)
+            .create_network();
 
     let raw_message = RawMessage {
         source: Some(peers[11]),
@@ -1069,11 +1076,12 @@ fn test_handle_iwant_msg_cached() {
 /// Tests that messages are sent correctly depending on the shifting of the message cache.
 #[test]
 fn test_handle_iwant_msg_cached_shifted() {
-    let (mut gs, peers, _) = inject_nodes1()
-        .peer_no(20)
-        .topics(Vec::new())
-        .to_subscribe(true)
-        .create_network();
+    let (mut gs, peers, _) =
+        inject_nodes1()
+            .peer_no(20)
+            .topics(Vec::new())
+            .to_subscribe(true)
+            .create_network();
 
     // perform 10 memshifts and check that it leaves the cache
     for shift in 1..10 {
@@ -1134,11 +1142,12 @@ fn test_handle_iwant_msg_cached_shifted() {
 #[test]
 // tests that an event is not created when a peers asks for a message not in our cache
 fn test_handle_iwant_msg_not_cached() {
-    let (mut gs, peers, _) = inject_nodes1()
-        .peer_no(20)
-        .topics(Vec::new())
-        .to_subscribe(true)
-        .create_network();
+    let (mut gs, peers, _) =
+        inject_nodes1()
+            .peer_no(20)
+            .topics(Vec::new())
+            .to_subscribe(true)
+            .create_network();
 
     let events_before = gs.events.len();
     gs.handle_iwant(&peers[7], vec![MessageId::new(b"unknown id")]);
@@ -1165,15 +1174,18 @@ fn test_handle_ihave_subscribed_and_msg_not_cached() {
     );
 
     // check that we sent an IWANT request for `unknown id`
-    let iwant_exists = match gs.control_pool.get(&peers[7]) {
-        Some(controls) => controls.iter().any(|c| match c {
-            ControlAction::IWant { message_ids } => message_ids
-                .iter()
-                .any(|m| *m == MessageId::new(b"unknown id")),
+    let iwant_exists =
+        match gs.control_pool.get(&peers[7]) {
+            Some(controls) => {
+                controls.iter().any(|c| match c {
+                    ControlAction::IWant { message_ids } => message_ids
+                        .iter()
+                        .any(|m| *m == MessageId::new(b"unknown id")),
+                    _ => false,
+                })
+            }
             _ => false,
-        }),
-        _ => false,
-    };
+        };
 
     assert!(
         iwant_exists,
@@ -1381,14 +1393,14 @@ fn test_explicit_peer_gets_connected() {
     //add peer as explicit peer
     gs.add_explicit_peer(&peer);
 
-    let num_events = gs
-        .events
-        .iter()
-        .filter(|e| match e {
-            ToSwarm::Dial { opts } => opts.get_peer_id() == Some(peer),
-            _ => false,
-        })
-        .count();
+    let num_events =
+        gs.events
+            .iter()
+            .filter(|e| match e {
+                ToSwarm::Dial { opts } => opts.get_peer_id() == Some(peer),
+                _ => false,
+            })
+            .count();
 
     assert_eq!(
         num_events, 1,
@@ -1589,13 +1601,14 @@ fn do_forward_messages_to_explicit_peers() {
 
 #[test]
 fn explicit_peers_not_added_to_mesh_on_subscribe() {
-    let (mut gs, peers, _) = inject_nodes1()
-        .peer_no(2)
-        .topics(Vec::new())
-        .to_subscribe(true)
-        .gs_config(Config::default())
-        .explicit(1)
-        .create_network();
+    let (mut gs, peers, _) =
+        inject_nodes1()
+            .peer_no(2)
+            .topics(Vec::new())
+            .to_subscribe(true)
+            .gs_config(Config::default())
+            .explicit(1)
+            .create_network();
 
     //create new topic, both peers subscribing to it but we do not subscribe to it
     let topic = Topic::new(String::from("t"));
@@ -1635,13 +1648,14 @@ fn explicit_peers_not_added_to_mesh_on_subscribe() {
 
 #[test]
 fn explicit_peers_not_added_to_mesh_from_fanout_on_subscribe() {
-    let (mut gs, peers, _) = inject_nodes1()
-        .peer_no(2)
-        .topics(Vec::new())
-        .to_subscribe(true)
-        .gs_config(Config::default())
-        .explicit(1)
-        .create_network();
+    let (mut gs, peers, _) =
+        inject_nodes1()
+            .peer_no(2)
+            .topics(Vec::new())
+            .to_subscribe(true)
+            .gs_config(Config::default())
+            .explicit(1)
+            .create_network();
 
     //create new topic, both peers subscribing to it but we do not subscribe to it
     let topic = Topic::new(String::from("t"));
@@ -1767,13 +1781,14 @@ fn test_mesh_subtraction() {
     // Adds mesh_low peers and PRUNE 2 giving us a deficit.
     let n = config.mesh_n_high() + 10;
     //make all outbound connections so that we allow grafting to all
-    let (mut gs, peers, topics) = inject_nodes1()
-        .peer_no(n)
-        .topics(vec!["test".into()])
-        .to_subscribe(true)
-        .gs_config(config.clone())
-        .outbound(n)
-        .create_network();
+    let (mut gs, peers, topics) =
+        inject_nodes1()
+            .peer_no(n)
+            .topics(vec!["test".into()])
+            .to_subscribe(true)
+            .gs_config(config.clone())
+            .outbound(n)
+            .create_network();
 
     // graft all the peers
     for peer in peers {
@@ -1791,11 +1806,12 @@ fn test_mesh_subtraction() {
 fn test_connect_to_px_peers_on_handle_prune() {
     let config: Config = Config::default();
 
-    let (mut gs, peers, topics) = inject_nodes1()
-        .peer_no(1)
-        .topics(vec!["test".into()])
-        .to_subscribe(true)
-        .create_network();
+    let (mut gs, peers, topics) =
+        inject_nodes1()
+            .peer_no(1)
+            .topics(vec!["test".into()])
+            .to_subscribe(true)
+            .create_network();
 
     //handle prune from single peer with px peers
 
@@ -1817,14 +1833,14 @@ fn test_connect_to_px_peers_on_handle_prune() {
     );
 
     //Check DialPeer events for px peers
-    let dials: Vec<_> = gs
-        .events
-        .iter()
-        .filter_map(|e| match e {
-            ToSwarm::Dial { opts } => opts.get_peer_id(),
-            _ => None,
-        })
-        .collect();
+    let dials: Vec<_> =
+        gs.events
+            .iter()
+            .filter_map(|e| match e {
+                ToSwarm::Dial { opts } => opts.get_peer_id(),
+                _ => None,
+            })
+            .collect();
 
     // Exactly config.prune_peers() many random peers should be dialled
     assert_eq!(dials.len(), config.prune_peers());
@@ -1981,12 +1997,13 @@ fn test_do_not_graft_within_backoff_period() {
 #[test]
 fn test_do_not_graft_within_default_backoff_period_after_receiving_prune_without_backoff() {
     //set default backoff period to 1 second
-    let config = ConfigBuilder::default()
-        .prune_backoff(Duration::from_millis(90))
-        .backoff_slack(1)
-        .heartbeat_interval(Duration::from_millis(100))
-        .build()
-        .unwrap();
+    let config =
+        ConfigBuilder::default()
+            .prune_backoff(Duration::from_millis(90))
+            .backoff_slack(1)
+            .heartbeat_interval(Duration::from_millis(100))
+            .build()
+            .unwrap();
     //only one peer => mesh too small and will try to regraft as early as possible
     let (mut gs, peers, topics) = inject_nodes1()
         .peer_no(1)
@@ -2202,11 +2219,12 @@ fn test_gossip_to_at_most_gossip_factor_peers() {
 
     //add a lot of peers
     let m = config.mesh_n_low() + config.gossip_lazy() * (2.0 / config.gossip_factor()) as usize;
-    let (mut gs, _, topic_hashes) = inject_nodes1()
-        .peer_no(m)
-        .topics(vec!["topic".into()])
-        .to_subscribe(true)
-        .create_network();
+    let (mut gs, _, topic_hashes) =
+        inject_nodes1()
+            .peer_no(m)
+            .topics(vec!["topic".into()])
+            .to_subscribe(true)
+            .create_network();
 
     //receive message
     let raw_message = RawMessage {
@@ -2370,10 +2388,7 @@ fn test_prune_negative_scored_peers() {
         .gs_config(config.clone())
         .explicit(0)
         .outbound(0)
-        .scoring(Some((
-            PeerScoreParams::default(),
-            PeerScoreThresholds::default(),
-        )))
+        .scoring(Some((PeerScoreParams::default(), PeerScoreThresholds::default())))
         .create_network();
 
     //add penalty to peer
@@ -2413,10 +2428,7 @@ fn test_dont_graft_to_negative_scored_peers() {
         .topics(vec!["test".into()])
         .to_subscribe(true)
         .gs_config(config)
-        .scoring(Some((
-            PeerScoreParams::default(),
-            PeerScoreThresholds::default(),
-        )))
+        .scoring(Some((PeerScoreParams::default(), PeerScoreThresholds::default())))
         .create_network();
 
     //add two additional peers that will not be part of the mesh
@@ -2452,19 +2464,17 @@ fn test_ignore_px_from_negative_scored_peer() {
         .topics(vec!["test".into()])
         .to_subscribe(true)
         .gs_config(config.clone())
-        .scoring(Some((
-            PeerScoreParams::default(),
-            PeerScoreThresholds::default(),
-        )))
+        .scoring(Some((PeerScoreParams::default(), PeerScoreThresholds::default())))
         .create_network();
 
     //penalize peer
     gs.peer_score.as_mut().unwrap().0.add_penalty(&peers[0], 1);
 
     //handle prune from single peer with px peers
-    let px = vec![PeerInfo {
-        peer_id: Some(PeerId::random()),
-    }];
+    let px =
+        vec![PeerInfo {
+            peer_id: Some(PeerId::random()),
+        }];
 
     gs.handle_prune(
         &peers[0],
@@ -2501,10 +2511,7 @@ fn test_only_send_nonnegative_scoring_peers_in_px() {
         .gs_config(config)
         .explicit(0)
         .outbound(0)
-        .scoring(Some((
-            PeerScoreParams::default(),
-            PeerScoreThresholds::default(),
-        )))
+        .scoring(Some((PeerScoreParams::default(), PeerScoreThresholds::default())))
         .create_network();
 
     // Penalize first peer
@@ -2926,25 +2933,27 @@ fn test_ignore_rpc_from_peers_below_graylist_threshold() {
     //reduce score of p2 below publish_threshold but not below graylist_threshold
     gs.peer_score.as_mut().unwrap().0.add_penalty(&p2, 1);
 
-    let raw_message1 = RawMessage {
-        source: Some(PeerId::random()),
-        data: vec![1, 2, 3, 4],
-        sequence_number: Some(1u64),
-        topic: topics[0].clone(),
-        signature: None,
-        key: None,
-        validated: true,
-    };
+    let raw_message1 =
+        RawMessage {
+            source: Some(PeerId::random()),
+            data: vec![1, 2, 3, 4],
+            sequence_number: Some(1u64),
+            topic: topics[0].clone(),
+            signature: None,
+            key: None,
+            validated: true,
+        };
 
-    let raw_message2 = RawMessage {
-        source: Some(PeerId::random()),
-        data: vec![1, 2, 3, 4, 5],
-        sequence_number: Some(2u64),
-        topic: topics[0].clone(),
-        signature: None,
-        key: None,
-        validated: true,
-    };
+    let raw_message2 =
+        RawMessage {
+            source: Some(PeerId::random()),
+            data: vec![1, 2, 3, 4, 5],
+            sequence_number: Some(2u64),
+            topic: topics[0].clone(),
+            signature: None,
+            key: None,
+            validated: true,
+        };
 
     let raw_message3 = RawMessage {
         source: Some(PeerId::random()),
@@ -3053,9 +3062,10 @@ fn test_ignore_px_from_peers_below_accept_px_threshold() {
     gs.set_application_score(&peers[1], 1.0);
 
     // Handle prune from peer peers[0] with px peers
-    let px = vec![PeerInfo {
-        peer_id: Some(PeerId::random()),
-    }];
+    let px =
+        vec![PeerInfo {
+            peer_id: Some(PeerId::random()),
+        }];
     gs.handle_prune(
         &peers[0],
         vec![(
@@ -3075,9 +3085,10 @@ fn test_ignore_px_from_peers_below_accept_px_threshold() {
     );
 
     //handle prune from peer peers[1] with px peers
-    let px = vec![PeerInfo {
-        peer_id: Some(PeerId::random()),
-    }];
+    let px =
+        vec![PeerInfo {
+            peer_id: Some(PeerId::random()),
+        }];
     gs.handle_prune(
         &peers[1],
         vec![(
@@ -3116,10 +3127,7 @@ fn test_keep_best_scoring_peers_on_oversubscription() {
         .gs_config(config.clone())
         .explicit(0)
         .outbound(n)
-        .scoring(Some((
-            PeerScoreParams::default(),
-            PeerScoreThresholds::default(),
-        )))
+        .scoring(Some((PeerScoreParams::default(), PeerScoreThresholds::default())))
         .create_network();
 
     // graft all, will be accepted since the are outbound
@@ -4495,11 +4503,12 @@ fn test_ignore_too_many_ihaves() {
 
 #[test]
 fn test_ignore_too_many_messages_in_ihave() {
-    let config = ConfigBuilder::default()
-        .max_ihave_messages(10)
-        .max_ihave_length(10)
-        .build()
-        .unwrap();
+    let config =
+        ConfigBuilder::default()
+            .max_ihave_messages(10)
+            .max_ihave_length(10)
+            .build()
+            .unwrap();
     //build gossipsub with full mesh
     let (mut gs, _, topics) = inject_nodes1()
         .peer_no(config.mesh_n_high())
@@ -4575,11 +4584,12 @@ fn test_ignore_too_many_messages_in_ihave() {
 
 #[test]
 fn test_limit_number_of_message_ids_inside_ihave() {
-    let config = ConfigBuilder::default()
-        .max_ihave_messages(10)
-        .max_ihave_length(100)
-        .build()
-        .unwrap();
+    let config =
+        ConfigBuilder::default()
+            .max_ihave_messages(10)
+            .max_ihave_length(100)
+            .build()
+            .unwrap();
     //build gossipsub with full mesh
     let (mut gs, peers, topics) = inject_nodes1()
         .peer_no(config.mesh_n_high())
@@ -4928,11 +4938,12 @@ fn test_dont_add_floodsub_peers_to_mesh_on_join() {
 
 #[test]
 fn test_dont_send_px_to_old_gossipsub_peers() {
-    let (mut gs, _, topics) = inject_nodes1()
-        .peer_no(0)
-        .topics(vec!["test".into()])
-        .to_subscribe(false)
-        .create_network();
+    let (mut gs, _, topics) =
+        inject_nodes1()
+            .peer_no(0)
+            .topics(vec!["test".into()])
+            .to_subscribe(false)
+            .create_network();
 
     //add an old gossipsub peer
     let p1 = add_peer_with_addr_and_kind(
@@ -4965,11 +4976,12 @@ fn test_dont_send_px_to_old_gossipsub_peers() {
 #[test]
 fn test_dont_send_floodsub_peers_in_px() {
     //build mesh with one peer
-    let (mut gs, peers, topics) = inject_nodes1()
-        .peer_no(1)
-        .topics(vec!["test".into()])
-        .to_subscribe(true)
-        .create_network();
+    let (mut gs, peers, topics) =
+        inject_nodes1()
+            .peer_no(1)
+            .topics(vec!["test".into()])
+            .to_subscribe(true)
+            .create_network();
 
     //add two floodsub peers
     let _p1 = add_peer_with_addr_and_kind(
@@ -5002,11 +5014,12 @@ fn test_dont_send_floodsub_peers_in_px() {
 
 #[test]
 fn test_dont_add_floodsub_peers_to_mesh_in_heartbeat() {
-    let (mut gs, _, topics) = inject_nodes1()
-        .peer_no(0)
-        .topics(vec!["test".into()])
-        .to_subscribe(false)
-        .create_network();
+    let (mut gs, _, topics) =
+        inject_nodes1()
+            .peer_no(0)
+            .topics(vec!["test".into()])
+            .to_subscribe(false)
+            .create_network();
 
     //add two floodsub peer, one explicit, one implicit
     let _p1 = add_peer_with_addr_and_kind(
@@ -5062,12 +5075,11 @@ fn test_public_api() {
 fn test_subscribe_to_invalid_topic() {
     let t1 = Topic::new("t1");
     let t2 = Topic::new("t2");
-    let (mut gs, _, _) = inject_nodes::<IdentityTransform, _>()
-        .subscription_filter(WhitelistSubscriptionFilter(
-            vec![t1.hash()].into_iter().collect(),
-        ))
-        .to_subscribe(false)
-        .create_network();
+    let (mut gs, _, _) =
+        inject_nodes::<IdentityTransform, _>()
+            .subscription_filter(WhitelistSubscriptionFilter(vec![t1.hash()].into_iter().collect()))
+            .to_subscribe(false)
+            .create_network();
 
     assert!(gs.subscribe(&t1).is_ok());
     assert!(gs.subscribe(&t2).is_err());
@@ -5078,10 +5090,7 @@ fn test_subscribe_and_graft_with_negative_score() {
     //simulate a communication between two gossipsub instances
     let (mut gs1, _, topic_hashes) = inject_nodes1()
         .topics(vec!["test".into()])
-        .scoring(Some((
-            PeerScoreParams::default(),
-            PeerScoreThresholds::default(),
-        )))
+        .scoring(Some((PeerScoreParams::default(), PeerScoreThresholds::default())))
         .create_network();
 
     let (mut gs2, _, _) = inject_nodes1().create_network();
@@ -5101,33 +5110,34 @@ fn test_subscribe_and_graft_with_negative_score() {
     //subscribe to topic in gs2
     gs2.subscribe(&topic).unwrap();
 
-    let forward_messages_to_p1 = |gs1: &mut Behaviour<_, _>, gs2: &mut Behaviour<_, _>| {
-        //collect messages to p1
-        let messages_to_p1 = gs2.events.drain(..).filter_map(|e| match e {
-            ToSwarm::NotifyHandler { peer_id, event, .. } => {
-                if peer_id == p1 {
-                    if let HandlerIn::Message(m) = event {
-                        Some(m)
+    let forward_messages_to_p1 =
+        |gs1: &mut Behaviour<_, _>, gs2: &mut Behaviour<_, _>| {
+            //collect messages to p1
+            let messages_to_p1 = gs2.events.drain(..).filter_map(|e| match e {
+                ToSwarm::NotifyHandler { peer_id, event, .. } => {
+                    if peer_id == p1 {
+                        if let HandlerIn::Message(m) = event {
+                            Some(m)
+                        } else {
+                            None
+                        }
                     } else {
                         None
                     }
-                } else {
-                    None
                 }
+                _ => None,
+            });
+            for message in messages_to_p1 {
+                gs1.on_connection_handler_event(
+                    p2,
+                    connection_id,
+                    HandlerEvent::Message {
+                        rpc: proto_to_message(&message),
+                        invalid_messages: vec![],
+                    },
+                );
             }
-            _ => None,
-        });
-        for message in messages_to_p1 {
-            gs1.on_connection_handler_event(
-                p2,
-                connection_id,
-                HandlerEvent::Message {
-                    rpc: proto_to_message(&message),
-                    invalid_messages: vec![],
-                },
-            );
-        }
-    };
+        };
 
     //forward the subscribe message
     forward_messages_to_p1(&mut gs1, &mut gs2);
@@ -5154,11 +5164,12 @@ fn test_graft_without_subscribe() {
     let topic = String::from("test_subscribe");
     let subscribe_topic = vec![topic.clone()];
     let subscribe_topic_hash = vec![Topic::new(topic.clone()).hash()];
-    let (mut gs, peers, topic_hashes) = inject_nodes1()
-        .peer_no(1)
-        .topics(subscribe_topic)
-        .to_subscribe(false)
-        .create_network();
+    let (mut gs, peers, topic_hashes) =
+        inject_nodes1()
+            .peer_no(1)
+            .topics(subscribe_topic)
+            .to_subscribe(false)
+            .create_network();
 
     assert!(
         gs.mesh.get(&topic_hashes[0]).is_some(),

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -869,10 +869,11 @@ mod test {
 
     #[test]
     fn create_config_with_message_id_as_plain_function() {
-        let config = ConfigBuilder::default()
-            .message_id_fn(message_id_plain_function)
-            .build()
-            .unwrap();
+        let config =
+            ConfigBuilder::default()
+                .message_id_fn(message_id_plain_function)
+                .build()
+                .unwrap();
 
         let result = config.message_id(&get_gossipsub_message());
 

--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -487,10 +487,9 @@ impl ConnectionHandler for Handler {
                 }
 
                 match event {
-                    ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
-                        protocol,
-                        ..
-                    }) => match protocol {
+                    ConnectionEvent::FullyNegotiatedInbound(
+                        FullyNegotiatedInbound { protocol, .. }
+                    ) => match protocol {
                         Either::Left(protocol) => handler.on_fully_negotiated_inbound(protocol),
                         Either::Right(v) => void::unreachable(v),
                     },

--- a/protocols/gossipsub/src/mcache.rs
+++ b/protocols/gossipsub/src/mcache.rs
@@ -158,22 +158,24 @@ impl MessageCache {
             .iter()
             .fold(vec![], |mut current_entries, entries| {
                 // search for entries with desired topic
-                let mut found_entries: Vec<MessageId> = entries
-                    .iter()
-                    .filter_map(|entry| {
-                        if &entry.topic == topic {
-                            let mid = &entry.mid;
-                            // Only gossip validated messages
-                            if let Some(true) = self.msgs.get(mid).map(|(msg, _)| msg.validated) {
-                                Some(mid.clone())
+                let mut found_entries: Vec<MessageId> =
+                    entries
+                        .iter()
+                        .filter_map(|entry| {
+                            if &entry.topic == topic {
+                                let mid = &entry.mid;
+                                // Only gossip validated messages
+                                if let Some(true) = self.msgs.get(mid).map(|(msg, _)| msg.validated)
+                                {
+                                    Some(mid.clone())
+                                } else {
+                                    None
+                                }
                             } else {
                                 None
                             }
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
+                        })
+                        .collect();
 
                 // generate the list
                 current_entries.append(&mut found_entries);

--- a/protocols/gossipsub/src/metrics.rs
+++ b/protocols/gossipsub/src/metrics.rs
@@ -56,17 +56,18 @@ pub struct Config {
 impl Config {
     /// Create buckets for the score histograms based on score thresholds.
     pub fn buckets_using_scoring_thresholds(&mut self, params: &crate::PeerScoreThresholds) {
-        self.score_buckets = vec![
-            params.graylist_threshold,
-            params.publish_threshold,
-            params.gossip_threshold,
-            params.gossip_threshold / 2.0,
-            params.gossip_threshold / 4.0,
-            0.0,
-            1.0,
-            10.0,
-            100.0,
-        ];
+        self.score_buckets =
+            vec![
+                params.graylist_threshold,
+                params.publish_threshold,
+                params.gossip_threshold,
+                params.gossip_threshold / 2.0,
+                params.gossip_threshold / 4.0,
+                0.0,
+                1.0,
+                10.0,
+                100.0,
+            ];
     }
 }
 
@@ -76,17 +77,18 @@ impl Default for Config {
         let gossip_threshold = -4000.0;
         let publish_threshold = -8000.0;
         let graylist_threshold = -16000.0;
-        let score_buckets: Vec<f64> = vec![
-            graylist_threshold,
-            publish_threshold,
-            gossip_threshold,
-            gossip_threshold / 2.0,
-            gossip_threshold / 4.0,
-            0.0,
-            1.0,
-            10.0,
-            100.0,
-        ];
+        let score_buckets: Vec<f64> =
+            vec![
+                graylist_threshold,
+                publish_threshold,
+                gossip_threshold,
+                gossip_threshold / 2.0,
+                gossip_threshold / 4.0,
+                0.0,
+                1.0,
+                10.0,
+                100.0,
+            ];
         Config {
             max_topics: DEFAULT_MAX_TOPICS,
             max_never_subscribed_topics: DEFAULT_MAX_NEVER_SUBSCRIBED_TOPICS,
@@ -261,9 +263,10 @@ impl Metrics {
             "Bytes received from gossip messages for each topic"
         );
 
-        let hist_builder = HistBuilder {
-            buckets: score_buckets,
-        };
+        let hist_builder =
+            HistBuilder {
+                buckets: score_buckets,
+            };
 
         let score_per_mesh: Family<_, _, HistBuilder> = Family::new_with_constructor(hist_builder);
         registry.register(

--- a/protocols/gossipsub/src/peer_score.rs
+++ b/protocols/gossipsub/src/peer_score.rs
@@ -236,27 +236,29 @@ impl PeerScore {
 
                 // P1: time in mesh
                 if let MeshStatus::Active { mesh_time, .. } = topic_stats.mesh_status {
-                    let p1 = {
-                        let v = mesh_time.as_secs_f64()
-                            / topic_params.time_in_mesh_quantum.as_secs_f64();
-                        if v < topic_params.time_in_mesh_cap {
-                            v
-                        } else {
-                            topic_params.time_in_mesh_cap
-                        }
-                    };
+                    let p1 =
+                        {
+                            let v = mesh_time.as_secs_f64()
+                                / topic_params.time_in_mesh_quantum.as_secs_f64();
+                            if v < topic_params.time_in_mesh_cap {
+                                v
+                            } else {
+                                topic_params.time_in_mesh_cap
+                            }
+                        };
                     topic_score += p1 * topic_params.time_in_mesh_weight;
                 }
 
                 // P2: first message deliveries
-                let p2 = {
-                    let v = topic_stats.first_message_deliveries;
-                    if v < topic_params.first_message_deliveries_cap {
-                        v
-                    } else {
-                        topic_params.first_message_deliveries_cap
-                    }
-                };
+                let p2 =
+                    {
+                        let v = topic_stats.first_message_deliveries;
+                        if v < topic_params.first_message_deliveries_cap {
+                            v
+                        } else {
+                            topic_params.first_message_deliveries_cap
+                        }
+                    };
                 topic_score += p2 * topic_params.first_message_deliveries_weight;
 
                 // P3: mesh message deliveries
@@ -643,28 +645,29 @@ impl PeerScore {
             _ => {} // the rest are handled after record creation
         }
 
-        let peers: Vec<_> = {
-            let record = self.deliveries.entry(msg_id.clone()).or_default();
+        let peers: Vec<_> =
+            {
+                let record = self.deliveries.entry(msg_id.clone()).or_default();
 
-            // Multiple peers can now reject the same message as we track which peers send us the
-            // message. If we have already updated the status, return.
-            if record.status != DeliveryStatus::Unknown {
-                return;
-            }
+                // Multiple peers can now reject the same message as we track which peers send us the
+                // message. If we have already updated the status, return.
+                if record.status != DeliveryStatus::Unknown {
+                    return;
+                }
 
-            if let RejectReason::ValidationIgnored = reason {
-                // we were explicitly instructed by the validator to ignore the message but not penalize
-                // the peer
-                record.status = DeliveryStatus::Ignored;
-                record.peers.clear();
-                return;
-            }
+                if let RejectReason::ValidationIgnored = reason {
+                    // we were explicitly instructed by the validator to ignore the message but not penalize
+                    // the peer
+                    record.status = DeliveryStatus::Ignored;
+                    record.peers.clear();
+                    return;
+                }
 
-            // mark the message as invalid and penalize peers that have already forwarded it.
-            record.status = DeliveryStatus::Invalid;
-            // release the delivery time tracking map to free some memory early
-            record.peers.drain().collect()
-        };
+                // mark the message as invalid and penalize peers that have already forwarded it.
+                record.status = DeliveryStatus::Invalid;
+                // release the delivery time tracking map to free some memory early
+                record.peers.drain().collect()
+            };
 
         self.mark_invalid_message_delivery(from, topic_hash);
         for peer_id in peers.iter() {
@@ -806,12 +809,14 @@ impl PeerScore {
                     .get(topic_hash)
                     .expect("Topic must exist if there are known topic_stats")
                     .first_message_deliveries_cap;
-                topic_stats.first_message_deliveries =
-                    if topic_stats.first_message_deliveries + 1f64 > cap {
-                        cap
-                    } else {
-                        topic_stats.first_message_deliveries + 1f64
-                    };
+                topic_stats.first_message_deliveries = if topic_stats.first_message_deliveries
+                    + 1f64
+                    > cap
+                {
+                    cap
+                } else {
+                    topic_stats.first_message_deliveries + 1f64
+                };
 
                 if let MeshStatus::Active { .. } = topic_stats.mesh_status {
                     let cap = self
@@ -821,12 +826,14 @@ impl PeerScore {
                         .expect("Topic must exist if there are known topic_stats")
                         .mesh_message_deliveries_cap;
 
-                    topic_stats.mesh_message_deliveries =
-                        if topic_stats.mesh_message_deliveries + 1f64 > cap {
-                            cap
-                        } else {
-                            topic_stats.mesh_message_deliveries + 1f64
-                        };
+                    topic_stats.mesh_message_deliveries = if topic_stats.mesh_message_deliveries
+                        + 1f64
+                        > cap
+                    {
+                        cap
+                    } else {
+                        topic_stats.mesh_message_deliveries + 1f64
+                    };
                 }
             }
         }
@@ -841,11 +848,12 @@ impl PeerScore {
         validated_time: Option<Instant>,
     ) {
         if let Some(peer_stats) = self.peer_stats.get_mut(peer_id) {
-            let now = if validated_time.is_some() {
-                Some(Instant::now())
-            } else {
-                None
-            };
+            let now =
+                if validated_time.is_some() {
+                    Some(Instant::now())
+                } else {
+                    None
+                };
             if let Some(topic_stats) =
                 peer_stats.stats_or_default_mut(topic_hash.clone(), &self.params)
             {
@@ -874,12 +882,14 @@ impl PeerScore {
 
                     if falls_in_mesh_deliver_window {
                         let cap = topic_params.mesh_message_deliveries_cap;
-                        topic_stats.mesh_message_deliveries =
-                            if topic_stats.mesh_message_deliveries + 1f64 > cap {
-                                cap
-                            } else {
-                                topic_stats.mesh_message_deliveries + 1f64
-                            };
+                        topic_stats.mesh_message_deliveries = if topic_stats.mesh_message_deliveries
+                            + 1f64
+                            > cap
+                        {
+                            cap
+                        } else {
+                            topic_stats.mesh_message_deliveries + 1f64
+                        };
                     }
                 }
             }

--- a/protocols/gossipsub/src/peer_score/tests.rs
+++ b/protocols/gossipsub/src/peer_score/tests.rs
@@ -870,11 +870,12 @@ fn test_score_behaviour_penality() {
 
     let topic = Topic::new("test");
     let topic_hash = topic.hash();
-    let mut params = PeerScoreParams {
-        behaviour_penalty_decay,
-        behaviour_penalty_weight,
-        ..Default::default()
-    };
+    let mut params =
+        PeerScoreParams {
+            behaviour_penalty_decay,
+            behaviour_penalty_weight,
+            ..Default::default()
+        };
 
     let topic_params = TopicScoreParams {
         topic_weight: 1.0,

--- a/protocols/gossipsub/src/subscription_filter.rs
+++ b/protocols/gossipsub/src/subscription_filter.rs
@@ -259,16 +259,17 @@ mod test {
         let mut filter = WhitelistSubscriptionFilter(HashSet::from_iter(vec![t1.clone()]));
 
         let old = Default::default();
-        let subscriptions = vec![
-            Subscription {
-                action: Subscribe,
-                topic_hash: t1,
-            },
-            Subscription {
-                action: Subscribe,
-                topic_hash: t2,
-            },
-        ];
+        let subscriptions =
+            vec![
+                Subscription {
+                    action: Subscribe,
+                    topic_hash: t1,
+                },
+                Subscription {
+                    action: Subscribe,
+                    topic_hash: t2,
+                },
+            ];
 
         let result = filter
             .filter_incoming_subscriptions(&subscriptions, &old)
@@ -387,16 +388,17 @@ mod test {
         let mut filter = CallbackSubscriptionFilter(|h| h.as_str() == "t1");
 
         let old = Default::default();
-        let subscriptions = vec![
-            Subscription {
-                action: Subscribe,
-                topic_hash: t1,
-            },
-            Subscription {
-                action: Subscribe,
-                topic_hash: t2,
-            },
-        ];
+        let subscriptions =
+            vec![
+                Subscription {
+                    action: Subscribe,
+                    topic_hash: t1,
+                },
+                Subscription {
+                    action: Subscribe,
+                    topic_hash: t2,
+                },
+            ];
 
         let result = filter
             .filter_incoming_subscriptions(&subscriptions, &old)

--- a/protocols/gossipsub/src/topic.rs
+++ b/protocols/gossipsub/src/topic.rs
@@ -49,11 +49,12 @@ impl Hasher for Sha256Hash {
     fn hash(topic_string: String) -> TopicHash {
         use quick_protobuf::MessageWrite;
 
-        let topic_descripter = proto::TopicDescriptor {
-            name: Some(topic_string),
-            auth: None,
-            enc: None,
-        };
+        let topic_descripter =
+            proto::TopicDescriptor {
+                name: Some(topic_string),
+                auth: None,
+                enc: None,
+            };
         let mut bytes = Vec::with_capacity(topic_descripter.get_size());
         let mut writer = Writer::new(&mut bytes);
         topic_descripter

--- a/protocols/identify/src/behaviour.rs
+++ b/protocols/identify/src/behaviour.rs
@@ -359,11 +359,12 @@ impl NetworkBehaviour for Behaviour {
 
         if listen_addr_changed && self.config.push_listen_addr_updates {
             // trigger an identify push for all connected peers
-            let push_events = self.connected.keys().map(|peer| ToSwarm::NotifyHandler {
-                peer_id: *peer,
-                handler: NotifyHandler::Any,
-                event: InEvent::Push,
-            });
+            let push_events =
+                self.connected.keys().map(|peer| ToSwarm::NotifyHandler {
+                    peer_id: *peer,
+                    handler: NotifyHandler::Any,
+                    event: InEvent::Push,
+                });
 
             self.events.extend(push_events);
         }

--- a/protocols/identify/src/handler.rs
+++ b/protocols/identify/src/handler.rs
@@ -52,13 +52,14 @@ const MAX_CONCURRENT_STREAMS_PER_CONNECTION: usize = 10;
 pub struct Handler {
     remote_peer_id: PeerId,
     /// Pending events to yield.
-    events: SmallVec<
-        [ConnectionHandlerEvent<
-            Either<ReadyUpgrade<StreamProtocol>, ReadyUpgrade<StreamProtocol>>,
-            (),
-            Event,
-        >; 4],
-    >,
+    events:
+        SmallVec<
+            [ConnectionHandlerEvent<
+                Either<ReadyUpgrade<StreamProtocol>, ReadyUpgrade<StreamProtocol>>,
+                (),
+                Event,
+            >; 4],
+        >,
 
     active_streams: futures_bounded::FuturesSet<Result<Success, UpgradeError>>,
 
@@ -339,28 +340,26 @@ impl ConnectionHandler for Handler {
             Poll::Ready(Ok(Ok(Success::ReceivedIdentify(remote_info)))) => {
                 self.handle_incoming_info(&remote_info);
 
-                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(Event::Identified(
-                    remote_info,
-                )));
+                return Poll::Ready(
+                    ConnectionHandlerEvent::NotifyBehaviour(Event::Identified(remote_info))
+                );
             }
             Poll::Ready(Ok(Ok(Success::SentIdentifyPush(info)))) => {
-                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
-                    Event::IdentificationPushed(info),
-                ));
+                return Poll::Ready(
+                    ConnectionHandlerEvent::NotifyBehaviour(Event::IdentificationPushed(info))
+                );
             }
             Poll::Ready(Ok(Ok(Success::SentIdentify))) => {
-                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
-                    Event::Identification,
-                ));
+                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(Event::Identification));
             }
             Poll::Ready(Ok(Ok(Success::ReceivedIdentifyPush(remote_push_info)))) => {
                 if let Some(mut info) = self.remote_info.clone() {
                     info.merge(remote_push_info);
                     self.handle_incoming_info(&info);
 
-                    return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
-                        Event::Identified(info),
-                    ));
+                    return Poll::Ready(
+                        ConnectionHandlerEvent::NotifyBehaviour(Event::Identified(info))
+                    );
                 };
             }
             Poll::Ready(Ok(Err(e))) => {

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -150,13 +150,14 @@ where
     // remote's ACK, but it could be that the remote already dropped the stream
     // after finishing their write.
 
-    let info = FramedRead::new(
-        socket,
-        quick_protobuf_codec::Codec::<proto::Identify>::new(MAX_MESSAGE_SIZE_BYTES),
-    )
-    .next()
-    .await
-    .ok_or(UpgradeError::StreamClosed)??;
+    let info =
+        FramedRead::new(
+            socket,
+            quick_protobuf_codec::Codec::<proto::Identify>::new(MAX_MESSAGE_SIZE_BYTES),
+        )
+        .next()
+        .await
+        .ok_or(UpgradeError::StreamClosed)??;
 
     Ok(info)
 }
@@ -273,11 +274,12 @@ mod tests {
         let valid_multiaddr: Multiaddr = "/ip6/2001:db8::/tcp/1234".parse().unwrap();
         let valid_multiaddr_bytes = valid_multiaddr.to_vec();
 
-        let invalid_multiaddr = {
-            let a = vec![255; 8];
-            assert!(Multiaddr::try_from(a.clone()).is_err());
-            a
-        };
+        let invalid_multiaddr =
+            {
+                let a = vec![255; 8];
+                assert!(Multiaddr::try_from(a.clone()).is_err());
+                a
+            };
 
         let payload = proto::Identify {
             agentVersion: None,

--- a/protocols/identify/tests/smoke.rs
+++ b/protocols/identify/tests/smoke.rs
@@ -109,10 +109,11 @@ async fn only_emits_address_candidate_once_per_connection() {
 
     async_std::task::spawn(swarm2.loop_on_next());
 
-    let swarm_events = futures::stream::poll_fn(|cx| swarm1.poll_next_unpin(cx))
-        .take(5)
-        .collect::<Vec<_>>()
-        .await;
+    let swarm_events =
+        futures::stream::poll_fn(|cx| swarm1.poll_next_unpin(cx))
+            .take(5)
+            .collect::<Vec<_>>()
+            .await;
 
     let infos = swarm_events
         .iter()

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -58,11 +58,12 @@ fn build_node() -> (Multiaddr, TestSwarm) {
 fn build_node_with_config(cfg: Config) -> (Multiaddr, TestSwarm) {
     let local_key = identity::Keypair::generate_ed25519();
     let local_public_key = local_key.public();
-    let transport = MemoryTransport::default()
-        .upgrade(upgrade::Version::V1)
-        .authenticate(noise::Config::new(&local_key).unwrap())
-        .multiplex(yamux::Config::default())
-        .boxed();
+    let transport =
+        MemoryTransport::default()
+            .upgrade(upgrade::Version::V1)
+            .authenticate(noise::Config::new(&local_key).unwrap())
+            .multiplex(yamux::Config::default())
+            .boxed();
 
     let local_id = local_public_key.to_peer_id();
     let store = MemoryStore::new(local_id);
@@ -1243,15 +1244,16 @@ fn manual_bucket_inserts() {
     // 1 -> 2 -> [3 -> ...]
     let mut swarms = build_connected_nodes_with_config(3, 1, cfg);
     // The peers and their addresses for which we expect `RoutablePeer` events.
-    let mut expected = swarms
-        .iter()
-        .skip(2)
-        .map(|(a, s)| {
-            let pid = *Swarm::local_peer_id(s);
-            let addr = a.clone().with(Protocol::P2p(pid));
-            (addr, pid)
-        })
-        .collect::<HashMap<_, _>>();
+    let mut expected =
+        swarms
+            .iter()
+            .skip(2)
+            .map(|(a, s)| {
+                let pid = *Swarm::local_peer_id(s);
+                let addr = a.clone().with(Protocol::P2p(pid));
+                (addr, pid)
+            })
+            .collect::<HashMap<_, _>>();
     // We collect the peers for which a `RoutablePeer` event
     // was received in here to check at the end of the test
     // that none of them was inserted into a bucket.
@@ -1265,10 +1267,9 @@ fn manual_bucket_inserts() {
         for (_, swarm) in swarms.iter_mut() {
             loop {
                 match swarm.poll_next_unpin(ctx) {
-                    Poll::Ready(Some(SwarmEvent::Behaviour(Event::RoutablePeer {
-                        peer,
-                        address,
-                    }))) => {
+                    Poll::Ready(
+                        Some(SwarmEvent::Behaviour(Event::RoutablePeer { peer, address }))
+                    ) => {
                         assert_eq!(peer, expected.remove(&address).expect("Missing address"));
                         routable.push(peer);
                         if expected.is_empty() {
@@ -1405,10 +1406,9 @@ fn get_providers_single() {
                         ..
                     }) if id == query_id => {
                         if index.last {
-                            assert!(matches!(
-                                ok,
-                                GetProvidersOk::FinishedWithNoAdditionalRecord { .. }
-                            ));
+                            assert!(
+                                matches!(ok, GetProvidersOk::FinishedWithNoAdditionalRecord { .. })
+                            );
                             break;
                         } else {
                             assert!(matches!(ok, GetProvidersOk::FoundProviders { .. }));

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -916,9 +916,9 @@ impl futures::Stream for OutboundSubstreamState {
                             *this = OutboundSubstreamState::Closing(substream);
                             let event = process_kad_response(msg, query_id);
 
-                            return Poll::Ready(Some(ConnectionHandlerEvent::NotifyBehaviour(
-                                event,
-                            )));
+                            return Poll::Ready(
+                                Some(ConnectionHandlerEvent::NotifyBehaviour(event))
+                            );
                         }
                         Poll::Pending => {
                             *this = OutboundSubstreamState::WaitingAnswer(substream, query_id);
@@ -931,9 +931,9 @@ impl futures::Stream for OutboundSubstreamState {
                                 query_id,
                             };
 
-                            return Poll::Ready(Some(ConnectionHandlerEvent::NotifyBehaviour(
-                                event,
-                            )));
+                            return Poll::Ready(
+                                Some(ConnectionHandlerEvent::NotifyBehaviour(event))
+                            );
                         }
                         Poll::Ready(None) => {
                             *this = OutboundSubstreamState::Done;
@@ -942,9 +942,9 @@ impl futures::Stream for OutboundSubstreamState {
                                 query_id,
                             };
 
-                            return Poll::Ready(Some(ConnectionHandlerEvent::NotifyBehaviour(
-                                event,
-                            )));
+                            return Poll::Ready(
+                                Some(ConnectionHandlerEvent::NotifyBehaviour(event))
+                            );
                         }
                     }
                 }
@@ -1140,11 +1140,13 @@ fn process_kad_response(event: KadResponseMsg, query_id: QueryId) -> HandlerEven
         KadResponseMsg::GetProviders {
             closer_peers,
             provider_peers,
-        } => HandlerEvent::GetProvidersRes {
-            closer_peers,
-            provider_peers,
-            query_id,
-        },
+        } => {
+            HandlerEvent::GetProvidersRes {
+                closer_peers,
+                provider_peers,
+                query_id,
+            }
+        }
         KadResponseMsg::GetValue {
             record,
             closer_peers,

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -371,12 +371,14 @@ fn req_msg_to_proto(kad_msg: KadRequestMsg) -> proto::Message {
             providerPeers: vec![provider.into()],
             ..proto::Message::default()
         },
-        KadRequestMsg::GetValue { key } => proto::Message {
-            type_pb: proto::MessageType::GET_VALUE,
-            clusterLevelRaw: 10,
-            key: key.to_vec(),
-            ..proto::Message::default()
-        },
+        KadRequestMsg::GetValue { key } => {
+            proto::Message {
+                type_pb: proto::MessageType::GET_VALUE,
+                clusterLevelRaw: 10,
+                key: key.to_vec(),
+                ..proto::Message::default()
+            }
+        }
         KadRequestMsg::PutValue { record } => proto::Message {
             type_pb: proto::MessageType::PUT_VALUE,
             key: record.key.to_vec(),
@@ -552,11 +554,12 @@ fn record_from_proto(record: proto::Record) -> Result<Record, io::Error> {
         None
     };
 
-    let expires = if record.ttl > 0 {
-        Some(Instant::now() + Duration::from_secs(record.ttl as u64))
-    } else {
-        None
-    };
+    let expires =
+        if record.ttl > 0 {
+            Some(Instant::now() + Duration::from_secs(record.ttl as u64))
+        } else {
+            None
+        };
 
     Ok(Record {
         key,
@@ -627,11 +630,12 @@ mod tests {
             multiaddr.with_p2p(other_peer_id).unwrap()
         };
 
-        let invalid_multiaddr = {
-            let a = vec![255; 8];
-            assert!(Multiaddr::try_from(a.clone()).is_err());
-            a
-        };
+        let invalid_multiaddr =
+            {
+                let a = vec![255; 8];
+                assert!(Multiaddr::try_from(a.clone()).is_err());
+                a
+            };
 
         let payload = proto::Peer {
             id: peer_id.to_bytes(),

--- a/protocols/kad/src/query.rs
+++ b/protocols/kad/src/query.rs
@@ -134,16 +134,15 @@ impl<TInner> QueryPool<TInner> {
         T: Into<KeyBytes> + Clone,
         I: IntoIterator<Item = Key<PeerId>>,
     {
-        let cfg = ClosestPeersIterConfig {
-            num_results: self.config.replication_factor,
-            parallelism: self.config.parallelism,
-            ..ClosestPeersIterConfig::default()
-        };
+        let cfg =
+            ClosestPeersIterConfig {
+                num_results: self.config.replication_factor,
+                parallelism: self.config.parallelism,
+                ..ClosestPeersIterConfig::default()
+            };
 
         let peer_iter = if self.config.disjoint_query_paths {
-            QueryPeerIter::ClosestDisjoint(ClosestDisjointPeersIter::with_config(
-                cfg, target, peers,
-            ))
+            QueryPeerIter::ClosestDisjoint(ClosestDisjointPeersIter::with_config(cfg, target, peers))
         } else {
             QueryPeerIter::Closest(ClosestPeersIter::with_config(cfg, target, peers))
         };

--- a/protocols/kad/src/query/peers/closest.rs
+++ b/protocols/kad/src/query/peers/closest.rs
@@ -718,14 +718,14 @@ mod tests {
     fn timeout() {
         fn prop(mut iter: ClosestPeersIter) -> bool {
             let mut now = Instant::now();
-            let peer = iter
-                .closest_peers
-                .values()
-                .next()
-                .unwrap()
-                .key
-                .clone()
-                .into_preimage();
+            let peer =
+                iter.closest_peers
+                    .values()
+                    .next()
+                    .unwrap()
+                    .key
+                    .clone()
+                    .into_preimage();
 
             // Poll the iterator for the first peer to be in progress.
             match iter.next(now) {

--- a/protocols/kad/src/query/peers/closest/disjoint.rs
+++ b/protocols/kad/src/query/peers/closest/disjoint.rs
@@ -249,9 +249,9 @@ impl ClosestDisjointPeersIter {
                                 // The iterator is the first to contact this peer.
                                 self.contacted_peers
                                     .insert(peer.clone().into_owned(), PeerState::new(i));
-                                return PeersIterState::Waiting(Some(Cow::Owned(
-                                    peer.into_owned(),
-                                )));
+                                return PeersIterState::Waiting(
+                                    Some(Cow::Owned(peer.into_owned())),
+                                );
                             }
                         }
                     }

--- a/protocols/kad/src/query/peers/fixed.rs
+++ b/protocols/kad/src/query/peers/fixed.rs
@@ -174,10 +174,11 @@ mod test {
 
     #[test]
     fn decrease_num_waiting_on_failure() {
-        let mut iter = FixedPeersIter::new(
-            vec![PeerId::random(), PeerId::random()],
-            NonZeroUsize::new(1).unwrap(),
-        );
+        let mut iter =
+            FixedPeersIter::new(
+                vec![PeerId::random(), PeerId::random()],
+                NonZeroUsize::new(1).unwrap(),
+            );
 
         match iter.next() {
             PeersIterState::Waiting(Some(peer)) => {

--- a/protocols/perf/src/bin/perf.rs
+++ b/protocols/perf/src/bin/perf.rs
@@ -230,13 +230,14 @@ async fn connect(
     let start = Instant::now();
     swarm.dial(server_address.clone()).unwrap();
 
-    let server_peer_id = match swarm.next().await.unwrap() {
-        SwarmEvent::ConnectionEstablished { peer_id, .. } => peer_id,
-        SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
-            bail!("Outgoing connection error to {:?}: {:?}", peer_id, error);
-        }
-        e => panic!("{e:?}"),
-    };
+    let server_peer_id =
+        match swarm.next().await.unwrap() {
+            SwarmEvent::ConnectionEstablished { peer_id, .. } => peer_id,
+            SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
+                bail!("Outgoing connection error to {:?}: {:?}", peer_id, error);
+            }
+            e => panic!("{e:?}"),
+        };
 
     let duration = start.elapsed();
     let duration_seconds = duration.as_secs_f64();

--- a/protocols/perf/src/client/handler.rs
+++ b/protocols/perf/src/client/handler.rs
@@ -115,10 +115,9 @@ impl ConnectionHandler for Handler {
             ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
                 protocol, ..
             }) => void::unreachable(protocol),
-            ConnectionEvent::FullyNegotiatedOutbound(FullyNegotiatedOutbound {
-                protocol,
-                info: (),
-            }) => {
+            ConnectionEvent::FullyNegotiatedOutbound(
+                FullyNegotiatedOutbound { protocol, info: () }
+            ) => {
                 let Command { id, params } = self
                     .requested_streams
                     .pop_front()

--- a/protocols/perf/src/protocol.rs
+++ b/protocols/perf/src/protocol.rs
@@ -156,12 +156,13 @@ async fn send_receive_inner<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
 pub(crate) async fn receive_send<S: AsyncRead + AsyncWrite + Unpin>(
     mut stream: S,
 ) -> Result<Run, std::io::Error> {
-    let to_send = {
-        let mut buf = [0; 8];
-        stream.read_exact(&mut buf).await?;
+    let to_send =
+        {
+            let mut buf = [0; 8];
+            stream.read_exact(&mut buf).await?;
 
-        u64::from_be_bytes(buf) as usize
-    };
+            u64::from_be_bytes(buf) as usize
+        };
 
     let read_start = Instant::now();
 

--- a/protocols/perf/src/server/handler.rs
+++ b/protocols/perf/src/server/handler.rs
@@ -86,10 +86,9 @@ impl ConnectionHandler for Handler {
         >,
     ) {
         match event {
-            ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
-                protocol,
-                info: _,
-            }) => {
+            ConnectionEvent::FullyNegotiatedInbound(
+                FullyNegotiatedInbound { protocol, info: _ }
+            ) => {
                 if self
                     .inbound
                     .try_push(crate::protocol::receive_send(protocol).boxed())

--- a/protocols/ping/src/handler.rs
+++ b/protocols/ping/src/handler.rs
@@ -232,9 +232,9 @@ impl ConnectionHandler for Handler {
             }
             State::Inactive { reported: false } => {
                 self.state = State::Inactive { reported: true };
-                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(Err(
-                    Failure::Unsupported,
-                )));
+                return Poll::Ready(
+                    ConnectionHandlerEvent::NotifyBehaviour(Err(Failure::Unsupported))
+                );
             }
             State::Active => {}
         }
@@ -298,9 +298,9 @@ impl ConnectionHandler for Handler {
                         break;
                     }
                     Poll::Ready(()) => {
-                        self.outbound = Some(OutboundState::Ping(
-                            send_ping(stream, self.config.timeout).boxed(),
-                        ));
+                        self.outbound = Some(
+                            OutboundState::Ping(send_ping(stream, self.config.timeout).boxed())
+                        );
                     }
                 },
                 Some(OutboundState::OpenStream) => {
@@ -312,9 +312,9 @@ impl ConnectionHandler for Handler {
                     Poll::Ready(()) => {
                         self.outbound = Some(OutboundState::OpenStream);
                         let protocol = SubstreamProtocol::new(ReadyUpgrade::new(PROTOCOL_NAME), ());
-                        return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
-                            protocol,
-                        });
+                        return Poll::Ready(
+                            ConnectionHandlerEvent::OutboundSubstreamRequest { protocol }
+                        );
                     }
                 },
             }
@@ -345,9 +345,8 @@ impl ConnectionHandler for Handler {
                 ..
             }) => {
                 stream.ignore_for_keep_alive();
-                self.outbound = Some(OutboundState::Ping(
-                    send_ping(stream, self.config.timeout).boxed(),
-                ));
+                self.outbound =
+                    Some(OutboundState::Ping(send_ping(stream, self.config.timeout).boxed()));
             }
             ConnectionEvent::DialUpgradeError(dial_upgrade_error) => {
                 self.on_dial_upgrade_error(dial_upgrade_error)

--- a/protocols/ping/src/protocol.rs
+++ b/protocols/ping/src/protocol.rs
@@ -62,10 +62,7 @@ where
     if recv_payload == payload {
         Ok((stream, started.elapsed()))
     } else {
-        Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "Ping payload mismatch",
-        ))
+        Err(io::Error::new(io::ErrorKind::InvalidData, "Ping payload mismatch"))
     }
 }
 

--- a/protocols/relay/src/behaviour.rs
+++ b/protocols/relay/src/behaviour.rs
@@ -62,34 +62,30 @@ pub struct Config {
 
 impl Config {
     pub fn reservation_rate_per_peer(mut self, limit: NonZeroU32, interval: Duration) -> Self {
-        self.reservation_rate_limiters
-            .push(rate_limiter::new_per_peer(
-                rate_limiter::GenericRateLimiterConfig { limit, interval },
-            ));
+        self.reservation_rate_limiters.push(
+            rate_limiter::new_per_peer(rate_limiter::GenericRateLimiterConfig { limit, interval })
+        );
         self
     }
 
     pub fn circuit_src_per_peer(mut self, limit: NonZeroU32, interval: Duration) -> Self {
-        self.circuit_src_rate_limiters
-            .push(rate_limiter::new_per_peer(
-                rate_limiter::GenericRateLimiterConfig { limit, interval },
-            ));
+        self.circuit_src_rate_limiters.push(
+            rate_limiter::new_per_peer(rate_limiter::GenericRateLimiterConfig { limit, interval })
+        );
         self
     }
 
     pub fn reservation_rate_per_ip(mut self, limit: NonZeroU32, interval: Duration) -> Self {
-        self.reservation_rate_limiters
-            .push(rate_limiter::new_per_ip(
-                rate_limiter::GenericRateLimiterConfig { limit, interval },
-            ));
+        self.reservation_rate_limiters.push(
+            rate_limiter::new_per_ip(rate_limiter::GenericRateLimiterConfig { limit, interval })
+        );
         self
     }
 
     pub fn circuit_src_per_ip(mut self, limit: NonZeroU32, interval: Duration) -> Self {
-        self.circuit_src_rate_limiters
-            .push(rate_limiter::new_per_ip(
-                rate_limiter::GenericRateLimiterConfig { limit, interval },
-            ));
+        self.circuit_src_rate_limiters.push(
+            rate_limiter::new_per_ip(rate_limiter::GenericRateLimiterConfig { limit, interval })
+        );
         self
     }
 }

--- a/protocols/relay/src/behaviour/handler.rs
+++ b/protocols/relay/src/behaviour/handler.rs
@@ -804,9 +804,9 @@ impl ConnectionHandler for Handler {
             .map(|fut| fut.poll_unpin(cx))
         {
             self.active_reservation = None;
-            return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
-                Event::ReservationTimedOut {},
-            ));
+            return Poll::Ready(
+                ConnectionHandlerEvent::NotifyBehaviour(Event::ReservationTimedOut {})
+            );
         }
 
         // Progress reservation request.

--- a/protocols/relay/src/behaviour/rate_limiter.rs
+++ b/protocols/relay/src/behaviour/rate_limiter.rs
@@ -103,13 +103,15 @@ impl<Id: Eq + PartialEq + Hash + Clone> GenericRateLimiter<Id> {
 
         match self.buckets.get_mut(&id) {
             // If the bucket exists, try to take a token.
-            Some(balance) => match balance.checked_sub(1) {
-                Some(a) => {
-                    *balance = a;
-                    true
+            Some(balance) => {
+                match balance.checked_sub(1) {
+                    Some(a) => {
+                        *balance = a;
+                        true
+                    }
+                    None => false,
                 }
-                None => false,
-            },
+            }
             // If the bucket is missing, act like the bucket has `limit` number of tokens. Take one
             // token and track the new bucket balance.
             None => {

--- a/protocols/relay/src/behaviour/rate_limiter.rs
+++ b/protocols/relay/src/behaviour/rate_limiter.rs
@@ -126,7 +126,7 @@ impl<Id: Eq + PartialEq + Hash + Clone> GenericRateLimiter<Id> {
         // Note when used with a high number of buckets: This loop refills all the to-be-refilled
         // buckets at once, thus potentially delaying the parent call to `try_next`.
         loop {
-            match self.refill_schedule.get(0) {
+            match self.refill_schedule.front() {
                 // Only continue if (a) there is a bucket and (b) the bucket has not already been
                 // refilled recently.
                 Some((last_refill, _)) if now.duration_since(*last_refill) >= self.interval => {}

--- a/protocols/relay/src/copy_future.rs
+++ b/protocols/relay/src/copy_future.rs
@@ -74,10 +74,9 @@ where
 
         loop {
             if this.bytes_sent > this.max_circuit_bytes {
-                return Poll::Ready(Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Max circuit bytes reached.",
-                )));
+                return Poll::Ready(Err(
+                    io::Error::new(io::ErrorKind::Other, "Max circuit bytes reached.")
+                ));
             }
 
             enum Status {

--- a/protocols/relay/src/priv_client/handler.rs
+++ b/protocols/relay/src/priv_client/handler.rs
@@ -96,13 +96,14 @@ pub struct Handler {
     remote_addr: Multiaddr,
 
     /// Queue of events to return when polled.
-    queued_events: VecDeque<
-        ConnectionHandlerEvent<
-            <Handler as ConnectionHandler>::OutboundProtocol,
-            <Handler as ConnectionHandler>::OutboundOpenInfo,
-            <Handler as ConnectionHandler>::ToBehaviour,
+    queued_events:
+        VecDeque<
+            ConnectionHandlerEvent<
+                <Handler as ConnectionHandler>::OutboundProtocol,
+                <Handler as ConnectionHandler>::OutboundOpenInfo,
+                <Handler as ConnectionHandler>::ToBehaviour,
+            >,
         >,
-    >,
 
     /// We issue a stream upgrade for each pending request.
     pending_requests: VecDeque<PendingRequest>,
@@ -301,11 +302,9 @@ impl ConnectionHandler for Handler {
                     continue;
                 }
                 Poll::Ready((Err(futures_bounded::Timeout { .. }), mut to_listener)) => {
-                    if let Err(e) =
-                        to_listener.try_send(transport::ToListenerMsg::Reservation(Err(
-                            outbound_hop::ReserveError::Io(io::ErrorKind::TimedOut.into()),
-                        )))
-                    {
+                    if let Err(e) = to_listener.try_send(transport::ToListenerMsg::Reservation(
+                        Err(outbound_hop::ReserveError::Io(io::ErrorKind::TimedOut.into())),
+                    )) {
                         tracing::debug!("Unable to send error to listener: {}", e.into_send_error())
                     }
                     self.reservation.failed();
@@ -346,9 +345,7 @@ impl ConnectionHandler for Handler {
                 }
                 Poll::Ready((Err(futures_bounded::Timeout { .. }), to_dialer)) => {
                     if to_dialer
-                        .send(Err(outbound_hop::ConnectError::Io(
-                            io::ErrorKind::TimedOut.into(),
-                        )))
+                        .send(Err(outbound_hop::ConnectError::Io(io::ErrorKind::TimedOut.into())))
                         .is_err()
                     {
                         tracing::debug!("Unable to send error to dialer")
@@ -535,11 +532,12 @@ impl Reservation {
             },
         )));
 
-        *self = Reservation::Accepted {
-            renewal_timeout,
-            pending_msgs,
-            to_listener,
-        };
+        *self =
+            Reservation::Accepted {
+                renewal_timeout,
+                pending_msgs,
+                to_listener,
+            };
 
         Event::ReservationReqAccepted { renewal, limit }
     }

--- a/protocols/relay/src/protocol/outbound_hop.rs
+++ b/protocols/relay/src/protocol/outbound_hop.rs
@@ -139,14 +139,10 @@ pub(crate) async fn make_reservation(stream: Stream) -> Result<Reservation, Rese
 
     match type_pb {
         proto::HopMessageType::CONNECT => {
-            return Err(ReserveError::Protocol(
-                ProtocolViolation::UnexpectedTypeConnect,
-            ));
+            return Err(ReserveError::Protocol(ProtocolViolation::UnexpectedTypeConnect));
         }
         proto::HopMessageType::RESERVE => {
-            return Err(ReserveError::Protocol(
-                ProtocolViolation::UnexpectedTypeReserve,
-            ));
+            return Err(ReserveError::Protocol(ProtocolViolation::UnexpectedTypeReserve));
         }
         proto::HopMessageType::STATUS => {}
     }
@@ -161,21 +157,14 @@ pub(crate) async fn make_reservation(stream: Stream) -> Result<Reservation, Rese
         proto::Status::RESOURCE_LIMIT_EXCEEDED => {
             return Err(ReserveError::ResourceLimitExceeded);
         }
-        s => {
-            return Err(ReserveError::Protocol(ProtocolViolation::UnexpectedStatus(
-                s,
-            )))
-        }
+        s => return Err(ReserveError::Protocol(ProtocolViolation::UnexpectedStatus(s))),
     }
 
-    let reservation = reservation.ok_or(ReserveError::Protocol(
-        ProtocolViolation::MissingReservationField,
-    ))?;
+    let reservation =
+        reservation.ok_or(ReserveError::Protocol(ProtocolViolation::MissingReservationField))?;
 
     if reservation.addrs.is_empty() {
-        return Err(ReserveError::Protocol(
-            ProtocolViolation::NoAddressesInReservation,
-        ));
+        return Err(ReserveError::Protocol(ProtocolViolation::NoAddressesInReservation));
     }
 
     let addrs = reservation
@@ -197,9 +186,7 @@ pub(crate) async fn make_reservation(stream: Stream) -> Result<Reservation, Rese
         .and_then(|duration| duration.checked_sub(duration / 4))
         .map(Duration::from_secs)
         .map(Delay::new)
-        .ok_or(ReserveError::Protocol(
-            ProtocolViolation::InvalidReservationExpiration,
-        ))?;
+        .ok_or(ReserveError::Protocol(ProtocolViolation::InvalidReservationExpiration))?;
 
     Ok(Reservation {
         renewal_timeout,
@@ -240,14 +227,10 @@ pub(crate) async fn open_circuit(
 
     match type_pb {
         proto::HopMessageType::CONNECT => {
-            return Err(ConnectError::Protocol(
-                ProtocolViolation::UnexpectedTypeConnect,
-            ));
+            return Err(ConnectError::Protocol(ProtocolViolation::UnexpectedTypeConnect));
         }
         proto::HopMessageType::RESERVE => {
-            return Err(ConnectError::Protocol(
-                ProtocolViolation::UnexpectedTypeReserve,
-            ));
+            return Err(ConnectError::Protocol(ProtocolViolation::UnexpectedTypeReserve));
         }
         proto::HopMessageType::STATUS => {}
     }
@@ -267,14 +250,10 @@ pub(crate) async fn open_circuit(
             return Err(ConnectError::PermissionDenied);
         }
         Some(s) => {
-            return Err(ConnectError::Protocol(ProtocolViolation::UnexpectedStatus(
-                s,
-            )));
+            return Err(ConnectError::Protocol(ProtocolViolation::UnexpectedStatus(s)));
         }
         None => {
-            return Err(ConnectError::Protocol(
-                ProtocolViolation::MissingStatusField,
-            ));
+            return Err(ConnectError::Protocol(ProtocolViolation::MissingStatusField));
         }
     }
 

--- a/protocols/relay/tests/lib.rs
+++ b/protocols/relay/tests/lib.rs
@@ -241,9 +241,9 @@ async fn connection_established_to(
             SwarmEvent::Behaviour(ClientEvent::Ping(ping::Event { peer, .. })) if peer == other => {
                 break
             }
-            SwarmEvent::Behaviour(ClientEvent::Relay(
-                relay::client::Event::OutboundCircuitEstablished { .. },
-            )) => {}
+            SwarmEvent::Behaviour(
+                ClientEvent::Relay(relay::client::Event::OutboundCircuitEstablished { .. })
+            ) => {}
             SwarmEvent::Behaviour(ClientEvent::Relay(
                 relay::client::Event::InboundCircuitEstablished { src_peer_id, .. },
             )) => {
@@ -317,14 +317,15 @@ fn propagate_reservation_error_to_listener() {
     // Wait for connection to relay.
     assert!(pool.run_until(wait_for_dial(&mut client, relay_peer_id)));
 
-    let error = pool.run_until(client.wait(|e| match e {
-        SwarmEvent::ListenerClosed {
-            listener_id,
-            reason: Err(e),
-            ..
-        } if listener_id == reservation_listener => Some(e),
-        _ => None,
-    }));
+    let error =
+        pool.run_until(client.wait(|e| match e {
+            SwarmEvent::ListenerClosed {
+                listener_id,
+                reason: Err(e),
+                ..
+            } if listener_id == reservation_listener => Some(e),
+            _ => None,
+        }));
 
     let error = error
         .source()
@@ -366,17 +367,18 @@ fn propagate_connect_error_to_unknown_peer_to_dialer() {
 
     src.dial(opts).unwrap();
 
-    let (failed_address, error) = pool.run_until(src.wait(|e| match e {
-        SwarmEvent::OutgoingConnectionError {
-            connection_id,
-            error: DialError::Transport(mut errors),
-            ..
-        } if connection_id == circuit_connection_id => {
-            assert_eq!(errors.len(), 1);
-            Some(errors.remove(0))
-        }
-        _ => None,
-    }));
+    let (failed_address, error) =
+        pool.run_until(src.wait(|e| match e {
+            SwarmEvent::OutgoingConnectionError {
+                connection_id,
+                error: DialError::Transport(mut errors),
+                ..
+            } if connection_id == circuit_connection_id => {
+                assert_eq!(errors.len(), 1);
+                Some(errors.remove(0))
+            }
+            _ => None,
+        }));
 
     // This is a bit wonky but we need to get the _actual_ source error :)
     let error = error
@@ -388,10 +390,7 @@ fn propagate_connect_error_to_unknown_peer_to_dialer() {
         .unwrap();
 
     assert_eq!(failed_address, dst_addr);
-    assert!(matches!(
-        error,
-        relay::outbound::hop::ConnectError::NoReservation
-    ));
+    assert!(matches!(error, relay::outbound::hop::ConnectError::NoReservation));
 }
 
 #[test]
@@ -466,10 +465,11 @@ fn build_client_with_config(config: Config) -> Swarm<Client> {
     let local_peer_id = local_key.public().to_peer_id();
 
     let (relay_transport, behaviour) = relay::client::new(local_peer_id);
-    let transport = upgrade_transport(
-        OrTransport::new(relay_transport, MemoryTransport::default()).boxed(),
-        &local_key,
-    );
+    let transport =
+        upgrade_transport(
+            OrTransport::new(relay_transport, MemoryTransport::default()).boxed(),
+            &local_key,
+        );
 
     Swarm::new(
         transport,

--- a/protocols/rendezvous/src/codec.rs
+++ b/protocols/rendezvous/src/codec.rs
@@ -144,14 +144,15 @@ impl Cookie {
         }
 
         let namespace = bytes.split_off(8);
-        let namespace = if namespace.is_empty() {
-            None
-        } else {
-            Some(
-                Namespace::new(String::from_utf8(namespace).map_err(|_| InvalidCookie)?)
-                    .map_err(|_| InvalidCookie)?,
-            )
-        };
+        let namespace =
+            if namespace.is_empty() {
+                None
+            } else {
+                Some(
+                    Namespace::new(String::from_utf8(namespace).map_err(|_| InvalidCookie)?)
+                        .map_err(|_| InvalidCookie)?,
+                )
+            };
 
         let bytes = <[u8; 8]>::try_from(bytes).map_err(|_| InvalidCookie)?;
         let id = u64::from_be_bytes(bytes);
@@ -450,9 +451,9 @@ impl TryFrom<proto::Message> for Message {
                     .transpose()?
                     .ok_or(ConversionError::MissingNamespace)?,
                 ttl,
-                record: PeerRecord::from_signed_envelope(SignedEnvelope::from_protobuf_encoding(
-                    &signed_peer_record,
-                )?)?,
+                record: PeerRecord::from_signed_envelope(
+                    SignedEnvelope::from_protobuf_encoding(&signed_peer_record)?
+                )?,
             }),
             proto::Message {
                 type_pb: Some(proto::MessageType::REGISTER_RESPONSE),

--- a/protocols/rendezvous/src/server.rs
+++ b/protocols/rendezvous/src/server.rs
@@ -161,9 +161,7 @@ impl NetworkBehaviour for Behaviour {
         cx: &mut Context<'_>,
     ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
         if let Poll::Ready(ExpiredRegistration(registration)) = self.registrations.poll(cx) {
-            return Poll::Ready(ToSwarm::GenerateEvent(Event::RegistrationExpired(
-                registration,
-            )));
+            return Poll::Ready(ToSwarm::GenerateEvent(Event::RegistrationExpired(registration)));
         }
 
         loop {
@@ -203,16 +201,14 @@ impl NetworkBehaviour for Behaviour {
 
                         continue;
                     }
-                    ToSwarm::GenerateEvent(libp2p_request_response::Event::ResponseSent {
-                        ..
-                    })
+                    ToSwarm::GenerateEvent(libp2p_request_response::Event::ResponseSent { .. })
                     | ToSwarm::GenerateEvent(libp2p_request_response::Event::Message {
                         peer: _,
                         message: libp2p_request_response::Message::Response { .. },
                     })
-                    | ToSwarm::GenerateEvent(libp2p_request_response::Event::OutboundFailure {
-                        ..
-                    }) => {
+                    | ToSwarm::GenerateEvent(
+                        libp2p_request_response::Event::OutboundFailure { .. }
+                    ) => {
                         continue;
                     }
                     ToSwarm::Dial { .. }
@@ -459,10 +455,11 @@ impl Registrations {
             _ => {}
         }
 
-        let mut reggos_of_last_discover = cookie
-            .and_then(|cookie| self.cookies.get(&cookie))
-            .cloned()
-            .unwrap_or_default();
+        let mut reggos_of_last_discover =
+            cookie
+                .and_then(|cookie| self.cookies.get(&cookie))
+                .cloned()
+                .unwrap_or_default();
 
         let ids = self
             .registrations_for_peer

--- a/protocols/rendezvous/tests/rendezvous.rs
+++ b/protocols/rendezvous/tests/rendezvous.rs
@@ -288,23 +288,26 @@ async fn discover_allows_for_dial_by_peer_id() {
 
     bob.dial(alices_peer_id).unwrap();
 
-    let alice_connected_to = tokio::spawn(async move {
-        loop {
-            if let SwarmEvent::ConnectionEstablished { peer_id, .. } =
-                alice.select_next_some().await
-            {
-                break peer_id;
+    let alice_connected_to =
+        tokio::spawn(async move {
+            loop {
+                if let SwarmEvent::ConnectionEstablished { peer_id, .. } =
+                    alice.select_next_some().await
+                {
+                    break peer_id;
+                }
             }
-        }
-    });
-    let bob_connected_to = tokio::spawn(async move {
-        loop {
-            if let SwarmEvent::ConnectionEstablished { peer_id, .. } = bob.select_next_some().await
-            {
-                break peer_id;
+        });
+    let bob_connected_to =
+        tokio::spawn(async move {
+            loop {
+                if let SwarmEvent::ConnectionEstablished { peer_id, .. } =
+                    bob.select_next_some().await
+                {
+                    break peer_id;
+                }
             }
-        }
-    });
+        });
 
     assert_eq!(alice_connected_to.await.unwrap(), bobs_peer_id);
     assert_eq!(bob_connected_to.await.unwrap(), alices_peer_id);

--- a/protocols/request-response/src/handler.rs
+++ b/protocols/request-response/src/handler.rs
@@ -64,17 +64,19 @@ where
 
     requested_outbound: VecDeque<OutboundMessage<TCodec>>,
     /// A channel for receiving inbound requests.
-    inbound_receiver: mpsc::Receiver<(
-        InboundRequestId,
-        TCodec::Request,
-        oneshot::Sender<TCodec::Response>,
-    )>,
+    inbound_receiver:
+        mpsc::Receiver<(
+            InboundRequestId,
+            TCodec::Request,
+            oneshot::Sender<TCodec::Response>,
+        )>,
     /// The [`mpsc::Sender`] for the above receiver. Cloned for each inbound request.
-    inbound_sender: mpsc::Sender<(
-        InboundRequestId,
-        TCodec::Request,
-        oneshot::Sender<TCodec::Response>,
-    )>,
+    inbound_sender:
+        mpsc::Sender<(
+            InboundRequestId,
+            TCodec::Request,
+            oneshot::Sender<TCodec::Response>,
+        )>,
 
     inbound_request_id: Arc<AtomicU64>,
 
@@ -411,14 +413,14 @@ where
                 ));
             }
             Poll::Ready((RequestId::Inbound(id), Err(futures_bounded::Timeout { .. }))) => {
-                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
-                    Event::InboundTimeout(id),
-                ));
+                return Poll::Ready(
+                    ConnectionHandlerEvent::NotifyBehaviour(Event::InboundTimeout(id))
+                );
             }
             Poll::Ready((RequestId::Outbound(id), Err(futures_bounded::Timeout { .. }))) => {
-                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
-                    Event::OutboundTimeout(id),
-                ));
+                return Poll::Ready(
+                    ConnectionHandlerEvent::NotifyBehaviour(Event::OutboundTimeout(id))
+                );
             }
             Poll::Pending => {}
         }

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -862,10 +862,7 @@ where
                 );
 
                 self.pending_events
-                    .push_back(ToSwarm::GenerateEvent(Event::ResponseSent {
-                        peer,
-                        request_id,
-                    }));
+                    .push_back(ToSwarm::GenerateEvent(Event::ResponseSent { peer, request_id }));
             }
             handler::Event::ResponseOmission(request_id) => {
                 let removed = self.remove_pending_inbound_response(&peer, connection, request_id);

--- a/protocols/upnp/src/behaviour.rs
+++ b/protocols/upnp/src/behaviour.rs
@@ -258,13 +258,14 @@ impl NetworkBehaviour for Behaviour {
                 listener_id,
                 addr: multiaddr,
             }) => {
-                let (addr, protocol) = match multiaddr_to_socketaddr_protocol(multiaddr.clone()) {
-                    Ok(addr_port) => addr_port,
-                    Err(()) => {
-                        tracing::debug!("multiaddress not supported for UPnP {multiaddr}");
-                        return;
-                    }
-                };
+                let (addr, protocol) =
+                    match multiaddr_to_socketaddr_protocol(multiaddr.clone()) {
+                        Ok(addr_port) => addr_port,
+                        Err(()) => {
+                            tracing::debug!("multiaddress not supported for UPnP {multiaddr}");
+                            return;
+                        }
+                    };
 
                 if let Some((mapping, _state)) = self
                     .mappings
@@ -409,9 +410,9 @@ impl NetworkBehaviour for Behaviour {
                     if let Poll::Ready(Some(result)) = gateway.receiver.poll_next_unpin(cx) {
                         match result {
                             GatewayEvent::Mapped(mapping) => {
-                                let new_state = MappingState::Active(Delay::new(
-                                    Duration::from_secs(MAPPING_TIMEOUT),
-                                ));
+                                let new_state = MappingState::Active(
+                                    Delay::new(Duration::from_secs(MAPPING_TIMEOUT))
+                                );
 
                                 match self
                                     .mappings

--- a/protocols/upnp/src/tokio.rs
+++ b/protocols/upnp/src/tokio.rs
@@ -107,15 +107,16 @@ pub(crate) fn search_gateway() -> oneshot::Receiver<Result<Gateway, Box<dyn Erro
             }
         };
 
-        let external_addr = match gateway.get_external_ip().await {
-            Ok(addr) => addr,
-            Err(err) => {
-                search_result_sender
-                    .send(Err(err.into()))
-                    .expect("receiver shouldn't have been dropped");
-                return;
-            }
-        };
+        let external_addr =
+            match gateway.get_external_ip().await {
+                Ok(addr) => addr,
+                Err(err) => {
+                    search_result_sender
+                        .send(Err(err.into()))
+                        .expect("receiver shouldn't have been dropped");
+                    return;
+                }
+            };
 
         search_result_sender
             .send(Ok(Gateway {

--- a/swarm-test/src/lib.rs
+++ b/swarm-test/src/lib.rs
@@ -398,17 +398,18 @@ where
                 .listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap())
                 .unwrap();
 
-            let tcp_multiaddr = swarm
-                .wait(|e| match e {
-                    SwarmEvent::NewListenAddr {
-                        address,
-                        listener_id,
-                    } => (listener_id == tcp_addr_listener_id).then_some(address),
-                    other => {
-                        panic!("Unexpected event while waiting for `NewListenAddr`: {other:?}")
-                    }
-                })
-                .await;
+            let tcp_multiaddr =
+                swarm
+                    .wait(|e| match e {
+                        SwarmEvent::NewListenAddr {
+                            address,
+                            listener_id,
+                        } => (listener_id == tcp_addr_listener_id).then_some(address),
+                        other => {
+                            panic!("Unexpected event while waiting for `NewListenAddr`: {other:?}")
+                        }
+                    })
+                    .await;
 
             if self.add_memory_external {
                 swarm.add_external_address(memory_multiaddr.clone());

--- a/swarm/src/behaviour.rs
+++ b/swarm/src/behaviour.rs
@@ -320,11 +320,13 @@ impl<TOutEvent, TInEventOld> ToSwarm<TOutEvent, TInEventOld> {
                 peer_id,
                 handler,
                 event,
-            } => ToSwarm::NotifyHandler {
-                peer_id,
-                handler,
-                event: f(event),
-            },
+            } => {
+                ToSwarm::NotifyHandler {
+                    peer_id,
+                    handler,
+                    event: f(event),
+                }
+            }
             ToSwarm::CloseConnection {
                 peer_id,
                 connection,

--- a/swarm/src/behaviour/either.rs
+++ b/swarm/src/behaviour/either.rs
@@ -55,18 +55,22 @@ where
         remote_addr: &Multiaddr,
     ) -> Result<THandler<Self>, ConnectionDenied> {
         let handler = match self {
-            Either::Left(inner) => Either::Left(inner.handle_established_inbound_connection(
-                connection_id,
-                peer,
-                local_addr,
-                remote_addr,
-            )?),
-            Either::Right(inner) => Either::Right(inner.handle_established_inbound_connection(
-                connection_id,
-                peer,
-                local_addr,
-                remote_addr,
-            )?),
+            Either::Left(inner) => {
+                Either::Left(inner.handle_established_inbound_connection(
+                    connection_id,
+                    peer,
+                    local_addr,
+                    remote_addr,
+                )?)
+            }
+            Either::Right(inner) => {
+                Either::Right(inner.handle_established_inbound_connection(
+                    connection_id,
+                    peer,
+                    local_addr,
+                    remote_addr,
+                )?)
+            }
         };
 
         Ok(handler)
@@ -105,18 +109,22 @@ where
         role_override: Endpoint,
     ) -> Result<THandler<Self>, ConnectionDenied> {
         let handler = match self {
-            Either::Left(inner) => Either::Left(inner.handle_established_outbound_connection(
-                connection_id,
-                peer,
-                addr,
-                role_override,
-            )?),
-            Either::Right(inner) => Either::Right(inner.handle_established_outbound_connection(
-                connection_id,
-                peer,
-                addr,
-                role_override,
-            )?),
+            Either::Left(inner) => {
+                Either::Left(inner.handle_established_outbound_connection(
+                    connection_id,
+                    peer,
+                    addr,
+                    role_override,
+                )?)
+            }
+            Either::Right(inner) => {
+                Either::Right(inner.handle_established_outbound_connection(
+                    connection_id,
+                    peer,
+                    addr,
+                    role_override,
+                )?)
+            }
         };
 
         Ok(handler)

--- a/swarm/src/connection/pool/task.rs
+++ b/swarm/src/connection/pool/task.rs
@@ -107,21 +107,23 @@ pub(crate) async fn new_for_pending_outgoing_connection(
         }
         Either::Left((Ok(v), _)) => void::unreachable(v),
         Either::Right((Ok((address, output, errors)), _)) => {
-            let _ = events
-                .send(PendingConnectionEvent::ConnectionEstablished {
-                    id: connection_id,
-                    output,
-                    outgoing: Some((address, errors)),
-                })
-                .await;
+            let _ =
+                events
+                    .send(PendingConnectionEvent::ConnectionEstablished {
+                        id: connection_id,
+                        output,
+                        outgoing: Some((address, errors)),
+                    })
+                    .await;
         }
         Either::Right((Err(e), _)) => {
-            let _ = events
-                .send(PendingConnectionEvent::PendingFailed {
-                    id: connection_id,
-                    error: Either::Left(PendingOutboundConnectionError::Transport(e)),
-                })
-                .await;
+            let _ =
+                events
+                    .send(PendingConnectionEvent::PendingFailed {
+                        id: connection_id,
+                        error: Either::Left(PendingOutboundConnectionError::Transport(e)),
+                    })
+                    .await;
         }
     }
 }
@@ -154,14 +156,15 @@ pub(crate) async fn new_for_pending_incoming_connection<TFut>(
                 .await;
         }
         Either::Right((Err(e), _)) => {
-            let _ = events
-                .send(PendingConnectionEvent::PendingFailed {
-                    id: connection_id,
-                    error: Either::Right(PendingInboundConnectionError::Transport(
-                        TransportError::Other(e),
-                    )),
-                })
-                .await;
+            let _ =
+                events
+                    .send(PendingConnectionEvent::PendingFailed {
+                        id: connection_id,
+                        error: Either::Right(
+                            PendingInboundConnectionError::Transport(TransportError::Other(e))
+                        ),
+                    })
+                    .await;
         }
     }
 }
@@ -200,13 +203,14 @@ pub(crate) async fn new_for_established_connection<THandler>(
 
                     let error = closing_muxer.await.err().map(ConnectionError::IO);
 
-                    let _ = events
-                        .send(EstablishedConnectionEvent::Closed {
-                            id: connection_id,
-                            peer_id,
-                            error,
-                        })
-                        .await;
+                    let _ =
+                        events
+                            .send(EstablishedConnectionEvent::Closed {
+                                id: connection_id,
+                                peer_id,
+                                error,
+                            })
+                            .await;
                     return;
                 }
             },

--- a/swarm/src/handler/either.rs
+++ b/swarm/src/handler/either.rs
@@ -156,26 +156,26 @@ where
             ConnectionEvent::FullyNegotiatedInbound(fully_negotiated_inbound) => {
                 match (fully_negotiated_inbound.transpose(), self) {
                     (Either::Left(fully_negotiated_inbound), Either::Left(handler)) => handler
-                        .on_connection_event(ConnectionEvent::FullyNegotiatedInbound(
-                            fully_negotiated_inbound,
-                        )),
+                        .on_connection_event(
+                            ConnectionEvent::FullyNegotiatedInbound(fully_negotiated_inbound)
+                        ),
                     (Either::Right(fully_negotiated_inbound), Either::Right(handler)) => handler
-                        .on_connection_event(ConnectionEvent::FullyNegotiatedInbound(
-                            fully_negotiated_inbound,
-                        )),
+                        .on_connection_event(
+                            ConnectionEvent::FullyNegotiatedInbound(fully_negotiated_inbound)
+                        ),
                     _ => unreachable!(),
                 }
             }
             ConnectionEvent::FullyNegotiatedOutbound(fully_negotiated_outbound) => {
                 match (fully_negotiated_outbound.transpose(), self) {
                     (Either::Left(fully_negotiated_outbound), Either::Left(handler)) => handler
-                        .on_connection_event(ConnectionEvent::FullyNegotiatedOutbound(
-                            fully_negotiated_outbound,
-                        )),
+                        .on_connection_event(
+                            ConnectionEvent::FullyNegotiatedOutbound(fully_negotiated_outbound)
+                        ),
                     (Either::Right(fully_negotiated_outbound), Either::Right(handler)) => handler
-                        .on_connection_event(ConnectionEvent::FullyNegotiatedOutbound(
-                            fully_negotiated_outbound,
-                        )),
+                        .on_connection_event(
+                            ConnectionEvent::FullyNegotiatedOutbound(fully_negotiated_outbound)
+                        ),
                     _ => unreachable!(),
                 }
             }
@@ -191,13 +191,13 @@ where
             ConnectionEvent::ListenUpgradeError(listen_upgrade_error) => {
                 match (listen_upgrade_error.transpose(), self) {
                     (Either::Left(listen_upgrade_error), Either::Left(handler)) => handler
-                        .on_connection_event(ConnectionEvent::ListenUpgradeError(
-                            listen_upgrade_error,
-                        )),
+                        .on_connection_event(
+                            ConnectionEvent::ListenUpgradeError(listen_upgrade_error)
+                        ),
                     (Either::Right(listen_upgrade_error), Either::Right(handler)) => handler
-                        .on_connection_event(ConnectionEvent::ListenUpgradeError(
-                            listen_upgrade_error,
-                        )),
+                        .on_connection_event(
+                            ConnectionEvent::ListenUpgradeError(listen_upgrade_error)
+                        ),
                     _ => unreachable!(),
                 }
             }
@@ -210,21 +210,27 @@ where
                 }
             },
             ConnectionEvent::LocalProtocolsChange(supported_protocols) => match self {
-                Either::Left(handler) => handler.on_connection_event(
-                    ConnectionEvent::LocalProtocolsChange(supported_protocols),
-                ),
-                Either::Right(handler) => handler.on_connection_event(
-                    ConnectionEvent::LocalProtocolsChange(supported_protocols),
-                ),
+                Either::Left(handler) => {
+                    handler.on_connection_event(
+                        ConnectionEvent::LocalProtocolsChange(supported_protocols)
+                    )
+                }
+                Either::Right(handler) => {
+                    handler.on_connection_event(
+                        ConnectionEvent::LocalProtocolsChange(supported_protocols)
+                    )
+                }
             },
-            ConnectionEvent::RemoteProtocolsChange(supported_protocols) => match self {
-                Either::Left(handler) => handler.on_connection_event(
-                    ConnectionEvent::RemoteProtocolsChange(supported_protocols),
-                ),
-                Either::Right(handler) => handler.on_connection_event(
-                    ConnectionEvent::RemoteProtocolsChange(supported_protocols),
-                ),
-            },
+            ConnectionEvent::RemoteProtocolsChange(supported_protocols) => {
+                match self {
+                    Either::Left(handler) => handler.on_connection_event(
+                        ConnectionEvent::RemoteProtocolsChange(supported_protocols),
+                    ),
+                    Either::Right(handler) => handler.on_connection_event(
+                        ConnectionEvent::RemoteProtocolsChange(supported_protocols),
+                    ),
+                }
+            }
         }
     }
 }

--- a/swarm/src/handler/multi.rs
+++ b/swarm/src/handler/multi.rs
@@ -93,10 +93,9 @@ where
     ) {
         if let Some(h) = self.handlers.get_mut(&key) {
             if let Some(i) = info.take(&key) {
-                h.on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
-                    info: i,
-                    error,
-                }));
+                h.on_connection_event(
+                    ConnectionEvent::ListenUpgradeError(ListenUpgradeError { info: i, error })
+                );
             }
         }
     }
@@ -182,9 +181,9 @@ where
             }
             ConnectionEvent::AddressChange(AddressChange { new_address }) => {
                 for h in self.handlers.values_mut() {
-                    h.on_connection_event(ConnectionEvent::AddressChange(AddressChange {
-                        new_address,
-                    }));
+                    h.on_connection_event(
+                        ConnectionEvent::AddressChange(AddressChange { new_address })
+                    );
                 }
             }
             ConnectionEvent::DialUpgradeError(DialUpgradeError {
@@ -192,10 +191,9 @@ where
                 error,
             }) => {
                 if let Some(h) = self.handlers.get_mut(&key) {
-                    h.on_connection_event(ConnectionEvent::DialUpgradeError(DialUpgradeError {
-                        info: arg,
-                        error,
-                    }));
+                    h.on_connection_event(
+                        ConnectionEvent::DialUpgradeError(DialUpgradeError { info: arg, error })
+                    );
                 } else {
                     tracing::error!("DialUpgradeError: no handler for protocol")
                 }
@@ -205,16 +203,16 @@ where
             }
             ConnectionEvent::LocalProtocolsChange(supported_protocols) => {
                 for h in self.handlers.values_mut() {
-                    h.on_connection_event(ConnectionEvent::LocalProtocolsChange(
-                        supported_protocols.clone(),
-                    ));
+                    h.on_connection_event(
+                        ConnectionEvent::LocalProtocolsChange(supported_protocols.clone())
+                    );
                 }
             }
             ConnectionEvent::RemoteProtocolsChange(supported_protocols) => {
                 for h in self.handlers.values_mut() {
-                    h.on_connection_event(ConnectionEvent::RemoteProtocolsChange(
-                        supported_protocols.clone(),
-                    ));
+                    h.on_connection_event(
+                        ConnectionEvent::RemoteProtocolsChange(supported_protocols.clone())
+                    );
                 }
             }
         }

--- a/swarm/src/handler/one_shot.rs
+++ b/swarm/src/handler/one_shot.rs
@@ -135,9 +135,7 @@ where
         ConnectionHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Self::ToBehaviour>,
     > {
         if !self.events_out.is_empty() {
-            return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
-                self.events_out.remove(0),
-            ));
+            return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(self.events_out.remove(0)));
         } else {
             self.events_out.shrink_to_fit();
         }
@@ -168,16 +166,14 @@ where
         >,
     ) {
         match event {
-            ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
-                protocol: out,
-                ..
-            }) => {
+            ConnectionEvent::FullyNegotiatedInbound(
+                FullyNegotiatedInbound { protocol: out, .. }
+            ) => {
                 self.events_out.push(Ok(out.into()));
             }
-            ConnectionEvent::FullyNegotiatedOutbound(FullyNegotiatedOutbound {
-                protocol: out,
-                ..
-            }) => {
+            ConnectionEvent::FullyNegotiatedOutbound(
+                FullyNegotiatedOutbound { protocol: out, .. }
+            ) => {
                 self.dial_negotiated -= 1;
                 self.events_out.push(Ok(out.into()));
             }
@@ -221,10 +217,11 @@ mod tests {
 
     #[test]
     fn do_not_keep_idle_connection_alive() {
-        let mut handler: OneShotHandler<_, DeniedUpgrade, Void> = OneShotHandler::new(
-            SubstreamProtocol::new(DeniedUpgrade {}, ()),
-            Default::default(),
-        );
+        let mut handler: OneShotHandler<_, DeniedUpgrade, Void> =
+            OneShotHandler::new(
+                SubstreamProtocol::new(DeniedUpgrade {}, ()),
+                Default::default(),
+            );
 
         block_on(poll_fn(|cx| loop {
             if handler.poll(cx).is_pending() {

--- a/swarm/src/handler/select.rs
+++ b/swarm/src/handler/select.rs
@@ -157,18 +157,14 @@ where
     ) {
         match error {
             Either::Left(error) => {
-                self.proto1
-                    .on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
-                        info: i1,
-                        error,
-                    }));
+                self.proto1.on_connection_event(
+                    ConnectionEvent::ListenUpgradeError(ListenUpgradeError { info: i1, error })
+                );
             }
             Either::Right(error) => {
-                self.proto2
-                    .on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
-                        info: i2,
-                        error,
-                    }));
+                self.proto2.on_connection_event(
+                    ConnectionEvent::ListenUpgradeError(ListenUpgradeError { info: i2, error })
+                );
             }
         }
     }
@@ -239,9 +235,7 @@ where
 
         match self.proto2.poll(cx) {
             Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(event)) => {
-                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(Either::Right(
-                    event,
-                )));
+                return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(Either::Right(event)));
             }
             Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest { protocol }) => {
                 return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
@@ -326,24 +320,21 @@ where
                 self.on_listen_upgrade_error(listen_upgrade_error)
             }
             ConnectionEvent::LocalProtocolsChange(supported_protocols) => {
-                self.proto1
-                    .on_connection_event(ConnectionEvent::LocalProtocolsChange(
-                        supported_protocols.clone(),
-                    ));
+                self.proto1.on_connection_event(
+                    ConnectionEvent::LocalProtocolsChange(supported_protocols.clone())
+                );
                 self.proto2
                     .on_connection_event(ConnectionEvent::LocalProtocolsChange(
                         supported_protocols,
                     ));
             }
             ConnectionEvent::RemoteProtocolsChange(supported_protocols) => {
-                self.proto1
-                    .on_connection_event(ConnectionEvent::RemoteProtocolsChange(
-                        supported_protocols.clone(),
-                    ));
-                self.proto2
-                    .on_connection_event(ConnectionEvent::RemoteProtocolsChange(
-                        supported_protocols,
-                    ));
+                self.proto1.on_connection_event(
+                    ConnectionEvent::RemoteProtocolsChange(supported_protocols.clone())
+                );
+                self.proto2.on_connection_event(
+                    ConnectionEvent::RemoteProtocolsChange(supported_protocols)
+                );
             }
         }
     }

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -595,9 +595,7 @@ where
         }
 
         self.behaviour
-            .on_swarm_event(FromSwarm::NewListener(behaviour::NewListener {
-                listener_id,
-            }));
+            .on_swarm_event(FromSwarm::NewListener(behaviour::NewListener { listener_id }));
 
         Ok(())
     }
@@ -608,9 +606,7 @@ where
     /// The address is broadcast to all [`NetworkBehaviour`]s via [`FromSwarm::ExternalAddrConfirmed`].
     pub fn add_external_address(&mut self, a: Multiaddr) {
         self.behaviour
-            .on_swarm_event(FromSwarm::ExternalAddrConfirmed(ExternalAddrConfirmed {
-                addr: &a,
-            }));
+            .on_swarm_event(FromSwarm::ExternalAddrConfirmed(ExternalAddrConfirmed { addr: &a }));
         self.confirmed_external_addr.insert(a);
     }
 
@@ -1044,9 +1040,9 @@ where
                 );
                 let addrs = self.listened_addrs.remove(&listener_id).unwrap_or_default();
                 for addr in addrs.iter() {
-                    self.behaviour.on_swarm_event(FromSwarm::ExpiredListenAddr(
-                        ExpiredListenAddr { listener_id, addr },
-                    ));
+                    self.behaviour.on_swarm_event(
+                        FromSwarm::ExpiredListenAddr(ExpiredListenAddr { listener_id, addr })
+                    );
                 }
                 self.behaviour
                     .on_swarm_event(FromSwarm::ListenerClosed(ListenerClosed {
@@ -2133,9 +2129,9 @@ mod tests {
             {}
 
             match swarm2.poll_next_unpin(cx) {
-                Poll::Ready(Some(SwarmEvent::OutgoingConnectionError {
-                    peer_id, error, ..
-                })) => Poll::Ready((peer_id, error)),
+                Poll::Ready(Some(SwarmEvent::OutgoingConnectionError { peer_id, error, .. })) => {
+                    Poll::Ready((peer_id, error))
+                }
                 Poll::Ready(x) => panic!("unexpected {x:?}"),
                 Poll::Pending => Poll::Pending,
             }
@@ -2200,9 +2196,7 @@ mod tests {
                             return Poll::Ready(Ok(()));
                         }
                     }
-                    Poll::Ready(Some(SwarmEvent::IncomingConnectionError {
-                        local_addr, ..
-                    })) => {
+                    Poll::Ready(Some(SwarmEvent::IncomingConnectionError { local_addr, .. })) => {
                         assert!(!got_inc_err);
                         assert_eq!(local_addr, local_address);
                         got_inc_err = true;
@@ -2323,10 +2317,9 @@ mod tests {
         // This constitutes a fairly typical error for chained transports.
         let error = DialError::Transport(vec![(
             "/ip4/127.0.0.1/tcp/80".parse().unwrap(),
-            TransportError::Other(io::Error::new(
-                io::ErrorKind::Other,
-                MemoryTransportError::Unreachable,
-            )),
+            TransportError::Other(
+                io::Error::new(io::ErrorKind::Other, MemoryTransportError::Unreachable)
+            ),
         )]);
 
         let string = format!("{error}");

--- a/swarm/src/test.rs
+++ b/swarm/src/test.rs
@@ -303,18 +303,18 @@ where
             remaining_established,
         }: ConnectionClosed,
     ) {
-        let mut other_closed_connections = self
-            .on_connection_established
-            .iter()
-            .rev() // take last to first
-            .filter_map(|(peer, .., remaining_established)| {
-                if &peer_id == peer {
-                    Some(remaining_established)
-                } else {
-                    None
-                }
-            })
-            .take(remaining_established);
+        let mut other_closed_connections =
+            self.on_connection_established
+                .iter()
+                .rev() // take last to first
+                .filter_map(|(peer, .., remaining_established)| {
+                    if &peer_id == peer {
+                        Some(remaining_established)
+                    } else {
+                        None
+                    }
+                })
+                .take(remaining_established);
 
         // We are informed that there are `other_established` additional connections. Ensure that the
         // number of previous connections is consistent with this
@@ -368,11 +368,8 @@ where
         local_addr: &Multiaddr,
         remote_addr: &Multiaddr,
     ) -> Result<(), ConnectionDenied> {
-        self.handle_pending_inbound_connection.push((
-            connection_id,
-            local_addr.clone(),
-            remote_addr.clone(),
-        ));
+        self.handle_pending_inbound_connection
+            .push((connection_id, local_addr.clone(), remote_addr.clone()));
         self.inner
             .handle_pending_inbound_connection(connection_id, local_addr, remote_addr)
     }
@@ -465,26 +462,20 @@ where
             FromSwarm::NewListenAddr(NewListenAddr { listener_id, addr }) => {
                 self.on_new_listen_addr.push((listener_id, addr.clone()));
                 self.inner
-                    .on_swarm_event(FromSwarm::NewListenAddr(NewListenAddr {
-                        listener_id,
-                        addr,
-                    }));
+                    .on_swarm_event(FromSwarm::NewListenAddr(NewListenAddr { listener_id, addr }));
             }
             FromSwarm::ExpiredListenAddr(ExpiredListenAddr { listener_id, addr }) => {
                 self.on_expired_listen_addr
                     .push((listener_id, addr.clone()));
-                self.inner
-                    .on_swarm_event(FromSwarm::ExpiredListenAddr(ExpiredListenAddr {
-                        listener_id,
-                        addr,
-                    }));
+                self.inner.on_swarm_event(
+                    FromSwarm::ExpiredListenAddr(ExpiredListenAddr { listener_id, addr })
+                );
             }
             FromSwarm::NewExternalAddrCandidate(NewExternalAddrCandidate { addr }) => {
                 self.on_new_external_addr.push(addr.clone());
-                self.inner
-                    .on_swarm_event(FromSwarm::NewExternalAddrCandidate(
-                        NewExternalAddrCandidate { addr },
-                    ));
+                self.inner.on_swarm_event(
+                    FromSwarm::NewExternalAddrCandidate(NewExternalAddrCandidate { addr })
+                );
             }
             FromSwarm::ExternalAddrExpired(ExternalAddrExpired { addr }) => {
                 self.on_expired_external_addr.push(addr.clone());

--- a/swarm/tests/listener.rs
+++ b/swarm/tests/listener.rs
@@ -19,18 +19,19 @@ async fn behaviour_listener() {
     let addr: Multiaddr = Protocol::Memory(0).into();
     let id = swarm.behaviour_mut().listen(addr.clone());
 
-    let address = swarm
-        .wait(|e| match e {
-            SwarmEvent::NewListenAddr {
-                listener_id,
-                address,
-            } => {
-                assert_eq!(listener_id, id);
-                Some(address)
-            }
-            _ => None,
-        })
-        .await;
+    let address =
+        swarm
+            .wait(|e| match e {
+                SwarmEvent::NewListenAddr {
+                    listener_id,
+                    address,
+                } => {
+                    assert_eq!(listener_id, id);
+                    Some(address)
+                }
+                _ => None,
+            })
+            .await;
 
     swarm.behaviour_mut().stop_listening(id);
 

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -502,54 +502,58 @@ fn resolve<'a, E: 'a + Send, R: Resolver>(
                 Err(e) => Err(Error::ResolveError(e)),
             })
             .boxed(),
-        Protocol::Dns4(ref name) => resolver
-            .ipv4_lookup(name.clone().into_owned())
-            .map(move |res| match res {
-                Ok(ips) => {
-                    let mut ips = ips.into_iter();
-                    let one = ips
-                        .next()
-                        .expect("If there are no results, `Err(NoRecordsFound)` is expected.");
-                    if let Some(two) = ips.next() {
-                        Ok(Resolved::Many(
-                            iter::once(one)
-                                .chain(iter::once(two))
-                                .chain(ips)
-                                .map(Ipv4Addr::from)
-                                .map(Protocol::from)
-                                .collect(),
-                        ))
-                    } else {
-                        Ok(Resolved::One(Protocol::from(Ipv4Addr::from(one))))
+        Protocol::Dns4(ref name) => {
+            resolver
+                .ipv4_lookup(name.clone().into_owned())
+                .map(move |res| match res {
+                    Ok(ips) => {
+                        let mut ips = ips.into_iter();
+                        let one = ips
+                            .next()
+                            .expect("If there are no results, `Err(NoRecordsFound)` is expected.");
+                        if let Some(two) = ips.next() {
+                            Ok(Resolved::Many(
+                                iter::once(one)
+                                    .chain(iter::once(two))
+                                    .chain(ips)
+                                    .map(Ipv4Addr::from)
+                                    .map(Protocol::from)
+                                    .collect(),
+                            ))
+                        } else {
+                            Ok(Resolved::One(Protocol::from(Ipv4Addr::from(one))))
+                        }
                     }
-                }
-                Err(e) => Err(Error::ResolveError(e)),
-            })
-            .boxed(),
-        Protocol::Dns6(ref name) => resolver
-            .ipv6_lookup(name.clone().into_owned())
-            .map(move |res| match res {
-                Ok(ips) => {
-                    let mut ips = ips.into_iter();
-                    let one = ips
-                        .next()
-                        .expect("If there are no results, `Err(NoRecordsFound)` is expected.");
-                    if let Some(two) = ips.next() {
-                        Ok(Resolved::Many(
-                            iter::once(one)
-                                .chain(iter::once(two))
-                                .chain(ips)
-                                .map(Ipv6Addr::from)
-                                .map(Protocol::from)
-                                .collect(),
-                        ))
-                    } else {
-                        Ok(Resolved::One(Protocol::from(Ipv6Addr::from(one))))
+                    Err(e) => Err(Error::ResolveError(e)),
+                })
+                .boxed()
+        }
+        Protocol::Dns6(ref name) => {
+            resolver
+                .ipv6_lookup(name.clone().into_owned())
+                .map(move |res| match res {
+                    Ok(ips) => {
+                        let mut ips = ips.into_iter();
+                        let one = ips
+                            .next()
+                            .expect("If there are no results, `Err(NoRecordsFound)` is expected.");
+                        if let Some(two) = ips.next() {
+                            Ok(Resolved::Many(
+                                iter::once(one)
+                                    .chain(iter::once(two))
+                                    .chain(ips)
+                                    .map(Ipv6Addr::from)
+                                    .map(Protocol::from)
+                                    .collect(),
+                            ))
+                        } else {
+                            Ok(Resolved::One(Protocol::from(Ipv6Addr::from(one))))
+                        }
                     }
-                }
-                Err(e) => Err(Error::ResolveError(e)),
-            })
-            .boxed(),
+                    Err(e) => Err(Error::ResolveError(e)),
+                })
+                .boxed()
+        }
         Protocol::Dnsaddr(ref name) => {
             let name = [DNSADDR_PREFIX, name].concat();
             resolver

--- a/transports/noise/src/lib.rs
+++ b/transports/noise/src/lib.rs
@@ -122,13 +122,14 @@ impl Config {
     }
 
     fn into_responder<S: AsyncRead + AsyncWrite>(self, socket: S) -> Result<State<S>, Error> {
-        let session = noise_params_into_builder(
-            self.params,
-            &self.prologue,
-            self.dh_keys.keypair.secret(),
-            None,
-        )
-        .build_responder()?;
+        let session =
+            noise_params_into_builder(
+                self.params,
+                &self.prologue,
+                self.dh_keys.keypair.secret(),
+                None,
+            )
+            .build_responder()?;
 
         let state = State::new(
             socket,
@@ -142,13 +143,14 @@ impl Config {
     }
 
     fn into_initiator<S: AsyncRead + AsyncWrite>(self, socket: S) -> Result<State<S>, Error> {
-        let session = noise_params_into_builder(
-            self.params,
-            &self.prologue,
-            self.dh_keys.keypair.secret(),
-            None,
-        )
-        .build_initiator()?;
+        let session =
+            noise_params_into_builder(
+                self.params,
+                &self.prologue,
+                self.dh_keys.keypair.secret(),
+                None,
+            )
+            .build_initiator()?;
 
         let state = State::new(
             socket,

--- a/transports/noise/src/protocol.rs
+++ b/transports/noise/src/protocol.rs
@@ -31,11 +31,12 @@ use zeroize::Zeroize;
 /// Prefix of static key signatures for domain separation.
 pub(crate) const STATIC_KEY_DOMAIN: &str = "noise-libp2p-static-key:";
 
-pub(crate) static PARAMS_XX: Lazy<NoiseParams> = Lazy::new(|| {
-    "Noise_XX_25519_ChaChaPoly_SHA256"
-        .parse()
-        .expect("Invalid protocol name")
-});
+pub(crate) static PARAMS_XX: Lazy<NoiseParams> =
+    Lazy::new(|| {
+        "Noise_XX_25519_ChaChaPoly_SHA256"
+            .parse()
+            .expect("Invalid protocol name")
+    });
 
 pub(crate) fn noise_params_into_builder<'b>(
     params: NoiseParams,

--- a/transports/plaintext/tests/smoke.rs
+++ b/transports/plaintext/tests/smoke.rs
@@ -44,12 +44,13 @@ fn variable_msg_length() {
             let (
                 (received_client_id, mut server_channel),
                 (received_server_id, mut client_channel),
-            ) = futures::future::try_join(
-                plaintext::Config::new(&server_id).upgrade_inbound(server, ""),
-                plaintext::Config::new(&client_id).upgrade_inbound(client, ""),
-            )
-            .await
-            .unwrap();
+            ) =
+                futures::future::try_join(
+                    plaintext::Config::new(&server_id).upgrade_inbound(server, ""),
+                    plaintext::Config::new(&client_id).upgrade_inbound(client, ""),
+                )
+                .await
+                .unwrap();
 
             assert_eq!(received_server_id, server_id.public().to_peer_id());
             assert_eq!(received_client_id, client_id.public().to_peer_id());

--- a/transports/pnet/tests/smoke.rs
+++ b/transports/pnet/tests/smoke.rs
@@ -79,17 +79,18 @@ where
             };
         }
     };
-    let await_outbound_connection = async {
-        loop {
-            match swarm2.select_next_some().await {
-                SwarmEvent::ConnectionEstablished { peer_id, .. } => break peer_id,
-                SwarmEvent::OutgoingConnectionError { error, .. } => {
-                    panic!("Failed to dial: {error}")
-                }
-                _ => continue,
-            };
-        }
-    };
+    let await_outbound_connection =
+        async {
+            loop {
+                match swarm2.select_next_some().await {
+                    SwarmEvent::ConnectionEstablished { peer_id, .. } => break peer_id,
+                    SwarmEvent::OutgoingConnectionError { error, .. } => {
+                        panic!("Failed to dial: {error}")
+                    }
+                    _ => continue,
+                };
+            }
+        };
 
     let (inbound_peer_id, outbound_peer_id) =
         future::join(await_inbound_connection, await_outbound_connection).await;

--- a/transports/tcp/src/lib.rs
+++ b/transports/tcp/src/lib.rs
@@ -891,9 +891,7 @@ mod tests {
                     .unwrap()
             ),
             Ok(SocketAddr::new(
-                IpAddr::V6(Ipv6Addr::new(
-                    65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,
-                )),
+                IpAddr::V6(Ipv6Addr::new(65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535,)),
                 8080,
             ))
         );
@@ -1336,10 +1334,11 @@ mod tests {
 
         #[cfg(feature = "tokio")]
         {
-            let rt = ::tokio::runtime::Builder::new_current_thread()
-                .enable_io()
-                .build()
-                .unwrap();
+            let rt =
+                ::tokio::runtime::Builder::new_current_thread()
+                    .enable_io()
+                    .build()
+                    .unwrap();
             assert!(rt.block_on(cycle_listeners::<tokio::Tcp>()));
         }
     }
@@ -1372,10 +1371,11 @@ mod tests {
         }
         #[cfg(feature = "tokio")]
         {
-            let rt = ::tokio::runtime::Builder::new_current_thread()
-                .enable_io()
-                .build()
-                .unwrap();
+            let rt =
+                ::tokio::runtime::Builder::new_current_thread()
+                    .enable_io()
+                    .build()
+                    .unwrap();
             rt.block_on(async {
                 test::<async_io::Tcp>();
             });

--- a/transports/tcp/src/provider/async_io.rs
+++ b/transports/tcp/src/provider/async_io.rs
@@ -96,14 +96,16 @@ impl Provider for Tcp {
             match l.poll_readable(cx) {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
-                Poll::Ready(Ok(())) => match l.accept().now_or_never() {
-                    Some(Err(e)) => return Poll::Ready(Err(e)),
-                    Some(Ok(res)) => break res,
-                    None => {
-                        // Since it doesn't do any harm, account for false positives of
-                        // `poll_readable` just in case, i.e. try again.
+                Poll::Ready(Ok(())) => {
+                    match l.accept().now_or_never() {
+                        Some(Err(e)) => return Poll::Ready(Err(e)),
+                        Some(Ok(res)) => break res,
+                        None => {
+                            // Since it doesn't do any harm, account for false positives of
+                            // `poll_readable` just in case, i.e. try again.
+                        }
                     }
-                },
+                }
             }
         };
 

--- a/transports/tls/src/certificate.rs
+++ b/transports/tls/src/certificate.rs
@@ -58,10 +58,9 @@ pub fn generate(
     let certificate = {
         let mut params = rcgen::CertificateParams::new(vec![]);
         params.distinguished_name = rcgen::DistinguishedName::new();
-        params.custom_extensions.push(make_libp2p_extension(
-            identity_keypair,
-            &certificate_keypair,
-        )?);
+        params
+            .custom_extensions
+            .push(make_libp2p_extension(identity_keypair, &certificate_keypair)?);
         params.alg = P2P_SIGNATURE_ALGORITHM;
         params.key_pair = Some(certificate_keypair);
         rcgen::Certificate::from_params(params)?
@@ -289,10 +288,11 @@ impl P2pCertificate<'_> {
             _ => return Err(webpki::Error::UnsupportedSignatureAlgorithm),
         };
         let spki = &self.certificate.tbs_certificate.subject_pki;
-        let key = signature::UnparsedPublicKey::new(
-            verification_algorithm,
-            spki.subject_public_key.as_ref(),
-        );
+        let key =
+            signature::UnparsedPublicKey::new(
+                verification_algorithm,
+                spki.subject_public_key.as_ref(),
+            );
 
         Ok(key)
     }

--- a/transports/tls/src/lib.rs
+++ b/transports/tls/src/lib.rs
@@ -51,9 +51,9 @@ pub fn make_client_config(
         .with_safe_default_kx_groups()
         .with_protocol_versions(verifier::PROTOCOL_VERSIONS)
         .expect("Cipher suites and kx groups are configured; qed")
-        .with_custom_certificate_verifier(Arc::new(
-            verifier::Libp2pCertificateVerifier::with_remote_peer_id(remote_peer_id),
-        ))
+        .with_custom_certificate_verifier(
+            Arc::new(verifier::Libp2pCertificateVerifier::with_remote_peer_id(remote_peer_id))
+        )
         .with_client_auth_cert(vec![certificate], private_key)
         .expect("Client cert key DER is valid; qed");
     crypto.alpn_protocols = vec![P2P_ALPN.to_vec()];

--- a/transports/tls/src/verifier.rs
+++ b/transports/tls/src/verifier.rs
@@ -211,9 +211,7 @@ fn verify_presented_certs(
     intermediates: &[Certificate],
 ) -> Result<PeerId, rustls::Error> {
     if !intermediates.is_empty() {
-        return Err(rustls::Error::General(
-            "libp2p-tls requires exactly one certificate".into(),
-        ));
+        return Err(rustls::Error::General("libp2p-tls requires exactly one certificate".into()));
     }
 
     let cert = certificate::parse(end_entity)?;

--- a/transports/tls/tests/smoke.rs
+++ b/transports/tls/tests/smoke.rs
@@ -37,17 +37,18 @@ async fn can_establish_connection() {
             };
         }
     };
-    let await_outbound_connection = async {
-        loop {
-            match swarm2.next().await.unwrap() {
-                SwarmEvent::ConnectionEstablished { peer_id, .. } => break peer_id,
-                SwarmEvent::OutgoingConnectionError { error, .. } => {
-                    panic!("Failed to dial: {error}")
-                }
-                _ => continue,
-            };
-        }
-    };
+    let await_outbound_connection =
+        async {
+            loop {
+                match swarm2.next().await.unwrap() {
+                    SwarmEvent::ConnectionEstablished { peer_id, .. } => break peer_id,
+                    SwarmEvent::OutgoingConnectionError { error, .. } => {
+                        panic!("Failed to dial: {error}")
+                    }
+                    _ => continue,
+                };
+            }
+        };
 
     let (inbound_peer_id, outbound_peer_id) =
         future::join(await_inbound_connection, await_outbound_connection).await;

--- a/transports/uds/src/lib.rs
+++ b/transports/uds/src/lib.rs
@@ -54,13 +54,14 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{io, path::PathBuf};
 
-pub type Listener<T> = BoxStream<
-    'static,
-    Result<
-        TransportEvent<<T as Transport>::ListenerUpgrade, <T as Transport>::Error>,
-        Result<(), <T as Transport>::Error>,
-    >,
->;
+pub type Listener<T> =
+    BoxStream<
+        'static,
+        Result<
+            TransportEvent<<T as Transport>::ListenerUpgrade, <T as Transport>::Error>,
+            Result<(), <T as Transport>::Error>,
+        >,
+    >;
 
 macro_rules! codegen {
     ($feature_name:expr, $uds_config:ident, $build_listener:expr, $unix_stream:ty, $($mut_or_not:tt)*) => {
@@ -285,9 +286,8 @@ mod tests {
     fn communicating_between_dialer_and_listener() {
         let temp_dir = tempfile::tempdir().unwrap();
         let socket = temp_dir.path().join("socket");
-        let addr = Multiaddr::from(Protocol::Unix(Cow::Owned(
-            socket.to_string_lossy().into_owned(),
-        )));
+        let addr =
+            Multiaddr::from(Protocol::Unix(Cow::Owned(socket.to_string_lossy().into_owned())));
 
         let (tx, rx) = oneshot::channel();
 

--- a/transports/webrtc-websys/src/stream/poll_data_channel.rs
+++ b/transports/webrtc-websys/src/stream/poll_data_channel.rs
@@ -61,14 +61,15 @@ impl PollDataChannel {
 
         let write_waker = Rc::new(AtomicWaker::new());
         inner.set_buffered_amount_low_threshold(0);
-        let on_write_closure = Closure::new({
-            let write_waker = write_waker.clone();
+        let on_write_closure =
+            Closure::new({
+                let write_waker = write_waker.clone();
 
-            move |_: Event| {
-                tracing::trace!("DataChannel available for writing (again)");
-                write_waker.wake();
-            }
-        });
+                move |_: Event| {
+                    tracing::trace!("DataChannel available for writing (again)");
+                    write_waker.wake();
+                }
+            });
         inner.set_onbufferedamountlow(Some(on_write_closure.as_ref().unchecked_ref()));
 
         let close_waker = Rc::new(AtomicWaker::new());

--- a/transports/webrtc-websys/src/transport.rs
+++ b/transports/webrtc-websys/src/transport.rs
@@ -113,10 +113,11 @@ impl libp2p_core::Transport for Transport {
 /// See: `<https://bugzilla.mozilla.org/show_bug.cgi?id=1659672>` for more details
 fn maybe_local_firefox() -> bool {
     let window = &web_sys::window().expect("window should be available");
-    let ua = match window.navigator().user_agent() {
-        Ok(agent) => agent.to_lowercase(),
-        Err(_) => return false,
-    };
+    let ua =
+        match window.navigator().user_agent() {
+            Ok(agent) => agent.to_lowercase(),
+            Err(_) => return false,
+        };
 
     let hostname = match window
         .document()

--- a/transports/webrtc/src/tokio/certificate.rs
+++ b/transports/webrtc/src/tokio/certificate.rs
@@ -36,9 +36,8 @@ impl Certificate {
     where
         R: CryptoRng + Rng,
     {
-        let mut params = rcgen::CertificateParams::new(vec![
-            rand::distributions::Alphanumeric.sample_string(&mut rand::thread_rng(), 16)
-        ]);
+        let mut params = rcgen::CertificateParams::new(vec![rand::distributions::Alphanumeric
+            .sample_string(&mut rand::thread_rng(), 16)]);
         params.alg = &rcgen::PKCS_ECDSA_P256_SHA256;
         Ok(Self {
             inner: RTCCertificate::from_params(params).expect("default params to work"),

--- a/transports/webrtc/src/tokio/fingerprint.rs
+++ b/transports/webrtc/src/tokio/fingerprint.rs
@@ -53,9 +53,7 @@ impl Fingerprint {
 
     /// Converts [`Multihash`](multihash::Multihash) to [`Fingerprint`].
     pub fn try_from_multihash(hash: Multihash) -> Option<Self> {
-        Some(Self(libp2p_webrtc_utils::Fingerprint::try_from_multihash(
-            hash,
-        )?))
+        Some(Self(libp2p_webrtc_utils::Fingerprint::try_from_multihash(hash)?))
     }
 
     /// Converts this fingerprint to [`Multihash`](multihash::Multihash).

--- a/transports/webrtc/src/tokio/sdp.rs
+++ b/transports/webrtc/src/tokio/sdp.rs
@@ -42,12 +42,13 @@ pub(crate) fn answer(
 ///
 /// Certificate verification is disabled which is why we hardcode a dummy fingerprint here.
 pub(crate) fn offer(addr: SocketAddr, client_ufrag: &str) -> RTCSessionDescription {
-    let offer = render_description(
-        CLIENT_SESSION_DESCRIPTION,
-        addr,
-        Fingerprint::FF,
-        client_ufrag,
-    );
+    let offer =
+        render_description(
+            CLIENT_SESSION_DESCRIPTION,
+            addr,
+            Fingerprint::FF,
+            client_ufrag,
+        );
 
     tracing::trace!(offer=%offer, "Created SDP offer");
 

--- a/transports/webrtc/src/tokio/udp_mux.rs
+++ b/transports/webrtc/src/tokio/udp_mux.rs
@@ -247,13 +247,14 @@ impl UDPMuxNewAddr {
                     continue;
                 }
 
-                let muxed_conn = match self.create_muxed_conn(&ufrag) {
-                    Ok(conn) => conn,
-                    Err(e) => {
-                        let _ = response.send(Err(e));
-                        continue;
-                    }
-                };
+                let muxed_conn =
+                    match self.create_muxed_conn(&ufrag) {
+                        Ok(conn) => conn,
+                        Err(e) => {
+                            let _ = response.send(Err(e));
+                            continue;
+                        }
+                    };
                 let mut close_rx = muxed_conn.close_rx();
 
                 self.close_futures.push({
@@ -437,11 +438,12 @@ impl UdpMuxHandle {
         let (sender2, receiver2) = req_res_chan::new(1);
         let (sender3, receiver3) = req_res_chan::new(1);
 
-        let this = Self {
-            close_sender: sender1,
-            get_conn_sender: sender2,
-            remove_sender: sender3,
-        };
+        let this =
+            Self {
+                close_sender: sender1,
+                get_conn_sender: sender2,
+                remove_sender: sender3,
+            };
 
         (this, receiver1, receiver2, receiver3)
     }
@@ -550,9 +552,9 @@ fn ufrag_from_stun_message(buffer: &[u8], local_ufrag: bool) -> Result<String, E
         match String::from_utf8(attr.value) {
             // Per the RFC this shouldn't happen
             // https://datatracker.ietf.org/doc/html/rfc5389#section-15.3
-            Err(err) => Err(Error::Other(format!(
-                "failed to decode USERNAME from STUN message as UTF-8: {err}"
-            ))),
+            Err(err) => Err(
+                Error::Other(format!("failed to decode USERNAME from STUN message as UTF-8: {err}"))
+            ),
             Ok(s) => {
                 // s is a combination of the local_ufrag and the remote ufrag separated by `:`.
                 let res = if local_ufrag {

--- a/transports/webrtc/src/tokio/upgrade.rs
+++ b/transports/webrtc/src/tokio/upgrade.rs
@@ -115,11 +115,12 @@ async fn new_outbound_connection(
     let ufrag = random_ufrag();
     let se = setting_engine(udp_mux, &ufrag, addr);
 
-    let connection = APIBuilder::new()
-        .with_setting_engine(se)
-        .build()
-        .new_peer_connection(config)
-        .await?;
+    let connection =
+        APIBuilder::new()
+            .with_setting_engine(se)
+            .build()
+            .new_peer_connection(config)
+            .await?;
 
     Ok((connection, ufrag))
 }
@@ -141,11 +142,12 @@ async fn new_inbound_connection(
         se.set_answering_dtls_role(DTLSRole::Server)?;
     }
 
-    let connection = APIBuilder::new()
-        .with_setting_engine(se)
-        .build()
-        .new_peer_connection(config)
-        .await?;
+    let connection =
+        APIBuilder::new()
+            .with_setting_engine(se)
+            .build()
+            .new_peer_connection(config)
+            .await?;
 
     Ok(connection)
 }

--- a/transports/webrtc/tests/smoke.rs
+++ b/transports/webrtc/tests/smoke.rs
@@ -357,14 +357,15 @@ impl Future for ListenUpgrade<'_> {
                     send_back_addr,
                     ..
                 })) => {
-                    self.listener_upgrade_task = Some(
-                        async move {
-                            let (peer, conn) = upgrade.await.unwrap();
+                    self.listener_upgrade_task =
+                        Some(
+                            async move {
+                                let (peer, conn) = upgrade.await.unwrap();
 
-                            (peer, send_back_addr, conn)
-                        }
-                        .boxed(),
-                    );
+                                (peer, send_back_addr, conn)
+                            }
+                            .boxed(),
+                        );
                     continue;
                 }
                 Poll::Ready(None) => unreachable!("stream never ends"),

--- a/transports/websocket-websys/src/lib.rs
+++ b/transports/websocket-websys/src/lib.rs
@@ -135,11 +135,12 @@ fn extract_websocket_url(addr: &Multiaddr) -> Option<String> {
         _ => return None,
     };
 
-    let (scheme, wspath) = match protocols.next() {
-        Some(Protocol::Ws(path)) => ("ws", path.into_owned()),
-        Some(Protocol::Wss(path)) => ("wss", path.into_owned()),
-        _ => return None,
-    };
+    let (scheme, wspath) =
+        match protocols.next() {
+            Some(Protocol::Ws(path)) => ("ws", path.into_owned()),
+            Some(Protocol::Wss(path)) => ("wss", path.into_owned()),
+            _ => return None,
+        };
 
     Some(format!("{scheme}://{host_port}{wspath}"))
 }
@@ -258,12 +259,13 @@ impl Connection {
         socket.set_onclose(Some(onclose_closure.as_ref().unchecked_ref()));
 
         let errored = Rc::new(AtomicBool::new(false));
-        let onerror_closure = Closure::<dyn FnMut(_)>::new({
-            let errored = errored.clone();
-            move |_| {
-                errored.store(true, Ordering::SeqCst);
-            }
-        });
+        let onerror_closure =
+            Closure::<dyn FnMut(_)>::new({
+                let errored = errored.clone();
+                move |_| {
+                    errored.store(true, Ordering::SeqCst);
+                }
+            });
         socket.set_onerror(Some(onerror_closure.as_ref().unchecked_ref()));
 
         let read_buffer = Rc::new(Mutex::new(BytesMut::new()));

--- a/transports/websocket/src/quicksink.rs
+++ b/transports/websocket/src/quicksink.rs
@@ -183,19 +183,20 @@ where
                         return Poll::Ready(Ok(()));
                     }
                 }
-                State::Sending => match ready!(this.future.as_mut().as_pin_mut().unwrap().poll(cx))
-                {
-                    Ok(p) => {
-                        this.future.set(None);
-                        *this.param = Some(p);
-                        *this.state = State::Empty
+                State::Sending => {
+                    match ready!(this.future.as_mut().as_pin_mut().unwrap().poll(cx)) {
+                        Ok(p) => {
+                            this.future.set(None);
+                            *this.param = Some(p);
+                            *this.state = State::Empty
+                        }
+                        Err(e) => {
+                            this.future.set(None);
+                            *this.state = State::Failed;
+                            return Poll::Ready(Err(e));
+                        }
                     }
-                    Err(e) => {
-                        this.future.set(None);
-                        *this.state = State::Failed;
-                        return Poll::Ready(Err(e));
-                    }
-                },
+                }
                 State::Flushing => {
                     match ready!(this.future.as_mut().as_pin_mut().unwrap().poll(cx)) {
                         Ok(p) => {
@@ -243,19 +244,20 @@ where
                         return Poll::Ready(Ok(()));
                     }
                 }
-                State::Sending => match ready!(this.future.as_mut().as_pin_mut().unwrap().poll(cx))
-                {
-                    Ok(p) => {
-                        this.future.set(None);
-                        *this.param = Some(p);
-                        *this.state = State::Empty
+                State::Sending => {
+                    match ready!(this.future.as_mut().as_pin_mut().unwrap().poll(cx)) {
+                        Ok(p) => {
+                            this.future.set(None);
+                            *this.param = Some(p);
+                            *this.state = State::Empty
+                        }
+                        Err(e) => {
+                            this.future.set(None);
+                            *this.state = State::Failed;
+                            return Poll::Ready(Err(e));
+                        }
                     }
-                    Err(e) => {
-                        this.future.set(None);
-                        *this.state = State::Failed;
-                        return Poll::Ready(Err(e));
-                    }
-                },
+                }
                 State::Flushing => {
                     match ready!(this.future.as_mut().as_pin_mut().unwrap().poll(cx)) {
                         Ok(p) => {

--- a/transports/webtransport-websys/src/bindings.rs
+++ b/transports/webtransport-websys/src/bindings.rs
@@ -116,11 +116,12 @@ impl WebTransportHash {
     }
 
     pub fn algorithm(&mut self, val: &str) -> &mut Self {
-        let r = Reflect::set(
-            self.as_ref(),
-            &JsValue::from("algorithm"),
-            &JsValue::from(val),
-        );
+        let r =
+            Reflect::set(
+                self.as_ref(),
+                &JsValue::from("algorithm"),
+                &JsValue::from(val),
+            );
         debug_assert!(
             r.is_ok(),
             "setting properties should never fail on our dictionary objects"

--- a/transports/webtransport-websys/src/endpoint.rs
+++ b/transports/webtransport-websys/src/endpoint.rs
@@ -50,9 +50,9 @@ impl Endpoint {
                     host = Some(domain.to_string())
                 }
                 Protocol::Dnsaddr(_) => {
-                    return Err(Error::InvalidMultiaddr(
-                        "/dnsaddr not supported from within a browser",
-                    ));
+                    return Err(
+                        Error::InvalidMultiaddr("/dnsaddr not supported from within a browser")
+                    );
                 }
                 Protocol::Udp(p) => {
                     if port.is_some() {
@@ -72,9 +72,9 @@ impl Endpoint {
                 }
                 Protocol::WebTransport => {
                     if !found_quic {
-                        return Err(Error::InvalidMultiaddr(
-                            "/quic is not found before /webtransport",
-                        ));
+                        return Err(
+                            Error::InvalidMultiaddr("/quic is not found before /webtransport")
+                        );
                     }
 
                     found_webtransport = true;
@@ -100,9 +100,7 @@ impl Endpoint {
         }
 
         if !found_quic || !found_webtransport {
-            return Err(Error::InvalidMultiaddr(
-                "Not a /quic/webtransport multiaddr",
-            ));
+            return Err(Error::InvalidMultiaddr("Not a /quic/webtransport multiaddr"));
         }
 
         let host = host.ok_or_else(|| Error::InvalidMultiaddr("Host is not defined"))?;
@@ -166,13 +164,13 @@ mod tests {
         assert_eq!(endpoint.port, 44874);
         assert_eq!(endpoint.certhashes.len(), 2);
 
-        assert!(endpoint.certhashes.contains(&multihash_from_str(
-            "uEiCaDd1Ca1A8IVJ3hsIxIyi11cwxaDKqzVrBkGJbKZU5ng"
-        )));
+        assert!(endpoint
+            .certhashes
+            .contains(&multihash_from_str("uEiCaDd1Ca1A8IVJ3hsIxIyi11cwxaDKqzVrBkGJbKZU5ng")));
 
-        assert!(endpoint.certhashes.contains(&multihash_from_str(
-            "uEiDv-VGW8oXxui_G_Kqp-87YjvET-Hr2qYAMYPePJDcsjQ"
-        )));
+        assert!(endpoint
+            .certhashes
+            .contains(&multihash_from_str("uEiDv-VGW8oXxui_G_Kqp-87YjvET-Hr2qYAMYPePJDcsjQ")));
 
         assert_eq!(
             endpoint.remote_peer.unwrap(),

--- a/transports/webtransport-websys/src/stream.rs
+++ b/transports/webtransport-websys/src/stream.rs
@@ -78,16 +78,17 @@ impl StreamInner {
     fn poll_read(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<io::Result<usize>> {
         // If we have leftovers from a previous read, then use them.
         // Otherwise read new data.
-        let data = match self.read_leftovers.take() {
-            Some(data) => data,
-            None => {
-                match ready!(self.poll_reader_read(cx))? {
-                    Some(data) => data,
-                    // EOF
-                    None => return Poll::Ready(Ok(0)),
+        let data =
+            match self.read_leftovers.take() {
+                Some(data) => data,
+                None => {
+                    match ready!(self.poll_reader_read(cx))? {
+                        Some(data) => data,
+                        // EOF
+                        None => return Poll::Ready(Ok(0)),
+                    }
                 }
-            }
-        };
+            };
 
         if data.byte_length() == 0 {
             return Poll::Ready(Ok(0));


### PR DESCRIPTION
## Description

Ran cargo fmt and cargo clippy --fix with the respective new nightly versions.



## Notes & open questions


While I have no issues with the fixes introduced by clippy, I have issues with the new rustfmt version.

As you can see the changes are quite severe and the change in style is stronger then in previous releases.

We should be careful when merging into master, because every PR that doesn't use the nightly compiler and runs the format will probably have a merge conflict. But we probably have to do it eventually.

An upside of the changes, at least from my POV is that changes are now spread over more lines, which could be beneficial for merge conflict resolution.

I would suggest we keep this PR open and I update it regularly with the nightly versions of rustfmt. It's a lot of work to merge that probably, so I'd suggest we merge the version that will be released eventually.

## Change checklist

- [ ] I have performed a self-review of my own code
