### PR TITLE
feat(gossipsub): apply `max_transmit_size` to the published message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.47.1"
+version = "0.48.0"
 dependencies = [
  "async-std",
  "asynchronous-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ libp2p-core = { version = "0.42.0", path = "core" }
 libp2p-dcutr = { version = "0.12.0", path = "protocols/dcutr" }
 libp2p-dns = { version = "0.42.0", path = "transports/dns" }
 libp2p-floodsub = { version = "0.45.0", path = "protocols/floodsub" }
-libp2p-gossipsub = { version = "0.47.1", path = "protocols/gossipsub" }
+libp2p-gossipsub = { version = "0.48.0", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.45.1", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.9" }
 libp2p-kad = { version = "0.47.0", path = "protocols/kad" }

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.48.0
 
 - Apply `max_transmit_size` to the inner message instead of the final payload.
-  See [Discussion 5598](https://github.com/libp2p/rust-libp2p/discussions/5598).
+  See [PR 5642](https://github.com/libp2p/rust-libp2p/pull/5642).
 
 ## 0.47.1
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.48.0
+
+- Apply `max_transmit_size` to the inner message instead of the final payload.
+  See [Discussion 5598](https://github.com/libp2p/rust-libp2p/discussions/5598).
+
 ## 0.47.1
 
 - Attempt to publish to at least mesh_n peers when flood publish is disabled.

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-gossipsub"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Gossipsub protocol for libp2p"
-version = "0.47.1"
+version = "0.48.0"
 authors = ["Age Manning <Age@AgeManning.com>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -583,6 +583,11 @@ where
             .data_transform
             .outbound_transform(&topic, data.clone())?;
 
+        // check that the size doesn't exceed the max transmission size
+        if transformed_data.len() > self.config.max_transmit_size() {
+            return Err(PublishError::MessageTooLarge);
+        }
+
         let raw_message = self.build_raw_message(topic, transformed_data)?;
 
         // calculate the message id from the un-transformed data
@@ -592,11 +597,6 @@ where
             sequence_number: raw_message.sequence_number,
             topic: raw_message.topic.clone(),
         });
-
-        // check that the size doesn't exceed the max transmission size
-        if raw_message.raw_protobuf_len() > self.config.max_transmit_size() {
-            return Err(PublishError::MessageTooLarge);
-        }
 
         // Check the if the message has been published before
         if self.duplicate_cache.contains(&msg_id) {

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -583,7 +583,7 @@ where
             .data_transform
             .outbound_transform(&topic, data.clone())?;
 
-        // check that the size doesn't exceed the max transmission size
+        // check that the size doesn't exceed the max transmission size.
         if transformed_data.len() > self.config.max_transmit_size() {
             return Err(PublishError::MessageTooLarge);
         }

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -174,7 +174,8 @@ impl Config {
 
     /// The maximum byte size for each gossipsub RPC (default is 65536 bytes).
     ///
-    /// This represents the maximum size of the entire protobuf payload. It must be at least
+    /// This represents the maximum size of the published message. It is additionally wrapped
+    /// in a protobuf struct, so the actual wire size may be a bit larger. It must be at least
     /// large enough to support basic control messages. If Peer eXchange is enabled, this
     /// must be large enough to transmit the desired peer information on pruning. It must be at
     /// least 100 bytes. Default is 65536 bytes.


### PR DESCRIPTION
## Description

When trying to publish a message using gossipsub's `publish` method,
it should be possible to predict whether it will fit in the limit defined by
the `max_transmit_size` config option.
If this limit applies to the final protobuf payload, it's not possible to know
that in advance because the size of the added fields is not fixed.

This change makes the limit apply to the passed message size instead of the final wire size.

## Notes & open questions

This is a minor version change because it changes the meaning of the existing config option.
However, for the existing clients the limit will only become more permissive, so it shouldn't break anything.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
