### PR TITLE
fix(kad): iterator progress to be decided by any of new peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.45.2"
+version = "0.45.3"
 dependencies = [
  "arrayvec",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ libp2p-floodsub = { version = "0.44.0", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.46.1", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.44.1", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.8" }
-libp2p-kad = { version = "0.45.2", path = "protocols/kad" }
+libp2p-kad = { version = "0.45.3", path = "protocols/kad" }
 libp2p-mdns = { version = "0.45.1", path = "protocols/mdns" }
 libp2p-memory-connection-limits = { version = "0.2.0", path = "misc/memory-connection-limits" }
 libp2p-metrics = { version = "0.14.1", path = "misc/metrics" }

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.45.3
+
+- The progress of the close query iterator shall be decided by ANY of the new peers.
+  See [PR 4932](https://github.com/libp2p/rust-libp2p/pull/4932).
+
 ## 0.45.2
 
 - Ensure `Multiaddr` handled and returned by `Behaviour` are `/p2p` terminated.

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-kad"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Kademlia protocol for libp2p"
-version = "0.45.2"
+version = "0.45.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
The `progress` var is against the whole set of incoming closer_peers.
Hence, currently the last new peer will always overwrites the previous result.
i.e. the progress of the iterator is only decided by the last entry of the incoming closer_peers.

This commit is aimed to make the progress to be decided by any of the incoming closer_peer that turns out to be closer to the target.

## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
