### PR TITLE
feat(webrtc-websys): hide `libp2p_noise` from the public API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3294,7 +3294,6 @@ dependencies = [
  "js-sys",
  "libp2p-core",
  "libp2p-identity",
- "libp2p-noise",
  "libp2p-ping",
  "libp2p-swarm",
  "libp2p-webrtc-utils",

--- a/misc/webrtc-utils/src/noise.rs
+++ b/misc/webrtc-utils/src/noise.rs
@@ -27,12 +27,14 @@ use libp2p_noise as noise;
 
 use crate::fingerprint::Fingerprint;
 
+pub use noise::Error;
+
 pub async fn inbound<T>(
     id_keys: identity::Keypair,
     stream: T,
     client_fingerprint: Fingerprint,
     server_fingerprint: Fingerprint,
-) -> Result<PeerId, libp2p_noise::Error>
+) -> Result<PeerId, Error>
 where
     T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
@@ -54,7 +56,7 @@ pub async fn outbound<T>(
     stream: T,
     server_fingerprint: Fingerprint,
     client_fingerprint: Fingerprint,
-) -> Result<PeerId, libp2p_noise::Error>
+) -> Result<PeerId, Error>
 where
     T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {

--- a/transports/webrtc-websys/CHANGELOG.md
+++ b/transports/webrtc-websys/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Bump version in order to publish a new version dependent on latest `libp2p-core`.
   See [PR 4959](https://github.com/libp2p/rust-libp2p/pull/4959).
 - Remove `libp2p_noise` from the public API.
+  See [PR 4969](https://github.com/libp2p/rust-libp2p/pull/4969).
 
 ## 0.2.0-alpha
 

--- a/transports/webrtc-websys/CHANGELOG.md
+++ b/transports/webrtc-websys/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Bump version in order to publish a new version dependent on latest `libp2p-core`.
   See [PR 4959](https://github.com/libp2p/rust-libp2p/pull/4959).
+- Remove `libp2p_noise` from the public API.
 
 ## 0.2.0-alpha
 

--- a/transports/webrtc-websys/Cargo.toml
+++ b/transports/webrtc-websys/Cargo.toml
@@ -20,7 +20,6 @@ hex = "0.4.3"
 js-sys = { version = "0.3" }
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true }
-libp2p-noise = { workspace = true }
 libp2p-webrtc-utils = { workspace = true }
 send_wrapper = { version = "0.6.0", features = ["futures"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/transports/webrtc-websys/src/error.rs
+++ b/transports/webrtc-websys/src/error.rs
@@ -20,8 +20,13 @@ pub enum Error {
     Connection(String),
 
     #[error("Authentication error")]
-    Authentication(#[from] libp2p_noise::Error),
+    Authentication(#[from] AuthenticationError),
 }
+
+/// New-type wrapper to hide `libp2p_noise` from the public API.
+#[derive(thiserror::Error, Debug)]
+#[error(transparent)]
+pub struct AuthenticationError(pub(crate) libp2p_webrtc_utils::noise::Error);
 
 impl Error {
     pub(crate) fn from_js_value(value: JsValue) -> Self {
@@ -38,7 +43,7 @@ impl Error {
     }
 }
 
-impl std::convert::From<wasm_bindgen::JsValue> for Error {
+impl From<JsValue> for Error {
     fn from(value: JsValue) -> Self {
         Error::from_js_value(value)
     }

--- a/transports/webrtc-websys/src/upgrade.rs
+++ b/transports/webrtc-websys/src/upgrade.rs
@@ -1,5 +1,6 @@
 use super::Error;
 use crate::connection::RtcPeerConnection;
+use crate::error::AuthenticationError;
 use crate::sdp;
 use crate::Connection;
 use libp2p_identity::{Keypair, PeerId};
@@ -48,7 +49,9 @@ async fn outbound_inner(
     tracing::trace!(?local_fingerprint);
     tracing::trace!(?remote_fingerprint);
 
-    let peer_id = noise::outbound(id_keys, channel, remote_fingerprint, local_fingerprint).await?;
+    let peer_id = noise::outbound(id_keys, channel, remote_fingerprint, local_fingerprint)
+        .await
+        .map_err(AuthenticationError)?;
 
     tracing::debug!(peer=%peer_id, "Remote peer identified");
 


### PR DESCRIPTION
## Description

Currently, `libp2p-webrtc-websys` exposes the `libp2p_noise` dependency in its public API. It should really be a private dependency of the crate. By wrapping it in a new-type, we can achieve this.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

Merging this immediately to allow for a release of `libp2p-webrtc-websys`.

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
