### PR TITLE
fix(mdns): don't use Duration::MAX on TokioTimer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.45.1"
+version = "0.45.2"
 dependencies = [
  "async-io 2.3.2",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ libp2p-gossipsub = { version = "0.46.1", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.44.2", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.8" }
 libp2p-kad = { version = "0.46.0", path = "protocols/kad" }
-libp2p-mdns = { version = "0.45.1", path = "protocols/mdns" }
+libp2p-mdns = { version = "0.45.2", path = "protocols/mdns" }
 libp2p-memory-connection-limits = { version = "0.2.0", path = "misc/memory-connection-limits" }
 libp2p-metrics = { version = "0.14.1", path = "misc/metrics" }
 libp2p-mplex = { version = "0.41.0", path = "muxers/mplex" }

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.45.2 - unreleased
+- Fix `TokioTimer::at` panic.
+  See [PR 5297](https://github.com/libp2p/rust-libp2p/pull/5297).
+
 ## 0.45.1
 
 - Ensure `Multiaddr` handled and returned by `Behaviour` are `/p2p` terminated.

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-mdns"
 edition = "2021"
 rust-version = { workspace = true }
-version = "0.45.1"
+version = "0.45.2"
 description = "Implementation of the libp2p mDNS discovery method"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"


### PR DESCRIPTION
## Description

`at()` function. Closes #5296 and superseeds #5295 

cc @MOZGIII @bkchr

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
