### PR TITLE
refactor(examples): distributed-key-value-store identify and rendezvous

### DIFF
--- a/examples/distributed-key-value-store/Cargo.toml
+++ b/examples/distributed-key-value-store/Cargo.toml
@@ -9,10 +9,9 @@ license = "MIT"
 release = false
 
 [dependencies]
-async-std = { version = "1.12", features = ["attributes"] }
-async-trait = "0.1"
+tokio = { version = "1.37.0", features = ["full"] }
 futures = { workspace = true }
-libp2p = { path = "../../libp2p", features = [ "async-std", "dns", "kad", "mdns", "noise", "macros", "tcp", "yamux"] }
+libp2p = { path = "../../libp2p", features = [ "tokio", "dns", "kad", "mdns", "noise", "macros", "tcp", "yamux"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 

--- a/examples/distributed-key-value-store/src/main.rs
+++ b/examples/distributed-key-value-store/src/main.rs
@@ -20,8 +20,8 @@
 
 #![doc = include_str!("../README.md")]
 
-use async_std::io;
-use futures::{prelude::*, select};
+use tokio::{io, io::AsyncBufReadExt, select};
+use futures::stream::StreamExt;
 use libp2p::kad;
 use libp2p::kad::store::MemoryStore;
 use libp2p::kad::Mode;
@@ -34,7 +34,7 @@ use std::error::Error;
 use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
@@ -44,11 +44,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     #[derive(NetworkBehaviour)]
     struct Behaviour {
         kademlia: kad::Behaviour<MemoryStore>,
-        mdns: mdns::async_io::Behaviour,
+        mdns: mdns::tokio::Behaviour,
     }
 
     let mut swarm = libp2p::SwarmBuilder::with_new_identity()
-        .with_async_std()
+        .with_tokio()
         .with_tcp(
             tcp::Config::default(),
             noise::Config::new,
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     key.public().to_peer_id(),
                     MemoryStore::new(key.public().to_peer_id()),
                 ),
-                mdns: mdns::async_io::Behaviour::new(
+                mdns: mdns::tokio::Behaviour::new(
                     mdns::Config::default(),
                     key.public().to_peer_id(),
                 )?,
@@ -72,7 +72,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     swarm.behaviour_mut().kademlia.set_mode(Some(Mode::Server));
 
     // Read full lines from stdin
-    let mut stdin = io::BufReader::new(io::stdin()).lines().fuse();
+    let mut stdin = io::BufReader::new(io::stdin()).lines();
 
     // Listen on all interfaces and whatever port the OS assigns.
     swarm.listen_on("/ip4/0.0.0.0/tcp/0".parse()?)?;
@@ -80,7 +80,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Kick it off.
     loop {
         select! {
-        line = stdin.select_next_some() => handle_input_line(&mut swarm.behaviour_mut().kademlia, line.expect("Stdin not to close")),
+        line = stdin.next_line() => handle_input_line(&mut swarm.behaviour_mut().kademlia,
+        line.expect("Stdin not to close").expect("EOL")),
         event = swarm.select_next_some() => match event {
             SwarmEvent::NewListenAddr { address, .. } => {
                 println!("Listening in {address:?}");
@@ -142,6 +143,68 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
             _ => {}
         }
+        //line = stdin.select_next_some() => handle_input_line(&mut swarm.behaviour_mut().kademlia, line.expect("Stdin not to close")),
+        //event = swarm.select_next_some() => match event {
+        //    SwarmEvent::NewListenAddr { address, .. } => {
+        //        println!("Listening in {address:?}");
+        //    },
+        //    SwarmEvent::Behaviour(BehaviourEvent::Mdns(mdns::Event::Discovered(list))) => {
+        //        for (peer_id, multiaddr) in list {
+        //            swarm.behaviour_mut().kademlia.add_address(&peer_id, multiaddr);
+        //        }
+        //    }
+        //    SwarmEvent::Behaviour(BehaviourEvent::Kademlia(kad::Event::OutboundQueryProgressed { result, ..})) => {
+        //        match result {
+        //            kad::QueryResult::GetProviders(Ok(kad::GetProvidersOk::FoundProviders { key, providers, .. })) => {
+        //                for peer in providers {
+        //                    println!(
+        //                        "Peer {peer:?} provides key {:?}",
+        //                        std::str::from_utf8(key.as_ref()).unwrap()
+        //                    );
+        //                }
+        //            }
+        //            kad::QueryResult::GetProviders(Err(err)) => {
+        //                eprintln!("Failed to get providers: {err:?}");
+        //            }
+        //            kad::QueryResult::GetRecord(Ok(
+        //                kad::GetRecordOk::FoundRecord(kad::PeerRecord {
+        //                    record: kad::Record { key, value, .. },
+        //                    ..
+        //                })
+        //            )) => {
+        //                println!(
+        //                    "Got record {:?} {:?}",
+        //                    std::str::from_utf8(key.as_ref()).unwrap(),
+        //                    std::str::from_utf8(&value).unwrap(),
+        //                );
+        //            }
+        //            kad::QueryResult::GetRecord(Ok(_)) => {}
+        //            kad::QueryResult::GetRecord(Err(err)) => {
+        //                eprintln!("Failed to get record: {err:?}");
+        //            }
+        //            kad::QueryResult::PutRecord(Ok(kad::PutRecordOk { key })) => {
+        //                println!(
+        //                    "Successfully put record {:?}",
+        //                    std::str::from_utf8(key.as_ref()).unwrap()
+        //                );
+        //            }
+        //            kad::QueryResult::PutRecord(Err(err)) => {
+        //                eprintln!("Failed to put record: {err:?}");
+        //            }
+        //            kad::QueryResult::StartProviding(Ok(kad::AddProviderOk { key })) => {
+        //                println!(
+        //                    "Successfully put provider record {:?}",
+        //                    std::str::from_utf8(key.as_ref()).unwrap()
+        //                );
+        //            }
+        //            kad::QueryResult::StartProviding(Err(err)) => {
+        //                eprintln!("Failed to put provider record: {err:?}");
+        //            }
+        //            _ => {}
+        //        }
+        //    }
+        //    _ => {}
+        //}
         }
     }
 }

--- a/examples/distributed-key-value-store/src/main.rs
+++ b/examples/distributed-key-value-store/src/main.rs
@@ -20,7 +20,6 @@
 
 #![doc = include_str!("../README.md")]
 
-use tokio::{io, io::AsyncBufReadExt, select};
 use futures::stream::StreamExt;
 use libp2p::kad;
 use libp2p::kad::store::MemoryStore;
@@ -32,6 +31,7 @@ use libp2p::{
 };
 use std::error::Error;
 use std::time::Duration;
+use tokio::{io, io::AsyncBufReadExt, select};
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -143,68 +143,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
             _ => {}
         }
-        //line = stdin.select_next_some() => handle_input_line(&mut swarm.behaviour_mut().kademlia, line.expect("Stdin not to close")),
-        //event = swarm.select_next_some() => match event {
-        //    SwarmEvent::NewListenAddr { address, .. } => {
-        //        println!("Listening in {address:?}");
-        //    },
-        //    SwarmEvent::Behaviour(BehaviourEvent::Mdns(mdns::Event::Discovered(list))) => {
-        //        for (peer_id, multiaddr) in list {
-        //            swarm.behaviour_mut().kademlia.add_address(&peer_id, multiaddr);
-        //        }
-        //    }
-        //    SwarmEvent::Behaviour(BehaviourEvent::Kademlia(kad::Event::OutboundQueryProgressed { result, ..})) => {
-        //        match result {
-        //            kad::QueryResult::GetProviders(Ok(kad::GetProvidersOk::FoundProviders { key, providers, .. })) => {
-        //                for peer in providers {
-        //                    println!(
-        //                        "Peer {peer:?} provides key {:?}",
-        //                        std::str::from_utf8(key.as_ref()).unwrap()
-        //                    );
-        //                }
-        //            }
-        //            kad::QueryResult::GetProviders(Err(err)) => {
-        //                eprintln!("Failed to get providers: {err:?}");
-        //            }
-        //            kad::QueryResult::GetRecord(Ok(
-        //                kad::GetRecordOk::FoundRecord(kad::PeerRecord {
-        //                    record: kad::Record { key, value, .. },
-        //                    ..
-        //                })
-        //            )) => {
-        //                println!(
-        //                    "Got record {:?} {:?}",
-        //                    std::str::from_utf8(key.as_ref()).unwrap(),
-        //                    std::str::from_utf8(&value).unwrap(),
-        //                );
-        //            }
-        //            kad::QueryResult::GetRecord(Ok(_)) => {}
-        //            kad::QueryResult::GetRecord(Err(err)) => {
-        //                eprintln!("Failed to get record: {err:?}");
-        //            }
-        //            kad::QueryResult::PutRecord(Ok(kad::PutRecordOk { key })) => {
-        //                println!(
-        //                    "Successfully put record {:?}",
-        //                    std::str::from_utf8(key.as_ref()).unwrap()
-        //                );
-        //            }
-        //            kad::QueryResult::PutRecord(Err(err)) => {
-        //                eprintln!("Failed to put record: {err:?}");
-        //            }
-        //            kad::QueryResult::StartProviding(Ok(kad::AddProviderOk { key })) => {
-        //                println!(
-        //                    "Successfully put provider record {:?}",
-        //                    std::str::from_utf8(key.as_ref()).unwrap()
-        //                );
-        //            }
-        //            kad::QueryResult::StartProviding(Err(err)) => {
-        //                eprintln!("Failed to put provider record: {err:?}");
-        //            }
-        //            _ => {}
-        //        }
-        //    }
-        //    _ => {}
-        //}
         }
     }
 }

--- a/examples/identify/Cargo.toml
+++ b/examples/identify/Cargo.toml
@@ -9,10 +9,9 @@ license = "MIT"
 release = false
 
 [dependencies]
-async-std = { version = "1.12", features = ["attributes"] }
-async-trait = "0.1"
+tokio = { version = "1.37.0", features = ["full"] }
 futures = { workspace = true }
-libp2p = { path = "../../libp2p", features = ["async-std", "dns", "dcutr", "identify", "macros", "noise", "ping", "relay", "rendezvous", "tcp", "tokio","yamux"] }
+libp2p = { path = "../../libp2p", features = ["identify", "noise", "tcp", "tokio", "yamux"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 

--- a/examples/identify/src/main.rs
+++ b/examples/identify/src/main.rs
@@ -25,14 +25,14 @@ use libp2p::{core::multiaddr::Multiaddr, identify, noise, swarm::SwarmEvent, tcp
 use std::{error::Error, time::Duration};
 use tracing_subscriber::EnvFilter;
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
 
     let mut swarm = libp2p::SwarmBuilder::with_new_identity()
-        .with_async_std()
+        .with_tokio()
         .with_tcp(
             tcp::Config::default(),
             noise::Config::new,

--- a/examples/rendezvous/Cargo.toml
+++ b/examples/rendezvous/Cargo.toml
@@ -9,10 +9,8 @@ license = "MIT"
 release = false
 
 [dependencies]
-async-std = { version = "1.12", features = ["attributes"] }
-async-trait = "0.1"
 futures = { workspace = true }
-libp2p = { path = "../../libp2p", features = [ "async-std", "identify", "macros", "noise", "ping", "rendezvous", "tcp", "tokio", "yamux"] }
+libp2p = { path = "../../libp2p", features = ["identify", "macros", "noise", "ping", "rendezvous", "tcp", "tokio", "yamux"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }


### PR DESCRIPTION
## Description
Following on issue #4449 
Refactor and cleanup on three examples:
refactor: use tokio instead of async-std in the distributed-key-value-store example and remove unnecesary dependencies
refactor: remove unnecesary dependencies rendezvous example (async-std)
refactor: use tokio instead of async-std in the identify example and remove unnecesary dependencies
<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

* in the distributed-key-value example is it ok to put "EOL"in the expect?
* in the rendezvous example there where unnecessary dependencies  in the Cargo.toml (so as in the identify)
<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist
* Removed unecesary dependencies on examples/rendezvous/Cargo.toml and examples/identify/Cargo.toml

* Changed async-std for tokio in examples/distributed-key-value-store/Cargo.toml  and examples/identify/Cargo.toml

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
