### PR TITLE
fix(autonat): reject inbound dial request from peer if its not connected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-autonat"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ futures-bounded = { version = "0.2.4" }
 futures-rustls = { version = "0.26.0", default-features = false }
 libp2p = { version = "0.54.1", path = "libp2p" }
 libp2p-allow-block-list = { version = "0.4.1", path = "misc/allow-block-list" }
-libp2p-autonat = { version = "0.13.0", path = "protocols/autonat" }
+libp2p-autonat = { version = "0.13.1", path = "protocols/autonat" }
 libp2p-connection-limits = { version = "0.4.0", path = "misc/connection-limits" }
 libp2p-core = { version = "0.42.0", path = "core" }
 libp2p-dcutr = { version = "0.12.0", path = "protocols/dcutr" }

--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.13.1
+- Verify that an incoming AutoNAT dial comes from a connected peer. See [PR 5597](https://github.com/libp2p/rust-libp2p/pull/5597).
+
 ## 0.13.0
 
 - Due to the refactor of `Transport` it's no longer required to create a seperate transport for

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-autonat"
 edition = "2021"
 rust-version = { workspace = true }
 description = "NAT and firewall detection for libp2p"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["David Craven <david@craven.ch>", "Elena Frank <elena.frank@protonmail.com>", "Hannes Furmans <hannes@umgefahren.xyz>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/autonat/src/v1/behaviour/as_server.rs
+++ b/protocols/autonat/src/v1/behaviour/as_server.rs
@@ -107,6 +107,21 @@ impl<'a> HandleInnerEvent for AsServer<'a> {
                     },
             } => {
                 let probe_id = self.probe_id.next();
+                if !self.connected.contains_key(&peer) {
+                    tracing::debug!(
+                        %peer,
+                        "Reject inbound dial request from peer since it is not connected"
+                    );
+
+                    return VecDeque::from([ToSwarm::GenerateEvent(Event::InboundProbe(
+                        InboundProbeEvent::Error {
+                            probe_id,
+                            peer,
+                            error: InboundProbeError::Response(ResponseError::DialRefused),
+                        },
+                    ))]);
+                }
+
                 match self.resolve_inbound_request(peer, request) {
                     Ok(addrs) => {
                         tracing::debug!(


### PR DESCRIPTION
## Description
As discovered and described in the issue below, there are situations where an incoming AutoNAT dial can come from a non-connected peer. However `resolve_inbound_request` expects that this situation cannot occur. This PR adds a check upfront and refuses the incoming dial when no connected peer is found.

Fixes https://github.com/libp2p/rust-libp2p/issues/5570.
## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
