### PR TITLE
refactor(examples): use tokio instead of async-std in relay-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4970,11 +4970,10 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 name = "relay-server-example"
 version = "0.1.0"
 dependencies = [
- "async-std",
- "async-trait",
  "clap",
  "futures",
  "libp2p",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/examples/relay-server/Cargo.toml
+++ b/examples/relay-server/Cargo.toml
@@ -10,10 +10,9 @@ release = false
 
 [dependencies]
 clap = { version = "4.5.6", features = ["derive"] }
-async-std = { version = "1.12", features = ["attributes"] }
-async-trait = "0.1"
+tokio = { version = "1.37.0", features = ["full"] }
 futures = { workspace = true }
-libp2p = { path = "../../libp2p", features = [ "async-std", "noise", "macros", "ping", "tcp", "identify", "yamux", "relay", "quic"] }
+libp2p = { path = "../../libp2p", features = ["tokio", "noise", "macros", "ping", "tcp", "identify", "yamux", "relay", "quic"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 

--- a/examples/relay-server/src/main.rs
+++ b/examples/relay-server/src/main.rs
@@ -22,7 +22,6 @@
 #![doc = include_str!("../README.md")]
 
 use clap::Parser;
-use futures::executor::block_on;
 use futures::StreamExt;
 use libp2p::{
     core::multiaddr::Protocol,
@@ -82,27 +81,27 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with(Protocol::QuicV1);
     swarm.listen_on(listen_addr_quic)?;
 
-    block_on(async {
-        loop {
-            match swarm.next().await.expect("Infinite Stream.") {
-                SwarmEvent::Behaviour(event) => {
-                    if let BehaviourEvent::Identify(identify::Event::Received {
-                        info: identify::Info { observed_addr, .. },
-                        ..
-                    }) = &event
-                    {
-                        swarm.add_external_address(observed_addr.clone());
-                    }
 
-                    println!("{event:?}")
+    loop {
+        match swarm.next().await.expect("Infinite Stream.") {
+            SwarmEvent::Behaviour(event) => {
+                if let BehaviourEvent::Identify(identify::Event::Received {
+                    info: identify::Info { observed_addr, .. },
+                    ..
+                }) = &event
+                {
+                    swarm.add_external_address(observed_addr.clone());
                 }
-                SwarmEvent::NewListenAddr { address, .. } => {
-                    println!("Listening on {address:?}");
-                }
-                _ => {}
+
+                println!("{event:?}")
             }
+            SwarmEvent::NewListenAddr { address, .. } => {
+                println!("Listening on {address:?}");
+            }
+            _ => {}
         }
-    })
+    }
+
 }
 
 #[derive(NetworkBehaviour)]

--- a/examples/relay-server/src/main.rs
+++ b/examples/relay-server/src/main.rs
@@ -23,7 +23,7 @@
 
 use clap::Parser;
 use futures::executor::block_on;
-use futures::stream::StreamExt;
+use futures::StreamExt;
 use libp2p::{
     core::multiaddr::Protocol,
     core::Multiaddr,
@@ -35,7 +35,8 @@ use std::error::Error;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use tracing_subscriber::EnvFilter;
 
-fn main() -> Result<(), Box<dyn Error>> {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
@@ -46,7 +47,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let local_key: identity::Keypair = generate_ed25519(opt.secret_key_seed);
 
     let mut swarm = libp2p::SwarmBuilder::with_existing_identity(local_key)
-        .with_async_std()
+        .with_tokio()
         .with_tcp(
             tcp::Config::default(),
             noise::Config::new,

--- a/examples/relay-server/src/main.rs
+++ b/examples/relay-server/src/main.rs
@@ -81,7 +81,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with(Protocol::QuicV1);
     swarm.listen_on(listen_addr_quic)?;
 
-
     loop {
         match swarm.next().await.expect("Infinite Stream.") {
             SwarmEvent::Behaviour(event) => {
@@ -101,7 +100,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             _ => {}
         }
     }
-
 }
 
 #[derive(NetworkBehaviour)]


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->
Following on issue #4449 
refactor: use tokio instead of async-std in the relay-servert example and remove unnecessary dependencies
## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->
Fails on testing with the [whole punch tutorial](https://docs.rs/libp2p/0.54.1/libp2p/tutorials/hole_punching/index.html) possibly because of my networking topology.  connection established event registered.

I will publish the logs and testing information as a comment 

## Change checklist
* Removed unnecessary dependencies on examples/relay-server/Cargo.toml
* Updated tokio version  to "1.37.0"
<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
