### PR TITLE
chore(kad): remove unrequired generics 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.41.4"
+version = "0.41.3"
 dependencies = [
  "async-std",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ libp2p = { version = "0.54.0", path = "libp2p" }
 libp2p-allow-block-list = { version = "0.3.0", path = "misc/allow-block-list" }
 libp2p-autonat = { version = "0.12.1", path = "protocols/autonat" }
 libp2p-connection-limits = { version = "0.3.1", path = "misc/connection-limits" }
-libp2p-core = { version = "0.41.4", path = "core" }
+libp2p-core = { version = "0.41.3", path = "core" }
 libp2p-dcutr = { version = "0.11.1", path = "protocols/dcutr" }
 libp2p-dns = { version = "0.41.1", path = "transports/dns" }
 libp2p-floodsub = { version = "0.44.0", path = "protocols/floodsub" }

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,8 +1,4 @@
-## 0.41.4
-- Add `PeerInfo` struct.
-  See [PR 5475](https://github.com/libp2p/rust-libp2p/pull/5475)
-
-## 0.41.3 
+## 0.41.3
 - Use `web-time` instead of `instant`.
   See [PR 5347](https://github.com/libp2p/rust-libp2p/pull/5347).
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-core"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Core traits and structs of libp2p"
-version = "0.41.4"
+version = "0.41.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -35,8 +35,8 @@ void = "1"
 
 [dev-dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }
-libp2p-mplex = { path = "../muxers/mplex" }                    # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
-libp2p-noise = { path = "../transports/noise" }                # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
+libp2p-mplex = { path = "../muxers/mplex" } # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
+libp2p-noise = { path = "../transports/noise" } # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
 multihash = { workspace = true, features = ["arb"] }
 quickcheck = { workspace = true }
 libp2p-identity = { workspace = true, features = ["ed25519", "rand"] }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -69,10 +69,3 @@ pub use upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
 pub struct DecodeError(quick_protobuf::Error);
-
-/// Peer Info combines a Peer ID with a set of multiaddrs that the peer is listening on.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PeerInfo {
-    pub peer_id: PeerId,
-    pub addrs: Vec<Multiaddr>,
-}

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -35,7 +35,7 @@ use crate::record::{
 };
 use crate::{jobs::*, protocol};
 use fnv::FnvHashSet;
-use libp2p_core::{ConnectedPoint, Endpoint, Multiaddr, PeerInfo};
+use libp2p_core::{ConnectedPoint, Endpoint, Multiaddr};
 use libp2p_identity::PeerId;
 use libp2p_swarm::behaviour::{
     AddressChange, ConnectionClosed, ConnectionEstablished, DialFailure, FromSwarm,
@@ -2636,6 +2636,13 @@ where
             _ => {}
         }
     }
+}
+
+/// Peer Info combines a Peer ID with a set of multiaddrs that the peer is listening on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerInfo {
+    pub peer_id: PeerId,
+    pub addrs: Vec<Multiaddr>,
 }
 
 /// A quorum w.r.t. the configured replication factor specifies the minimum

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -23,7 +23,7 @@
 use super::*;
 
 use crate::record::{store::MemoryStore, Key};
-use crate::{PROTOCOL_NAME, SHA_256_MH};
+use crate::{K_VALUE, PROTOCOL_NAME, SHA_256_MH};
 use futures::{executor::block_on, future::poll_fn, prelude::*};
 use futures_timer::Delay;
 use libp2p_core::{

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -1187,7 +1187,7 @@ fn disjoint_query_does_not_finish_before_all_paths_did() {
         .behaviour()
         .queries
         .iter()
-        .for_each(|q| match &q.inner.info {
+        .for_each(|q| match &q.info {
             QueryInfo::GetRecord { step, .. } => {
                 assert_eq!(usize::from(step.count), 2);
             }

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -59,9 +59,9 @@ pub use behaviour::{
     AddProviderContext, AddProviderError, AddProviderOk, AddProviderPhase, AddProviderResult,
     BootstrapError, BootstrapOk, BootstrapResult, GetClosestPeersError, GetClosestPeersOk,
     GetClosestPeersResult, GetProvidersError, GetProvidersOk, GetProvidersResult, GetRecordError,
-    GetRecordOk, GetRecordResult, InboundRequest, Mode, NoKnownPeers, PeerRecord, PutRecordContext,
-    PutRecordError, PutRecordOk, PutRecordPhase, PutRecordResult, QueryInfo, QueryMut, QueryRef,
-    QueryResult, QueryStats, RoutingUpdate,
+    GetRecordOk, GetRecordResult, InboundRequest, Mode, NoKnownPeers, PeerInfo, PeerRecord,
+    PutRecordContext, PutRecordError, PutRecordOk, PutRecordPhase, PutRecordResult, QueryInfo,
+    QueryMut, QueryRef, QueryResult, QueryStats, RoutingUpdate,
 };
 pub use behaviour::{
     Behaviour, BucketInserts, Caching, Config, Event, ProgressStep, Quorum, StoreInserts,

--- a/protocols/kad/src/query.rs
+++ b/protocols/kad/src/query.rs
@@ -20,45 +20,71 @@
 
 mod peers;
 
+use libp2p_core::Multiaddr;
 use peers::closest::{
     disjoint::ClosestDisjointPeersIter, ClosestPeersIter, ClosestPeersIterConfig,
 };
 use peers::fixed::FixedPeersIter;
 use peers::PeersIterState;
+use smallvec::SmallVec;
 
+use crate::handler::HandlerIn;
 use crate::kbucket::{Key, KeyBytes};
-use crate::{ALPHA_VALUE, K_VALUE};
+use crate::{QueryInfo, ALPHA_VALUE, K_VALUE};
 use either::Either;
 use fnv::FnvHashMap;
 use libp2p_identity::PeerId;
 use std::{num::NonZeroUsize, time::Duration};
 use web_time::Instant;
 
+/// The internal `Query` state.
+pub(crate) struct QueryInner {
+    /// The query-specific state.
+    pub(crate) info: QueryInfo,
+    /// Addresses of peers discovered during a query.
+    pub(crate) addresses: FnvHashMap<PeerId, SmallVec<[Multiaddr; 8]>>,
+    /// A map of pending requests to peers.
+    ///
+    /// A request is pending if the targeted peer is not currently connected
+    /// and these requests are sent as soon as a connection to the peer is established.
+    pub(crate) pending_rpcs: SmallVec<[(PeerId, HandlerIn); K_VALUE.get()]>,
+}
+
+impl QueryInner {
+    pub(crate) fn new(info: QueryInfo) -> Self {
+        QueryInner {
+            info,
+            addresses: Default::default(),
+            pending_rpcs: SmallVec::default(),
+        }
+    }
+}
+
 /// A `QueryPool` provides an aggregate state machine for driving `Query`s to completion.
 ///
 /// Internally, a `Query` is in turn driven by an underlying `QueryPeerIter`
 /// that determines the peer selection strategy, i.e. the order in which the
 /// peers involved in the query should be contacted.
-pub(crate) struct QueryPool<TInner> {
+pub(crate) struct QueryPool {
     next_id: usize,
     config: QueryConfig,
-    queries: FnvHashMap<QueryId, Query<TInner>>,
+    queries: FnvHashMap<QueryId, Query>,
 }
 
 /// The observable states emitted by [`QueryPool::poll`].
-pub(crate) enum QueryPoolState<'a, TInner> {
+pub(crate) enum QueryPoolState<'a> {
     /// The pool is idle, i.e. there are no queries to process.
     Idle,
     /// At least one query is waiting for results. `Some(request)` indicates
     /// that a new request is now being waited on.
-    Waiting(Option<(&'a mut Query<TInner>, PeerId)>),
+    Waiting(Option<(&'a mut Query, PeerId)>),
     /// A query has finished.
-    Finished(Query<TInner>),
+    Finished(Query),
     /// A query has timed out.
-    Timeout(Query<TInner>),
+    Timeout(Query),
 }
 
-impl<TInner> QueryPool<TInner> {
+impl QueryPool {
     /// Creates a new `QueryPool` with the given configuration.
     pub(crate) fn new(config: QueryConfig) -> Self {
         QueryPool {
@@ -74,7 +100,7 @@ impl<TInner> QueryPool<TInner> {
     }
 
     /// Returns an iterator over the queries in the pool.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &Query<TInner>> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &Query> {
         self.queries.values()
     }
 
@@ -84,12 +110,12 @@ impl<TInner> QueryPool<TInner> {
     }
 
     /// Returns an iterator that allows modifying each query in the pool.
-    pub(crate) fn iter_mut(&mut self) -> impl Iterator<Item = &mut Query<TInner>> {
+    pub(crate) fn iter_mut(&mut self) -> impl Iterator<Item = &mut Query> {
         self.queries.values_mut()
     }
 
     /// Adds a query to the pool that contacts a fixed set of peers.
-    pub(crate) fn add_fixed<I>(&mut self, peers: I, inner: TInner) -> QueryId
+    pub(crate) fn add_fixed<I>(&mut self, peers: I, inner: QueryInner) -> QueryId
     where
         I: IntoIterator<Item = PeerId>,
     {
@@ -101,7 +127,7 @@ impl<TInner> QueryPool<TInner> {
     /// Continues an earlier query with a fixed set of peers, reusing
     /// the given query ID, which must be from a query that finished
     /// earlier.
-    pub(crate) fn continue_fixed<I>(&mut self, id: QueryId, peers: I, inner: TInner)
+    pub(crate) fn continue_fixed<I>(&mut self, id: QueryId, peers: I, inner: QueryInner)
     where
         I: IntoIterator<Item = PeerId>,
     {
@@ -113,7 +139,12 @@ impl<TInner> QueryPool<TInner> {
     }
 
     /// Adds a query to the pool that iterates towards the closest peers to the target.
-    pub(crate) fn add_iter_closest<T, I>(&mut self, target: T, peers: I, inner: TInner) -> QueryId
+    pub(crate) fn add_iter_closest<T, I>(
+        &mut self,
+        target: T,
+        peers: I,
+        inner: QueryInner,
+    ) -> QueryId
     where
         T: Into<KeyBytes> + Clone,
         I: IntoIterator<Item = Key<PeerId>>,
@@ -129,7 +160,7 @@ impl<TInner> QueryPool<TInner> {
         id: QueryId,
         target: T,
         peers: I,
-        inner: TInner,
+        inner: QueryInner,
     ) where
         T: Into<KeyBytes> + Clone,
         I: IntoIterator<Item = Key<PeerId>>,
@@ -159,17 +190,17 @@ impl<TInner> QueryPool<TInner> {
     }
 
     /// Returns a reference to a query with the given ID, if it is in the pool.
-    pub(crate) fn get(&self, id: &QueryId) -> Option<&Query<TInner>> {
+    pub(crate) fn get(&self, id: &QueryId) -> Option<&Query> {
         self.queries.get(id)
     }
 
     /// Returns a mutablereference to a query with the given ID, if it is in the pool.
-    pub(crate) fn get_mut(&mut self, id: &QueryId) -> Option<&mut Query<TInner>> {
+    pub(crate) fn get_mut(&mut self, id: &QueryId) -> Option<&mut Query> {
         self.queries.get_mut(id)
     }
 
     /// Polls the pool to advance the queries.
-    pub(crate) fn poll(&mut self, now: Instant) -> QueryPoolState<'_, TInner> {
+    pub(crate) fn poll(&mut self, now: Instant) -> QueryPoolState<'_> {
         let mut finished = None;
         let mut timeout = None;
         let mut waiting = None;
@@ -264,7 +295,7 @@ impl Default for QueryConfig {
 }
 
 /// A query in a `QueryPool`.
-pub(crate) struct Query<TInner> {
+pub(crate) struct Query {
     /// The unique ID of the query.
     id: QueryId,
     /// The peer iterator that drives the query state.
@@ -272,7 +303,7 @@ pub(crate) struct Query<TInner> {
     /// Execution statistics of the query.
     stats: QueryStats,
     /// The opaque inner query state.
-    pub(crate) inner: TInner,
+    pub(crate) inner: QueryInner,
 }
 
 /// The peer selection strategies that can be used by queries.
@@ -282,9 +313,9 @@ enum QueryPeerIter {
     Fixed(FixedPeersIter),
 }
 
-impl<TInner> Query<TInner> {
+impl Query {
     /// Creates a new query without starting it.
-    fn new(id: QueryId, peer_iter: QueryPeerIter, inner: TInner) -> Self {
+    fn new(id: QueryId, peer_iter: QueryPeerIter, inner: QueryInner) -> Self {
         Query {
             id,
             inner,
@@ -406,7 +437,7 @@ impl<TInner> Query<TInner> {
     }
 
     /// Consumes the query, producing the final `QueryResult`.
-    pub(crate) fn into_result(self) -> QueryResult<TInner, impl Iterator<Item = PeerId>> {
+    pub(crate) fn into_result(self) -> QueryResult<QueryInner, impl Iterator<Item = PeerId>> {
         let peers = match self.peer_iter {
             QueryPeerIter::Closest(iter) => Either::Left(Either::Left(iter.into_result())),
             QueryPeerIter::ClosestDisjoint(iter) => Either::Left(Either::Right(iter.into_result())),


### PR DESCRIPTION
## Description

Remove the unrequired generics in `kad` and refactor the code for less duplication.
Please review by commit order as it will be easier to understand each commit's rational and logic 