### PR TITLE
fix(ci): address cargo-deny advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,9 +833,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 dependencies = [
  "serde",
 ]
@@ -4585,30 +4585,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4724,7 +4700,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "rustls 0.23.11",
  "thiserror",
  "tokio",
@@ -4733,14 +4709,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.2"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e974563a4b1c2206bbc61191ca4da9c22e4308b4c455e8906751cc7828393f08"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
  "rand 0.8.5",
  "ring 0.17.8",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustls 0.23.11",
  "slab",
  "thiserror",
@@ -5207,6 +5183,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5471,18 +5453,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5513,9 +5495,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5976,12 +5958,15 @@ dependencies = [
 
 [[package]]
 name = "thirtyfour"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0641fa1353dd7b7864a7a7782e495433de18a9096bc91b5a2d5838ac209c2fa8"
+checksum = "940c3778665cf311d848d8fa4207377c2ee8e5ddbb8c6fb4cff3f33072b2eb26"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "base64 0.22.1",
+ "bytes",
+ "cfg-if",
  "futures",
  "http 1.0.0",
  "indexmap 2.2.1",
@@ -6002,30 +5987,29 @@ dependencies = [
 
 [[package]]
 name = "thirtyfour-macros"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cae91d1c7c61ec65817f1064954640ee350a50ae6548ff9a1bdd2489d6ffbb0"
+checksum = "b72d056365e368fc57a56d0cec9e41b02fb4a3474a61c8735262b1cfebe67425"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6576,9 +6560,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna 0.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5958,15 +5958,12 @@ dependencies = [
 
 [[package]]
 name = "thirtyfour"
-version = "0.34.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940c3778665cf311d848d8fa4207377c2ee8e5ddbb8c6fb4cff3f33072b2eb26"
+checksum = "0641fa1353dd7b7864a7a7782e495433de18a9096bc91b5a2d5838ac209c2fa8"
 dependencies = [
- "arc-swap",
  "async-trait",
  "base64 0.22.1",
- "bytes",
- "cfg-if",
  "futures",
  "http 1.0.0",
  "indexmap 2.2.1",

--- a/examples/autonatv2/Dockerfile
+++ b/examples/autonatv2/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.75-alpine as builder
+FROM rust:1.81-alpine as builder
 
 RUN apk add musl-dev
 

--- a/hole-punching-tests/Dockerfile
+++ b/hole-punching-tests/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.5-labs
-FROM rust:1.75.0 as builder
+FROM rust:1.81.0 as builder
 
 # Run with access to the target cache to speed up builds
 WORKDIR /workspace

--- a/interop-tests/Cargo.toml
+++ b/interop-tests/Cargo.toml
@@ -33,7 +33,7 @@ redis = { version = "0.24.0", default-features = false, features = [
 ] }
 rust-embed = "8.4"
 serde_json = "1"
-thirtyfour = "=0.32.0" # https://github.com/stevepryde/thirtyfour/issues/169
+thirtyfour = "0.34.0"
 tokio = { workspace = true, features = ["full"] }
 tower-http = { version = "0.5", features = ["cors", "fs", "trace"] }
 tracing = { workspace = true }

--- a/interop-tests/Cargo.toml
+++ b/interop-tests/Cargo.toml
@@ -33,7 +33,7 @@ redis = { version = "0.24.0", default-features = false, features = [
 ] }
 rust-embed = "8.4"
 serde_json = "1"
-thirtyfour = "0.34.0"
+thirtyfour = "=0.32.0" # https://github.com/stevepryde/thirtyfour/issues/169
 tokio = { workspace = true, features = ["full"] }
 tower-http = { version = "0.5", features = ["cors", "fs", "trace"] }
 tracing = { workspace = true }

--- a/interop-tests/Dockerfile.chromium
+++ b/interop-tests/Dockerfile.chromium
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.5-labs
-FROM rust:1.75.0 as chef
+FROM rust:1.81 as chef
 RUN rustup target add wasm32-unknown-unknown
 RUN wget -q -O- https://github.com/rustwasm/wasm-pack/releases/download/v0.12.1/wasm-pack-v0.12.1-x86_64-unknown-linux-musl.tar.gz | tar -zx -C /usr/local/bin --strip-components 1 --wildcards "wasm-pack-*/wasm-pack"
 RUN wget -q -O- https://github.com/WebAssembly/binaryen/releases/download/version_115/binaryen-version_115-x86_64-linux.tar.gz | tar -zx -C /usr/local/bin --strip-components 2 --wildcards "binaryen-version_*/bin/wasm-opt"

--- a/interop-tests/Dockerfile.native
+++ b/interop-tests/Dockerfile.native
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.5-labs
-FROM lukemathwalker/cargo-chef:0.1.62-rust-1.75.0 as chef
+FROM lukemathwalker/cargo-chef:0.1.67-rust-bullseye as chef
 WORKDIR /app
 
 FROM chef AS planner

--- a/misc/server/Dockerfile
+++ b/misc/server/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.5-labs
-FROM rust:1.75.0 as chef
+FROM rust:1.81.0 as chef
 RUN wget -q -O- https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.62/cargo-chef-x86_64-unknown-linux-gnu.tar.gz | tar -zx -C /usr/local/bin
 RUN cargo install --locked --root /usr/local libp2p-lookup --version 0.6.4
 WORKDIR /app

--- a/protocols/perf/Dockerfile
+++ b/protocols/perf/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.5-labs
-FROM rust:1.75.0 as builder
+FROM rust:1.81.0 as builder
 
 # Run with access to the target cache to speed up builds
 WORKDIR /workspace


### PR DESCRIPTION
## Description
by updating:
-  `bytes` to 1.7.1, `1.6.0` was [yanked](https://crates.io/crates/bytes/1.6.0)
- `quinn-proto` to 0.11.8 to address  [RUSTSEC-2024-0373](https://rustsec.org/advisories/RUSTSEC-2024-0373.html) 
- thirtyfour-macros to 0.1.11 to remove `proc-macro-error` dependency and address [RUSTSEC-2024-0370](https://rustsec.org/advisories/RUSTSEC-2024-0370.html)