### PR TITLE
fix(identity): fix test when no features are enabled

### DIFF
--- a/identity/src/keypair.rs
+++ b/identity/src/keypair.rs
@@ -819,6 +819,12 @@ impl From<rsa::PublicKey> for PublicKey {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(any(
+        feature = "ecdsa",
+        feature = "secp256k1",
+        feature = "ed25519",
+        feature = "rsa"
+    ))]
     use super::*;
 
     #[test]

--- a/identity/tests/keypair_api.rs
+++ b/identity/tests/keypair_api.rs
@@ -1,5 +1,11 @@
 use libp2p_identity::Keypair;
 
+#[cfg(any(
+    feature = "ecdsa",
+    feature = "secp256k1",
+    feature = "ed25519",
+    feature = "rsa"
+))]
 #[test]
 fn calling_keypair_api() {
     let _ = Keypair::from_protobuf_encoding(&[]);


### PR DESCRIPTION
## Description

On master branch the test for identity when they are no features enabled are currently broken. See

```sh
cargo test --package libp2p-identity
# or
cd identity/
cargo test
```

This PR add the required `#[cfg()]` to make the test pass.

## Change checklist

Not sure if we need a changelog entry for something this small

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
