### PR TITLE
feat(kad): add `mode` getter on `Behaviour`

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Expose a kad query facility allowing specify num_results dynamicly.
   See [PR 5555](https://github.com/libp2p/rust-libp2p/pull/5555).
+- Add `mode` getter on `Behaviour`.
+  See [PR 5573](https://github.com/libp2p/rust-libp2p/pull/5573).
+  
 
 ## 0.46.2
 

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -1111,6 +1111,11 @@ where
         }
     }
 
+    /// Get the [`Mode`] in which the DHT is currently operating.
+    pub fn mode(&self) -> Mode {
+        self.mode
+    }
+
     fn reconfigure_mode(&mut self) {
         if self.connections.is_empty() {
             return;


### PR DESCRIPTION
## Description

Small PR adding a getter for the `mode` attribute of the `kad::Behaviour` in order to get the mode that the DHT is operating in, at the moment. 

## Notes & open questions

In our project, we needed to expose an API endpoint which included the mode that the DHT was operating. Having a getter was necessary so we are upstreaming this change. 

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
