### PR TITLE
feat: make runtime features optional in swarm-test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-test"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ libp2p-server = { version = "0.12.7", path = "misc/server" }
 libp2p-stream = { version = "0.2.0-alpha", path = "protocols/stream" }
 libp2p-swarm = { version = "0.45.1", path = "swarm" }
 libp2p-swarm-derive = { version = "=0.35.0", path = "swarm-derive" } # `libp2p-swarm-derive` may not be compatible with different `libp2p-swarm` non-breaking releases. E.g. `libp2p-swarm` might introduce a new enum variant `FromSwarm` (which is `#[non-exhaustive]`) in a non-breaking release. Older versions of `libp2p-swarm-derive` would not forward this enum variant within the `NetworkBehaviour` hierarchy. Thus the version pinning is required.
-libp2p-swarm-test = { version = "0.4.0", path = "swarm-test" }
+libp2p-swarm-test = { version = "0.4.1", path = "swarm-test" }
 libp2p-tcp = { version = "0.42.0", path = "transports/tcp" }
 libp2p-tls = { version = "0.5.0", path = "transports/tls" }
 libp2p-uds = { version = "0.41.0", path = "transports/uds" }

--- a/swarm-test/CHANGELOG.md
+++ b/swarm-test/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.1
+
 ## 0.4.0
 
 <!-- Update to libp2p-swarm v0.45.0 -->

--- a/swarm-test/CHANGELOG.md
+++ b/swarm-test/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.4.1
 
+- Add `tokio` runtime support and make `tokio` and `async-std` runtimes optional behind features.
+  See [PR 5551].
+
+[PR 5551]: https://github.com/libp2p/rust-libp2p/pull/5551
+
 ## 0.4.0
 
 <!-- Update to libp2p-swarm v0.45.0 -->

--- a/swarm-test/Cargo.toml
+++ b/swarm-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-swarm-test"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = { workspace = true }
 license = "MIT"
@@ -16,13 +16,19 @@ async-trait = "0.1.80"
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true, features = ["rand"] }
 libp2p-plaintext = { workspace = true }
-libp2p-swarm = { workspace = true, features = ["async-std"] }
-libp2p-tcp = { workspace = true, features = ["async-io"] }
+libp2p-swarm = { workspace = true }
+libp2p-tcp = { workspace = true }
 libp2p-yamux = { workspace = true }
 futures = { workspace = true }
 rand = "0.8.5"
 tracing = { workspace = true }
 futures-timer = "3.0.3"
+
+[features]
+default = ["async-std"]
+
+async-std = ["libp2p-swarm/async-std", "libp2p-tcp/async-io"]
+tokio = ["libp2p-swarm/tokio", "libp2p-tcp/tokio"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

Sometimes a test uses custom swarm building logic and doesn't need `fn new_ephemeral`, and sometimes a test uses `tokio` runtime other than `async-std`.
This PR adds the `tokio` runtime support and makes both `async-std` and `tokio` runtimes optional behind features to make it more flexible.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
