### PR TITLE
deps: update ring to 0.17.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2889,7 +2889,7 @@ dependencies = [
  "quick-protobuf",
  "quickcheck-ext",
  "rand 0.8.5",
- "ring 0.17.5",
+ "ring 0.17.8",
  "rmp-serde",
  "sec1",
  "serde",
@@ -3395,7 +3395,7 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-yamux",
  "rcgen",
- "ring 0.16.20",
+ "ring 0.17.8",
  "rustls 0.21.11",
  "rustls-webpki 0.101.7",
  "thiserror",
@@ -4966,16 +4966,17 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.5"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom 0.2.14",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5149,7 +5150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
 dependencies = [
  "log",
- "ring 0.17.5",
+ "ring 0.17.8",
  "rustls-webpki 0.101.7",
  "sct",
 ]
@@ -5161,7 +5162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
- "ring 0.17.5",
+ "ring 0.17.8",
  "rustls-pki-types",
  "rustls-webpki 0.102.2",
  "subtle",
@@ -5190,7 +5191,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.5",
+ "ring 0.17.8",
  "untrusted 0.9.0",
 ]
 
@@ -5200,7 +5201,7 @@ version = "0.102.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
- "ring 0.17.5",
+ "ring 0.17.8",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
@@ -5564,7 +5565,7 @@ dependencies = [
  "chacha20poly1305",
  "curve25519-dalek",
  "rand_core 0.6.4",
- "ring 0.17.5",
+ "ring 0.17.8",
  "rustc_version",
  "sha2 0.10.8",
  "subtle",
@@ -5695,7 +5696,7 @@ dependencies = [
  "lazy_static",
  "md-5",
  "rand 0.8.5",
- "ring 0.17.5",
+ "ring 0.17.8",
  "subtle",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ unsigned-varint = { version = "0.8.0" }
 tokio = { version = "1.37", default-features = false }
 tracing = "0.1.37"
 futures = "0.3.30"
+ring = "0.17.8"
 
 [patch.crates-io]
 

--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -19,7 +19,7 @@ hkdf = { version = "0.12.4", optional = true }
 libsecp256k1 = { version = "0.7.0", optional = true }
 tracing = { workspace = true }
 multihash = { version = "0.19.1", optional = true }
-p256 = { version = "0.13", default-features = false, features = [ "ecdsa", "std", "pem"], optional = true }
+p256 = { version = "0.13", default-features = false, features = ["ecdsa", "std", "pem"], optional = true }
 quick-protobuf = "0.8.1"
 rand = { version = "0.8", optional = true }
 sec1 = { version = "0.7", default-features = false, optional = true }
@@ -30,7 +30,7 @@ void = { version = "1.0", optional = true }
 zeroize = { version = "1.7", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ring = { version = "0.17.5", features = [ "alloc", "std"], default-features = false, optional = true }
+ring = { workspace = true, features = ["alloc", "std"], optional = true }
 
 [features]
 secp256k1 = ["dep:libsecp256k1", "dep:asn1_der", "dep:sha2", "dep:hkdf", "dep:zeroize"]

--- a/transports/tls/Cargo.toml
+++ b/transports/tls/Cargo.toml
@@ -14,7 +14,7 @@ futures-rustls = "0.24.0"
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true }
 rcgen = "0.11.3"
-ring = "0.16.20"
+ring = { workspace = true }
 thiserror = "1.0.59"
 webpki = { version = "0.101.4", package = "rustls-webpki", features = ["std"] }
 x509-parser = "0.16.0"


### PR DESCRIPTION
## Description
deps: update ring to 0.17.8 and move it to a workspace dependency
`quic`'s `ring` dependency will be upgraded in its own PR as it also needs `quinn` to be upgraded