### PR TITLE
fix(request-response): Avoid hanging at capacity and  on dial IO errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ libp2p-pnet = { version = "0.24.0", path = "transports/pnet" }
 libp2p-quic = { version = "0.10.3", path = "transports/quic" }
 libp2p-relay = { version = "0.17.2", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.14.0", path = "protocols/rendezvous" }
-libp2p-request-response = { version = "0.26.2", path = "protocols/request-response" }
+libp2p-request-response = { version = "0.26.3", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.7", path = "misc/server" }
 libp2p-stream = { version = "0.1.0-alpha.1", path = "protocols/stream" }
 libp2p-swarm = { version = "0.44.2", path = "swarm" }

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.26.3
+
+- Avoid hanging at capacity and dial IO errors.
+  See [PR 5419](https://github.com/libp2p/rust-libp2p/pull/5419).
+
 ## 0.26.2
 
 - Deprecate `Behaviour::add_address` in favor of `Swarm::add_peer_address`.

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-request-response"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Generic Request/Response Protocols"
-version = "0.26.2"
+version = "0.26.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -79,6 +79,7 @@ pub use handler::ProtocolSupport;
 use crate::handler::OutboundMessage;
 use futures::channel::oneshot;
 use handler::Handler;
+use instant::Instant;
 use libp2p_core::{ConnectedPoint, Endpoint, Multiaddr};
 use libp2p_identity::PeerId;
 use libp2p_swarm::{
@@ -428,6 +429,7 @@ where
             request_id,
             request,
             protocols: self.outbound_protocols.clone(),
+            time: Instant::now(),
         };
 
         if let Some(request) = self.try_send_request(peer, request) {


### PR DESCRIPTION
## Description

This is an alternative fix of https://github.com/libp2p/rust-libp2p/pull/5417 that does not introduce a breaking change.

The idea is to reschedule the request but also avoid a potential infinite rescheduling by applying a timeout on it.

This fixes also a potential infinite rescheduling issue on dial IO errors:

https://github.com/libp2p/rust-libp2p/blob/94fef37d9b2e66c25a2baab87ce74ac1adeee4fd/protocols/request-response/src/handler.rs#L238-L244

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

Due to the nature of rescheduling and timeout, it is very hard to create a unit test. I couldn't find a reliable way of doing it.

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
