### PR TITLE
feat: refactor distributed-key-value-store example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,10 +1361,10 @@ dependencies = [
 name = "distributed-key-value-store-example"
 version = "0.1.0"
 dependencies = [
- "async-std",
  "async-trait",
  "futures",
  "libp2p",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/examples/distributed-key-value-store/Cargo.toml
+++ b/examples/distributed-key-value-store/Cargo.toml
@@ -9,10 +9,10 @@ license = "MIT"
 release = false
 
 [dependencies]
-async-std = { version = "1.12", features = ["attributes"] }
+tokio = { workspace = true, features = ["full"] }
 async-trait = "0.1"
 futures = { workspace = true }
-libp2p = { path = "../../libp2p", features = [ "async-std", "dns", "kad", "mdns", "noise", "macros", "tcp", "yamux"] }
+libp2p = { path = "../../libp2p", features = [ "tokio", "dns", "kad", "mdns", "noise", "macros", "tcp", "yamux"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 


### PR DESCRIPTION
## Description

ref #4449 

Refactored distributed-key-value-store example to use `tokio` instead of `async-std`

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
