### PR TITLE
fix(kad): close progress whenever closer in range

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -4,6 +4,8 @@
   See [PR 5270](https://github.com/libp2p/rust-libp2p/pull/5270)
 - Update to DHT republish interval and expiration time defaults to 22h and 48h respectively, rationale in [libp2p/specs#451](https://github.com/libp2p/specs/pull/451)
   See [PR 3230](https://github.com/libp2p/rust-libp2p/pull/3230)
+- QueryClose progress whenever closer in range, instead of having to be the closest.
+  See [PR 4934](https://github.com/libp2p/rust-libp2p/pull/4934).
 
 ## 0.45.4
 


### PR DESCRIPTION
`Closer` shall be calculated as `closer to the seen num_results peers`,
not just to be `being the closest` as current.

This is in parallel to the PR https://github.com/libp2p/rust-libp2p/pull/4932
Split them into two to make the work easier to be discussed and reviewed.

## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
