### PR TITLE
fix(relay): external addr not expiring when relayed listen addr expire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3206,7 +3206,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "asynchronous-codec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ libp2p-ping = { version = "0.45.0", path = "protocols/ping" }
 libp2p-plaintext = { version = "0.42.0", path = "transports/plaintext" }
 libp2p-pnet = { version = "0.25.0", path = "transports/pnet" }
 libp2p-quic = { version = "0.11.1", path = "transports/quic" }
-libp2p-relay = { version = "0.18.0", path = "protocols/relay" }
+libp2p-relay = { version = "0.18.1", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.15.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.27.0", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.7", path = "misc/server" }

--- a/protocols/dcutr/tests/lib.rs
+++ b/protocols/dcutr/tests/lib.rs
@@ -57,8 +57,7 @@ async fn connect() {
 
     let dst_relayed_addr = relay_tcp_addr
         .with(Protocol::P2p(relay_peer_id))
-        .with(Protocol::P2pCircuit)
-        .with(Protocol::P2p(dst_peer_id));
+        .with(Protocol::P2pCircuit);
     dst.listen_on(dst_relayed_addr.clone()).unwrap();
 
     wait_for_reservation(
@@ -70,7 +69,8 @@ async fn connect() {
     .await;
     async_std::task::spawn(dst.loop_on_next());
 
-    src.dial_and_wait(dst_relayed_addr.clone()).await;
+    src.dial_and_wait(dst_relayed_addr.with(Protocol::P2p(dst_peer_id)))
+        .await;
 
     let dst_addr = dst_tcp_addr.with(Protocol::P2p(dst_peer_id));
 

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.18.1
+
+- Fix relayed `ExternalAddr` not expiring when stopping to listen through relay.
+  Removing `/p2p/<local_peer_id>` part from the listen and external addresses reported by the relay `Behaviour`.
+  See [PR 5577](https://github.com/libp2p/rust-libp2p/pull/5577).
+
 ## 0.18.0
 
 <!-- Update to libp2p-swarm v0.45.0 -->

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-relay"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Communications relaying for libp2p"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Parity Technologies <admin@parity.io>", "Max Inden <mail@max-inden.de>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
## Description

We encountered a bug when our app is connected and listening through a relay and that it decided to stop listening through the relay but still let the connection with the relay open (some other streams are opened with this peer), then the previously confirmed `ExternalAddress` does not expire.

The PR solves this problem and simplify a little bit the way to emit `ExternalAddrConfirmed` and `ExternalAddrExpired` by only watching `NewListenAddr` and `ExpiredListenAddr` events if they are notifying about a relayed listen address.

Also, when renewing reservation, `NewListenAddr` should not be emitted again if the same `listen_addr` is given, but it should emit a `ListenAddrExpired` event if a previously reserved one was not reserved again. 

## Notes & open questions

I have also included a correlated change by removing the `/p2p/<local_peer_id>` of the relayed listen addresses and external addresses (corresponding to a listen addresses). Indeed, every other transport does not include it so I think it is better that the `relay` transport acts the same. If necessary, I can do a separated PR.
## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
