### PR TITLE
fix(server): removing dependency on libp2p-lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-server"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "axum 0.7.5",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,10 +100,10 @@ libp2p-quic = { version = "0.11.1", path = "transports/quic" }
 libp2p-relay = { version = "0.18.0", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.15.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.27.0", path = "protocols/request-response" }
-libp2p-server = { version = "0.12.7", path = "misc/server" }
+libp2p-server = { version = "0.12.8", path = "misc/server" }
 libp2p-stream = { version = "0.2.0-alpha", path = "protocols/stream" }
 libp2p-swarm = { version = "0.45.1", path = "swarm" }
-libp2p-swarm-derive = { version = "=0.35.0", path = "swarm-derive" } # `libp2p-swarm-derive` may not be compatible with different `libp2p-swarm` non-breaking releases. E.g. `libp2p-swarm` might introduce a new enum variant `FromSwarm` (which is `#[non-exhaustive]`) in a non-breaking release. Older versions of `libp2p-swarm-derive` would not forward this enum variant within the `NetworkBehaviour` hierarchy. Thus the version pinning is required.
+libp2p-swarm-derive = { version = "=0.35.0", path = "swarm-derive" }                            # `libp2p-swarm-derive` may not be compatible with different `libp2p-swarm` non-breaking releases. E.g. `libp2p-swarm` might introduce a new enum variant `FromSwarm` (which is `#[non-exhaustive]`) in a non-breaking release. Older versions of `libp2p-swarm-derive` would not forward this enum variant within the `NetworkBehaviour` hierarchy. Thus the version pinning is required.
 libp2p-swarm-test = { version = "0.4.0", path = "swarm-test" }
 libp2p-tcp = { version = "0.42.0", path = "transports/tcp" }
 libp2p-tls = { version = "0.5.0", path = "transports/tls" }
@@ -151,4 +151,8 @@ clippy.manual_let_else = "warn"
 clippy.dbg_macro = "warn"
 
 [workspace.metadata.release]
-pre-release-hook = ["/bin/sh", '-c', '/bin/sh $WORKSPACE_ROOT/scripts/add-changelog-header.sh'] # Nested use of shell to expand variables.
+pre-release-hook = [
+    "/bin/sh",
+    '-c',
+    '/bin/sh $WORKSPACE_ROOT/scripts/add-changelog-header.sh',
+] # Nested use of shell to expand variables.

--- a/misc/server/CHANGELOG.md
+++ b/misc/server/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Changed
 
 - Remove deprecated [`libp2p-lookup`](https://github.com/mxinden/libp2p-lookup) from Dockerfile.
-  See PR XXXX
+  See [PR 5610](https://github.com/libp2p/rust-libp2p/pull/5610).
 
 ## 0.12.7
 

--- a/misc/server/CHANGELOG.md
+++ b/misc/server/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.12.8
+
+### Changed
+
+- Remove deprecated [`libp2p-lookup`](https://github.com/mxinden/libp2p-lookup) from Dockerfile.
+  See PR XXXX
+
 ## 0.12.7
 
 ### Changed
@@ -31,6 +38,7 @@
 ## 0.12.3
 
 ### Changed
+
 - Add libp2p-lookup to Dockerfile to enable healthchecks.
 
 ### Fixed
@@ -42,14 +50,18 @@
 [PR 4467]: https://github.com/libp2p/rust-libp2p/pull/4467
 
 ## 0.12.2
+
 ### Fixed
+
 - Adhere to `--metrics-path` flag and listen on `0.0.0.0:8888` (default IPFS metrics port).
   [PR 4392]
 
 [PR 4392]: https://github.com/libp2p/rust-libp2p/pull/4392
 
 ## 0.12.1
+
 ### Changed
+
 - Move to tokio and hyper.
   See [PR 4311].
 - Move to distroless Docker base image.
@@ -58,39 +70,57 @@
 [PR 4311]: https://github.com/libp2p/rust-libp2p/pull/4311
 
 ## 0.8.0
+
 ### Changed
+
 - Remove mplex support.
 
 ## 0.7.0
+
 ### Changed
+
 - Update to libp2p v0.47.0.
 
 ## 0.6.0 - 2022-05-05
+
 ### Changed
+
 - Update to libp2p v0.44.0.
 
 ## 0.5.4 - 2022-01-11
+
 ### Changed
+
 - Pull latest autonat changes.
 
 ## 0.5.3 - 2021-12-25
+
 ### Changed
+
 - Update dependencies.
 - Pull in autonat fixes.
 
 ## 0.5.2 - 2021-12-20
+
 ### Added
+
 - Add support for libp2p autonat protocol via `--enable-autonat`.
 
 ## 0.5.1 - 2021-12-20
+
 ### Fixed
+
 - Update dependencies.
 - Fix typo in command line flag `--enable-kademlia`.
 
 ## 0.5.0 - 2021-11-18
+
 ### Changed
+
 - Disable Kademlia protocol by default.
 
 ## 0.4.0 - 2021-11-18
+
 ### Fixed
+
 - Update dependencies.

--- a/misc/server/Cargo.toml
+++ b/misc/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-server"
-version = "0.12.7"
+version = "0.12.8"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2021"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -16,7 +16,23 @@ clap = { version = "4.5.6", features = ["derive"] }
 futures = { workspace = true }
 futures-timer = "3"
 axum = "0.7"
-libp2p = { workspace = true, features = ["autonat", "dns", "tokio", "noise", "tcp", "yamux", "identify", "kad", "ping", "relay", "metrics", "rsa", "macros", "quic", "websocket"] }
+libp2p = { workspace = true, features = [
+    "autonat",
+    "dns",
+    "tokio",
+    "noise",
+    "tcp",
+    "yamux",
+    "identify",
+    "kad",
+    "ping",
+    "relay",
+    "metrics",
+    "rsa",
+    "macros",
+    "quic",
+    "websocket",
+] }
 prometheus-client = { workspace = true }
 serde = "1.0.203"
 serde_derive = "1.0.125"

--- a/misc/server/Dockerfile
+++ b/misc/server/Dockerfile
@@ -1,7 +1,6 @@
 # syntax=docker/dockerfile:1.5-labs
 FROM rust:1.81.0 as chef
 RUN wget -q -O- https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.62/cargo-chef-x86_64-unknown-linux-gnu.tar.gz | tar -zx -C /usr/local/bin
-RUN cargo install --locked --root /usr/local libp2p-lookup --version 0.6.4
 WORKDIR /app
 
 FROM chef AS planner
@@ -17,5 +16,4 @@ COPY . .
 RUN cargo build --release --package libp2p-server
 
 FROM gcr.io/distroless/cc
-COPY --from=builder /usr/local/bin/libp2p-server /usr/local/bin/libp2p-lookup /usr/local/bin/
 CMD ["libp2p-server"]

--- a/misc/server/README.md
+++ b/misc/server/README.md
@@ -25,17 +25,10 @@ Options:
   -h, --help                         Print help
 ```
 
-
 ```
 cargo run -- --config ~/.ipfs/config
 
 Local peer id: PeerId("12D3KooWSa1YEeQVSwvoqAMhwjKQ6kqZQckhWPb3RWEGV3sZGU6Z")
 Listening on "/ip4/127.0.0.1/udp/4001/quic"
 [...]
-```
-
-The Docker container includes [libp2-lookup](https://github.com/mxinden/libp2p-lookup/) to enable adding a proper healthcheck for container startup, e.g.
-
-``` shell
-docker run --health-cmd 'libp2p-lookup direct --address /ip4/127.0.0.1/tcp/4001/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa' /home/ipfs/.ipfs:/ipfs ghcr.io/libp2p/rust-libp2p-server --config /ipfs/config
 ```


### PR DESCRIPTION
## Description

Remove dependency on [`libp2p-lookup`](https://github.com/mxinden/libp2p-lookup) which is no longer maintained, and [makes checks fail](https://github.com/libp2p/rust-libp2p/actions/runs/11016492372/job/30628121728).

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
