### PR TITLE
fix(kad): moving changelog entries

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -6,9 +6,6 @@
   See [PR 3230](https://github.com/libp2p/rust-libp2p/pull/3230)
 - QueryClose progress whenever closer in range, instead of having to be the closest.
   See [PR 4934](https://github.com/libp2p/rust-libp2p/pull/4934).
-
-## 0.45.4
-
 - Add periodic and automatic bootstrap.
   See [PR 4838](https://github.com/libp2p/rust-libp2p/pull/4838).
 - Make it mandatory to provide protocol names when creating a `kad::Config`.


### PR DESCRIPTION
## Description

`libp2p-kad` `v0.45.4` won't be released. Moving changes to `v0.46.0`.

## Notes & open questions

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
