### PR TITLE
chore(ci): only run interop tests on commits to master

### DIFF
--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -1,6 +1,5 @@
 name: Interoperability Testing
 on:
-  pull_request:
   push:
     branches:
       - "master"


### PR DESCRIPTION
## Description

This is done as temporary measure to unblock PR merging as the CI is currently broken