### PR TITLE
chore(quic): set `max_idle_timeout` to quinn default timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "async-std",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ libp2p-perf = { version = "0.3.0", path = "protocols/perf" }
 libp2p-ping = { version = "0.44.0", path = "protocols/ping" }
 libp2p-plaintext = { version = "0.41.0", path = "transports/plaintext" }
 libp2p-pnet = { version = "0.24.0", path = "transports/pnet" }
-libp2p-quic = { version = "0.10.1", path = "transports/quic" }
+libp2p-quic = { version = "0.10.2", path = "transports/quic" }
 libp2p-relay = { version = "0.17.1", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.14.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.26.0", path = "protocols/request-response" }

--- a/transports/quic/CHANGELOG.md
+++ b/transports/quic/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.2 - unreleased
+## 0.10.2
 
 - Change `max_idle_timeout`to 10s.
   See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).

--- a/transports/quic/CHANGELOG.md
+++ b/transports/quic/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.2 - unreleased
+
+- Change `max_idle_timeout`to 10s.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+
 ## 0.10.1
 
 - Allow disabling path MTU discovery.

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-quic"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 rust-version = { workspace = true }

--- a/transports/quic/src/config.rs
+++ b/transports/quic/src/config.rs
@@ -78,9 +78,9 @@ impl Config {
             server_tls_config,
             support_draft_29: false,
             handshake_timeout: Duration::from_secs(5),
-            max_idle_timeout: 30 * 1000,
+            max_idle_timeout: 10 * 1000,
             max_concurrent_stream_limit: 256,
-            keep_alive_interval: Duration::from_secs(15),
+            keep_alive_interval: Duration::from_secs(5),
             max_connection_data: 15_000_000,
 
             // Ensure that one stream is not consuming the whole connection.


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

Resolves #4917.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

Would be open to decreasing it to 5 seconds as noted in #4917, but if it it is reduced to that amount, what should we set `keep_alive_interval` to since it is noted that it should be less than `max_idle_timeout`? 

https://github.com/libp2p/rust-libp2p/blob/e889e2e446e32e29a6c979d4b37775181bb55455/transports/quic/src/config.rs#L32-L38

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
