### PR TITLE
chore(swarm): reword CHANGELOG.md

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.45.1"
+version = "0.45.0"
 dependencies = [
  "async-std",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ libp2p-rendezvous = { version = "0.14.1", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.26.4", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.7", path = "misc/server" }
 libp2p-stream = { version = "0.1.0-alpha.1", path = "protocols/stream" }
-libp2p-swarm = { version = "0.45.1", path = "swarm" }
+libp2p-swarm = { version = "0.45.0", path = "swarm" }
 libp2p-swarm-derive = { version = "=0.34.2", path = "swarm-derive" } # `libp2p-swarm-derive` may not be compatible with different `libp2p-swarm` non-breaking releases. E.g. `libp2p-swarm` might introduce a new enum variant `FromSwarm` (which is `#[non-exhaustive]`) in a non-breaking release. Older versions of `libp2p-swarm-derive` would not forward this enum variant within the `NetworkBehaviour` hierarchy. Thus the version pinning is required.
 libp2p-swarm-test = { version = "0.3.0", path = "swarm-test" }
 libp2p-tcp = { version = "0.42.0", path = "transports/tcp" }

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,15 +1,11 @@
 
-## 0.45.1
+## 0.45.0
 
 - Optimize internal connection `fn poll`. New implementation now scales much better with number of listen protocols active.
   No changes to public API introduced.
   See [PR 5026](https://github.com/libp2p/rust-libp2p/pull/5026)
-
-## 0.45.0
-
 - Add peer_id to `FromSwarm::ListenFailure`.
   See [PR 4818](https://github.com/libp2p/rust-libp2p/pull/4818).
-
 - Use `web-time` instead of `instant`.
   See [PR 5347](https://github.com/libp2p/rust-libp2p/pull/5347).
 - Add `#[track_caller]` on all `spawn` wrappers.

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-swarm"
 edition = "2021"
 rust-version = { workspace = true }
 description = "The libp2p swarm"
-version = "0.45.1"
+version = "0.45.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
## Description

`libp2p-swarm` `0.45.0` hasn't been released.