### PR TITLE
feat(kad): derive Copy for kbucket::key::Key

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -15,6 +15,8 @@
   See [PR 5122](https://github.com/libp2p/rust-libp2p/pull/5122).
 - Compute `jobs_query_capacity` accurately.
   See [PR 5148](https://github.com/libp2p/rust-libp2p/pull/5148).
+- Derive `Copy` for `kbucket::key::Key<T>`.
+  See [PR 5317](https://github.com/libp2p/rust-libp2p/pull/5317).
 
 ## 0.45.3
 

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -931,7 +931,7 @@ where
     /// This parameter is used to call [`Behaviour::bootstrap`] periodically and automatically
     /// to ensure a healthy routing table.
     pub fn bootstrap(&mut self) -> Result<QueryId, NoKnownPeers> {
-        let local_key = self.kbuckets.local_key().clone();
+        let local_key = *self.kbuckets.local_key();
         let info = QueryInfo::Bootstrap {
             peer: *local_key.preimage(),
             remaining: None,
@@ -1396,7 +1396,7 @@ where
                 remaining,
                 mut step,
             } => {
-                let local_key = self.kbuckets.local_key().clone();
+                let local_key = *self.kbuckets.local_key();
                 let mut remaining = remaining.unwrap_or_else(|| {
                     debug_assert_eq!(&peer, local_key.preimage());
                     // The lookup for the local key finished. To complete the bootstrap process,
@@ -1446,7 +1446,7 @@ where
                     let peers = self.kbuckets.closest_keys(&target);
                     let inner = QueryInner::new(info);
                     self.queries
-                        .continue_iter_closest(query_id, target.clone(), peers, inner);
+                        .continue_iter_closest(query_id, target, peers, inner);
                 } else {
                     step.last = true;
                     self.bootstrap_status.on_finish();
@@ -1642,14 +1642,14 @@ where
                     remaining.take().and_then(|mut r| Some((r.next()?, r)))
                 {
                     let info = QueryInfo::Bootstrap {
-                        peer: target.clone().into_preimage(),
+                        peer: target.into_preimage(),
                         remaining: Some(remaining),
                         step: step.next(),
                     };
                     let peers = self.kbuckets.closest_keys(&target);
                     let inner = QueryInner::new(info);
                     self.queries
-                        .continue_iter_closest(query_id, target.clone(), peers, inner);
+                        .continue_iter_closest(query_id, target, peers, inner);
                 } else {
                     step.last = true;
                     self.bootstrap_status.on_finish();

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -534,7 +534,7 @@ mod tests {
         fn arbitrary(g: &mut Gen) -> TestTable {
             let local_key = Key::from(PeerId::random());
             let timeout = Duration::from_secs(g.gen_range(1..360));
-            let mut table = TestTable::new(local_key.clone().into(), timeout);
+            let mut table = TestTable::new(local_key.into(), timeout);
             let mut num_total = g.gen_range(0..100);
             for (i, b) in &mut table.buckets.iter_mut().enumerate().rev() {
                 let ix = BucketIndex(i);
@@ -543,10 +543,7 @@ mod tests {
                 for _ in 0..num {
                     let distance = ix.rand_distance(&mut rand::thread_rng());
                     let key = local_key.for_distance(distance);
-                    let node = Node {
-                        key: key.clone(),
-                        value: (),
-                    };
+                    let node = Node { key, value: () };
                     let status = NodeStatus::arbitrary(g);
                     match b.insert(node, status) {
                         InsertResult::Inserted => {}
@@ -643,7 +640,7 @@ mod tests {
     #[test]
     fn entry_self() {
         let local_key = Key::from(PeerId::random());
-        let mut table = KBucketsTable::<_, ()>::new(local_key.clone(), Duration::from_secs(5));
+        let mut table = KBucketsTable::<_, ()>::new(local_key, Duration::from_secs(5));
 
         assert!(table.entry(&local_key).is_none())
     }
@@ -671,7 +668,7 @@ mod tests {
         let mut expected_keys: Vec<_> = table
             .buckets
             .iter()
-            .flat_map(|t| t.iter().map(|(n, _)| n.key.clone()))
+            .flat_map(|t| t.iter().map(|(n, _)| n.key))
             .collect();
 
         for _ in 0..10 {
@@ -686,7 +683,7 @@ mod tests {
     #[test]
     fn applied_pending() {
         let local_key = Key::from(PeerId::random());
-        let mut table = KBucketsTable::<_, ()>::new(local_key.clone(), Duration::from_millis(1));
+        let mut table = KBucketsTable::<_, ()>::new(local_key, Duration::from_millis(1));
         let expected_applied;
         let full_bucket_index;
         loop {
@@ -698,10 +695,7 @@ mod tests {
                             match e.insert((), NodeStatus::Connected) {
                                 InsertResult::Pending { disconnected } => {
                                     expected_applied = AppliedPending {
-                                        inserted: Node {
-                                            key: key.clone(),
-                                            value: (),
-                                        },
+                                        inserted: Node { key, value: () },
                                         evicted: Some(Node {
                                             key: disconnected,
                                             value: (),

--- a/protocols/kad/src/kbucket/bucket.rs
+++ b/protocols/kad/src/kbucket/bucket.rs
@@ -439,10 +439,7 @@ mod tests {
             let num_nodes = g.gen_range(1..K_VALUE.get() + 1);
             for _ in 0..num_nodes {
                 let key = Key::from(PeerId::random());
-                let node = Node {
-                    key,
-                    value: (),
-                };
+                let node = Node { key, value: () };
                 let status = NodeStatus::arbitrary(g);
                 match bucket.insert(node, status) {
                     InsertResult::Inserted => {}
@@ -492,10 +489,7 @@ mod tests {
             // Fill the bucket, thereby populating the expected lists in insertion order.
             for status in status {
                 let key = Key::from(PeerId::random());
-                let node = Node {
-                    key,
-                    value: (),
-                };
+                let node = Node { key, value: () };
                 let full = bucket.num_entries() == K_VALUE.get();
                 if let InsertResult::Inserted = bucket.insert(node, status) {
                     let vec = match status {

--- a/protocols/kad/src/kbucket/key.rs
+++ b/protocols/kad/src/kbucket/key.rs
@@ -39,7 +39,7 @@ construct_uint! {
 ///
 /// `Key`s have an XOR metric as defined in the Kademlia paper, i.e. the bitwise XOR of
 /// the hash digests, interpreted as an integer. See [`Key::distance`].
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Key<T> {
     preimage: T,
     bytes: KeyBytes,
@@ -145,7 +145,7 @@ impl<T> Hash for Key<T> {
 }
 
 /// The raw bytes of a key in the DHT keyspace.
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct KeyBytes(GenericArray<u8, U32>);
 
 impl KeyBytes {

--- a/protocols/kad/src/query/peers/closest.rs
+++ b/protocols/kad/src/query/peers/closest.rs
@@ -600,7 +600,7 @@ mod tests {
             let num_known = expected.len();
             let max_parallelism = usize::min(iter.config.parallelism.get(), num_known);
 
-            let target = iter.target.clone();
+            let target = iter.target;
             let mut remaining;
             let mut num_failures = 0;
 

--- a/protocols/kad/src/query/peers/closest.rs
+++ b/protocols/kad/src/query/peers/closest.rs
@@ -556,12 +556,12 @@ mod tests {
     #[test]
     fn new_iter() {
         fn prop(iter: ClosestPeersIter) {
-            let target = iter.target.clone();
+            let target = iter.target;
 
             let (keys, states): (Vec<_>, Vec<_>) = iter
                 .closest_peers
                 .values()
-                .map(|e| (e.key.clone(), &e.state))
+                .map(|e| (e.key, &e.state))
                 .unzip();
 
             let none_contacted = states.iter().all(|s| matches!(s, PeerState::NotContacted));
@@ -595,7 +595,7 @@ mod tests {
             let mut expected = iter
                 .closest_peers
                 .values()
-                .map(|e| e.key.clone())
+                .map(|e| e.key)
                 .collect::<Vec<_>>();
             let num_known = expected.len();
             let max_parallelism = usize::min(iter.config.parallelism.get(), num_known);
@@ -667,7 +667,7 @@ mod tests {
                 .values()
                 .all(|e| !matches!(e.state, PeerState::NotContacted | PeerState::Waiting { .. }));
 
-            let target = iter.target.clone();
+            let target = iter.target;
             let num_results = iter.config.num_results;
             let result = iter.into_result();
             let closest = result.map(Key::from).collect::<Vec<_>>();
@@ -744,7 +744,6 @@ mod tests {
                 .next()
                 .unwrap()
                 .key
-                .clone()
                 .into_preimage();
 
             // Poll the iterator for the first peer to be in progress.

--- a/protocols/kad/src/query/peers/closest/disjoint.rs
+++ b/protocols/kad/src/query/peers/closest/disjoint.rs
@@ -460,7 +460,7 @@ mod tests {
                 peers.into_iter()
             });
 
-            ResultIter::new(target.clone(), iters)
+            ResultIter::new(target, iters)
         }
 
         fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
@@ -481,7 +481,7 @@ mod tests {
                 .collect();
 
             Box::new(ResultIterShrinker {
-                target: self.target.clone(),
+                target: self.target,
                 peers,
                 iters,
             })
@@ -511,7 +511,7 @@ mod tests {
                 Some(iter.into_iter())
             });
 
-            Some(ResultIter::new(self.target.clone(), iters))
+            Some(ResultIter::new(self.target, iters))
         }
     }
 
@@ -867,7 +867,7 @@ mod tests {
             let closest = drive_to_finish(
                 PeerIterator::Closest(ClosestPeersIter::with_config(
                     cfg.clone(),
-                    target.clone(),
+                    target,
                     known_closest_peers.clone(),
                 )),
                 graph.clone(),
@@ -877,7 +877,7 @@ mod tests {
             let disjoint = drive_to_finish(
                 PeerIterator::Disjoint(ClosestDisjointPeersIter::with_config(
                     cfg,
-                    target.clone(),
+                    target,
                     known_closest_peers.clone(),
                 )),
                 graph,

--- a/protocols/kad/src/record/store/memory.rs
+++ b/protocols/kad/src/record/store/memory.rs
@@ -157,7 +157,7 @@ impl RecordStore for MemoryStore {
             providers.as_mut()[i] = record;
         } else {
             // It is a new provider record for that key.
-            let local_key = self.local_key.clone();
+            let local_key = self.local_key;
             let key = kbucket::Key::new(record.key.clone());
             let provider = kbucket::Key::from(record.provider);
             if let Some(i) = providers.iter().position(|p| {


### PR DESCRIPTION
## Description

Derive `Copy` for `kbucket::key::Key` and `kbucket::key::KeyBytes` because `Key` is almost always used with `PeerId`, which is `Copy`.
This will make it easier to iterate over kbuckets.

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit mesages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions
Quality of life feature.
<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
