### PR TITLE
feat(webrtc): increase max message size to 256kiB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-webrtc"
-version = "0.8.0-alpha"
+version = "0.9.0-alpha"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-webrtc-utils"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-webrtc-websys"
-version = "0.4.0-alpha.2"
+version = "0.5.0-alpha"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,9 +109,9 @@ libp2p-tcp = { version = "0.42.0", path = "transports/tcp" }
 libp2p-tls = { version = "0.5.0", path = "transports/tls" }
 libp2p-uds = { version = "0.41.0", path = "transports/uds" }
 libp2p-upnp = { version = "0.3.0", path = "protocols/upnp" }
-libp2p-webrtc = { version = "0.8.0-alpha", path = "transports/webrtc" }
-libp2p-webrtc-utils = { version = "0.3.0", path = "misc/webrtc-utils" }
-libp2p-webrtc-websys = { version = "0.4.0-alpha.2", path = "transports/webrtc-websys" }
+libp2p-webrtc = { version = "0.9.0-alpha", path = "transports/webrtc" }
+libp2p-webrtc-utils = { version = "0.4.0", path = "misc/webrtc-utils" }
+libp2p-webrtc-websys = { version = "0.5.0-alpha", path = "transports/webrtc-websys" }
 libp2p-websocket = { version = "0.44.0", path = "transports/websocket" }
 libp2p-websocket-websys = { version = "0.4.0", path = "transports/websocket-websys" }
 libp2p-webtransport-websys = { version = "0.4.0", path = "transports/webtransport-websys" }

--- a/misc/webrtc-utils/CHANGELOG.md
+++ b/misc/webrtc-utils/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0
+
+- Increase WebRTC max message size from 16 KiB to 256 KiB.
+  See [PR 5589](https://github.com/libp2p/rust-libp2p/pull/5589)
+
 ## 0.3.0
 
 <!-- Update to libp2p-swarm v0.45.0 -->

--- a/misc/webrtc-utils/Cargo.toml
+++ b/misc/webrtc-utils/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "libp2p-webrtc-utils"
 repository = "https://github.com/libp2p/rust-libp2p"
 rust-version = { workspace = true }
-version = "0.3.0"
+version = "0.4.0"
 publish = true
 
 [dependencies]

--- a/misc/webrtc-utils/src/sdp.rs
+++ b/misc/webrtc-utils/src/sdp.rs
@@ -90,7 +90,7 @@ a=ice-pwd:{pwd}
 a=fingerprint:{fingerprint_algorithm} {fingerprint_value}
 a=setup:passive
 a=sctp-port:5000
-a=max-message-size:16384
+a=max-message-size:262144
 a=candidate:1467250027 1 UDP 1467250027 {target_ip} {target_port} typ host
 a=end-of-candidates
 ";

--- a/misc/webrtc-utils/src/stream.rs
+++ b/misc/webrtc-utils/src/stream.rs
@@ -41,10 +41,11 @@ mod state;
 
 /// Maximum length of a message.
 ///
-/// "As long as message interleaving is not supported, the sender SHOULD limit the maximum message
-/// size to 16 KB to avoid monopolization."
-/// Source: <https://www.rfc-editor.org/rfc/rfc8831#name-transferring-user-data-on-a>
-pub const MAX_MSG_LEN: usize = 16 * 1024;
+/// See:
+/// <https://github.com/libp2p/specs/pull/628>
+/// <https://blog.mozilla.org/webrtc/large-data-channel-messages/>
+/// <https://issues.webrtc.org/issues/40644524>
+pub const MAX_MSG_LEN: usize = 256 * 1024; // 256 KiB
 /// Length of varint, in bytes.
 const VARINT_LEN: usize = 2;
 /// Overhead of the protobuf encoding, in bytes.

--- a/misc/webrtc-utils/src/stream.rs
+++ b/misc/webrtc-utils/src/stream.rs
@@ -47,7 +47,7 @@ mod state;
 /// <https://issues.webrtc.org/issues/40644524>
 pub const MAX_MSG_LEN: usize = 256 * 1024; // 256 KiB
 /// Length of varint, in bytes.
-const VARINT_LEN: usize = 2;
+const VARINT_LEN: usize = 4;
 /// Overhead of the protobuf encoding, in bytes.
 const PROTO_OVERHEAD: usize = 5;
 /// Maximum length of data, in bytes.

--- a/transports/webrtc-websys/CHANGELOG.md
+++ b/transports/webrtc-websys/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0-alpha
+
+- Increase WebRTC max message size from 16 KiB to 256 KiB.
+  See [PR 5589](https://github.com/libp2p/rust-libp2p/pull/5589)
+
 ## 0.4.0-alpha.2
 
 - Bump version of web-sys and update `__Nonexhaustive` to `__Invalid`.

--- a/transports/webrtc-websys/Cargo.toml
+++ b/transports/webrtc-websys/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "libp2p-webrtc-websys"
 repository = "https://github.com/libp2p/rust-libp2p"
 rust-version = { workspace = true }
-version = "0.4.0-alpha.2"
+version = "0.5.0-alpha"
 publish = true
 
 [dependencies]

--- a/transports/webrtc-websys/src/connection.rs
+++ b/transports/webrtc-websys/src/connection.rs
@@ -298,7 +298,7 @@ mod sdp_tests {
 
     #[test]
     fn test_fingerprint() {
-        let sdp = "v=0\r\no=- 0 0 IN IP6 ::1\r\ns=-\r\nc=IN IP6 ::1\r\nt=0 0\r\na=ice-lite\r\nm=application 61885 UDP/DTLS/SCTP webrtc-datachannel\r\na=mid:0\r\na=setup:passive\r\na=ice-ufrag:libp2p+webrtc+v1/YwapWySn6fE6L9i47PhlB6X4gzNXcgFs\r\na=ice-pwd:libp2p+webrtc+v1/YwapWySn6fE6L9i47PhlB6X4gzNXcgFs\r\na=fingerprint:sha-256 A8:17:77:1E:02:7E:D1:2B:53:92:70:A6:8E:F9:02:CC:21:72:3A:92:5D:F4:97:5F:27:C4:5E:75:D4:F4:31:89\r\na=sctp-port:5000\r\na=max-message-size:16384\r\na=candidate:1467250027 1 UDP 1467250027 ::1 61885 typ host\r\n";
+        let sdp = "v=0\r\no=- 0 0 IN IP6 ::1\r\ns=-\r\nc=IN IP6 ::1\r\nt=0 0\r\na=ice-lite\r\nm=application 61885 UDP/DTLS/SCTP webrtc-datachannel\r\na=mid:0\r\na=setup:passive\r\na=ice-ufrag:libp2p+webrtc+v1/YwapWySn6fE6L9i47PhlB6X4gzNXcgFs\r\na=ice-pwd:libp2p+webrtc+v1/YwapWySn6fE6L9i47PhlB6X4gzNXcgFs\r\na=fingerprint:sha-256 A8:17:77:1E:02:7E:D1:2B:53:92:70:A6:8E:F9:02:CC:21:72:3A:92:5D:F4:97:5F:27:C4:5E:75:D4:F4:31:89\r\na=sctp-port:5000\r\na=max-message-size:262144\r\na=candidate:1467250027 1 UDP 1467250027 ::1 61885 typ host\r\n";
 
         let fingerprint = parse_fingerprint(sdp).unwrap();
 

--- a/transports/webrtc/CHANGELOG.md
+++ b/transports/webrtc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0-alpha
+- Increase WebRTC max message size from 16 KiB to 256 KiB.
+  See [PR 5589](https://github.com/libp2p/rust-libp2p/pull/5589)
+
 ## 0.8.0-alpha
 
 - Implement refactored `Transport`.

--- a/transports/webrtc/Cargo.toml
+++ b/transports/webrtc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-webrtc"
-version = "0.8.0-alpha"
+version = "0.9.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "WebRTC transport for libp2p"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/transports/webrtc/src/tokio/sdp.rs
+++ b/transports/webrtc/src/tokio/sdp.rs
@@ -140,5 +140,5 @@ a=ice-pwd:{pwd}
 a=fingerprint:{fingerprint_algorithm} {fingerprint_value}
 a=setup:actpass
 a=sctp-port:5000
-a=max-message-size:16384
+a=max-message-size:262144
 ";


### PR DESCRIPTION
## Description

Increasing WebRTC max message size from 16 kiB to 256 kiB after fix browser bugs.

Context: https://github.com/libp2p/specs/pull/628

## Notes & open questions

To be merged after https://github.com/libp2p/specs/pull/628 is merged.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
