### PR TITLE
fix(relay): malformed reported relayed addr when relay peer is dialer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3206,7 +3206,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "asynchronous-codec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ libp2p-ping = { version = "0.45.0", path = "protocols/ping" }
 libp2p-plaintext = { version = "0.42.0", path = "transports/plaintext" }
 libp2p-pnet = { version = "0.25.0", path = "transports/pnet" }
 libp2p-quic = { version = "0.11.1", path = "transports/quic" }
-libp2p-relay = { version = "0.18.0", path = "protocols/relay" }
+libp2p-relay = { version = "0.18.1", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.15.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.27.0", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.7", path = "misc/server" }

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.18.1
+
+- Fix malformed reported relayed address when relay peer was dialer.
+  See [PR 5576](https://github.com/libp2p/rust-libp2p/pull/5576).
+
 ## 0.18.0
 
 <!-- Update to libp2p-swarm v0.45.0 -->

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-relay"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Communications relaying for libp2p"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Parity Technologies <admin@parity.io>", "Max Inden <mail@max-inden.de>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
## Description

I don't know if it is a bug or not, but in the `NetworkBehaviour` trait, there is a discrepancy with the remote multiaddr given to `handle_established_Inbound_connection` and the one given to `handle_established_OUTbound_connection`.

`handle_established_Inbound_connection` receive the `remote_addr` not suffixed with `/p2p/<remote_peer_id>` but `handle_established_OUTbound_connection` do receive `addr` suffixed with `/p2p/<remote_peer_id>`.

This is causing a weird behavior in the `relay` protocol because when creating the `Handler`, the remote address is passed down as is, and when a "relayed connection" is negotiated with a remote peer through the relay peer, the `/p2p-circuit` is simply pushed without checking the form of the multiaddr.

Because of that, we encountered some bug where address was reported like this: `/ip4/1.2.3.4/udp/1234/quic/p2p-circuit` (note the relay peer_id missing), which is invalid ([here](https://github.com/libp2p/specs/blob/master/addressing/README.md#p2p-circuit-relay-addresses) the specs of a correct relayed address).

This PR simply address the bug of the relay peer but maybe something should be done to make sure that the same format is received, both from `incoming` and `outgoing` connections. Since I don't know if it could have side effects else-were, I have just addressed the problem described above.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
