### PR TITLE
fix(relay): Add resource limits to `CircuitReq` to be set 

### DIFF
--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.17.3
 - Use `web-time` instead of `instant`.
   See [PR 5347](https://github.com/libp2p/rust-libp2p/pull/5347).
-- Fix `CircuitReq` to store the resource limits.
+- Add resource limits to `CircuitReq` to be set
   See [PR 5493](https://github.com/libp2p/rust-libp2p/pull/5493)  
 
 ## 0.17.2

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.17.3
 - Use `web-time` instead of `instant`.
   See [PR 5347](https://github.com/libp2p/rust-libp2p/pull/5347).
+- Fix `CircuitReq` to store the resource limits.
+  See [PR 5493](https://github.com/libp2p/rust-libp2p/pull/5493)  
 
 ## 0.17.2
 

--- a/protocols/relay/src/protocol/inbound_hop.rs
+++ b/protocols/relay/src/protocol/inbound_hop.rs
@@ -214,7 +214,12 @@ pub(crate) async fn handle_inbound_request(
 
             let dst = peer_id_res.map_err(|_| Error::ParsePeerId)?;
 
-            Either::Right(CircuitReq { dst, substream , max_circuit_duration, max_circuit_bytes})
+            Either::Right(CircuitReq {
+                dst,
+                substream,
+                max_circuit_duration,
+                max_circuit_bytes,
+            })
         }
         Type::STATUS => return Err(Error::UnexpectedTypeStatus),
     };

--- a/protocols/relay/src/protocol/inbound_hop.rs
+++ b/protocols/relay/src/protocol/inbound_hop.rs
@@ -115,6 +115,8 @@ impl ReservationReq {
 pub struct CircuitReq {
     dst: PeerId,
     substream: Framed<Stream, quick_protobuf_codec::Codec<proto::HopMessage>>,
+    max_circuit_duration: Duration,
+    max_circuit_bytes: u64,
 }
 
 impl CircuitReq {
@@ -127,7 +129,15 @@ impl CircuitReq {
             type_pb: proto::HopMessageType::STATUS,
             peer: None,
             reservation: None,
-            limit: None,
+            limit: Some(proto::Limit {
+                duration: Some(
+                    self.max_circuit_duration
+                        .as_secs()
+                        .try_into()
+                        .expect("`max_circuit_duration` not to exceed `u32::MAX`."),
+                ),
+                data: Some(self.max_circuit_bytes),
+            }),
             status: Some(proto::Status::OK),
         };
 

--- a/protocols/relay/src/protocol/inbound_hop.rs
+++ b/protocols/relay/src/protocol/inbound_hop.rs
@@ -214,7 +214,7 @@ pub(crate) async fn handle_inbound_request(
 
             let dst = peer_id_res.map_err(|_| Error::ParsePeerId)?;
 
-            Either::Right(CircuitReq { dst, substream })
+            Either::Right(CircuitReq { dst, substream , max_circuit_duration, max_circuit_bytes})
         }
         Type::STATUS => return Err(Error::UnexpectedTypeStatus),
     };


### PR DESCRIPTION
## Description

Fixes #5466 
Adds resource limits to `CircuitReq` to be set .

## Change checklist

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] A changelog entry has been made in the appropriate crates
