### PR TITLE
chore: refactor ping tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,7 +3023,6 @@ dependencies = [
 name = "libp2p-ping"
 version = "0.45.0"
 dependencies = [
- "async-std",
  "either",
  "futures",
  "futures-timer",
@@ -3033,6 +3032,7 @@ dependencies = [
  "libp2p-swarm-test",
  "quickcheck-ext",
  "rand 0.8.5",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "void",

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -23,11 +23,11 @@ tracing = { workspace = true }
 void = "1.0"
 
 [dev-dependencies]
-async-std = "1.6.2"
 libp2p-swarm = { workspace = true, features = ["macros"] }
 libp2p-swarm-test = { path = "../../swarm-test" }
 quickcheck = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tokio = {workspace = true, features = ["rt", "rt-multi-thread", "macros"]}
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -27,7 +27,7 @@ libp2p-swarm = { workspace = true, features = ["macros"] }
 libp2p-swarm-test = { path = "../../swarm-test" }
 quickcheck = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-tokio = {workspace = true, features = ["rt", "rt-multi-thread", "macros"]}
+tokio = {workspace = true, features = ["rt", "macros"]}
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/protocols/ping/src/protocol.rs
+++ b/protocols/ping/src/protocol.rs
@@ -89,8 +89,8 @@ mod tests {
         Endpoint,
     };
 
-    #[test]
-    fn ping_pong() {
+    #[tokio::test]
+    async fn ping_pong() {
         let mem_addr = multiaddr![Memory(thread_rng().gen::<u64>())];
         let mut transport = MemoryTransport::new().boxed();
         transport.listen_on(ListenerId::next(), mem_addr).unwrap();
@@ -101,27 +101,25 @@ mod tests {
             .and_then(|ev| ev.into_new_address())
             .expect("MemoryTransport not listening on an address!");
 
-        async_std::task::spawn(async move {
+        tokio::spawn(async move {
             let transport_event = transport.next().await.unwrap();
             let (listener_upgrade, _) = transport_event.into_incoming().unwrap();
             let conn = listener_upgrade.await.unwrap();
             recv_ping(conn).await.unwrap();
         });
 
-        async_std::task::block_on(async move {
-            let c = MemoryTransport::new()
-                .dial(
-                    listener_addr,
-                    DialOpts {
-                        role: Endpoint::Dialer,
-                        port_use: PortUse::Reuse,
-                    },
-                )
-                .unwrap()
-                .await
-                .unwrap();
-            let (_, rtt) = send_ping(c).await.unwrap();
-            assert!(rtt > Duration::from_secs(0));
-        });
+        let c = MemoryTransport::new()
+            .dial(
+                listener_addr,
+                DialOpts {
+                    role: Endpoint::Dialer,
+                    port_use: PortUse::Reuse,
+                },
+            )
+            .unwrap()
+            .await
+            .unwrap();
+        let (_, rtt) = send_ping(c).await.unwrap();
+        assert!(rtt > Duration::from_secs(0));
     }
 }


### PR DESCRIPTION
## Description

ref #4449 

Refactored ping tests to use `tokio` instead of `async-std`.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
