### PR TITLE
chore: refactor dcutr and gossipsub tests to use tokio instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2665,7 +2665,6 @@ dependencies = [
 name = "libp2p-dcutr"
 version = "0.12.0"
 dependencies = [
- "async-std",
  "asynchronous-codec",
  "clap",
  "either",
@@ -2689,6 +2688,7 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.5",
  "thiserror",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "web-time 1.1.0",
@@ -2736,7 +2736,6 @@ dependencies = [
 name = "libp2p-gossipsub"
 version = "0.48.0"
 dependencies = [
- "async-std",
  "asynchronous-codec",
  "base64 0.22.1",
  "byteorder",
@@ -2763,6 +2762,7 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "smallvec",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "web-time 1.1.0",

--- a/protocols/dcutr/Cargo.toml
+++ b/protocols/dcutr/Cargo.toml
@@ -27,7 +27,6 @@ lru = "0.12.3"
 futures-bounded = { workspace = true }
 
 [dev-dependencies]
-async-std = { version = "1.12.0", features = ["attributes"] }
 clap = { version = "4.5.6", features = ["derive"] }
 libp2p-dns = { workspace = true, features = ["async-std"] }
 libp2p-identify = { workspace = true }
@@ -41,6 +40,7 @@ libp2p-tcp = { workspace = true, features = ["async-io"] }
 libp2p-yamux = { workspace = true }
 rand = "0.8"
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tokio = { workspace = true, features = ["rt", "macros"] }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/protocols/dcutr/tests/lib.rs
+++ b/protocols/dcutr/tests/lib.rs
@@ -32,7 +32,7 @@ use libp2p_swarm_test::SwarmExt as _;
 use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 
-#[async_std::test]
+#[tokio::test]
 async fn connect() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
@@ -53,7 +53,7 @@ async fn connect() {
     let relay_peer_id = *relay.local_peer_id();
     let dst_peer_id = *dst.local_peer_id();
 
-    async_std::task::spawn(relay.loop_on_next());
+    tokio::spawn(relay.loop_on_next());
 
     let dst_relayed_addr = relay_tcp_addr
         .with(Protocol::P2p(relay_peer_id))
@@ -68,7 +68,7 @@ async fn connect() {
         false, // No renewal.
     )
     .await;
-    async_std::task::spawn(dst.loop_on_next());
+    tokio::spawn(dst.loop_on_next());
 
     src.dial_and_wait(dst_relayed_addr.clone()).await;
 

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -41,7 +41,6 @@ tracing = { workspace = true }
 prometheus-client = { workspace = true }
 
 [dev-dependencies]
-async-std = { version = "1.6.3", features = ["unstable"] }
 hex = "0.4.2"
 libp2p-core = { workspace = true }
 libp2p-yamux = { workspace = true }
@@ -49,6 +48,7 @@ libp2p-noise = { workspace = true }
 libp2p-swarm-test = { path = "../../swarm-test" }
 quickcheck = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "time"] }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -23,10 +23,10 @@
 use super::*;
 use crate::subscription_filter::WhitelistSubscriptionFilter;
 use crate::{config::ConfigBuilder, types::Rpc, IdentTopic as Topic};
-use async_std::net::Ipv4Addr;
 use byteorder::{BigEndian, ByteOrder};
 use libp2p_core::ConnectedPoint;
 use rand::Rng;
+use std::net::Ipv4Addr;
 use std::thread::sleep;
 
 #[derive(Default, Debug)]


### PR DESCRIPTION
## Description

 ref #4449 

Refactored dcutr and gossipsub tests to use `tokio` instead of `async-std`.