### PR TITLE
fix: old macOS quinn issue by using a more recent version of quinn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4508,11 +4508,10 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
+version = "0.11.0"
+source = "git+https://github.com/quinn-rs/quinn?rev=1c7c46049c55939764d32754bf22080f1f648d5a#1c7c46049c55939764d32754bf22080f1f648d5a"
 dependencies = [
- "async-io 1.13.0",
+ "async-io 2.3.2",
  "async-std",
  "bytes",
  "futures-io",
@@ -4528,9 +4527,8 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c78e758510582acc40acb90458401172d41f1016f8c9dde89e49677afb7eec1"
+version = "0.11.0"
+source = "git+https://github.com/quinn-rs/quinn?rev=1c7c46049c55939764d32754bf22080f1f648d5a#1c7c46049c55939764d32754bf22080f1f648d5a"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -4545,15 +4543,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df19e284d93757a9fb91d63672f7741b129246a669db09d1c0063071debc0c0"
+version = "0.5.0"
+source = "git+https://github.com/quinn-rs/quinn?rev=1c7c46049c55939764d32754bf22080f1f648d5a#1c7c46049c55939764d32754bf22080f1f648d5a"
 dependencies = [
  "bytes",
  "libc",
+ "once_cell",
  "socket2 0.5.6",
  "tracing",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -18,7 +18,7 @@ libp2p-core = { workspace = true }
 libp2p-tls = { workspace = true }
 libp2p-identity = { workspace = true }
 parking_lot = "0.12.0"
-quinn = { version = "0.10.2", default-features = false, features = ["tls-rustls", "futures-io"] }
+quinn = { git = "https://github.com/quinn-rs/quinn", rev = "1c7c46049c55939764d32754bf22080f1f648d5a", default-features = false, features = ["tls-rustls", "futures-io"] }
 rand = "0.8.5"
 rustls = { version = "0.21.9", default-features = false }
 thiserror = "1.0.58"

--- a/transports/quic/src/connection/stream.rs
+++ b/transports/quic/src/connection/stream.rs
@@ -67,7 +67,9 @@ impl AsyncWrite for Stream {
         cx: &mut Context,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.send).poll_write(cx, buf)
+        Pin::new(&mut self.send)
+            .poll_write(cx, buf)
+            .map_err(Into::into)
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {


### PR DESCRIPTION
## Description

Fix for #5139

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
