### PR TITLE
fix(swarm): don't report `NewExternalAddrCandidate` if already confirmed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.45.1"
+version = "0.45.2"
 dependencies = [
  "async-std",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ libp2p-rendezvous = { version = "0.15.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.27.0", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.7", path = "misc/server" }
 libp2p-stream = { version = "0.2.0-alpha", path = "protocols/stream" }
-libp2p-swarm = { version = "0.45.1", path = "swarm" }
+libp2p-swarm = { version = "0.45.2", path = "swarm" }
 libp2p-swarm-derive = { version = "=0.35.0", path = "swarm-derive" } # `libp2p-swarm-derive` may not be compatible with different `libp2p-swarm` non-breaking releases. E.g. `libp2p-swarm` might introduce a new enum variant `FromSwarm` (which is `#[non-exhaustive]`) in a non-breaking release. Older versions of `libp2p-swarm-derive` would not forward this enum variant within the `NetworkBehaviour` hierarchy. Thus the version pinning is required.
 libp2p-swarm-test = { version = "0.4.0", path = "swarm-test" }
 libp2p-tcp = { version = "0.42.0", path = "transports/tcp" }

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.45.2
 
 - Don't report `NewExternalAddrCandidate` for confirmed external addresses.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+  See [PR 5582](https://github.com/libp2p/rust-libp2p/pull/5582).
 
 ## 0.45.1
 

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.45.2
+
+- Don't report `NewExternalAddrCandidate` for confirmed external addresses.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+
 ## 0.45.1
 
 - Update `libp2p-swarm-derive` to version `0.35.0`, see [PR 5545]
@@ -295,9 +300,9 @@
 
   In other words:
 
-  |Search|Replace|
-    |---|---|
-  |`NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>`|`NetworkBehaviourAction<Self::OutEvent, THandlerInEvent<Self>>`|
+  | Search                                                            | Replace                                                         |
+  | ----------------------------------------------------------------- | --------------------------------------------------------------- |
+  | `NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>` | `NetworkBehaviourAction<Self::OutEvent, THandlerInEvent<Self>>` |
 
   If you reference `NetworkBehaviourAction` somewhere else as well,
   you may have to fill in the type of `ConnectionHandler::InEvent` manually as the 2nd parameter.

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -300,9 +300,9 @@
 
   In other words:
 
-  | Search                                                            | Replace                                                         |
-  | ----------------------------------------------------------------- | --------------------------------------------------------------- |
-  | `NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>` | `NetworkBehaviourAction<Self::OutEvent, THandlerInEvent<Self>>` |
+  |Search|Replace|
+    |---|---|
+  |`NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>`|`NetworkBehaviourAction<Self::OutEvent, THandlerInEvent<Self>>`|
 
   If you reference `NetworkBehaviourAction` somewhere else as well,
   you may have to fill in the type of `ConnectionHandler::InEvent` manually as the 2nd parameter.

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-swarm"
 edition = "2021"
 rust-version = { workspace = true }
 description = "The libp2p swarm"
-version = "0.45.1"
+version = "0.45.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1140,12 +1140,14 @@ where
                 self.pending_handler_event = Some((peer_id, handler, event));
             }
             ToSwarm::NewExternalAddrCandidate(addr) => {
-                self.behaviour
-                    .on_swarm_event(FromSwarm::NewExternalAddrCandidate(
-                        NewExternalAddrCandidate { addr: &addr },
-                    ));
-                self.pending_swarm_events
-                    .push_back(SwarmEvent::NewExternalAddrCandidate { address: addr });
+                if !self.confirmed_external_addr.contains(&addr) {
+                    self.behaviour
+                        .on_swarm_event(FromSwarm::NewExternalAddrCandidate(
+                            NewExternalAddrCandidate { addr: &addr },
+                        ));
+                    self.pending_swarm_events
+                        .push_back(SwarmEvent::NewExternalAddrCandidate { address: addr });
+                }
             }
             ToSwarm::ExternalAddrConfirmed(addr) => {
                 self.add_external_address(addr.clone());


### PR DESCRIPTION
## Description

Currently, `NewExternalAddrCandidate` events are emitted for every connections. However, we continue to get this event even when `autonat` has already confirmed that this address is external. So we should not continue to advertise the "candidate" event.

## Notes & open questions

We have made the changes in the `swarm` instead of `identify` because it does not make it necessary to duplicate the `ConfirmedExternalAddr` vector in the `identify` Behaviour. Moreover, if any future Behaviour emit `NewExternalAddrCandidate`, the same rule will also be applied. 

I had to edit the `autonat_v2` tests which were always expecting a `NewExternalAddrCandidate` but the address was already confirmed.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
