### PR TITLE
fix: add example metrics's `tracing::info`

### DIFF
--- a/examples/metrics/src/http_service.rs
+++ b/examples/metrics/src/http_service.rs
@@ -40,6 +40,9 @@ pub(crate) async fn metrics_server(registry: Registry) -> Result<(), std::io::Er
         .with_state(service);
     let tcp_listener = TcpListener::bind(addr).await?;
     let local_addr = tcp_listener.local_addr()?;
+
+    println!("Metrics server: {}", local_addr);
+
     tracing::info!(metrics_server=%format!("http://{}/metrics", local_addr));
     axum::serve(tcp_listener, server.into_make_service()).await?;
     Ok(())

--- a/examples/metrics/src/http_service.rs
+++ b/examples/metrics/src/http_service.rs
@@ -40,9 +40,7 @@ pub(crate) async fn metrics_server(registry: Registry) -> Result<(), std::io::Er
         .with_state(service);
     let tcp_listener = TcpListener::bind(addr).await?;
     let local_addr = tcp_listener.local_addr()?;
-
-    println!("Metrics server: {}", local_addr);
-
+    
     tracing::info!(metrics_server=%format!("http://{}/metrics", local_addr));
     axum::serve(tcp_listener, server.into_make_service()).await?;
     Ok(())

--- a/examples/metrics/src/http_service.rs
+++ b/examples/metrics/src/http_service.rs
@@ -40,7 +40,6 @@ pub(crate) async fn metrics_server(registry: Registry) -> Result<(), std::io::Er
         .with_state(service);
     let tcp_listener = TcpListener::bind(addr).await?;
     let local_addr = tcp_listener.local_addr()?;
-    
     tracing::info!(metrics_server=%format!("http://{}/metrics", local_addr));
     axum::serve(tcp_listener, server.into_make_service()).await?;
     Ok(())

--- a/examples/metrics/src/main.rs
+++ b/examples/metrics/src/main.rs
@@ -66,6 +66,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     loop {
         match swarm.select_next_some().await {
+            SwarmEvent::NewListenAddr { address, .. } => {
+                println!("Local node is listening on\n {}/p2p/{}", address, swarm.local_peer_id());
+            },
             SwarmEvent::Behaviour(BehaviourEvent::Ping(ping_event)) => {
                 tracing::info!(?ping_event);
                 metrics.record(&ping_event);

--- a/examples/metrics/src/main.rs
+++ b/examples/metrics/src/main.rs
@@ -67,8 +67,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     loop {
         match swarm.select_next_some().await {
             SwarmEvent::NewListenAddr { address, .. } => {
-                tracing::info!("Local node is listening on\n {}/p2p/{}", address, swarm.local_peer_id());
-            },
+                tracing::info!(
+                    "Local node is listening on\n {}/p2p/{}",
+                    address,
+                    swarm.local_peer_id()
+                );
+            }
             SwarmEvent::Behaviour(BehaviourEvent::Ping(ping_event)) => {
                 tracing::info!(?ping_event);
                 metrics.record(&ping_event);

--- a/examples/metrics/src/main.rs
+++ b/examples/metrics/src/main.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     loop {
         match swarm.select_next_some().await {
             SwarmEvent::NewListenAddr { address, .. } => {
-                println!("Local node is listening on\n {}/p2p/{}", address, swarm.local_peer_id());
+                tracing::info!("Local node is listening on\n {}/p2p/{}", address, swarm.local_peer_id());
             },
             SwarmEvent::Behaviour(BehaviourEvent::Ping(ping_event)) => {
                 tracing::info!(?ping_event);


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

Adding a Minimal `println!()` Syntax for Metrics Example

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

In order to use this example, at least one node's peer ID must be obtained to use the metrics server, but paradoxically, the node's peer ID was not output, making it inconvenient to use. Therefore, I added one sentence of the output syntax

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
