### PR TITLE
fix(webrtc-utils): read buffer only if empty message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3500,7 +3500,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-webrtc-utils"
-version = "0.3.0"
+version = "0.2.1"
 dependencies = [
  "asynchronous-codec",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3500,7 +3500,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-webrtc-utils"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "asynchronous-codec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ libp2p-tls = { version = "0.4.0", path = "transports/tls" }
 libp2p-uds = { version = "0.40.0", path = "transports/uds" }
 libp2p-upnp = { version = "0.2.2", path = "protocols/upnp" }
 libp2p-webrtc = { version = "0.7.1-alpha", path = "transports/webrtc" }
-libp2p-webrtc-utils = { version = "0.3.0", path = "misc/webrtc-utils" }
+libp2p-webrtc-utils = { version = "0.2.1", path = "misc/webrtc-utils" }
 libp2p-webrtc-websys = { version = "0.3.0-alpha", path = "transports/webrtc-websys" }
 libp2p-websocket = { version = "0.43.0", path = "transports/websocket" }
 libp2p-websocket-websys = { version = "0.3.2", path = "transports/websocket-websys" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ libp2p-tls = { version = "0.4.0", path = "transports/tls" }
 libp2p-uds = { version = "0.40.0", path = "transports/uds" }
 libp2p-upnp = { version = "0.2.2", path = "protocols/upnp" }
 libp2p-webrtc = { version = "0.7.1-alpha", path = "transports/webrtc" }
-libp2p-webrtc-utils = { version = "0.2.0", path = "misc/webrtc-utils" }
+libp2p-webrtc-utils = { version = "0.3.0", path = "misc/webrtc-utils" }
 libp2p-webrtc-websys = { version = "0.3.0-alpha", path = "transports/webrtc-websys" }
 libp2p-websocket = { version = "0.43.0", path = "transports/websocket" }
 libp2p-websocket-websys = { version = "0.3.2", path = "transports/websocket-websys" }

--- a/misc/webrtc-utils/CHANGELOG.md
+++ b/misc/webrtc-utils/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0
+## 0.2.1
 
 - Fix end of stream handling when buffer is empty or not present.
   See [PR 5439](https://github.com/libp2p/rust-libp2p/pull/5439).

--- a/misc/webrtc-utils/CHANGELOG.md
+++ b/misc/webrtc-utils/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0
+
+- Fix end of stream handling when buffer is empty or not present.
+  See [PR 5439](https://github.com/libp2p/rust-libp2p/pull/5439).
+
 ## 0.2.0
 
 - Update to latest version of `libp2p-noise`.

--- a/misc/webrtc-utils/Cargo.toml
+++ b/misc/webrtc-utils/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "libp2p-webrtc-utils"
 repository = "https://github.com/libp2p/rust-libp2p"
 rust-version = { workspace = true }
-version = "0.2.0"
+version = "0.3.0"
 publish = true
 
 [dependencies]

--- a/misc/webrtc-utils/Cargo.toml
+++ b/misc/webrtc-utils/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "libp2p-webrtc-utils"
 repository = "https://github.com/libp2p/rust-libp2p"
 rust-version = { workspace = true }
-version = "0.3.0"
+version = "0.2.1"
 publish = true
 
 [dependencies]

--- a/misc/webrtc-utils/src/stream.rs
+++ b/misc/webrtc-utils/src/stream.rs
@@ -146,8 +146,14 @@ where
                     }
 
                     debug_assert!(read_buffer.is_empty());
-                    if let Some(message) = message {
-                        *read_buffer = message.into();
+                    match message {
+                        Some(msg) if !msg.is_empty() => {
+                            *read_buffer = msg.into();
+                        }
+                        _ => {
+                            tracing::debug!("poll_read buffer is empty, received None");
+                            return Poll::Ready(Ok(0));
+                        }
                     }
                 }
                 None => {


### PR DESCRIPTION
Fixes #5438

## Description

This PR adds a return of `Poll::Ready(Ok(0))` when the `message` vector is empty or not present.

This missing return was causing the stream not to finish, then to be dropped, causing the request response protocol to fail over WebRTC. 

Now that empty or non existent message vectors get returned as `Ok(0)` the stream can be read and request response works now over WebRTC.
## Notes & open questions

I don't think there are any specific tests for request response over WebRTC, though I believe @jxs is working on a branch for them?

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
