### PR TITLE
fix(kad): changelog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.47.0"
+version = "0.46.0"
 dependencies = [
  "arrayvec",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ libp2p-floodsub = { version = "0.44.0", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.46.2", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.45.0", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.9" }
-libp2p-kad = { version = "0.47.0", path = "protocols/kad" }
+libp2p-kad = { version = "0.46.0", path = "protocols/kad" }
 libp2p-mdns = { version = "0.45.1", path = "protocols/mdns" }
 libp2p-memory-connection-limits = { version = "0.2.0", path = "misc/memory-connection-limits" }
 libp2p-metrics = { version = "0.14.2", path = "misc/metrics" }

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.46.0 -- not released
+## 0.46.0
 
 - Included multiaddresses of found peers alongside peer IDs in `GetClosestPeers` query results.
   See [PR 5475](https://github.com/libp2p/rust-libp2p/pull/5475)

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,9 +1,7 @@
-## 0.47.0
+## 0.46.0 -- not released
+
 - Included multiaddresses of found peers alongside peer IDs in `GetClosestPeers` query results.
   See [PR 5475](https://github.com/libp2p/rust-libp2p/pull/5475)
-
-## 0.46.0
-
 - Changed `FIND_NODE` response: now includes a list of closest peers when querying the recipient peer ID. Previously, this request yielded an empty response.
   See [PR 5270](https://github.com/libp2p/rust-libp2p/pull/5270)
 - Update to DHT republish interval and expiration time defaults to 22h and 48h respectively, rationale in [libp2p/specs#451](https://github.com/libp2p/specs/pull/451)

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-kad"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Kademlia protocol for libp2p"
-version = "0.47.0"
+version = "0.46.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
## Description

Correct `kad` changelog after https://github.com/libp2p/rust-libp2p/pull/5475

`kad` `0.46.0` isn't released yet, hence changelog entry from https://github.com/libp2p/rust-libp2p/pull/5475 will be published with `0.46.0`. 

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates

cc: @Wiezzel @stormshield-frb @jxs 
