### PR TITLE
chore: update interop test run condition

### DIFF
--- a/.github/workflows/interop-test.yml
+++ b/.github/workflows/interop-test.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   run-transport-interop:
     name: Run transport interoperability tests
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ fromJSON(github.repository == 'libp2p/rust-libp2p' && '["self-hosted", "linux", "x64", "4xlarge"]' || '"ubuntu-latest"') }}
     strategy:
       matrix:
@@ -39,6 +40,7 @@ jobs:
           worker-count: 16
   run-holepunching-interop:
     name: Run hole-punch interoperability tests
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ fromJSON(github.repository == 'libp2p/rust-libp2p' && '["self-hosted", "linux", "x64", "4xlarge"]' || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Follow up to https://github.com/libp2p/rust-libp2p/pull/5604. Interop tests only work on the main `rust-libp2p` repo, and not on forks, because of the S3 cache (introduced in https://github.com/libp2p/rust-libp2p/pull/5586).

The interop tests currently don't run in the PRs, but they run after the PRs are merged to `master`. This PR is trying to run interop tests in PR that are branches of the main repo (not forks).