### PR TITLE
feat(kad): add `Behavior::find_closest_local_peers()`

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## 0.47.0
 
-- Expose a kad query facility allowing specify num_results dynamicly.
+- Expose a kad query facility allowing specify num_results dynamicaly.
   See [PR 5555](https://github.com/libp2p/rust-libp2p/pull/5555).
 - Add `mode` getter on `Behaviour`.
   See [PR 5573](https://github.com/libp2p/rust-libp2p/pull/5573).
-  
+- Add `Behavior::find_closest_local_peers()`.
+  See [PR 5645](https://github.com/libp2p/rust-libp2p/pull/5645).
 
 ## 0.46.2
 

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -69,7 +69,7 @@ pub use behaviour::{
 pub use kbucket::{
     Distance as KBucketDistance, EntryView, KBucketRef, Key as KBucketKey, NodeStatus,
 };
-pub use protocol::ConnectionType;
+pub use protocol::{ConnectionType, KadPeer};
 pub use query::QueryId;
 pub use record::{store, Key as RecordKey, ProviderRecord, Record};
 


### PR DESCRIPTION
## Description

Fixes https://github.com/libp2p/rust-libp2p/issues/5626

## Notes & open questions

This is the nicest way I came up with, I decided to leave `get_closest_local_peers` as is since it does return all peers, not just `replication_factor` peers.

Looking at https://github.com/libp2p/rust-libp2p/pull/2436 it is not clear if @folex really needed all peers returned or it just happened that way. I'm also happy to change proposed API to return all peers if that is preferred by others.

It is very unfortunate that `&mut self` is needed for this, I created https://github.com/libp2p/rust-libp2p/issues/5644 that if resolved will allow to have `&self` instead.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
