### PR TITLE
fix:  rendezvous identify example

### DIFF
--- a/examples/rendezvous/src/bin/rzv-identify.rs
+++ b/examples/rendezvous/src/bin/rzv-identify.rs
@@ -79,9 +79,8 @@ async fn main() {
                 info,
                 ..
             })) => {
-                // register our external address. this is not normal behaviour under identify, usually
-                // local addresses need to be added manually. this is done for the sake of
-                // running the example.
+                // Register our external address. Needs to be done explicitly 
+                // for this case, as it's a local address.
                 swarm.add_external_address(info.observed_addr);
                 if let Err(error) = swarm.behaviour_mut().rendezvous.register(
                     rendezvous::Namespace::from_static("rendezvous"),

--- a/examples/rendezvous/src/bin/rzv-identify.rs
+++ b/examples/rendezvous/src/bin/rzv-identify.rs
@@ -79,7 +79,7 @@ async fn main() {
                 info,
                 ..
             })) => {
-                // Register our external address. Needs to be done explicitly 
+                // Register our external address. Needs to be done explicitly
                 // for this case, as it's a local address.
                 swarm.add_external_address(info.observed_addr);
                 if let Err(error) = swarm.behaviour_mut().rendezvous.register(

--- a/examples/rendezvous/src/bin/rzv-identify.rs
+++ b/examples/rendezvous/src/bin/rzv-identify.rs
@@ -79,7 +79,7 @@ async fn main() {
                 info,
                 ..
             })) => {
-                // register our external address. this is not normal behaviour, usually
+                // register our external address. this is not normal behaviour under identify, usually
                 // local addresses need to be added manually. this is done for the sake of
                 // running the example.
                 swarm.add_external_address(info.observed_addr);

--- a/examples/rendezvous/src/bin/rzv-identify.rs
+++ b/examples/rendezvous/src/bin/rzv-identify.rs
@@ -76,8 +76,13 @@ async fn main() {
             }
             // once `/identify` did its job, we know our external address and can register
             SwarmEvent::Behaviour(MyBehaviourEvent::Identify(identify::Event::Received {
+                info,
                 ..
             })) => {
+                // register our external address. this is not normal behaviour, usually
+                // local addresses need to be added manually. this is done for the sake of
+                // running the example.
+                swarm.add_external_address(info.observed_addr);
                 if let Err(error) = swarm.behaviour_mut().rendezvous.register(
                     rendezvous::Namespace::from_static("rendezvous"),
                     rendezvous_point,


### PR DESCRIPTION
## Description
This pr closes https://github.com/libp2p/rust-libp2p/issues/5388 by explicitly adding the local observed address, noting this is out of protocol behaviour in non-example cases

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
