### PR TITLE
feat(kad): improve automatic bootstrap

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -23,6 +23,10 @@
   See [PR 5347](https://github.com/libp2p/rust-libp2p/pull/5347).
 - Correctly handle the `NoKnownPeers` error on automatic bootstrap.
   See [PR 5349](https://github.com/libp2p/rust-libp2p/pull/5349).
+- Improve automatic bootstrap triggering conditions:
+  trigger when the routing table is updated and we have less that `K_VALUE` peers in it,
+  trigger when a new listen address is discovered and we have no connected peers.
+  See [PR 5474](https://github.com/libp2p/rust-libp2p/pull/5474).
 
 ## 0.45.3
 

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -23,7 +23,6 @@
 mod test;
 
 use crate::addresses::Addresses;
-use crate::bootstrap;
 use crate::handler::{Handler, HandlerEvent, HandlerIn, RequestId};
 use crate::kbucket::{self, Distance, KBucketsTable, NodeStatus};
 use crate::protocol::{ConnectionType, KadPeer, ProtocolConfig};
@@ -33,6 +32,7 @@ use crate::record::{
     store::{self, RecordStore},
     ProviderRecord, Record,
 };
+use crate::{bootstrap, K_VALUE};
 use crate::{jobs::*, protocol};
 use fnv::FnvHashSet;
 use libp2p_core::{ConnectedPoint, Endpoint, Multiaddr};
@@ -1381,7 +1381,12 @@ where
     /// table is currently small (less that `K_VALUE` peers are present) and only
     /// trigger a bootstrap in that case
     fn bootstrap_on_low_peers(&mut self) {
-        if self.kbuckets().count() < K_VALUE.get() {
+        if self
+            .kbuckets()
+            .map(|kbucket| kbucket.num_entries())
+            .sum::<usize>()
+            < K_VALUE.get()
+        {
             self.bootstrap_status.trigger();
         }
     }

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -604,7 +604,7 @@ where
                 };
                 match entry.insert(addresses.clone(), status) {
                     kbucket::InsertResult::Inserted => {
-                        self.trigger_bootstrap_if_routing_table_is_almost_empty();
+                        self.bootstrap_on_low_peers();
 
                         self.queued_events.push_back(ToSwarm::GenerateEvent(
                             Event::RoutingUpdated {
@@ -1325,7 +1325,7 @@ where
                         let addresses = Addresses::new(a);
                         match entry.insert(addresses.clone(), new_status) {
                             kbucket::InsertResult::Inserted => {
-                                self.trigger_bootstrap_if_routing_table_is_almost_empty();
+                                self.bootstrap_on_low_peers();
 
                                 let event = Event::RoutingUpdated {
                                     peer,
@@ -1380,7 +1380,7 @@ where
     /// A new peer has been inserted in the routing table but we check if the routing
     /// table is currently small (less that `K_VALUE` peers are present) and only
     /// trigger a bootstrap in that case
-    fn trigger_bootstrap_if_routing_table_is_almost_empty(&mut self) {
+    fn bootstrap_on_low_peers(&mut self) {
         if self.kbuckets().count() < K_VALUE.get() {
             self.bootstrap_status.trigger();
         }


### PR DESCRIPTION
## Description

As discussed in the last maintainer call, some improvements are probably necessary for the automatic bootstrap feature (introduced by https://github.com/libp2p/rust-libp2p/pull/4838). Indeed, like @drHuangMHT mentioned in https://github.com/libp2p/rust-libp2p/issues/5341 and like @guillaumemichel has agreed, triggering a bootstrap every time an update happens inside the routing table consumes a lot more resources.

The idea behind the automatic bootstrap feature it that, when a peer is starting, if a routing table update happens we probably don't want to wait for the periodic bootstrap to trigger and we want to trigger it right now. However, like @guillaumemichel said, this is something we want to do at startup or when a network connectivity problem happens, we don't want to do that all the time.

This PR is a proposal to trigger automatically a bootstrap on routing table update but only when we have less that `K_VALUE` peers in it (meaning that we are starting up or something went wrong and the fact that a new peer is inserted is probably a sign that the network connectivity issue is resolved). 

I have also added a new triggering condition like mentioned in the maintainer call. When discovering a new listen address and if we have no connected peers, we trigger a bootstrap. This condition is based on our own experience at Stormshield : some peers were starting before the network interfaces were up, doing so, the automatic and periodic bootstrap failed, but when the network interfaces were finally up, we were waiting X minutes for the periodic bootstrap to actually trigger a bootstrap and join the p2p network.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
