### PR TITLE
fix: use `cc-debian12` base image for interop tests

### DIFF
--- a/interop-tests/Dockerfile.native
+++ b/interop-tests/Dockerfile.native
@@ -15,7 +15,7 @@ RUN cargo chef cook --release --package interop-tests --bin native_ping --recipe
 COPY . .
 RUN cargo build --release --package interop-tests --bin native_ping
 
-FROM gcr.io/distroless/cc
+FROM gcr.io/distroless/cc-debian12
 COPY --from=builder /app/target/release/native_ping /usr/local/bin/testplan
 ENV RUST_BACKTRACE=1
 ENTRYPOINT ["testplan"]


### PR DESCRIPTION
## Description

With the update to Rust 1.73, we need glibc > 3.32 which is not available in the regular `cc` base image.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
