### PR TITLE
reproduce closure invoked recursively or after being dropped error

### DIFF
--- a/examples/browser-webrtc/Cargo.toml
+++ b/examples/browser-webrtc/Cargo.toml
@@ -24,7 +24,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 axum = "0.7.5"
-libp2p = { path = "../../libp2p", features = [ "ed25519", "macros", "ping", "tokio"] }
+libp2p = { path = "../../libp2p", features = [ "ed25519", "macros", "ping", "tokio", "autonat"] }
 libp2p-webrtc = { workspace = true, features = ["tokio"] }
 rust-embed = { version = "8.4.0", features = ["include-exclude", "interpolate-folder-path"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "signal"] }

--- a/examples/browser-webrtc/src/main.rs
+++ b/examples/browser-webrtc/src/main.rs
@@ -11,7 +11,7 @@ use libp2p::{
     core::muxing::StreamMuxerBox,
     core::Transport,
     multiaddr::{Multiaddr, Protocol},
-    ping,
+    autonat,
     swarm::SwarmEvent,
 };
 use libp2p_webrtc as webrtc;
@@ -36,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
             )
             .map(|(peer_id, conn), _| (peer_id, StreamMuxerBox::new(conn))))
         })?
-        .with_behaviour(|_| ping::Behaviour::default())?
+        .with_behaviour(|key| autonat::Behaviour::new(key.public().to_peer_id(), Default::default()))?
         .with_swarm_config(|cfg| {
             cfg.with_idle_connection_timeout(
                 Duration::from_secs(u64::MAX), // Allows us to observe the pings.


### PR DESCRIPTION
## Description

Create a protocol unsupported error in browser-webrtc example to reproduce browser error `Uncaught Error: closure invoked recursively or after being dropped`

## Notes & open questions

This error happens whenever there are errors in webrtc connection.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
