### PR TITLE
ci: always compare version in `CHANGELOG.md` and `Cargo.toml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Enforce version in CHANGELOG.md matches version in manifest
         run: |
+          MANIFEST_PATH=$(cargo metadata --format-version=1 --no-deps | jq -e -r '.packages[] | select(.name == "'"$CRATE"'") | .manifest_path')
+          DIR_TO_CRATE=$(dirname "$MANIFEST_PATH")
           VERSION_IN_CHANGELOG=$(awk -F' ' '/^## [0-9]+\.[0-9]+\.[0-9]+/{print $2; exit}' "$DIR_TO_CRATE/CHANGELOG.md")
 
           echo "Package version: $CRATE_VERSION";

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,13 +73,6 @@ jobs:
           test "$PACKAGE_VERSION" = "$SPECIFIED_VERSION" || test "=$PACKAGE_VERSION" = "$SPECIFIED_VERSION"
 
       - name: Ensure manifest and CHANGELOG are properly updated
-        if: >
-          github.event_name == 'pull_request' &&
-          !startsWith(github.event.pull_request.title, 'chore') &&
-          !startsWith(github.event.pull_request.title, 'refactor') &&
-          !startsWith(github.event.pull_request.title, 'deps') &&
-          !startsWith(github.event.pull_request.title, 'docs') &&
-          !contains(github.event.pull_request.labels.*.name, 'internal-change')
         run: |
           git fetch origin master:master
           git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
@@ -87,6 +80,15 @@ jobs:
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_BASE: ${{ github.event.pull_request.base.ref }}
+          ASSERT_CHANGELOG_UPDATED: |
+            ${{ 
+              github.event_name == 'pull_request' &&
+              !startsWith(github.event.pull_request.title, 'chore') &&
+              !startsWith(github.event.pull_request.title, 'refactor') &&
+              !startsWith(github.event.pull_request.title, 'deps') &&
+              !startsWith(github.event.pull_request.title, 'docs') &&
+              !contains(github.event.pull_request.labels.*.name, 'internal-change')
+            }}
 
   wasm_tests:
     name: Run all WASM tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,18 +61,39 @@ jobs:
         with:
           tool: tomlq
 
+      - name: Extract version from manifest
+        run: |
+          CRATE_VERSION=$(cargo metadata --format-version=1 --no-deps | jq -e -r '.packages[] | select(.name == "'"$CRATE"'") | .version')
+          
+          echo "CRATE_VERSION=$CRATE_VERSION" >> $GITHUB_ENV
+
       - name: Enforce version in `workspace.dependencies` matches latest version
         if: env.CRATE != 'libp2p'
         run: |
-          PACKAGE_VERSION=$(cargo metadata --format-version=1 --no-deps | jq -e -r '.packages[] | select(.name == "'"$CRATE"'") | .version')
           SPECIFIED_VERSION=$(tomlq "workspace.dependencies.$CRATE.version" --file ./Cargo.toml)
 
-          echo "Package version: $PACKAGE_VERSION";
+          echo "Package version: $CRATE_VERSION";
           echo "Specified version: $SPECIFIED_VERSION";
 
-          test "$PACKAGE_VERSION" = "$SPECIFIED_VERSION" || test "=$PACKAGE_VERSION" = "$SPECIFIED_VERSION"
+          test "$CRATE_VERSION" = "$SPECIFIED_VERSION" || test "=$CRATE_VERSION" = "$SPECIFIED_VERSION"
+
+      - name: Enforce version in CHANGELOG.md matches version in manifest
+        run: |
+          VERSION_IN_CHANGELOG=$(awk -F' ' '/^## [0-9]+\.[0-9]+\.[0-9]+/{print $2; exit}' "$DIR_TO_CRATE/CHANGELOG.md")
+
+          echo "Package version: $CRATE_VERSION";
+          echo "Changelog version: $VERSION_IN_CHANGELOG";
+
+          test "$CRATE_VERSION" = "$VERSION_IN_CHANGELOG"
 
       - name: Ensure manifest and CHANGELOG are properly updated
+        if: >
+          github.event_name == 'pull_request' &&
+          !startsWith(github.event.pull_request.title, 'chore') &&
+          !startsWith(github.event.pull_request.title, 'refactor') &&
+          !startsWith(github.event.pull_request.title, 'deps') &&
+          !startsWith(github.event.pull_request.title, 'docs') &&
+          !contains(github.event.pull_request.labels.*.name, 'internal-change')
         run: |
           git fetch origin master:master
           git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
@@ -80,15 +101,6 @@ jobs:
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_BASE: ${{ github.event.pull_request.base.ref }}
-          ASSERT_CHANGELOG_UPDATED: |
-            ${{ 
-              github.event_name == 'pull_request' &&
-              !startsWith(github.event.pull_request.title, 'chore') &&
-              !startsWith(github.event.pull_request.title, 'refactor') &&
-              !startsWith(github.event.pull_request.title, 'deps') &&
-              !startsWith(github.event.pull_request.title, 'docs') &&
-              !contains(github.event.pull_request.labels.*.name, 'internal-change')
-            }}
 
   wasm_tests:
     name: Run all WASM tests

--- a/scripts/ensure-version-bump-and-changelog.sh
+++ b/scripts/ensure-version-bump-and-changelog.sh
@@ -24,6 +24,11 @@ if [ -z "$SRC_DIFF_TO_BASE" ]; then
   exit 0;
 fi
 
+# Exit early if we shouldn't assert for an updated changelog entry.
+if [ "$ASSERT_CHANGELOG_UPDATED" == "false" ]; then
+  exit 0;
+fi
+
 # Code was touched, ensure changelog is updated too.
 if [ -z "$CHANGELOG_DIFF" ]; then
     echo "Files in $DIR_TO_CRATE have changed, please write a changelog entry in $DIR_TO_CRATE/CHANGELOG.md"

--- a/scripts/ensure-version-bump-and-changelog.sh
+++ b/scripts/ensure-version-bump-and-changelog.sh
@@ -10,22 +10,8 @@ MERGE_BASE=$(git merge-base "$HEAD_SHA" "$PR_BASE") # Find the merge base. This 
 SRC_DIFF_TO_BASE=$(git diff "$HEAD_SHA".."$MERGE_BASE" --name-status -- "$DIR_TO_CRATE/src" "$DIR_TO_CRATE/Cargo.toml")
 CHANGELOG_DIFF=$(git diff "$HEAD_SHA".."$MERGE_BASE" --name-only -- "$DIR_TO_CRATE/CHANGELOG.md")
 
-VERSION_IN_CHANGELOG=$(awk -F' ' '/^## [0-9]+\.[0-9]+\.[0-9]+/{print $2; exit}' "$DIR_TO_CRATE/CHANGELOG.md")
-VERSION_IN_MANIFEST=$(cargo metadata --format-version=1 --no-deps | jq -e -r '.packages[] | select(.name == "'"$CRATE"'") | .version')
-
-# First, ensure version in Cargo.toml and CHANGELOG are in sync. This should always hold, regardless of whether the code in the crate was modified.
-if [[ "$VERSION_IN_CHANGELOG" != "$VERSION_IN_MANIFEST" ]]; then
-    echo "Version in Cargo.toml ($VERSION_IN_MANIFEST) does not match version in CHANGELOG ($VERSION_IN_CHANGELOG)"
-    exit 1
-fi
-
 # If the source files of this crate weren't touched in this PR, exit early.
 if [ -z "$SRC_DIFF_TO_BASE" ]; then
-  exit 0;
-fi
-
-# Exit early if we shouldn't assert for an updated changelog entry.
-if [ "$ASSERT_CHANGELOG_UPDATED" == "false" ]; then
   exit 0;
 fi
 
@@ -36,7 +22,7 @@ if [ -z "$CHANGELOG_DIFF" ]; then
 fi
 
 # Code was touched, ensure the version used in the manifest hasn't been released yet.
-if git tag | grep -q "^$CRATE-v${VERSION_IN_MANIFEST}$"; then
-    echo "v$VERSION_IN_MANIFEST of '$CRATE' has already been released, please bump the version."
+if git tag | grep -q "^$CRATE-v${CRATE_VERSION}$"; then
+    echo "v$CRATE_VERSION of '$CRATE' has already been released, please bump the version."
     exit 1
 fi


### PR DESCRIPTION
## Description

Ensuring that the version numbers within the changelog and the manifest are the same is useful independent of the kind of change.

Related: #4939.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
