### PR TITLE
test(mdns): Add a test to demonstrate a timer panic

### DIFF
--- a/protocols/mdns/src/behaviour/timer.rs
+++ b/protocols/mdns/src/behaviour/timer.rs
@@ -128,4 +128,17 @@ pub(crate) mod tokio {
             (std::usize::MAX, None)
         }
     }
+
+    #[cfg(test)]
+    mod tests {
+        use futures::{future::poll_fn, StreamExt};
+
+        use super::Builder;
+
+        #[tokio::test]
+        async fn does_not_panic_with_basic_usage() {
+            let mut timer = super::TokioTimer::at(std::time::Instant::now());
+            poll_fn(|cx| (&mut timer).poll_next_unpin(cx)).await;
+        }
+    }
 }


### PR DESCRIPTION
## Description

This issue was discovered in the wild and the test is added to capture and demonstrate that the very basic use of the tokio timer fails.

## Notes & open questions

This PR does not fix the issue, just adds a test to catch it.

Refs: https://github.com/paritytech/polkadot-sdk/issues/1974

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
