### PR TITLE
feat(relay): allow to configure default rate limiters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3206,7 +3206,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "asynchronous-codec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ libp2p-ping = { version = "0.45.0", path = "protocols/ping" }
 libp2p-plaintext = { version = "0.42.0", path = "transports/plaintext" }
 libp2p-pnet = { version = "0.25.0", path = "transports/pnet" }
 libp2p-quic = { version = "0.11.1", path = "transports/quic" }
-libp2p-relay = { version = "0.18.0", path = "protocols/relay" }
+libp2p-relay = { version = "0.18.1", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.15.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.27.0", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.7", path = "misc/server" }

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.18.1
+
+- Allow to configure default rate limiters.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+
 ## 0.18.0
 
 <!-- Update to libp2p-swarm v0.45.0 -->

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.18.1
 
 - Allow to configure default rate limiters.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+  See [PR 5584](https://github.com/libp2p/rust-libp2p/pull/5584).
 
 ## 0.18.0
 

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-relay"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Communications relaying for libp2p"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Parity Technologies <admin@parity.io>", "Max Inden <mail@max-inden.de>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/relay/src/behaviour.rs
+++ b/protocols/relay/src/behaviour.rs
@@ -21,7 +21,7 @@
 //! [`NetworkBehaviour`] to act as a circuit relay v2 **relay**.
 
 pub(crate) mod handler;
-pub(crate) mod rate_limiter;
+pub mod rate_limiter;
 use crate::behaviour::handler::Handler;
 use crate::multiaddr_ext::MultiaddrExt;
 use crate::proto;

--- a/protocols/relay/src/behaviour/rate_limiter.rs
+++ b/protocols/relay/src/behaviour/rate_limiter.rs
@@ -78,7 +78,7 @@ pub(crate) struct GenericRateLimiter<Id> {
     buckets: HashMap<Id, u32>,
 }
 
-/// Configuration for a [`GenericRateLimiter`].
+/// Configuration for a `GenericRateLimiter`.
 #[derive(Debug, Clone, Copy)]
 pub struct GenericRateLimiterConfig {
     /// The maximum number of tokens in the bucket at any point in time.

--- a/protocols/relay/src/behaviour/rate_limiter.rs
+++ b/protocols/relay/src/behaviour/rate_limiter.rs
@@ -37,12 +37,14 @@ pub trait RateLimiter: Send {
     fn try_next(&mut self, peer: PeerId, addr: &Multiaddr, now: Instant) -> bool;
 }
 
-pub(crate) fn new_per_peer(config: GenericRateLimiterConfig) -> Box<dyn RateLimiter> {
+/// For each peer ID one reservation/circuit every `config.interval` minutes with up to `config.limit` reservations per hour.
+pub fn new_per_peer(config: GenericRateLimiterConfig) -> Box<dyn RateLimiter> {
     let mut limiter = GenericRateLimiter::new(config);
     Box::new(move |peer_id, _addr: &Multiaddr, now| limiter.try_next(peer_id, now))
 }
 
-pub(crate) fn new_per_ip(config: GenericRateLimiterConfig) -> Box<dyn RateLimiter> {
+/// For each source IP address one reservation/circuit every `config.interval` minutes with up to `config.limit` reservations per hour.
+pub fn new_per_ip(config: GenericRateLimiterConfig) -> Box<dyn RateLimiter> {
     let mut limiter = GenericRateLimiter::new(config);
     Box::new(move |_peer_id, addr: &Multiaddr, now| {
         multiaddr_to_ip(addr)
@@ -78,11 +80,11 @@ pub(crate) struct GenericRateLimiter<Id> {
 
 /// Configuration for a [`GenericRateLimiter`].
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct GenericRateLimiterConfig {
-    // The maximum number of tokens in the bucket at any point in time.
-    pub(crate) limit: NonZeroU32,
-    // The interval at which a single token is added to the bucket.
-    pub(crate) interval: Duration,
+pub struct GenericRateLimiterConfig {
+    /// The maximum number of tokens in the bucket at any point in time.
+    pub limit: NonZeroU32,
+    /// The interval at which a single token is added to the bucket.
+    pub interval: Duration,
 }
 
 impl<Id: Eq + PartialEq + Hash + Clone> GenericRateLimiter<Id> {

--- a/protocols/relay/src/lib.rs
+++ b/protocols/relay/src/lib.rs
@@ -39,7 +39,10 @@ mod proto {
     };
 }
 
-pub use behaviour::{rate_limiter::RateLimiter, Behaviour, CircuitId, Config, Event};
+pub use behaviour::{
+    rate_limiter::{self, RateLimiter},
+    Behaviour, CircuitId, Config, Event,
+};
 pub use protocol::{HOP_PROTOCOL_NAME, STOP_PROTOCOL_NAME};
 
 /// Types related to the relay protocol inbound.


### PR DESCRIPTION
## Description

Making the `GenericRateLimiterConfig`, `rate_limiter::new_per_peer` and `rate_limiter::new_per_ip` public to be able to configure the default rate limiters and still use them.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
