### PR TITLE
ci: unset `RUSTFLAGS` value in semver job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,15 @@ jobs:
 
   semver:
     runs-on: ubuntu-latest
+    env:
+      # Unset the global `RUSTFLAGS` env to allow warnings.
+      # cargo-semver-checks intentionally re-locks dependency versions
+      # before checking, and we shouldn't fail here if a dep has a warning.
+      #
+      # More context:
+      # https://github.com/libp2p/rust-libp2p/pull/4932#issuecomment-1829014527
+      # https://github.com/obi1kenobi/cargo-semver-checks/issues/589
+      RUSTFLAGS: ''
     steps:
       - uses: actions/checkout@v4
       - run: wget -q -O- https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v0.25.0/cargo-semver-checks-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C ~/.cargo/bin


### PR DESCRIPTION
## Description

Don't fail semver-checking if a dependency version has warnings, such as deprecation notices.

Related: https://github.com/libp2p/rust-libp2p/pull/4932#issuecomment-1829014527.
Related: https://github.com/obi1kenobi/cargo-semver-checks/issues/589.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
