### PR TITLE
chore: parameterise s3 build cache setup

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,7 +6,6 @@ on:
       - 'master'
     tags:
       - 'libp2p-server-**'
-  pull_request:
 
 jobs:
   server:
@@ -34,11 +33,6 @@ jobs:
         with:
           context: .
           file: ./misc/server/Dockerfile
-          push: ${{ ! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }} # Only push image if we have the required permissions, i.e. not running from a fork
-          cache-from: ${{ ! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && format('type=s3,mode=max,bucket={0},region=us-east-1,prefix=buildCache,name=rust-libp2p-server', vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME) }}
-          cache-to:   ${{ ! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && format('type=s3,mode=max,bucket={0},region=us-east-1,prefix=buildCache,name=rust-libp2p-server', vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME) }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -35,10 +35,10 @@ jobs:
           context: .
           file: ./misc/server/Dockerfile
           push: ${{ ! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }} # Only push image if we have the required permissions, i.e. not running from a fork
-          cache-from: ${{ ! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && type=s3,mode=max,bucket=libp2p-by-tf-aws-bootstrap,region=us-east-1,prefix=buildCache,name=rust-libp2p-server }}
-          cache-to:   ${{ ! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && type=s3,mode=max,bucket=libp2p-by-tf-aws-bootstrap,region=us-east-1,prefix=buildCache,name=rust-libp2p-server }}
+          cache-from: ${{ ! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && format('type=s3,mode=max,bucket={0},region=us-east-1,prefix=buildCache,name=rust-libp2p-server', vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME) }}
+          cache-to:   ${{ ! github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && format('type=s3,mode=max,bucket={0},region=us-east-1,prefix=buildCache,name=rust-libp2p-server', vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
         env:
-          AWS_ACCESS_KEY_ID: ${{ vars.TEST_PLANS_BUILD_CACHE_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_PLANS_BUILD_CACHE_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -24,8 +24,9 @@ jobs:
       - name: Build ${{ matrix.flavour }} image
         run: ./scripts/build-interop-image.sh
         env:
-          AWS_ACCESS_KEY_ID: ${{ vars.TEST_PLANS_BUILD_CACHE_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_PLANS_BUILD_CACHE_KEY }}
+          AWS_BUCKET_NAME: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
+          AWS_ACCESS_KEY_ID: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
           FLAVOUR: ${{ matrix.flavour }}
 
       - name: Run ${{ matrix.flavour }} tests
@@ -33,9 +34,9 @@ jobs:
         with:
           test-filter: ${{ matrix.flavour }}-rust-libp2p-head
           extra-versions: ${{ github.workspace }}/interop-tests/${{ matrix.flavour }}-ping-version.json
-          s3-cache-bucket: libp2p-by-tf-aws-bootstrap
-          s3-access-key-id: ${{ vars.TEST_PLANS_BUILD_CACHE_KEY_ID }}
-          s3-secret-access-key: ${{ secrets.TEST_PLANS_BUILD_CACHE_KEY }}
+          s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
+          s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
+          s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
           worker-count: 16
   run-holepunching-interop:
     name: Run hole-punch interoperability tests
@@ -50,7 +51,7 @@ jobs:
         with:
           test-filter: rust-libp2p-head
           extra-versions: ${{ github.workspace }}/hole-punching-tests/version.json
-          s3-cache-bucket: libp2p-by-tf-aws-bootstrap
-          s3-access-key-id: ${{ vars.TEST_PLANS_BUILD_CACHE_KEY_ID }}
-          s3-secret-access-key: ${{ secrets.TEST_PLANS_BUILD_CACHE_KEY }}
+          s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
+          s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
+          s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
           worker-count: 16

--- a/scripts/build-interop-image.sh
+++ b/scripts/build-interop-image.sh
@@ -6,13 +6,13 @@ CACHE_TO=""
 
 # If we have credentials, write to cache
 if [[ -n "${AWS_SECRET_ACCESS_KEY}" ]]; then
-  CACHE_TO="--cache-to   type=s3,mode=max,bucket=libp2p-by-tf-aws-bootstrap,region=us-east-1,prefix=buildCache,name=${FLAVOUR}-rust-libp2p-head"
+  CACHE_TO="--cache-to   type=s3,mode=max,bucket=${AWS_BUCKET_NAME},region=us-east-1,prefix=buildCache,name=${FLAVOUR}-rust-libp2p-head"
 fi
 
 docker buildx build \
   --load \
   $CACHE_TO \
-  --cache-from type=s3,mode=max,bucket=libp2p-by-tf-aws-bootstrap,region=us-east-1,prefix=buildCache,name=${FLAVOUR}-rust-libp2p-head \
+  --cache-from type=s3,mode=max,bucket=${AWS_BUCKET_NAME},region=us-east-1,prefix=buildCache,name=${FLAVOUR}-rust-libp2p-head \
   -t ${FLAVOUR}-rust-libp2p-head \
   . \
   -f interop-tests/Dockerfile.${FLAVOUR}


### PR DESCRIPTION
As we're setting up a new cache bucket, we'd like to be able to control its' configuration via GitHub vars/secrets fully. 

FYI, the secrets are not set up yet.