### PR TITLE
chore: use if-watch-plus instead of if-watch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2305,10 +2305,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "if-watch"
-version = "3.2.0"
+name = "if-watch-plus"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b0422c86d7ce0e97169cc42e04ae643caf278874a7a3c87b8150a220dc7e1e"
+checksum = "1ceea2310d74439e0cc58ef11ab033ffd2de9376fb2af5a3ed87e12d519393ea"
 dependencies = [
  "async-io 2.3.3",
  "core-foundation",
@@ -2319,7 +2319,7 @@ dependencies = [
  "log",
  "rtnetlink",
  "smol",
- "system-configuration",
+ "system-configuration 0.6.1",
  "tokio",
  "windows 0.51.1",
 ]
@@ -2925,7 +2925,7 @@ dependencies = [
  "data-encoding",
  "futures",
  "hickory-proto",
- "if-watch",
+ "if-watch-plus",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-noise",
@@ -3138,7 +3138,7 @@ dependencies = [
  "bytes",
  "futures",
  "futures-timer",
- "if-watch",
+ "if-watch-plus",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-muxer-test-harness",
@@ -3353,7 +3353,7 @@ dependencies = [
  "async-std",
  "futures",
  "futures-timer",
- "if-watch",
+ "if-watch-plus",
  "libc",
  "libp2p-core",
  "libp2p-identity",
@@ -3420,7 +3420,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "hex",
- "if-watch",
+ "if-watch-plus",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-noise",
@@ -4954,7 +4954,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -5876,7 +5876,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.4.1",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -5884,6 +5895,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "async-io 2.3.3",
  "async-std",
@@ -3132,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "async-std",
  "bytes",
@@ -3347,7 +3347,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "async-io 2.3.3",
  "async-std",
@@ -3413,7 +3413,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-webrtc"
-version = "0.8.0-alpha"
+version = "0.8.1-alpha"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ libp2p-gossipsub = { version = "0.47.1", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.45.1", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.9" }
 libp2p-kad = { version = "0.47.0", path = "protocols/kad" }
-libp2p-mdns = { version = "0.46.0", path = "protocols/mdns" }
+libp2p-mdns = { version = "0.46.1", path = "protocols/mdns" }
 libp2p-memory-connection-limits = { version = "0.3.0", path = "misc/memory-connection-limits" }
 libp2p-metrics = { version = "0.15.0", path = "misc/metrics" }
 libp2p-mplex = { version = "0.42.0", path = "muxers/mplex" }
@@ -96,7 +96,7 @@ libp2p-perf = { version = "0.4.0", path = "protocols/perf" }
 libp2p-ping = { version = "0.45.0", path = "protocols/ping" }
 libp2p-plaintext = { version = "0.42.0", path = "transports/plaintext" }
 libp2p-pnet = { version = "0.25.0", path = "transports/pnet" }
-libp2p-quic = { version = "0.11.1", path = "transports/quic" }
+libp2p-quic = { version = "0.11.2", path = "transports/quic" }
 libp2p-relay = { version = "0.18.0", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.15.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.27.0", path = "protocols/request-response" }
@@ -105,11 +105,11 @@ libp2p-stream = { version = "0.2.0-alpha", path = "protocols/stream" }
 libp2p-swarm = { version = "0.45.2", path = "swarm" }
 libp2p-swarm-derive = { version = "=0.35.0", path = "swarm-derive" } # `libp2p-swarm-derive` may not be compatible with different `libp2p-swarm` non-breaking releases. E.g. `libp2p-swarm` might introduce a new enum variant `FromSwarm` (which is `#[non-exhaustive]`) in a non-breaking release. Older versions of `libp2p-swarm-derive` would not forward this enum variant within the `NetworkBehaviour` hierarchy. Thus the version pinning is required.
 libp2p-swarm-test = { version = "0.4.0", path = "swarm-test" }
-libp2p-tcp = { version = "0.42.0", path = "transports/tcp" }
+libp2p-tcp = { version = "0.42.1", path = "transports/tcp" }
 libp2p-tls = { version = "0.5.0", path = "transports/tls" }
 libp2p-uds = { version = "0.41.0", path = "transports/uds" }
 libp2p-upnp = { version = "0.3.0", path = "protocols/upnp" }
-libp2p-webrtc = { version = "0.8.0-alpha", path = "transports/webrtc" }
+libp2p-webrtc = { version = "0.8.1-alpha", path = "transports/webrtc" }
 libp2p-webrtc-utils = { version = "0.3.0", path = "misc/webrtc-utils" }
 libp2p-webrtc-websys = { version = "0.4.0-alpha.2", path = "transports/webrtc-websys" }
 libp2p-websocket = { version = "0.44.0", path = "transports/websocket" }

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.46.1
+- Changed unmaintained `if-watch@3.2.0` to `if-watch-plus@1.0.0`
+See [PR 5624](https://github.com/libp2p/rust-libp2p/pull/5624)
+
 ## 0.46.0
 
 <!-- Update to libp2p-swarm v0.45.0 -->

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -15,7 +15,7 @@ async-std  = { version = "1.12.0", optional = true }
 async-io  = { version = "2.3.3", optional = true }
 data-encoding = "2.6.0"
 futures = { workspace = true }
-if-watch = "3.2.0"
+if-watch = {package = "if-watch-plus", version="1.0.0"}
 libp2p-core = { workspace = true }
 libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true }

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-mdns"
 edition = "2021"
 rust-version = { workspace = true }
-version = "0.46.0"
+version = "0.46.1"
 description = "Implementation of the libp2p mDNS discovery method"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"

--- a/transports/quic/CHANGELOG.md
+++ b/transports/quic/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.2
+- Changed unmaintained `if-watch@3.2.0` to `if-watch-plus@1.0.0`
+See [PR 5624](https://github.com/libp2p/rust-libp2p/pull/5624)
+
 ## 0.11.1
 
 - Update `libp2p-tls` to version `0.5.0`, see [PR 5547]

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-quic"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 rust-version = { workspace = true }

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -13,7 +13,7 @@ async-std = { version = "1.12.0", optional = true }
 bytes = "1.6.0"
 futures = { workspace = true }
 futures-timer = "3.0.3"
-if-watch = "3.2.0"
+if-watch = {package = "if-watch-plus", version="1.0.0"}
 libp2p-core = { workspace = true }
 libp2p-tls = { workspace = true }
 libp2p-identity = { workspace = true }

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.42.1
+- Changed unmaintained `if-watch@3.2.0` to `if-watch-plus@1.0.0`
+See [PR 5624](https://github.com/libp2p/rust-libp2p/pull/5624)
+
 ## 0.42.0
 
 - Implement refactored `Transport`.

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["network-programming", "asynchronous"]
 async-io = { version = "2.3.3", optional = true }
 futures = { workspace = true }
 futures-timer = "3.0"
-if-watch = "3.2.0"
+if-watch = {package="if-watch-plus", version="1.0.0"}
 libc = "0.2.155"
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true }

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-tcp"
 edition = "2021"
 rust-version = { workspace = true }
 description = "TCP/IP transport protocol for libp2p"
-version = "0.42.0"
+version = "0.42.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/transports/webrtc/CHANGELOG.md
+++ b/transports/webrtc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1-alpha
+- Changed unmaintained `if-watch@3.2.0` to `if-watch-plus@1.0.0`
+See [PR 5624](https://github.com/libp2p/rust-libp2p/pull/5624)
+
 ## 0.8.0-alpha
 
 - Implement refactored `Transport`.

--- a/transports/webrtc/Cargo.toml
+++ b/transports/webrtc/Cargo.toml
@@ -16,7 +16,7 @@ bytes = "1"
 futures = { workspace = true }
 futures-timer = "3"
 hex = "0.4"
-if-watch = "3.2"
+if-watch = {package = "if-watch-plus", version="1.0.0"}
 libp2p-core = { workspace = true }
 libp2p-noise = { workspace = true }
 libp2p-identity = { workspace = true }

--- a/transports/webrtc/Cargo.toml
+++ b/transports/webrtc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-webrtc"
-version = "0.8.0-alpha"
+version = "0.8.1-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "WebRTC transport for libp2p"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION

## Description

Libp2p relies on a package called `if-watch@3.2.0` in 4 different places:
- `transport/tcp`
- `transport/quic`
- `transport/webrtc`
- `protocol/mdns`

This **_unmaintained_** library uses a deprecate iOS interface through one of its own dependencies `system-configurations@0.5.0:
- https://discuss.libp2p.io/t/rust-libp2p-link-error-on-ios-undefined-symbols-kscnetworkinterfacetypeirda/2208
- https://github.com/libp2p/rust-libp2p/issues/5140

Seeing that our bindings use this deprecated interface, iOS apps will fail to build for everyone using `rust-libp2p`.

## Notes & open questions
- This PR uses a forked version of `if-watch` that only updates the `system-configurations` dependency to the latest version that addresses the deprecated interface
- This PR does not cover tests that should fall under `system-configurations`

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
