### PR TITLE
fix(tls): fix rustls panic due to critical libp2p extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tls"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "futures",
  "futures-rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,7 +1727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.9",
+ "rustls 0.23.11",
  "rustls-pki-types",
 ]
 
@@ -3159,7 +3159,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "ring 0.17.8",
- "rustls 0.23.9",
+ "rustls 0.23.11",
  "socket2 0.5.7",
  "thiserror",
  "tokio",
@@ -3385,7 +3385,7 @@ dependencies = [
  "libp2p-yamux",
  "rcgen",
  "ring 0.17.8",
- "rustls 0.23.9",
+ "rustls 0.23.11",
  "rustls-webpki 0.101.7",
  "thiserror",
  "tokio",
@@ -4607,7 +4607,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.9",
+ "rustls 0.23.11",
  "thiserror",
  "tokio",
  "tracing",
@@ -4623,7 +4623,7 @@ dependencies = [
  "rand 0.8.5",
  "ring 0.17.8",
  "rustc-hash",
- "rustls 0.23.9",
+ "rustls 0.23.11",
  "slab",
  "thiserror",
  "tinyvec",
@@ -5156,21 +5156,21 @@ dependencies = [
  "log",
  "ring 0.17.8",
  "rustls-pki-types",
- "rustls-webpki 0.102.4",
+ "rustls-webpki 0.102.5",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.9"
+version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a218f0f6d05669de4eabfb24f31ce802035c952429d037507b4a4a39f0e60c5b"
+checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
 dependencies = [
  "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
- "rustls-webpki 0.102.4",
+ "rustls-webpki 0.102.5",
  "subtle",
  "zeroize",
 ]
@@ -5203,9 +5203,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
  "ring 0.17.8",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ libp2p-swarm = { version = "0.45.0", path = "swarm" }
 libp2p-swarm-derive = { version = "=0.34.2", path = "swarm-derive" } # `libp2p-swarm-derive` may not be compatible with different `libp2p-swarm` non-breaking releases. E.g. `libp2p-swarm` might introduce a new enum variant `FromSwarm` (which is `#[non-exhaustive]`) in a non-breaking release. Older versions of `libp2p-swarm-derive` would not forward this enum variant within the `NetworkBehaviour` hierarchy. Thus the version pinning is required.
 libp2p-swarm-test = { version = "0.3.0", path = "swarm-test" }
 libp2p-tcp = { version = "0.42.0", path = "transports/tcp" }
-libp2p-tls = { version = "0.4.0", path = "transports/tls" }
+libp2p-tls = { version = "0.4.1", path = "transports/tls" }
 libp2p-uds = { version = "0.40.0", path = "transports/uds" }
 libp2p-upnp = { version = "0.2.2", path = "protocols/upnp" }
 libp2p-webrtc = { version = "0.7.1-alpha", path = "transports/webrtc" }

--- a/transports/tls/CHANGELOG.md
+++ b/transports/tls/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.1
 
-- Mark TLS extension as non-critical to prevent panic with `rustls` version `0.23.11`.
+- Fix a panic caused by `rustls` parsing the libp2p TLS extension.
   See [PR 5498](https://github.com/libp2p/rust-libp2p/pull/5498).
 
 ## 0.4.0

--- a/transports/tls/CHANGELOG.md
+++ b/transports/tls/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.1
+
+- Mark TLS extension as non-critical to prevent panic with `rustls` version `0.23.11`.
+  See [PR 5498](https://github.com/libp2p/rust-libp2p/pull/5498).
+
 ## 0.4.0
 
 - Upgrade `rustls` to `0.23`. See [PR 5385](https://github.com/libp2p/rust-libp2p/pull/5385)

--- a/transports/tls/Cargo.toml
+++ b/transports/tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-tls"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = { workspace = true }
 description = "TLS configuration based on libp2p TLS specs."

--- a/transports/tls/src/certificate.rs
+++ b/transports/tls/src/certificate.rs
@@ -75,7 +75,10 @@ impl rustls::client::ResolvesClientCert for AlwaysResolvesCert {
 }
 
 impl rustls::server::ResolvesServerCert for AlwaysResolvesCert {
-    fn resolve(&self, _client_hello: rustls::server::ClientHello<'_>) -> Option<Arc<rustls::sign::CertifiedKey>> {
+    fn resolve(
+        &self,
+        _client_hello: rustls::server::ClientHello<'_>,
+    ) -> Option<Arc<rustls::sign::CertifiedKey>> {
         Some(Arc::clone(&self.0))
     }
 }

--- a/transports/tls/src/certificate.rs
+++ b/transports/tls/src/certificate.rs
@@ -26,6 +26,8 @@ use libp2p_identity as identity;
 use libp2p_identity::PeerId;
 use x509_parser::{prelude::*, signature_algorithm::SignatureAlgorithm};
 
+use std::sync::Arc;
+
 /// The libp2p Public Key Extension is a X.509 extension
 /// with the Object Identifier 1.3.6.1.4.1.53594.1.1,
 /// allocated by IANA to the libp2p project at Protocol Labs.
@@ -41,6 +43,42 @@ const P2P_SIGNING_PREFIX: [u8; 21] = *b"libp2p-tls-handshake:";
 // Certificates MUST use the NamedCurve encoding for elliptic curve parameters.
 // Similarly, hash functions with an output length less than 256 bits MUST NOT be used.
 static P2P_SIGNATURE_ALGORITHM: &rcgen::SignatureAlgorithm = &rcgen::PKCS_ECDSA_P256_SHA256;
+
+#[derive(Debug)]
+pub(crate) struct AlwaysResolvesCert(Arc<rustls::sign::CertifiedKey>);
+
+impl AlwaysResolvesCert {
+    pub(crate) fn new(
+        cert: rustls::pki_types::CertificateDer<'static>,
+        key: &rustls::pki_types::PrivateKeyDer<'_>,
+    ) -> Result<Self, rustls::Error> {
+        let certified_key = rustls::sign::CertifiedKey::new(
+            vec![cert],
+            rustls::crypto::ring::sign::any_ecdsa_type(key)?,
+        );
+        Ok(Self(Arc::new(certified_key)))
+    }
+}
+
+impl rustls::client::ResolvesClientCert for AlwaysResolvesCert {
+    fn resolve(
+        &self,
+        _root_hint_subjects: &[&[u8]],
+        _sigschemes: &[rustls::SignatureScheme],
+    ) -> Option<Arc<rustls::sign::CertifiedKey>> {
+        Some(Arc::clone(&self.0))
+    }
+
+    fn has_certs(&self) -> bool {
+        true
+    }
+}
+
+impl rustls::server::ResolvesServerCert for AlwaysResolvesCert {
+    fn resolve(&self, _client_hello: rustls::server::ClientHello<'_>) -> Option<Arc<rustls::sign::CertifiedKey>> {
+        Some(Arc::clone(&self.0))
+    }
+}
 
 /// Generates a self-signed TLS certificate that includes a libp2p-specific
 /// certificate extension containing the public key of the given keypair.
@@ -229,12 +267,9 @@ fn make_libp2p_extension(
         yasna::encode_der(&(serialized_pubkey, signature))
     };
 
+    // This extension MAY be marked critical.
     let mut ext = rcgen::CustomExtension::from_oid_content(&P2P_EXT_OID, extension_content);
-    // This extension MAY be marked critical as per the libp2p TLS spec.
-    // But rustls =0.23.11 will throw a `[rustls_webpki::Error::UnsupportedCriticalExtension]`
-    // when verifying the certificate consistency (see https://github.com/rustls/rustls/pull/2034).
-    // So we explicitly set it to non-critical.
-    ext.set_criticality(false);
+    ext.set_criticality(true);
 
     Ok(ext)
 }

--- a/transports/tls/src/certificate.rs
+++ b/transports/tls/src/certificate.rs
@@ -229,9 +229,12 @@ fn make_libp2p_extension(
         yasna::encode_der(&(serialized_pubkey, signature))
     };
 
-    // This extension MAY be marked critical.
     let mut ext = rcgen::CustomExtension::from_oid_content(&P2P_EXT_OID, extension_content);
-    ext.set_criticality(true);
+    // This extension MAY be marked critical as per the libp2p TLS spec.
+    // But rustls =0.23.11 will throw a `[rustls_webpki::Error::UnsupportedCriticalExtension]`
+    // when verifying the certificate consistency (see https://github.com/rustls/rustls/pull/2034).
+    // So we explicitly set it to non-critical.
+    ext.set_criticality(false);
 
     Ok(ext)
 }


### PR DESCRIPTION
## Description

Resolves #5487.

## Notes & open questions

While parsing a certificate, `rustls-webpki` throws up a `UnsupportedCriticalExtension` if the certificate has any non-standard TLS extensions that are marked critical.
Since the [libp2p TLS extension spec](https://github.com/libp2p/specs/blob/master/tls/tls.md#peer-authentication) says `This extension MAY be marked critical`, not marking the extension as critical should be okay.

Ideally, the certificate consistency check added [upstream](https://github.com/rustls/rustls/pull/2034) should probably ignore non-critical errors like this.

If this seems like an acceptable solution, I'll add in a changelog entry.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
