### PR TITLE
chore: replace async-std with tokio in autonat tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,7 +2593,6 @@ dependencies = [
 name = "libp2p-autonat"
 version = "0.13.1"
 dependencies = [
- "async-std",
  "async-trait",
  "asynchronous-codec",
  "bytes",

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -4,7 +4,11 @@ edition = "2021"
 rust-version = { workspace = true }
 description = "NAT and firewall detection for libp2p"
 version = "0.13.1"
-authors = ["David Craven <david@craven.ch>", "Elena Frank <elena.frank@protonmail.com>", "Hannes Furmans <hannes@umgefahren.xyz>"]
+authors = [
+    "David Craven <david@craven.ch>",
+    "Elena Frank <elena.frank@protonmail.com>",
+    "Hannes Furmans <hannes@umgefahren.xyz>",
+]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
 keywords = ["peer-to-peer", "libp2p", "networking"]
@@ -33,17 +37,23 @@ thiserror = { version = "1.0.52", optional = true }
 void = { version = "1", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt", "sync"]}
-async-std = { version = "1.10", features = ["attributes"] }
+tokio = { workspace = true, features = ["macros", "rt", "sync"] }
 libp2p-swarm-test = { path = "../../swarm-test" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 libp2p-identify = { workspace = true }
-libp2p-swarm = { workspace = true, features = ["macros"]}
+libp2p-swarm = { workspace = true, features = ["macros"] }
 
 [features]
 default = ["v1", "v2"]
 v1 = ["dep:libp2p-request-response", "dep:web-time", "dep:async-trait"]
-v2 = ["dep:bytes", "dep:either", "dep:futures-bounded", "dep:thiserror", "dep:void", "dep:rand_core"]
+v2 = [
+    "dep:bytes",
+    "dep:either",
+    "dep:futures-bounded",
+    "dep:thiserror",
+    "dep:void",
+    "dep:rand_core",
+]
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/protocols/autonat/tests/test_client.rs
+++ b/protocols/autonat/tests/test_client.rs
@@ -18,7 +18,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use async_std::task::JoinHandle;
 use libp2p_autonat::{
     Behaviour, Config, Event, NatStatus, OutboundProbeError, OutboundProbeEvent, ResponseError,
 };
@@ -27,12 +26,13 @@ use libp2p_identity::PeerId;
 use libp2p_swarm::{Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt as _;
 use std::time::Duration;
+use tokio::task::JoinHandle;
 
 const MAX_CONFIDENCE: usize = 3;
 const TEST_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 const TEST_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 
-#[async_std::test]
+#[tokio::test]
 async fn test_auto_probe() {
     let mut client = Swarm::new_ephemeral(|key| {
         Behaviour::new(
@@ -133,7 +133,7 @@ async fn test_auto_probe() {
     assert!(client.behaviour().public_address().is_some());
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn test_confidence() {
     let mut client = Swarm::new_ephemeral(|key| {
         Behaviour::new(
@@ -217,7 +217,7 @@ async fn test_confidence() {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn test_throttle_server_period() {
     let mut client = Swarm::new_ephemeral(|key| {
         Behaviour::new(
@@ -268,7 +268,7 @@ async fn test_throttle_server_period() {
     assert_eq!(client.behaviour().confidence(), 0);
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn test_use_connected_as_server() {
     let mut client = Swarm::new_ephemeral(|key| {
         Behaviour::new(
@@ -306,7 +306,7 @@ async fn test_use_connected_as_server() {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn test_outbound_failure() {
     let mut client = Swarm::new_ephemeral(|key| {
         Behaviour::new(
@@ -351,7 +351,7 @@ async fn test_outbound_failure() {
     let mut inactive_servers = Vec::new();
 
     for (id, handle) in servers.split_off(1) {
-        handle.cancel().await;
+        handle.abort();
         inactive_servers.push(id);
     }
 
@@ -375,7 +375,7 @@ async fn test_outbound_failure() {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn test_global_ips_config() {
     let mut client = Swarm::new_ephemeral(|key| {
         Behaviour::new(
@@ -426,7 +426,7 @@ async fn new_server_swarm() -> (PeerId, Multiaddr, JoinHandle<()>) {
     let (_, multiaddr) = swarm.listen().await;
     let peer_id = *swarm.local_peer_id();
 
-    let task = async_std::task::spawn(swarm.loop_on_next());
+    let task = tokio::spawn(swarm.loop_on_next());
 
     (peer_id, multiaddr, task)
 }

--- a/protocols/autonat/tests/test_server.rs
+++ b/protocols/autonat/tests/test_server.rs
@@ -28,12 +28,12 @@ use libp2p_swarm::{Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt as _;
 use std::{num::NonZeroU32, time::Duration};
 
-#[async_std::test]
+#[tokio::test]
 async fn test_dial_back() {
     let (mut server, server_id, server_addr) = new_server_swarm(None).await;
     let (mut client, client_id) = new_client_swarm(server_id, server_addr).await;
     let (_, client_addr) = client.listen().await;
-    async_std::task::spawn(client.loop_on_next());
+    tokio::spawn(client.loop_on_next());
 
     let client_port = client_addr
         .into_iter()
@@ -128,14 +128,14 @@ async fn test_dial_back() {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn test_dial_error() {
     let (mut server, server_id, server_addr) = new_server_swarm(None).await;
     let (mut client, client_id) = new_client_swarm(server_id, server_addr).await;
     client
         .behaviour_mut()
         .probe_address("/ip4/127.0.0.1/tcp/12345".parse().unwrap());
-    async_std::task::spawn(client.loop_on_next());
+    tokio::spawn(client.loop_on_next());
 
     let request_probe_id = match server.next_behaviour_event().await {
         Event::InboundProbe(InboundProbeEvent::Request { peer, probe_id, .. }) => {
@@ -178,7 +178,7 @@ async fn test_dial_error() {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn test_throttle_global_max() {
     let (mut server, server_id, server_addr) = new_server_swarm(Some(Config {
         throttle_clients_global_max: 1,
@@ -190,7 +190,7 @@ async fn test_throttle_global_max() {
     for _ in 0..2 {
         let (mut client, _) = new_client_swarm(server_id, server_addr.clone()).await;
         client.listen().await;
-        async_std::task::spawn(client.loop_on_next());
+        tokio::spawn(client.loop_on_next());
     }
 
     let (first_probe_id, first_peer_id) = match server.next_behaviour_event().await {
@@ -218,7 +218,7 @@ async fn test_throttle_global_max() {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn test_throttle_peer_max() {
     let (mut server, server_id, server_addr) = new_server_swarm(Some(Config {
         throttle_clients_peer_max: 1,
@@ -230,7 +230,7 @@ async fn test_throttle_peer_max() {
 
     let (mut client, client_id) = new_client_swarm(server_id, server_addr.clone()).await;
     client.listen().await;
-    async_std::task::spawn(client.loop_on_next());
+    tokio::spawn(client.loop_on_next());
 
     let first_probe_id = match server.next_behaviour_event().await {
         Event::InboundProbe(InboundProbeEvent::Request { peer, probe_id, .. }) => {
@@ -265,7 +265,7 @@ async fn test_throttle_peer_max() {
     };
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn test_dial_multiple_addr() {
     let (mut server, server_id, server_addr) = new_server_swarm(Some(Config {
         throttle_clients_peer_max: 1,
@@ -280,7 +280,7 @@ async fn test_dial_multiple_addr() {
     client
         .behaviour_mut()
         .probe_address("/ip4/127.0.0.1/tcp/12345".parse().unwrap());
-    async_std::task::spawn(client.loop_on_next());
+    tokio::spawn(client.loop_on_next());
 
     let dial_addresses = match server.next_behaviour_event().await {
         Event::InboundProbe(InboundProbeEvent::Request {
@@ -327,7 +327,7 @@ async fn test_dial_multiple_addr() {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn test_global_ips_config() {
     let (mut server, server_id, server_addr) = new_server_swarm(Some(Config {
         // Enforce that only clients outside of the local network are qualified for dial-backs.
@@ -338,7 +338,7 @@ async fn test_global_ips_config() {
 
     let (mut client, _) = new_client_swarm(server_id, server_addr.clone()).await;
     client.listen().await;
-    async_std::task::spawn(client.loop_on_next());
+    tokio::spawn(client.loop_on_next());
 
     // Expect the probe to be refused as both peers run on the same machine and thus in the same local network.
     match server.next_behaviour_event().await {


### PR DESCRIPTION
## Description

ref #4449 

Refactored `autonat` tests to use `tokio` instead of `async-std`.