### PR TITLE
fix(kad,mdns,misc): ensure instant is used instead of std::time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.45.1"
+version = "0.45.2"
 dependencies = [
  "async-io 2.3.2",
  "async-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-memory-connection-limits"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-std",
  "instant",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2957,6 +2957,7 @@ dependencies = [
  "futures",
  "hickory-proto",
  "if-watch",
+ "instant",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-noise",
@@ -2978,6 +2979,7 @@ name = "libp2p-memory-connection-limits"
 version = "0.2.0"
 dependencies = [
  "async-std",
+ "instant",
  "libp2p-core",
  "libp2p-identify",
  "libp2p-identity",

--- a/misc/memory-connection-limits/CHANGELOG.md
+++ b/misc/memory-connection-limits/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.1 -- unreleased
+
+- Replace usage of `std::time` with `instant` crate for wasm compatibility.
+  See [PR 5391](https://github.com/libp2p/rust-libp2p/pull/5391)
+
 ## 0.2.0
 
 

--- a/misc/memory-connection-limits/Cargo.toml
+++ b/misc/memory-connection-limits/Cargo.toml
@@ -14,6 +14,7 @@ memory-stats = { version = "1", features = ["always_use_statm"] }
 libp2p-core = { workspace = true }
 libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true, features = ["peerid"] }
+instant = "0.1.12"
 sysinfo = "0.29"
 tracing = { workspace = true }
 void = "1"

--- a/misc/memory-connection-limits/Cargo.toml
+++ b/misc/memory-connection-limits/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-memory-connection-limits"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Memory usage based connection limits for libp2p."
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
 keywords = ["peer-to-peer", "libp2p", "networking"]

--- a/misc/memory-connection-limits/src/lib.rs
+++ b/misc/memory-connection-limits/src/lib.rs
@@ -18,6 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use instant::{Duration, Instant};
 use libp2p_core::{Endpoint, Multiaddr};
 use libp2p_identity::PeerId;
 use libp2p_swarm::{
@@ -29,7 +30,6 @@ use void::Void;
 use std::{
     fmt,
     task::{Context, Poll},
-    time::{Duration, Instant},
 };
 
 /// A [`NetworkBehaviour`] that enforces a set of memory usage based limits.

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.46.0 -- unreleased
 
 - Replace usage of `std::time` with `instant` crate for wasm compatibility.
+  See [PR 5391](https://github.com/libp2p/rust-libp2p/pull/5391)
 - Changed `FIND_NODE` response: now includes a list of closest peers when querying the recipient peer ID. Previously, this request yielded an empty response.
   See [PR 5270](https://github.com/libp2p/rust-libp2p/pull/5270)
 - Update to DHT republish interval and expiration time defaults to 22h and 48h respectively, rationale in [libp2p/specs#451](https://github.com/libp2p/specs/pull/451)

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.46.0 -- unreleased
 
+- Replace usage of `std::time` with `instant` crate for wasm compatibility.
 - Changed `FIND_NODE` response: now includes a list of closest peers when querying the recipient peer ID. Previously, this request yielded an empty response.
   See [PR 5270](https://github.com/libp2p/rust-libp2p/pull/5270)
 - Update to DHT republish interval and expiration time defaults to 22h and 48h respectively, rationale in [libp2p/specs#451](https://github.com/libp2p/specs/pull/451)

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -77,8 +77,8 @@ pub use entry::*;
 
 use arrayvec::ArrayVec;
 use bucket::KBucket;
+use instant::{Duration, Instant};
 use std::collections::VecDeque;
-use std::time::{Duration, Instant};
 
 /// Maximum number of k-buckets.
 const NUM_BUCKETS: usize = 256;

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,6 +1,10 @@
-## 0.45.1
+## 0.45.2 -- unreleased
 
 - Replace usage of `std::time` with `instant` crate for wasm compatibility.
+  See [PR 5391](https://github.com/libp2p/rust-libp2p/pull/5391)
+
+## 0.45.1
+
 - Ensure `Multiaddr` handled and returned by `Behaviour` are `/p2p` terminated.
   See [PR 4596](https://github.com/libp2p/rust-libp2p/pull/4596).
 - Fix a bug in the `Behaviour::poll` method causing missed mdns packets.

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.45.1
 
+- Replace usage of `std::time` with `instant` crate for wasm compatibility.
 - Ensure `Multiaddr` handled and returned by `Behaviour` are `/p2p` terminated.
   See [PR 4596](https://github.com/libp2p/rust-libp2p/pull/4596).
 - Fix a bug in the `Behaviour::poll` method causing missed mdns packets.

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-mdns"
 edition = "2021"
 rust-version = { workspace = true }
-version = "0.45.1"
+version = "0.45.2"
 description = "Implementation of the libp2p mDNS discovery method"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -16,6 +16,7 @@ async-io  = { version = "2.3.2", optional = true }
 data-encoding = "2.6.0"
 futures = { workspace = true }
 if-watch = "3.2.0"
+instant = "0.1.12"
 libp2p-core = { workspace = true }
 libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true }

--- a/protocols/mdns/src/behaviour.rs
+++ b/protocols/mdns/src/behaviour.rs
@@ -28,6 +28,7 @@ use crate::Config;
 use futures::channel::mpsc;
 use futures::{Stream, StreamExt};
 use if_watch::IfEvent;
+use instant::Instant;
 use libp2p_core::{Endpoint, Multiaddr};
 use libp2p_identity::PeerId;
 use libp2p_swarm::behaviour::FromSwarm;
@@ -39,7 +40,7 @@ use smallvec::SmallVec;
 use std::collections::hash_map::{Entry, HashMap};
 use std::future::Future;
 use std::sync::{Arc, RwLock};
-use std::{cmp, fmt, io, net::IpAddr, pin::Pin, task::Context, task::Poll, time::Instant};
+use std::{cmp, fmt, io, net::IpAddr, pin::Pin, task::Context, task::Poll};
 
 /// An abstraction to allow for compatibility with various async runtimes.
 pub trait Provider: 'static {

--- a/protocols/mdns/src/behaviour/iface.rs
+++ b/protocols/mdns/src/behaviour/iface.rs
@@ -27,6 +27,7 @@ use crate::behaviour::{socket::AsyncSocket, timer::Builder};
 use crate::Config;
 use futures::channel::mpsc;
 use futures::{SinkExt, StreamExt};
+use instant::{Duration, Instant};
 use libp2p_core::Multiaddr;
 use libp2p_identity::PeerId;
 use libp2p_swarm::ListenAddresses;
@@ -39,7 +40,6 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
     pin::Pin,
     task::{Context, Poll},
-    time::{Duration, Instant},
 };
 
 /// Initial interval for starting probe

--- a/protocols/mdns/src/behaviour/iface/query.rs
+++ b/protocols/mdns/src/behaviour/iface/query.rs
@@ -24,13 +24,13 @@ use hickory_proto::{
     op::Message,
     rr::{Name, RData},
 };
+use instant::{Duration, Instant};
 use libp2p_core::{
     address_translation,
     multiaddr::{Multiaddr, Protocol},
 };
 use libp2p_identity::PeerId;
-use std::time::Instant;
-use std::{fmt, net::SocketAddr, str, time::Duration};
+use std::{fmt, net::SocketAddr, str};
 
 /// A valid mDNS packet received by the service.
 #[derive(Debug)]

--- a/protocols/mdns/src/behaviour/timer.rs
+++ b/protocols/mdns/src/behaviour/timer.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::time::{Duration, Instant};
+use instant::{Duration, Instant};
 
 /// Simple wrapper for the different type of timers
 #[derive(Debug)]


### PR DESCRIPTION
## Description

`std::time` is not implemented on platforms like browser wasm and it's usage fails with a runtime error.
This ensures that `instant` is used everywhere as it is compatible with wasm environments.
<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
