### PR TITLE
feat(kad): FIND_NODE for own peer id returns closest peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2521,7 +2521,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libp2p"
-version = "0.53.2"
+version = "0.54.0"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.45.4"
+version = "0.46.0"
 dependencies = [
  "arrayvec",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ rust-version = "1.73.0"
 [workspace.dependencies]
 asynchronous-codec = { version = "0.7.0" }
 futures-bounded = { version = "0.2.3" }
-libp2p = { version = "0.53.2", path = "libp2p" }
+libp2p = { version = "0.54.0", path = "libp2p" }
 libp2p-allow-block-list = { version = "0.3.0", path = "misc/allow-block-list" }
 libp2p-autonat = { version = "0.12.0", path = "protocols/autonat" }
 libp2p-connection-limits = { version = "0.3.1", path = "misc/connection-limits" }
@@ -84,7 +84,7 @@ libp2p-floodsub = { version = "0.44.0", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.46.1", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.44.2", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.8" }
-libp2p-kad = { version = "0.45.4", path = "protocols/kad" }
+libp2p-kad = { version = "0.46.0", path = "protocols/kad" }
 libp2p-mdns = { version = "0.45.1", path = "protocols/mdns" }
 libp2p-memory-connection-limits = { version = "0.2.0", path = "misc/memory-connection-limits" }
 libp2p-metrics = { version = "0.14.1", path = "misc/metrics" }

--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.54.0 -- unreleased
+
+- Update individual crates.
+    - Update to [`libp2p-kad` `v0.46.0`](protocols/kad/CHANGELOG.md#0460).
+
+
 ## 0.53.2
 
 - Allow `SwarmBuilder::with_bandwidth_metrics` after `SwarmBuilder::with_websocket`.

--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Peer-to-peer networking library"
-version = "0.53.2"
+version = "0.54.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.46.0 -- unreleased
+
+- Changed `FIND_NODE` response: now includes a list of closest peers when querying the recipient peer ID. Previously, this request yielded an empty response.
+  See [PR 5270](https://github.com/libp2p/rust-libp2p/pull/5270)
+
 ## 0.45.4
 
 - Add periodic and automatic bootstrap.

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-kad"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Kademlia protocol for libp2p"
-version = "0.45.4"
+version = "0.46.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -1180,16 +1180,12 @@ where
         target: &kbucket::Key<T>,
         source: &PeerId,
     ) -> Vec<KadPeer> {
-        if target == self.kbuckets.local_key() {
-            Vec::new()
-        } else {
-            self.kbuckets
-                .closest(target)
-                .filter(|e| e.node.key.preimage() != source)
-                .take(self.queries.config().replication_factor.get())
-                .map(KadPeer::from)
-                .collect()
-        }
+        self.kbuckets
+            .closest(target)
+            .filter(|e| e.node.key.preimage() != source)
+            .take(self.queries.config().replication_factor.get())
+            .map(KadPeer::from)
+            .collect()
     }
 
     /// Collects all peers who are known to be providers of the value for a given `Multihash`.


### PR DESCRIPTION
## Description

Fixes https://github.com/libp2p/rust-libp2p/issues/5269.

## Notes & open questions

`FIND_NODE` response should not contain self nor the requester ID, but should never be empty if it has any other peers in the routing table.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (no changes required)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
