### PR TITLE
chore(webrtc-utils): bump version to allow for new release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-webrtc-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "asynchronous-codec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ libp2p-tls = { version = "0.3.0", path = "transports/tls" }
 libp2p-uds = { version = "0.40.0", path = "transports/uds" }
 libp2p-upnp = { version = "0.2.0", path = "protocols/upnp" }
 libp2p-webrtc = { version = "0.7.0-alpha", path = "transports/webrtc" }
-libp2p-webrtc-utils = { version = "0.1.0", path = "misc/webrtc-utils" }
+libp2p-webrtc-utils = { version = "0.2.0", path = "misc/webrtc-utils" }
 libp2p-webrtc-websys = { version = "0.3.0-alpha", path = "transports/webrtc-websys" }
 libp2p-websocket = { version = "0.43.0", path = "transports/websocket" }
 libp2p-websocket-websys = { version = "0.3.1", path = "transports/websocket-websys" }

--- a/misc/webrtc-utils/CHANGELOG.md
+++ b/misc/webrtc-utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+- Update to latest version of `libp2p-noise`.
+
 ## 0.1.0
 
 - Initial release.

--- a/misc/webrtc-utils/CHANGELOG.md
+++ b/misc/webrtc-utils/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.0
 
 - Update to latest version of `libp2p-noise`.
+  See [PR 4968](https://github.com/libp2p/rust-libp2p/pull/4968).
 
 ## 0.1.0
 

--- a/misc/webrtc-utils/Cargo.toml
+++ b/misc/webrtc-utils/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "libp2p-webrtc-utils"
 repository = "https://github.com/libp2p/rust-libp2p"
 rust-version = { workspace = true }
-version = "0.1.0"
+version = "0.2.0"
 publish = true
 
 [dependencies]


### PR DESCRIPTION
## Description

We didn't bump this crate's version despite it depending on `libp2p_noise`. As such, we can't release `libp2p-webrtc-websys` at the moment because it needs a new release of this crate.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
