### PR TITLE
fix(tutorial): import dependencies via meta crate

### DIFF
--- a/libp2p/src/tutorials/ping.rs
+++ b/libp2p/src/tutorials/ping.rs
@@ -55,7 +55,7 @@
 //!        edition = "2021"
 //!
 //!    [dependencies]
-//!        libp2p = { version = "0.52", features = ["tcp", "dns", "async-std", "noise", "yamux", "websocket", "ping", "macros"] }
+//!        libp2p = { version = "0.52", features = ["tcp", "tls", "dns", "async-std", "noise", "yamux", "websocket", "ping", "macros"] }
 //!        futures = "0.3.21"
 //!        async-std = { version = "1.12.0", features = ["attributes"] }
 //!        tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -95,7 +95,6 @@
 //! trait.
 //!
 //! ```rust
-//! use libp2p::{identity, PeerId};
 //! use std::error::Error;
 //! use tracing_subscriber::EnvFilter;
 //!
@@ -106,9 +105,9 @@
 //!     let mut swarm = libp2p::SwarmBuilder::with_new_identity()
 //!         .with_async_std()
 //!         .with_tcp(
-//!             libp2p_tcp::Config::default(),
-//!             libp2p_tls::Config::new,
-//!             libp2p_yamux::Config::default,
+//!             libp2p::tcp::Config::default(),
+//!             libp2p::tls::Config::new,
+//!             libp2p::yamux::Config::default,
 //!         )?;
 //!
 //!     Ok(())
@@ -138,8 +137,7 @@
 //! With the above in mind, let's extend our example, creating a [`ping::Behaviour`](crate::ping::Behaviour) at the end:
 //!
 //! ```rust
-//! use libp2p::swarm::NetworkBehaviour;
-//! use libp2p::{identity, ping, PeerId};
+//! use libp2p::ping;
 //! use tracing_subscriber::EnvFilter;
 //! use std::error::Error;
 //!
@@ -150,9 +148,9 @@
 //!     let mut swarm = libp2p::SwarmBuilder::with_new_identity()
 //!         .with_async_std()
 //!         .with_tcp(
-//!             libp2p_tcp::Config::default(),
-//!             libp2p_tls::Config::new,
-//!             libp2p_yamux::Config::default,
+//!             libp2p::tcp::Config::default(),
+//!             libp2p::tls::Config::new,
+//!             libp2p::yamux::Config::default,
 //!         )?
 //!         .with_behaviour(|_| ping::Behaviour::default())?;
 //!
@@ -168,8 +166,7 @@
 //! to the [`Transport`] as well as events from the [`Transport`] to the [`NetworkBehaviour`].
 //!
 //! ```rust
-//! use libp2p::swarm::NetworkBehaviour;
-//! use libp2p::{identity, ping, PeerId};
+//! use libp2p::ping;
 //! use std::error::Error;
 //! use tracing_subscriber::EnvFilter;
 //!
@@ -180,9 +177,9 @@
 //!     let mut swarm = libp2p::SwarmBuilder::with_new_identity()
 //!         .with_async_std()
 //!         .with_tcp(
-//!             libp2p_tcp::Config::default(),
-//!             libp2p_tls::Config::new,
-//!             libp2p_yamux::Config::default,
+//!             libp2p::tcp::Config::default(),
+//!             libp2p::tls::Config::new,
+//!             libp2p::yamux::Config::default,
 //!         )?
 //!         .with_behaviour(|_| ping::Behaviour::default())?
 //!         .build();
@@ -202,8 +199,7 @@
 //! Thus, without any other behaviour in place, we would not be able to observe the pings.
 //!
 //! ```rust
-//! use libp2p::swarm::NetworkBehaviour;
-//! use libp2p::{identity, ping, PeerId};
+//! use libp2p::ping;
 //! use std::error::Error;
 //! use std::time::Duration;
 //! use tracing_subscriber::EnvFilter;
@@ -215,9 +211,9 @@
 //!     let mut swarm = libp2p::SwarmBuilder::with_new_identity()
 //!         .with_async_std()
 //!         .with_tcp(
-//!             libp2p_tcp::Config::default(),
-//!             libp2p_tls::Config::new,
-//!             libp2p_yamux::Config::default,
+//!             libp2p::tcp::Config::default(),
+//!             libp2p::tls::Config::new,
+//!             libp2p::yamux::Config::default,
 //!         )?
 //!         .with_behaviour(|_| ping::Behaviour::default())?
 //!         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(30))) // Allows us to observe pings for 30 seconds.
@@ -254,7 +250,7 @@
 //! remote peer.
 //!
 //! ```rust
-//! use libp2p::{identity, ping, Multiaddr, PeerId};
+//! use libp2p::{ping, Multiaddr};
 //! use std::error::Error;
 //! use std::time::Duration;
 //! use tracing_subscriber::EnvFilter;
@@ -266,9 +262,9 @@
 //!     let mut swarm = libp2p::SwarmBuilder::with_new_identity()
 //!         .with_async_std()
 //!         .with_tcp(
-//!             libp2p_tcp::Config::default(),
-//!             libp2p_tls::Config::new,
-//!             libp2p_yamux::Config::default,
+//!             libp2p::tcp::Config::default(),
+//!             libp2p::tls::Config::new,
+//!             libp2p::yamux::Config::default,
 //!         )?
 //!         .with_behaviour(|_| ping::Behaviour::default())?
 //!         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(30))) // Allows us to observe pings for 30 seconds.
@@ -298,8 +294,8 @@
 //!
 //! ```no_run
 //! use futures::prelude::*;
-//! use libp2p::swarm::{NetworkBehaviour, SwarmEvent};
-//! use libp2p::{identity, ping, Multiaddr, PeerId};
+//! use libp2p::swarm::SwarmEvent;
+//! use libp2p::{ping, Multiaddr};
 //! use std::error::Error;
 //! use std::time::Duration;
 //! use tracing_subscriber::EnvFilter;
@@ -311,9 +307,9 @@
 //!     let mut swarm = libp2p::SwarmBuilder::with_new_identity()
 //!         .with_async_std()
 //!         .with_tcp(
-//!             libp2p_tcp::Config::default(),
-//!             libp2p_tls::Config::new,
-//!             libp2p_yamux::Config::default,
+//!             libp2p::tcp::Config::default(),
+//!             libp2p::tls::Config::new,
+//!             libp2p::yamux::Config::default,
 //!         )?
 //!         .with_behaviour(|_| ping::Behaviour::default())?
 //!         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(30))) // Allows us to observe pings for 30 seconds.


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->
## Notes & open questions
I'm new to this lib, and I find directly copying the ping example as the tutorial said has some import issues. For example, `libp2p_tls` is the dependency in the `libp2p` codebase, but will not be in the application codes only if you specify it. I don't know whether the confusion is a side effect of passing the doctests.
<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
