### PR TITLE
docs: As implied by #5517 make sure everything still builds on docs.rs

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -48,8 +48,6 @@ serde = ["multihash/serde-codec", "dep:serde", "libp2p-identity/serde"]
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -56,8 +56,6 @@ harness = false
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -150,8 +150,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/misc/metrics/Cargo.toml
+++ b/misc/metrics/Cargo.toml
@@ -40,8 +40,6 @@ libp2p-identity = { workspace = true, features = ["rand"] }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -30,8 +30,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/misc/quick-protobuf-codec/Cargo.toml
+++ b/misc/quick-protobuf-codec/Cargo.toml
@@ -30,8 +30,6 @@ harness = false
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/misc/rw-stream-sink/Cargo.toml
+++ b/misc/rw-stream-sink/Cargo.toml
@@ -22,8 +22,6 @@ async-std = "1.0"
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -42,8 +42,6 @@ harness = false
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/muxers/yamux/Cargo.toml
+++ b/muxers/yamux/Cargo.toml
@@ -27,8 +27,6 @@ libp2p-muxer-test-harness = { path = "../test-harness" }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -34,8 +34,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/protocols/dcutr/Cargo.toml
+++ b/protocols/dcutr/Cargo.toml
@@ -47,8 +47,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -30,8 +30,6 @@ tracing = { workspace = true }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -55,8 +55,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -37,8 +37,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -52,8 +52,6 @@ serde = ["dep:serde", "bytes/serde"]
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -54,8 +54,6 @@ required-features = ["tokio"]
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/protocols/perf/Cargo.toml
+++ b/protocols/perf/Cargo.toml
@@ -42,8 +42,6 @@ libp2p-swarm-test = { path = "../../swarm-test" }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -33,8 +33,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -44,8 +44,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/protocols/rendezvous/Cargo.toml
+++ b/protocols/rendezvous/Cargo.toml
@@ -44,8 +44,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -47,8 +47,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/protocols/upnp/Cargo.toml
+++ b/protocols/upnp/Cargo.toml
@@ -30,5 +30,3 @@ workspace = true
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]

--- a/swarm-derive/Cargo.toml
+++ b/swarm-derive/Cargo.toml
@@ -23,8 +23,6 @@ proc-macro2 = "1.0"
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -67,8 +67,6 @@ required-features = ["macros"]
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [[bench]]
 name = "connection_handler"

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -35,8 +35,6 @@ tokio = ["hickory-resolver/tokio-runtime"]
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/transports/noise/Cargo.toml
+++ b/transports/noise/Cargo.toml
@@ -43,8 +43,6 @@ libp2p-identity = { workspace = true, features = ["rand"] }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/transports/plaintext/Cargo.toml
+++ b/transports/plaintext/Cargo.toml
@@ -31,8 +31,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/transports/pnet/Cargo.toml
+++ b/transports/pnet/Cargo.toml
@@ -33,8 +33,6 @@ tokio = { workspace = true, features = ["full"] }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -35,8 +35,6 @@ async-std = ["dep:async-std", "if-watch/smol", "quinn/runtime-async-std"]
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -37,8 +37,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 [package.metadata.docs.rs]
 all-features = true
 
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/transports/tls/Cargo.toml
+++ b/transports/tls/Cargo.toml
@@ -40,8 +40,6 @@ tokio = { workspace = true, features = ["full"] }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/transports/uds/Cargo.toml
+++ b/transports/uds/Cargo.toml
@@ -24,8 +24,6 @@ tempfile = "3.10"
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/transports/webrtc/Cargo.toml
+++ b/transports/webrtc/Cargo.toml
@@ -55,5 +55,3 @@ workspace = true
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]

--- a/transports/websocket-websys/Cargo.toml
+++ b/transports/websocket-websys/Cargo.toml
@@ -26,8 +26,6 @@ web-sys = { version = "0.3.69", features = ["BinaryType", "CloseEvent", "Message
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]
 libp2p-yamux = { workspace = true }

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -36,8 +36,6 @@ rcgen = { workspace = true }
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/transports/webtransport-websys/Cargo.toml
+++ b/transports/webtransport-websys/Cargo.toml
@@ -44,8 +44,6 @@ multibase = "0.9.1"
 # More information: https://docs.rs/about/builds#cross-compiling
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-rustc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

As @guillaumemichel already found out, passing the `docsrs` cfg to rustc now breaks the documentation build. Although I couldn't exactly reproduce the docs.rs build env (everyone is welcome to try; it's explained [here](https://github.com/rust-lang/docs.rs/blob/master/README.md#build-subcommand)) it's safe to assume that the same problem will occur when we push to docs.rs.

Passing the docsrs flag is also no longer required since it's now automatically passed to rustdoc when building on docs.rs. Explanation: https://docs.rs/about/builds#detecting-docsrs

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

None. (I'm pretty sure it will work on docs.rs)

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code