### PR TITLE
fix(browser-webrtc-example): use `tracing-wasm` logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,9 +676,9 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "tracing-wasm",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-logger",
  "web-sys",
 ]
 
@@ -5965,6 +5965,17 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log 0.2.0",
+]
+
+[[package]]
+name = "tracing-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/examples/browser-webrtc/Cargo.toml
+++ b/examples/browser-webrtc/Cargo.toml
@@ -24,7 +24,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 axum = "0.6.19"
-libp2p = { path = "../../libp2p", features = [ "ed25519", "macros", "ping", "wasm-bindgen", "tokio"] }
+libp2p = { path = "../../libp2p", features = [ "ed25519", "macros", "ping", "tokio"] }
 libp2p-webrtc = { workspace = true, features = ["tokio"] }
 rust-embed = { version = "8.0.0", features = ["include-exclude", "interpolate-folder-path"] }
 tokio = { version = "1.34", features = ["macros", "net", "rt", "signal"] }

--- a/examples/browser-webrtc/Cargo.toml
+++ b/examples/browser-webrtc/Cargo.toml
@@ -37,9 +37,9 @@ mime_guess = "2.0.4"
 js-sys = "0.3.66"
 libp2p = { path = "../../libp2p", features = [ "ed25519", "macros", "ping", "wasm-bindgen"] }
 libp2p-webrtc-websys = { workspace = true }
+tracing-wasm = "0.2.1"
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.38"
-wasm-logger = { version = "0.2.0" }
 web-sys = { version = "0.3", features = ['Document', 'Element', 'HtmlElement', 'Node', 'Response', 'Window'] }
 
 [lints]

--- a/examples/browser-webrtc/src/lib.rs
+++ b/examples/browser-webrtc/src/lib.rs
@@ -13,7 +13,7 @@ use web_sys::{Document, HtmlElement};
 
 #[wasm_bindgen]
 pub async fn run(libp2p_endpoint: String) -> Result<(), JsError> {
-    wasm_logger::init(wasm_logger::Config::default());
+    tracing_wasm::set_as_global_default();
 
     let body = Body::from_current_window()?;
     body.append_p("Let's ping the WebRTC Server!")?;


### PR DESCRIPTION
When `log` was replaced by `tracing`, it broke the logging in this example. Now we can use `tracing-wasm` instead of the legacy `wasm-logger` to get our output logs.

## Description

Upgrade `wasm-logger` to `tracing-wasm`. 

Related: #4950.

## Notes & open questions

None, just figure logs will be useful to troubleshoot #4950. 

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- ~~[x] I have made corresponding changes to the documentation~~
- ~~[x] I have added tests that prove my fix is effective or that my feature works~~
- ~~[x] A changelog entry has been made in the appropriate crates~~
