### PR TITLE
chore: bump crate versions and update changelogs for #5676

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2525,7 +2525,7 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libp2p"
-version = "0.54.1"
+version = "0.54.2"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2577,7 +2577,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-std",
  "libp2p-core",
@@ -2618,7 +2618,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-std",
  "libp2p-core",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "async-std",
  "either",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dcutr"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-std",
  "asynchronous-codec",
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "asn1_der",
  "base64 0.22.1",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-memory-connection-limits"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-std",
  "libp2p-core",
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "either",
  "futures",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "async-std",
  "bytes",
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -3152,7 +3152,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "async-std",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-stream"
-version = "0.2.0-alpha"
+version = "0.2.0-alpha.1"
 dependencies = [
  "futures",
  "libp2p-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ libp2p-dns = { version = "0.42.0", path = "transports/dns" }
 libp2p-floodsub = { version = "0.45.0", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.48.0", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.46.0", path = "protocols/identify" }
-libp2p-identity = { version = "0.2.9" }
+libp2p-identity = { version = "0.2.10" }
 libp2p-kad = { version = "0.47.0", path = "protocols/kad" }
 libp2p-mdns = { version = "0.46.0", path = "protocols/mdns" }
 libp2p-memory-connection-limits = { version = "0.3.1", path = "misc/memory-connection-limits" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,12 +75,12 @@ rust-version = "1.75.0"
 asynchronous-codec = { version = "0.7.0" }
 futures-bounded = { version = "0.2.4" }
 futures-rustls = { version = "0.26.0", default-features = false }
-libp2p = { version = "0.54.1", path = "libp2p" }
-libp2p-allow-block-list = { version = "0.4.1", path = "misc/allow-block-list" }
+libp2p = { version = "0.54.2", path = "libp2p" }
+libp2p-allow-block-list = { version = "0.4.2", path = "misc/allow-block-list" }
 libp2p-autonat = { version = "0.13.1", path = "protocols/autonat" }
-libp2p-connection-limits = { version = "0.4.0", path = "misc/connection-limits" }
-libp2p-core = { version = "0.42.0", path = "core" }
-libp2p-dcutr = { version = "0.12.0", path = "protocols/dcutr" }
+libp2p-connection-limits = { version = "0.4.1", path = "misc/connection-limits" }
+libp2p-core = { version = "0.42.1", path = "core" }
+libp2p-dcutr = { version = "0.12.1", path = "protocols/dcutr" }
 libp2p-dns = { version = "0.42.0", path = "transports/dns" }
 libp2p-floodsub = { version = "0.45.0", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.48.0", path = "protocols/gossipsub" }
@@ -88,20 +88,20 @@ libp2p-identify = { version = "0.46.0", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.9" }
 libp2p-kad = { version = "0.47.0", path = "protocols/kad" }
 libp2p-mdns = { version = "0.46.0", path = "protocols/mdns" }
-libp2p-memory-connection-limits = { version = "0.3.0", path = "misc/memory-connection-limits" }
+libp2p-memory-connection-limits = { version = "0.3.1", path = "misc/memory-connection-limits" }
 libp2p-metrics = { version = "0.15.0", path = "misc/metrics" }
 libp2p-mplex = { version = "0.42.0", path = "muxers/mplex" }
 libp2p-noise = { version = "0.45.0", path = "transports/noise" }
 libp2p-perf = { version = "0.4.0", path = "protocols/perf" }
-libp2p-ping = { version = "0.45.0", path = "protocols/ping" }
+libp2p-ping = { version = "0.45.1", path = "protocols/ping" }
 libp2p-plaintext = { version = "0.42.0", path = "transports/plaintext" }
 libp2p-pnet = { version = "0.25.0", path = "transports/pnet" }
-libp2p-quic = { version = "0.11.1", path = "transports/quic" }
-libp2p-relay = { version = "0.18.0", path = "protocols/relay" }
+libp2p-quic = { version = "0.11.2", path = "transports/quic" }
+libp2p-relay = { version = "0.18.1", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.15.0", path = "protocols/rendezvous" }
-libp2p-request-response = { version = "0.27.0", path = "protocols/request-response" }
+libp2p-request-response = { version = "0.27.1", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.8", path = "misc/server" }
-libp2p-stream = { version = "0.2.0-alpha", path = "protocols/stream" }
+libp2p-stream = { version = "0.2.0-alpha.1", path = "protocols/stream" }
 libp2p-swarm = { version = "0.45.2", path = "swarm" }
 libp2p-swarm-derive = { version = "=0.35.0", path = "swarm-derive" } # `libp2p-swarm-derive` may not be compatible with different `libp2p-swarm` non-breaking releases. E.g. `libp2p-swarm` might introduce a new enum variant `FromSwarm` (which is `#[non-exhaustive]`) in a non-breaking release. Older versions of `libp2p-swarm-derive` would not forward this enum variant within the `NetworkBehaviour` hierarchy. Thus the version pinning is required.
 libp2p-swarm-test = { version = "0.5.0", path = "swarm-test" }

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.42.1
+
+- Added `libp2p::core::util::unreachable` that is a drop-in replacement of `void::unreachable`.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+
 ## 0.42.0
 
 - Update `Transport::dial` function signature with a `DialOpts` param and remove `Transport::dial_as_listener`:

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-core"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Core traits and structs of libp2p"
-version = "0.42.0"
+version = "0.42.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/identity/CHANGELOG.md
+++ b/identity/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.10
+
+- Deprecate `void` crate.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+
 ## 0.2.9
 
 - Add `rand` feature gate to ecdsa methods requiring a random number generator.

--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-identity"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 description = "Data structures and algorithms for identifying peers in libp2p."
 rust-version = "1.73.0" # MUST NOT inherit from workspace because we don't want to publish breaking changes to `libp2p-identity`.

--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.54.2
+
+- Deprecate `void` crate.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+
 ## 0.54.1
 
 - Update individual crates.

--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Peer-to-peer networking library"
-version = "0.54.1"
+version = "0.54.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/misc/allow-block-list/CHANGELOG.md
+++ b/misc/allow-block-list/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.2
+
+- Deprecate `void` crate.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+
 ## 0.4.1
 
 - Add getters & setters for the allowed/blocked peers.

--- a/misc/allow-block-list/Cargo.toml
+++ b/misc/allow-block-list/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-allow-block-list"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Allow/block list connection management for libp2p."
-version = "0.4.1"
+version = "0.4.2"
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
 keywords = ["peer-to-peer", "libp2p", "networking"]

--- a/misc/connection-limits/CHANGELOG.md
+++ b/misc/connection-limits/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.1
+
+- Deprecate `void` crate.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+
 ## 0.4.0
 
 <!-- Update to libp2p-swarm v0.45.0 -->

--- a/misc/connection-limits/Cargo.toml
+++ b/misc/connection-limits/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-connection-limits"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Connection limits for libp2p."
-version = "0.4.0"
+version = "0.4.1"
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
 keywords = ["peer-to-peer", "libp2p", "networking"]

--- a/misc/memory-connection-limits/CHANGELOG.md
+++ b/misc/memory-connection-limits/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1
+
+- Deprecate `void` crate.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+
 ## 0.3.0
 
 <!-- Update to libp2p-swarm v0.45.0 -->

--- a/misc/memory-connection-limits/Cargo.toml
+++ b/misc/memory-connection-limits/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-memory-connection-limits"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Memory usage based connection limits for libp2p."
-version = "0.3.0"
+version = "0.3.1"
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
 keywords = ["peer-to-peer", "libp2p", "networking"]

--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.13.1
+
 - Verify that an incoming AutoNAT dial comes from a connected peer. See [PR 5597](https://github.com/libp2p/rust-libp2p/pull/5597).
+
+- Deprecate `void` crate.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
 
 ## 0.13.0
 

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.1
+
+- Deprecate `void` crate.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+
 ## 0.12.0
 
 <!-- Update to libp2p-swarm v0.45.0 -->

--- a/protocols/dcutr/Cargo.toml
+++ b/protocols/dcutr/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-dcutr"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Direct connection upgrade through relay"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Max Inden <mail@max-inden.de>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Apply `max_transmit_size` to the inner message instead of the final payload.
   See [PR 5642](https://github.com/libp2p/rust-libp2p/pull/5642).
 
+- Deprecate `void` crate.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+
 ## 0.47.1
 
 - Attempt to publish to at least mesh_n peers when flood publish is disabled.

--- a/protocols/perf/CHANGELOG.md
+++ b/protocols/perf/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Add ConnectionError to FromSwarm::ConnectionClosed.
   See [PR 5485](https://github.com/libp2p/rust-libp2p/pull/5485).
 
+- Deprecate `void` crate.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+
 ## 0.3.1
 - Use `web-time` instead of `instant`.
   See [PR 5347](https://github.com/libp2p/rust-libp2p/pull/5347).

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.45.1
+
+- Deprecate `void` crate.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+
 ## 0.45.0
 
 <!-- Update to libp2p-swarm v0.45.0 -->

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-ping"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Ping protocol for libp2p"
-version = "0.45.0"
+version = "0.45.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.18.1
+
+- Deprecate `void` crate.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+
 ## 0.18.0
 
 <!-- Update to libp2p-swarm v0.45.0 -->

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-relay"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Communications relaying for libp2p"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Parity Technologies <admin@parity.io>", "Max Inden <mail@max-inden.de>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.27.1
+
+- Deprecate `void` crate.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+
 ## 0.27.0
 
 <!-- Update to libp2p-swarm v0.45.0 -->

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-request-response"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Generic Request/Response Protocols"
-version = "0.27.0"
+version = "0.27.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/stream/CHANGELOG.md
+++ b/protocols/stream/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.0-alpha.1
+
+- Deprecate `void` crate.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+
 ## 0.2.0-alpha
 
 <!-- Update to libp2p-swarm v0.45.0 -->

--- a/protocols/stream/Cargo.toml
+++ b/protocols/stream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-stream"
-version = "0.2.0-alpha"
+version = "0.2.0-alpha.1"
 edition = "2021"
 rust-version.workspace = true
 description = "Generic stream protocols for libp2p"

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Don't report `NewExternalAddrCandidate` for confirmed external addresses.
   See [PR 5582](https://github.com/libp2p/rust-libp2p/pull/5582).
 
+- Deprecate `void` crate.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+
 ## 0.45.1
 
 - Update `libp2p-swarm-derive` to version `0.35.0`, see [PR 5545]

--- a/transports/quic/CHANGELOG.md
+++ b/transports/quic/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.11.2
+
+- Deprecate `void` crate.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+
 ## 0.11.1
 
 - Update `libp2p-tls` to version `0.5.0`, see [PR 5547]

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-quic"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 rust-version = { workspace = true }


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

This PR bumps crate versions and add changelog entries for crates that are changed in #5676

Question: When should a crate version bump in the current release process? Should it be right before or right after publishing? I see most of current crate versions are published while some are not (e.g. libp2p-autonat@0.13.1 libp2p-gossisub@0.48.0 and libp2p-perf@0.4.0 etc.)

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
