### PR TITLE
feat(quic): Add support for ip6zone in quic transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3183,6 +3183,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
+ "libc",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-muxer-test-harness",
@@ -3841,9 +3842,9 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b852bc02a2da5feed68cd14fa50d0774b92790a5bdbfa932a813926c8472070"
+checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
 dependencies = [
  "arrayref",
  "byteorder",
@@ -3854,7 +3855,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.7.2",
+ "unsigned-varint 0.8.0",
  "url",
 ]
 
@@ -5471,18 +5472,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "async-std",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ libp2p-perf = { version = "0.4.0", path = "protocols/perf" }
 libp2p-ping = { version = "0.45.0", path = "protocols/ping" }
 libp2p-plaintext = { version = "0.42.0", path = "transports/plaintext" }
 libp2p-pnet = { version = "0.25.0", path = "transports/pnet" }
-libp2p-quic = { version = "0.11.1", path = "transports/quic" }
+libp2p-quic = { version = "0.11.2", path = "transports/quic" }
 libp2p-relay = { version = "0.18.0", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.15.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.27.0", path = "protocols/request-response" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ libp2p-websocket = { version = "0.44.0", path = "transports/websocket" }
 libp2p-websocket-websys = { version = "0.4.0", path = "transports/websocket-websys" }
 libp2p-webtransport-websys = { version = "0.4.0", path = "transports/webtransport-websys" }
 libp2p-yamux = { version = "0.46.0", path = "muxers/yamux" }
-multiaddr = "0.18.1"
+multiaddr = "0.18.2"
 multihash = "0.19.1"
 multistream-select = { version = "0.13.0", path = "misc/multistream-select" }
 prometheus-client = "0.22.2"

--- a/transports/quic/CHANGELOG.md
+++ b/transports/quic/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.11.2
+
+- Add support for the `ip6zone` Multiaddr protocol.
+  See [PR 5609](https://github.com/libp2p/rust-libp2p/pull/5609).
+
 ## 0.11.1
 
 - Update `libp2p-tls` to version `0.5.0`, see [PR 5547]

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-quic"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 rust-version = { workspace = true }

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -14,6 +14,7 @@ bytes = "1.6.0"
 futures = { workspace = true }
 futures-timer = "3.0.3"
 if-watch = "3.2.0"
+libc = "0.2.155"
 libp2p-core = { workspace = true }
 libp2p-tls = { workspace = true }
 libp2p-identity = { workspace = true }

--- a/transports/quic/src/transport.rs
+++ b/transports/quic/src/transport.rs
@@ -26,7 +26,7 @@ use std::{
     fmt,
     hash::{Hash, Hasher},
     io,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6, UdpSocket},
     pin::Pin,
     task::{Context, Poll, Waker},
     time::Duration,


### PR DESCRIPTION
## Description

Add support for ip6zone in the quic transport

The quic transport now correctly sets the scope_id of socket addresses
converted from multiaddrs containing both the ip6 and ip6zone protocols.
On Unix systems, if the zone string is not an integer, it is converted
into an interface index using the if_nametoindex function. Otherwise, it
is parsed directly as an interface index. This interface index will then
be used as the scope_id for the socket address. When converting a socket
address back to a multiaddr, the scope_id will be included in the
ip6zone protocol, if it is not 0.

Related https://github.com/libp2p/rust-libp2p/issues/5608

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
