### PR TITLE
fix(kad): wake `Handler` after pushing into `pending_messages`

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Ensure `Multiaddr` handled and returned by `Behaviour` are `/p2p` terminated.
   See [PR 4596](https://github.com/libp2p/rust-libp2p/pull/4596).
+- Fix missing wake-up of `Handler` when new messages arrive from the `NetworkBehaviour`.
+  See [PR 4961](https://github.com/libp2p/rust-libp2p/pull/4961).
 
 ## 0.45.1
 


### PR DESCRIPTION
## Description

Fixes: #4960.

## Notes & open questions

N/A

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
