### PR TITLE
fix(dcutr): handle empty holepunch_candidates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dcutr"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-std",
  "asynchronous-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ libp2p-allow-block-list = { version = "0.4.1", path = "misc/allow-block-list" }
 libp2p-autonat = { version = "0.13.0", path = "protocols/autonat" }
 libp2p-connection-limits = { version = "0.4.0", path = "misc/connection-limits" }
 libp2p-core = { version = "0.42.0", path = "core" }
-libp2p-dcutr = { version = "0.12.0", path = "protocols/dcutr" }
+libp2p-dcutr = { version = "0.12.1", path = "protocols/dcutr" }
 libp2p-dns = { version = "0.42.0", path = "transports/dns" }
 libp2p-floodsub = { version = "0.45.0", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.47.0", path = "protocols/gossipsub" }

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.1
+
+- Handle empty hole-punch candidates at relayed connection startup.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+
 ## 0.12.0
 
 <!-- Update to libp2p-swarm v0.45.0 -->

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.12.1
 
 - Handle empty hole-punch candidates at relayed connection startup.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+  See [PR 5583](https://github.com/libp2p/rust-libp2p/pull/5583).
 
 ## 0.12.0
 

--- a/protocols/dcutr/Cargo.toml
+++ b/protocols/dcutr/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-dcutr"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Direct connection upgrade through relay"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Max Inden <mail@max-inden.de>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
## Description

A few months ago, we were experiencing from time to time some weird failures with `DCUTr`. After some research to find out the problem, it was a race condition : sometimes `identify` must be a little bit slow and the `DCUTr` handler is created before an `identify` event is received. Alone, this is not necessarily a problem. But if this race happens when the  holepunch candidates list of `DCUTr` is empty, then `DCUTr` will always fail for this connection. Indeed, when receiving an new relayed established connection, `DCUTr` will create an `Handler` for this connection which will be responsible to make the hole-punching. However, the candidates that are used are the one known at `Handler` instantiation, so any future updates about `NewExternalAddrCandidate` will not be forwarded to the `Handler`s. 

This PR is the upstream of the fix we did several months ago and we did not encountered any particular problem with it since.  

#### Timetable of the problem

|Peer 1|Time|Peer 2|
|-|-|-|
|Connected to relay|0.416||
|Receive identify from relay|0.420||
||0.646|Connected to relay|
||0.650|Dial Peer 1 through relay|
||0.655|Connected to Peer1 through relay|
||0.655|Create DCUTr handler with no hole-punch candidates|
|Connected to Peer 2 through relay|0.657||
||0.659|Receive identify from relay (first observed_addr)|
|DCUTr fail `OutboundError(NoAddress)`|0.663||
||0.664|DCUTr fail `InboundError(UnexpectedEof)`|

## Notes & open questions

1. I have put some `TODO`s about the potential merging of `self.attempts += 1`. When `inbound`, `self.attempts` is incremented when starting an handshake, however, when `outbound`, `self.attempts` is incremented at the "new outbound substream" request. Before I don't think it was a problem, but now that we do not necessarily trigger an handshake if there is no hole-punch candidates, I think we might was to increment `self.attempts` only when effectively starting the handshake. What do you think ?

2. It is noted in the log when starting a new handshake that, if the corresponding stream (`inbound_stream` or `outbound_stream`) was not empty, then we replace the handshake. There is `warn` level log stating `New inbound/outbound connect stream while still upgrading previous one. Replacing previous with new`. However, when reading the code of the `FuturesSet::try_push` method and then the [`FuturesMap::try_push`](https://github.com/thomaseizinger/rust-futures-bounded/blob/7a9b5a96663835c1234df5251fe88df75d26fb86/src/futures_map.rs#L50-L57) method (which is used inside), the future pushed never replaces any old one when capacity is reached, it just returns an error. So what do you think should be done ? Should be actually replace the old with the new like the log says ? Or should we not replace the old with the new and update the log to say that the new one was dropped ? 

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
