### PR TITLE
refactor(examples): use tokio instead of async-std in identify example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,10 +2311,9 @@ dependencies = [
 name = "identify-example"
 version = "0.1.0"
 dependencies = [
- "async-std",
- "async-trait",
  "futures",
  "libp2p",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/examples/identify/Cargo.toml
+++ b/examples/identify/Cargo.toml
@@ -9,10 +9,9 @@ license = "MIT"
 release = false
 
 [dependencies]
-async-std = { version = "1.12", features = ["attributes"] }
-async-trait = "0.1"
+tokio = { version = "1.37.0", features = ["full"] }
 futures = { workspace = true }
-libp2p = { path = "../../libp2p", features = ["async-std", "dns", "dcutr", "identify", "macros", "noise", "ping", "relay", "rendezvous", "tcp", "tokio","yamux"] }
+libp2p = { path = "../../libp2p", features = ["identify", "noise", "tcp", "tokio", "yamux"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 

--- a/examples/identify/src/main.rs
+++ b/examples/identify/src/main.rs
@@ -25,14 +25,14 @@ use libp2p::{core::multiaddr::Multiaddr, identify, noise, swarm::SwarmEvent, tcp
 use std::{error::Error, time::Duration};
 use tracing_subscriber::EnvFilter;
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
 
     let mut swarm = libp2p::SwarmBuilder::with_new_identity()
-        .with_async_std()
+        .with_tokio()
         .with_tcp(
             tcp::Config::default(),
             noise::Config::new,


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->
Following on issue #4449 
refactor: use tokio instead of async-std in the identify example and remove unnecesary dependencies

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

* Removed unnecessary dependencies on examples/identify/Cargo.toml

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
