### PR TITLE
feat(floodsub): Add option to configure the maximum message length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "asynchronous-codec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ libp2p-connection-limits = { version = "0.4.0", path = "misc/connection-limits" 
 libp2p-core = { version = "0.42.0", path = "core" }
 libp2p-dcutr = { version = "0.12.0", path = "protocols/dcutr" }
 libp2p-dns = { version = "0.42.0", path = "transports/dns" }
-libp2p-floodsub = { version = "0.45.0", path = "protocols/floodsub" }
+libp2p-floodsub = { version = "0.46.0", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.47.0", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.45.0", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.9" }

--- a/protocols/floodsub/CHANGELOG.md
+++ b/protocols/floodsub/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.46.0
+
+- Add a `max_message_len` option to `FloodsubConfig` for configuring the maximum message length.
+  See [PR 5588](https://github.com/libp2p/rust-libp2p/pull/5588)
+
 ## 0.45.0
 
 <!-- Update to libp2p-swarm v0.45.0 -->

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-floodsub"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Floodsub protocol for libp2p"
-version = "0.45.0"
+version = "0.46.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -46,6 +46,7 @@ pub struct Floodsub {
     /// Events that need to be yielded to the outside when polling.
     events: VecDeque<ToSwarm<FloodsubEvent, FloodsubRpc>>,
 
+    /// The floodsub configuration
     config: FloodsubConfig,
 
     /// List of peers to send messages to.
@@ -345,7 +346,7 @@ impl NetworkBehaviour for Floodsub {
         _: &Multiaddr,
     ) -> Result<THandler<Self>, ConnectionDenied> {
         Ok(OneShotHandler::new(
-            SubstreamProtocol::new(FloodsubProtocol::new(self.config.max_message_len), ()),
+            SubstreamProtocol::new(FloodsubProtocol::from_config(&self.config), ()),
             OneShotHandlerConfig::default(),
         ))
     }
@@ -359,7 +360,7 @@ impl NetworkBehaviour for Floodsub {
         _: PortUse,
     ) -> Result<THandler<Self>, ConnectionDenied> {
         Ok(OneShotHandler::new(
-            SubstreamProtocol::new(FloodsubProtocol::new(self.config.max_message_len), ()),
+            SubstreamProtocol::new(FloodsubProtocol::from_config(&self.config), ()),
             OneShotHandlerConfig::default(),
         ))
     }

--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -346,7 +346,10 @@ impl NetworkBehaviour for Floodsub {
         _: &Multiaddr,
     ) -> Result<THandler<Self>, ConnectionDenied> {
         Ok(OneShotHandler::new(
-            SubstreamProtocol::new(FloodsubProtocol::from_config(&self.config), ()),
+            SubstreamProtocol::new(
+                FloodsubProtocol::new().with_max_message_len(self.config.max_message_len),
+                (),
+            ),
             OneShotHandlerConfig::default(),
         ))
     }
@@ -360,7 +363,10 @@ impl NetworkBehaviour for Floodsub {
         _: PortUse,
     ) -> Result<THandler<Self>, ConnectionDenied> {
         Ok(OneShotHandler::new(
-            SubstreamProtocol::new(FloodsubProtocol::from_config(&self.config), ()),
+            SubstreamProtocol::new(
+                FloodsubProtocol::new().with_max_message_len(self.config.max_message_len),
+                (),
+            ),
             OneShotHandlerConfig::default(),
         ))
     }

--- a/protocols/floodsub/src/lib.rs
+++ b/protocols/floodsub/src/lib.rs
@@ -23,6 +23,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 use libp2p_identity::PeerId;
+use protocol::DEFAULT_MAX_MESSAGE_LEN_BYTES;
 
 pub mod protocol;
 
@@ -48,6 +49,9 @@ pub struct FloodsubConfig {
     /// `true` if messages published by local node should be propagated as messages received from
     /// the network, `false` by default.
     pub subscribe_local_messages: bool,
+
+    /// Maximum message length in bytes. Defaults to 2KiB.
+    pub max_message_len: usize,
 }
 
 impl FloodsubConfig {
@@ -55,6 +59,20 @@ impl FloodsubConfig {
         Self {
             local_peer_id,
             subscribe_local_messages: false,
+            max_message_len: DEFAULT_MAX_MESSAGE_LEN_BYTES,
         }
+    }
+
+    /// Set whether or not messages published by local node should be
+    /// propagated as messages received from the network.
+    pub fn with_subscribe_local_messages(mut self, subscribe_local_messages: bool) -> Self {
+        self.subscribe_local_messages = subscribe_local_messages;
+        self
+    }
+
+    /// Set the maximum message length in bytes.
+    pub fn with_max_message_len(mut self, max_message_len: usize) -> Self {
+        self.max_message_len = max_message_len;
+        self
     }
 }

--- a/protocols/floodsub/src/protocol.rs
+++ b/protocols/floodsub/src/protocol.rs
@@ -18,8 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::proto;
 use crate::topic::Topic;
+use crate::{proto, FloodsubConfig};
 use asynchronous_codec::Framed;
 use bytes::Bytes;
 use futures::{
@@ -44,9 +44,16 @@ pub struct FloodsubProtocol {
 }
 
 impl FloodsubProtocol {
-    /// Builds a new `FloodsubProtocol`.
-    pub fn new(max_message_len: usize) -> FloodsubProtocol {
-        Self { max_message_len }
+    /// Builds a new `FloodsubProtocol` with default parameters.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Builds a new `FloodsubProtocol` taking parameters from the given configuration.
+    pub fn from_config(config: &FloodsubConfig) -> Self {
+        Self {
+            max_message_len: config.max_message_len,
+        }
     }
 }
 

--- a/protocols/floodsub/src/protocol.rs
+++ b/protocols/floodsub/src/protocol.rs
@@ -18,8 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use crate::proto;
 use crate::topic::Topic;
-use crate::{proto, FloodsubConfig};
 use asynchronous_codec::Framed;
 use bytes::Bytes;
 use futures::{
@@ -49,11 +49,10 @@ impl FloodsubProtocol {
         Self::default()
     }
 
-    /// Builds a new `FloodsubProtocol` taking parameters from the given configuration.
-    pub fn from_config(config: &FloodsubConfig) -> Self {
-        Self {
-            max_message_len: config.max_message_len,
-        }
+    /// Set the maximum message length.
+    pub fn with_max_message_len(mut self, max_message_len: usize) -> Self {
+        self.max_message_len = max_message_len;
+        self
     }
 }
 


### PR DESCRIPTION

## Description

This PR adds a `max_message_len` option to `FloodsubConfig` for configuring the maximum message length.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
