### PR TITLE
chore: introduce `rustfmt.toml`

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 - Update `Transport::dial` function signature with a `DialOpts` param and remove `Transport::dial_as_listener`:
   - `DialOpts` struct contains `PortUse` and `Endpoint`, 
-  - `PortUse` allows controlling port allocation of new connections (defaults to `PortUse::Reuse`)   - 
+  - `PortUse` allows controling port allocation of new connections (defaults to `PortUse::Reuse`)   - 
   - Add `port_use` field to `ConnectedPoint`
   - Set `endpoint` field in `DialOpts` to `Endpoint::Listener` to dial as a listener
 - Remove `Transport::address_translation` and relocate functionality to `libp2p_swarm`

--- a/core/src/connection.rs
+++ b/core/src/connection.rs
@@ -83,12 +83,14 @@ pub enum ConnectedPoint {
         ///   connection as a dialer and one peer dial the other and upgrade the
         ///   connection _as a listener_ overriding its role.
         role_override: Endpoint,
-        /// Whether the port for the outgoing connection was reused from a listener
-        /// or a new port was allocated. This is useful for address translation.
+        /// Whether the port for the outgoing connection was reused from a
+        /// listener or a new port was allocated. This is useful for
+        /// address translation.
         ///
-        /// The port use is implemented on a best-effort basis. It is not guaranteed
-        /// that [`PortUse::Reuse`] actually reused a port. A good example is the case
-        /// where there is no listener available to reuse a port from.
+        /// The port use is implemented on a best-effort basis. It is not
+        /// guaranteed that [`PortUse::Reuse`] actually reused a port. A
+        /// good example is the case where there is no listener
+        /// available to reuse a port from.
         port_use: PortUse,
     },
     /// We received the node.
@@ -153,10 +155,11 @@ impl ConnectedPoint {
 
     /// Returns the address of the remote stored in this struct.
     ///
-    /// For `Dialer`, this returns `address`. For `Listener`, this returns `send_back_addr`.
+    /// For `Dialer`, this returns `address`. For `Listener`, this returns
+    /// `send_back_addr`.
     ///
-    /// Note that the remote node might not be listening on this address and hence the address might
-    /// not be usable to establish new connections.
+    /// Note that the remote node might not be listening on this address and
+    /// hence the address might not be usable to establish new connections.
     pub fn get_remote_address(&self) -> &Multiaddr {
         match self {
             ConnectedPoint::Dialer { address, .. } => address,
@@ -166,7 +169,8 @@ impl ConnectedPoint {
 
     /// Modifies the address of the remote stored in this struct.
     ///
-    /// For `Dialer`, this modifies `address`. For `Listener`, this modifies `send_back_addr`.
+    /// For `Dialer`, this modifies `address`. For `Listener`, this modifies
+    /// `send_back_addr`.
     pub fn set_remote_address(&mut self, new_address: Multiaddr) {
         match self {
             ConnectedPoint::Dialer { address, .. } => *address = new_address,

--- a/core/src/either.rs
+++ b/core/src/either.rs
@@ -18,17 +18,20 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::muxing::StreamMuxerEvent;
-use crate::transport::DialOpts;
-use crate::{
-    muxing::StreamMuxer,
-    transport::{ListenerId, Transport, TransportError, TransportEvent},
-    Multiaddr,
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
 };
+
 use either::Either;
 use futures::prelude::*;
 use pin_project::pin_project;
-use std::{pin::Pin, task::Context, task::Poll};
+
+use crate::{
+    muxing::{StreamMuxer, StreamMuxerEvent},
+    transport::{DialOpts, ListenerId, Transport, TransportError, TransportEvent},
+    Multiaddr,
+};
 
 impl<A, B> StreamMuxer for future::Either<A, B>
 where
@@ -88,7 +91,8 @@ where
     }
 }
 
-/// Implements `Future` and dispatches all method calls to either `First` or `Second`.
+/// Implements `Future` and dispatches all method calls to either `First` or
+/// `Second`.
 #[pin_project(project = EitherFutureProj)]
 #[derive(Debug, Copy, Clone)]
 #[must_use = "futures do nothing unless polled"]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -28,8 +28,8 @@
 //!   to a remote and can subdivide this connection into multiple substreams.
 //!   See the [`muxing`] module.
 //! - The [`UpgradeInfo`], [`InboundUpgrade`] and [`OutboundUpgrade`] traits
-//!   define how to upgrade each individual substream to use a protocol.
-//!   See the `upgrade` module.
+//!   define how to upgrade each individual substream to use a protocol. See the
+//!   `upgrade` module.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
@@ -37,7 +37,8 @@ mod proto {
     #![allow(unreachable_pub)]
     include!("generated/mod.rs");
     pub use self::{
-        envelope_proto::*, peer_record_proto::mod_PeerRecord::*, peer_record_proto::PeerRecord,
+        envelope_proto::*,
+        peer_record_proto::{mod_PeerRecord::*, PeerRecord},
     };
 }
 

--- a/core/src/muxing/boxed.rs
+++ b/core/src/muxing/boxed.rs
@@ -1,12 +1,16 @@
-use crate::muxing::{StreamMuxer, StreamMuxerEvent};
+use std::{
+    error::Error,
+    fmt,
+    io,
+    io::{IoSlice, IoSliceMut},
+    pin::Pin,
+    task::{Context, Poll},
+};
+
 use futures::{AsyncRead, AsyncWrite};
 use pin_project::pin_project;
-use std::error::Error;
-use std::fmt;
-use std::io;
-use std::io::{IoSlice, IoSliceMut};
-use std::pin::Pin;
-use std::task::{Context, Poll};
+
+use crate::muxing::{StreamMuxer, StreamMuxerEvent};
 
 /// Abstract `StreamMuxer`.
 pub struct StreamMuxerBox {
@@ -21,8 +25,8 @@ impl fmt::Debug for StreamMuxerBox {
 
 /// Abstract type for asynchronous reading and writing.
 ///
-/// A [`SubstreamBox`] erases the concrete type it is given and only retains its `AsyncRead`
-/// and `AsyncWrite` capabilities.
+/// A [`SubstreamBox`] erases the concrete type it is given and only retains its
+/// `AsyncRead` and `AsyncWrite` capabilities.
 pub struct SubstreamBox(Pin<Box<dyn AsyncReadWrite + Send>>);
 
 #[pin_project]
@@ -139,7 +143,8 @@ impl StreamMuxer for StreamMuxerBox {
 }
 
 impl SubstreamBox {
-    /// Construct a new [`SubstreamBox`] from something that implements [`AsyncRead`] and [`AsyncWrite`].
+    /// Construct a new [`SubstreamBox`] from something that implements
+    /// [`AsyncRead`] and [`AsyncWrite`].
     pub fn new<S: AsyncRead + AsyncWrite + Send + 'static>(stream: S) -> Self {
         Self(Box::pin(stream))
     }
@@ -155,7 +160,8 @@ impl fmt::Debug for SubstreamBox {
 trait AsyncReadWrite: AsyncRead + AsyncWrite {
     /// Helper function to capture the erased inner type.
     ///
-    /// Used to make the [`Debug`] implementation of [`SubstreamBox`] more useful.
+    /// Used to make the [`Debug`] implementation of [`SubstreamBox`] more
+    /// useful.
     fn type_name(&self) -> &'static str;
 }
 

--- a/core/src/peer_record.rs
+++ b/core/src/peer_record.rs
@@ -1,18 +1,16 @@
-use crate::signed_envelope::SignedEnvelope;
-use crate::{proto, signed_envelope, DecodeError, Multiaddr};
-use libp2p_identity::Keypair;
-use libp2p_identity::PeerId;
-use libp2p_identity::SigningError;
+use libp2p_identity::{Keypair, PeerId, SigningError};
 use quick_protobuf::{BytesReader, Writer};
 use web_time::SystemTime;
+
+use crate::{proto, signed_envelope, signed_envelope::SignedEnvelope, DecodeError, Multiaddr};
 
 const PAYLOAD_TYPE: &str = "/libp2p/routing-state-record";
 const DOMAIN_SEP: &str = "libp2p-routing-state";
 
 /// Represents a peer routing record.
 ///
-/// Peer records are designed to be distributable and carry a signature by being wrapped in a signed envelope.
-/// For more information see RFC0003 of the libp2p specifications: <https://github.com/libp2p/specs/blob/master/RFC/0003-routing-records.md>
+/// Peer records are designed to be distributable and carry a signature by being
+/// wrapped in a signed envelope. For more information see RFC0003 of the libp2p specifications: <https://github.com/libp2p/specs/blob/master/RFC/0003-routing-records.md>
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct PeerRecord {
     peer_id: PeerId,
@@ -21,14 +19,16 @@ pub struct PeerRecord {
 
     /// A signed envelope representing this [`PeerRecord`].
     ///
-    /// If this [`PeerRecord`] was constructed from a [`SignedEnvelope`], this is the original instance.
+    /// If this [`PeerRecord`] was constructed from a [`SignedEnvelope`], this
+    /// is the original instance.
     envelope: SignedEnvelope,
 }
 
 impl PeerRecord {
     /// Attempt to re-construct a [`PeerRecord`] from a [`SignedEnvelope`].
     ///
-    /// If this function succeeds, the [`SignedEnvelope`] contained a peer record with a valid signature and can hence be considered authenticated.
+    /// If this function succeeds, the [`SignedEnvelope`] contained a peer
+    /// record with a valid signature and can hence be considered authenticated.
     pub fn from_signed_envelope(envelope: SignedEnvelope) -> Result<Self, FromEnvelopeError> {
         use quick_protobuf::MessageRead;
 
@@ -58,9 +58,12 @@ impl PeerRecord {
         })
     }
 
-    /// Construct a new [`PeerRecord`] by authenticating the provided addresses with the given key.
+    /// Construct a new [`PeerRecord`] by authenticating the provided addresses
+    /// with the given key.
     ///
-    /// This is the same key that is used for authenticating every libp2p connection of your application, i.e. what you use when setting up your [`crate::transport::Transport`].
+    /// This is the same key that is used for authenticating every libp2p
+    /// connection of your application, i.e. what you use when setting up your
+    /// [`crate::transport::Transport`].
     pub fn new(key: &Keypair, addresses: Vec<Multiaddr>) -> Result<Self, SigningError> {
         use quick_protobuf::MessageWrite;
 

--- a/core/src/signed_envelope.rs
+++ b/core/src/signed_envelope.rs
@@ -1,11 +1,13 @@
-use crate::{proto, DecodeError};
-use libp2p_identity::SigningError;
-use libp2p_identity::{Keypair, PublicKey};
-use quick_protobuf::{BytesReader, Writer};
 use std::fmt;
+
+use libp2p_identity::{Keypair, PublicKey, SigningError};
+use quick_protobuf::{BytesReader, Writer};
 use unsigned_varint::encode::usize_buffer;
 
-/// A signed envelope contains an arbitrary byte string payload, a signature of the payload, and the public key that can be used to verify the signature.
+use crate::{proto, DecodeError};
+
+/// A signed envelope contains an arbitrary byte string payload, a signature of
+/// the payload, and the public key that can be used to verify the signature.
 ///
 /// For more details see libp2p RFC0002: <https://github.com/libp2p/specs/blob/master/RFC/0002-signed-envelopes.md>
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -36,7 +38,8 @@ impl SignedEnvelope {
         })
     }
 
-    /// Verify this [`SignedEnvelope`] against the provided domain-separation string.
+    /// Verify this [`SignedEnvelope`] against the provided domain-separation
+    /// string.
     #[must_use]
     pub fn verify(&self, domain_separation: String) -> bool {
         let buffer = signature_payload(domain_separation, &self.payload_type, &self.payload);
@@ -46,8 +49,10 @@ impl SignedEnvelope {
 
     /// Extract the payload and signing key of this [`SignedEnvelope`].
     ///
-    /// You must provide the correct domain-separation string and expected payload type in order to get the payload.
-    /// This guards against accidental mis-use of the payload where the signature was created for a different purpose or payload type.
+    /// You must provide the correct domain-separation string and expected
+    /// payload type in order to get the payload. This guards against
+    /// accidental mis-use of the payload where the signature was created for a
+    /// different purpose or payload type.
     ///
     /// It is the caller's responsibility to check that the signing key is what
     /// is expected. For example, checking that the signing key is from a
@@ -71,7 +76,8 @@ impl SignedEnvelope {
         Ok((&self.payload, &self.key))
     }
 
-    /// Encode this [`SignedEnvelope`] using the protobuf encoding specified in the RFC.
+    /// Encode this [`SignedEnvelope`] using the protobuf encoding specified in
+    /// the RFC.
     pub fn into_protobuf_encoding(self) -> Vec<u8> {
         use quick_protobuf::MessageWrite;
 
@@ -92,7 +98,8 @@ impl SignedEnvelope {
         buf
     }
 
-    /// Decode a [`SignedEnvelope`] using the protobuf encoding specified in the RFC.
+    /// Decode a [`SignedEnvelope`] using the protobuf encoding specified in the
+    /// RFC.
     pub fn from_protobuf_encoding(bytes: &[u8]) -> Result<Self, DecodingError> {
         use quick_protobuf::MessageRead;
 
@@ -139,16 +146,19 @@ fn signature_payload(domain_separation: String, payload_type: &[u8], payload: &[
     buffer
 }
 
-/// Errors that occur whilst decoding a [`SignedEnvelope`] from its byte representation.
+/// Errors that occur whilst decoding a [`SignedEnvelope`] from its byte
+/// representation.
 #[derive(thiserror::Error, Debug)]
 pub enum DecodingError {
     /// Decoding the provided bytes as a signed envelope failed.
     #[error("Failed to decode envelope")]
     InvalidEnvelope(#[from] DecodeError),
-    /// The public key in the envelope could not be converted to our internal public key type.
+    /// The public key in the envelope could not be converted to our internal
+    /// public key type.
     #[error("Failed to convert public key")]
     InvalidPublicKey(#[from] libp2p_identity::DecodingError),
-    /// The public key in the envelope could not be converted to our internal public key type.
+    /// The public key in the envelope could not be converted to our internal
+    /// public key type.
     #[error("Public key is missing from protobuf struct")]
     MissingPublicKey,
 }
@@ -156,7 +166,8 @@ pub enum DecodingError {
 /// Errors that occur whilst extracting the payload of a [`SignedEnvelope`].
 #[derive(Debug)]
 pub enum ReadPayloadError {
-    /// The signature on the signed envelope does not verify with the provided domain separation string.
+    /// The signature on the signed envelope does not verify with the provided
+    /// domain separation string.
     InvalidSignature,
     /// The payload contained in the envelope is not of the expected type.
     UnexpectedPayloadType { expected: Vec<u8>, got: Vec<u8> },

--- a/core/src/transport/and_then.rs
+++ b/core/src/transport/and_then.rs
@@ -18,14 +18,21 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::{
+    error,
+    marker::PhantomPinned,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use either::Either;
+use futures::prelude::*;
+use multiaddr::Multiaddr;
+
 use crate::{
     connection::ConnectedPoint,
     transport::{DialOpts, ListenerId, Transport, TransportError, TransportEvent},
 };
-use either::Either;
-use futures::prelude::*;
-use multiaddr::Multiaddr;
-use std::{error, marker::PhantomPinned, pin::Pin, task::Context, task::Poll};
 
 /// See the [`Transport::and_then`] method.
 #[pin_project::pin_project]

--- a/core/src/transport/boxed.rs
+++ b/core/src/transport/boxed.rs
@@ -18,15 +18,18 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::transport::{DialOpts, ListenerId, Transport, TransportError, TransportEvent};
-use futures::{prelude::*, stream::FusedStream};
-use multiaddr::Multiaddr;
 use std::{
     error::Error,
-    fmt, io,
+    fmt,
+    io,
     pin::Pin,
     task::{Context, Poll},
 };
+
+use futures::{prelude::*, stream::FusedStream};
+use multiaddr::Multiaddr;
+
+use crate::transport::{DialOpts, ListenerId, Transport, TransportError, TransportEvent};
 
 /// Creates a new [`Boxed`] transport from the given transport.
 pub(crate) fn boxed<T>(transport: T) -> Boxed<T::Output>

--- a/core/src/transport/choice.rs
+++ b/core/src/transport/choice.rs
@@ -18,12 +18,19 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::either::EitherFuture;
-use crate::transport::{DialOpts, ListenerId, Transport, TransportError, TransportEvent};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
 use either::Either;
 use futures::future;
 use multiaddr::Multiaddr;
-use std::{pin::Pin, task::Context, task::Poll};
+
+use crate::{
+    either::EitherFuture,
+    transport::{DialOpts, ListenerId, Transport, TransportError, TransportEvent},
+};
 
 /// Struct returned by `or_transport()`.
 #[derive(Debug, Copy, Clone)]

--- a/core/src/transport/dummy.rs
+++ b/core/src/transport/dummy.rs
@@ -18,14 +18,22 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::transport::{DialOpts, ListenerId, Transport, TransportError, TransportEvent};
-use crate::Multiaddr;
-use futures::{prelude::*, task::Context, task::Poll};
 use std::{fmt, io, marker::PhantomData, pin::Pin};
+
+use futures::{
+    prelude::*,
+    task::{Context, Poll},
+};
+
+use crate::{
+    transport::{DialOpts, ListenerId, Transport, TransportError, TransportEvent},
+    Multiaddr,
+};
 
 /// Implementation of `Transport` that doesn't support any multiaddr.
 ///
-/// Useful for testing purposes, or as a fallback implementation when no protocol is available.
+/// Useful for testing purposes, or as a fallback implementation when no
+/// protocol is available.
 pub struct DummyTransport<TOut = DummyStream>(PhantomData<TOut>);
 
 impl<TOut> DummyTransport<TOut> {
@@ -87,7 +95,8 @@ impl<TOut> Transport for DummyTransport<TOut> {
     }
 }
 
-/// Implementation of `AsyncRead` and `AsyncWrite`. Not meant to be instantiated.
+/// Implementation of `AsyncRead` and `AsyncWrite`. Not meant to be
+/// instantiated.
 pub struct DummyStream(());
 
 impl fmt::Debug for DummyStream {

--- a/core/src/transport/global_only.rs
+++ b/core/src/transport/global_only.rs
@@ -18,13 +18,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::{
-    multiaddr::{Multiaddr, Protocol},
-    transport::{DialOpts, ListenerId, TransportError, TransportEvent},
-};
 use std::{
     pin::Pin,
     task::{Context, Poll},
+};
+
+use crate::{
+    multiaddr::{Multiaddr, Protocol},
+    transport::{DialOpts, ListenerId, TransportError, TransportEvent},
 };
 
 /// Dropping all dial requests to non-global IP addresses.
@@ -33,7 +34,8 @@ pub struct Transport<T> {
     inner: T,
 }
 
-/// This module contains an implementation of the `is_global` IPv4 address space.
+/// This module contains an implementation of the `is_global` IPv4 address
+/// space.
 ///
 /// Credit for this implementation goes to the Rust standard library team.
 ///
@@ -41,9 +43,10 @@ pub struct Transport<T> {
 mod ipv4_global {
     use std::net::Ipv4Addr;
 
-    /// Returns [`true`] if this address is reserved by IANA for future use. [IETF RFC 1112]
-    /// defines the block of reserved addresses as `240.0.0.0/4`. This range normally includes the
-    /// broadcast address `255.255.255.255`, but this implementation explicitly excludes it, since
+    /// Returns [`true`] if this address is reserved by IANA for future use.
+    /// [IETF RFC 1112] defines the block of reserved addresses as
+    /// `240.0.0.0/4`. This range normally includes the broadcast address
+    /// `255.255.255.255`, but this implementation explicitly excludes it, since
     /// it is obviously not reserved for future use.
     ///
     /// [IETF RFC 1112]: https://tools.ietf.org/html/rfc1112
@@ -60,9 +63,10 @@ mod ipv4_global {
         a.octets()[0] & 240 == 240 && !a.is_broadcast()
     }
 
-    /// Returns [`true`] if this address part of the `198.18.0.0/15` range, which is reserved for
-    /// network devices benchmarking. This range is defined in [IETF RFC 2544] as `192.18.0.0`
-    /// through `198.19.255.255` but [errata 423] corrects it to `198.18.0.0/15`.
+    /// Returns [`true`] if this address part of the `198.18.0.0/15` range,
+    /// which is reserved for network devices benchmarking. This range is
+    /// defined in [IETF RFC 2544] as `192.18.0.0` through `198.19.255.255`
+    /// but [errata 423] corrects it to `198.18.0.0/15`.
     ///
     /// [IETF RFC 2544]: https://tools.ietf.org/html/rfc2544
     /// [errata 423]: https://www.rfc-editor.org/errata/eid423
@@ -72,8 +76,8 @@ mod ipv4_global {
         a.octets()[0] == 198 && (a.octets()[1] & 0xfe) == 18
     }
 
-    /// Returns [`true`] if this address is part of the Shared Address Space defined in
-    /// [IETF RFC 6598] (`100.64.0.0/10`).
+    /// Returns [`true`] if this address is part of the Shared Address Space
+    /// defined in [IETF RFC 6598] (`100.64.0.0/10`).
     ///
     /// [IETF RFC 6598]: https://tools.ietf.org/html/rfc6598
     #[must_use]
@@ -104,24 +108,32 @@ mod ipv4_global {
 
     /// Returns [`true`] if the address appears to be globally reachable
     /// as specified by the [IANA IPv4 Special-Purpose Address Registry].
-    /// Whether or not an address is practically reachable will depend on your network configuration.
+    /// Whether or not an address is practically reachable will depend on your
+    /// network configuration.
     ///
     /// Most IPv4 addresses are globally reachable;
     /// unless they are specifically defined as *not* globally reachable.
     ///
-    /// Non-exhaustive list of notable addresses that are not globally reachable:
+    /// Non-exhaustive list of notable addresses that are not globally
+    /// reachable:
     ///
-    /// - The [unspecified address] ([`is_unspecified`](Ipv4Addr::is_unspecified))
-    /// - Addresses reserved for private use ([`is_private`](Ipv4Addr::is_private))
-    /// - Addresses in the shared address space ([`is_shared`](Ipv4Addr::is_shared))
+    /// - The [unspecified address]
+    ///   ([`is_unspecified`](Ipv4Addr::is_unspecified))
+    /// - Addresses reserved for private use
+    ///   ([`is_private`](Ipv4Addr::is_private))
+    /// - Addresses in the shared address space
+    ///   ([`is_shared`](Ipv4Addr::is_shared))
     /// - Loopback addresses ([`is_loopback`](Ipv4Addr::is_loopback))
     /// - Link-local addresses ([`is_link_local`](Ipv4Addr::is_link_local))
-    /// - Addresses reserved for documentation ([`is_documentation`](Ipv4Addr::is_documentation))
-    /// - Addresses reserved for benchmarking ([`is_benchmarking`](Ipv4Addr::is_benchmarking))
+    /// - Addresses reserved for documentation
+    ///   ([`is_documentation`](Ipv4Addr::is_documentation))
+    /// - Addresses reserved for benchmarking
+    ///   ([`is_benchmarking`](Ipv4Addr::is_benchmarking))
     /// - Reserved addresses ([`is_reserved`](Ipv4Addr::is_reserved))
     /// - The [broadcast address] ([`is_broadcast`](Ipv4Addr::is_broadcast))
     ///
-    /// For the complete overview of which addresses are globally reachable, see the table at the [IANA IPv4 Special-Purpose Address Registry].
+    /// For the complete overview of which addresses are globally reachable, see
+    /// the table at the [IANA IPv4 Special-Purpose Address Registry].
     ///
     /// [IANA IPv4 Special-Purpose Address Registry]: https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
     /// [unspecified address]: Ipv4Addr::UNSPECIFIED
@@ -143,7 +155,8 @@ mod ipv4_global {
     }
 }
 
-/// This module contains an implementation of the `is_global` IPv6 address space.
+/// This module contains an implementation of the `is_global` IPv6 address
+/// space.
 ///
 /// Credit for this implementation goes to the Rust standard library team.
 ///
@@ -151,12 +164,14 @@ mod ipv4_global {
 mod ipv6_global {
     use std::net::Ipv6Addr;
 
-    /// Returns `true` if the address is a unicast address with link-local scope,
-    /// as defined in [RFC 4291].
+    /// Returns `true` if the address is a unicast address with link-local
+    /// scope, as defined in [RFC 4291].
     ///
-    /// A unicast address has link-local scope if it has the prefix `fe80::/10`, as per [RFC 4291 section 2.4].
-    /// Note that this encompasses more addresses than those defined in [RFC 4291 section 2.5.6],
-    /// which describes "Link-Local IPv6 Unicast Addresses" as having the following stricter format:
+    /// A unicast address has link-local scope if it has the prefix `fe80::/10`,
+    /// as per [RFC 4291 section 2.4]. Note that this encompasses more
+    /// addresses than those defined in [RFC 4291 section 2.5.6],
+    /// which describes "Link-Local IPv6 Unicast Addresses" as having the
+    /// following stricter format:
     ///
     /// ```text
     /// | 10 bits  |         54 bits         |          64 bits           |
@@ -164,12 +179,16 @@ mod ipv6_global {
     /// |1111111010|           0             |       interface ID         |
     /// +----------+-------------------------+----------------------------+
     /// ```
-    /// So while currently the only addresses with link-local scope an application will encounter are all in `fe80::/64`,
-    /// this might change in the future with the publication of new standards. More addresses in `fe80::/10` could be allocated,
-    /// and those addresses will have link-local scope.
+    /// So while currently the only addresses with link-local scope an
+    /// application will encounter are all in `fe80::/64`, this might change
+    /// in the future with the publication of new standards. More addresses in
+    /// `fe80::/10` could be allocated, and those addresses will have
+    /// link-local scope.
     ///
-    /// Also note that while [RFC 4291 section 2.5.3] mentions about the [loopback address] (`::1`) that "it is treated as having Link-Local scope",
-    /// this does not mean that the loopback address actually has link-local scope and this method will return `false` on it.
+    /// Also note that while [RFC 4291 section 2.5.3] mentions about the
+    /// [loopback address] (`::1`) that "it is treated as having Link-Local
+    /// scope", this does not mean that the loopback address actually has
+    /// link-local scope and this method will return `false` on it.
     ///
     /// [RFC 4291]: https://tools.ietf.org/html/rfc4291
     /// [RFC 4291 section 2.4]: https://tools.ietf.org/html/rfc4291#section-2.4
@@ -207,25 +226,33 @@ mod ipv6_global {
 
     /// Returns [`true`] if the address appears to be globally reachable
     /// as specified by the [IANA IPv6 Special-Purpose Address Registry].
-    /// Whether or not an address is practically reachable will depend on your network configuration.
+    /// Whether or not an address is practically reachable will depend on your
+    /// network configuration.
     ///
     /// Most IPv6 addresses are globally reachable;
     /// unless they are specifically defined as *not* globally reachable.
     ///
-    /// Non-exhaustive list of notable addresses that are not globally reachable:
-    /// - The [unspecified address] ([`is_unspecified`](Ipv6Addr::is_unspecified))
+    /// Non-exhaustive list of notable addresses that are not globally
+    /// reachable:
+    /// - The [unspecified address]
+    ///   ([`is_unspecified`](Ipv6Addr::is_unspecified))
     /// - The [loopback address] ([`is_loopback`](Ipv6Addr::is_loopback))
     /// - IPv4-mapped addresses
     /// - Addresses reserved for benchmarking
-    /// - Addresses reserved for documentation ([`is_documentation`](Ipv6Addr::is_documentation))
-    /// - Unique local addresses ([`is_unique_local`](Ipv6Addr::is_unique_local))
-    /// - Unicast addresses with link-local scope ([`is_unicast_link_local`](Ipv6Addr::is_unicast_link_local))
+    /// - Addresses reserved for documentation
+    ///   ([`is_documentation`](Ipv6Addr::is_documentation))
+    /// - Unique local addresses
+    ///   ([`is_unique_local`](Ipv6Addr::is_unique_local))
+    /// - Unicast addresses with link-local scope
+    ///   ([`is_unicast_link_local`](Ipv6Addr::is_unicast_link_local))
     ///
-    /// For the complete overview of which addresses are globally reachable, see the table at the [IANA IPv6 Special-Purpose Address Registry].
+    /// For the complete overview of which addresses are globally reachable, see
+    /// the table at the [IANA IPv6 Special-Purpose Address Registry].
     ///
-    /// Note that an address having global scope is not the same as being globally reachable,
-    /// and there is no direct relation between the two concepts: There exist addresses with global scope
-    /// that are not globally reachable (for example unique local addresses),
+    /// Note that an address having global scope is not the same as being
+    /// globally reachable, and there is no direct relation between the two
+    /// concepts: There exist addresses with global scope that are not
+    /// globally reachable (for example unique local addresses),
     /// and addresses that are globally reachable without having global scope
     /// (multicast addresses with non-global scope).
     ///

--- a/core/src/transport/map.rs
+++ b/core/src/transport/map.rs
@@ -18,16 +18,19 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::transport::DialOpts;
-use crate::{
-    connection::ConnectedPoint,
-    transport::{Transport, TransportError, TransportEvent},
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
 };
+
 use futures::prelude::*;
 use multiaddr::Multiaddr;
-use std::{pin::Pin, task::Context, task::Poll};
 
 use super::ListenerId;
+use crate::{
+    connection::ConnectedPoint,
+    transport::{DialOpts, Transport, TransportError, TransportEvent},
+};
 
 /// See `Transport::map`.
 #[derive(Debug, Copy, Clone)]

--- a/core/src/transport/map_err.rs
+++ b/core/src/transport/map_err.rs
@@ -18,10 +18,16 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::transport::{DialOpts, ListenerId, Transport, TransportError, TransportEvent};
+use std::{
+    error,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
 use futures::prelude::*;
 use multiaddr::Multiaddr;
-use std::{error, pin::Pin, task::Context, task::Poll};
+
+use crate::transport::{DialOpts, ListenerId, Transport, TransportError, TransportEvent};
 
 /// See `Transport::map_err`.
 #[derive(Debug, Copy, Clone)]

--- a/core/src/transport/optional.rs
+++ b/core/src/transport/optional.rs
@@ -18,16 +18,21 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::transport::{DialOpts, ListenerId, Transport, TransportError, TransportEvent};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
 use multiaddr::Multiaddr;
-use std::{pin::Pin, task::Context, task::Poll};
+
+use crate::transport::{DialOpts, ListenerId, Transport, TransportError, TransportEvent};
 
 /// Transport that is possibly disabled.
 ///
-/// An `OptionalTransport<T>` is a wrapper around an `Option<T>`. If it is disabled (read: contains
-/// `None`), then any attempt to dial or listen will return `MultiaddrNotSupported`. If it is
-/// enabled (read: contains `Some`), then dialing and listening will be handled by the inner
-/// transport.
+/// An `OptionalTransport<T>` is a wrapper around an `Option<T>`. If it is
+/// disabled (read: contains `None`), then any attempt to dial or listen will
+/// return `MultiaddrNotSupported`. If it is enabled (read: contains `Some`),
+/// then dialing and listening will be handled by the inner transport.
 #[derive(Debug, Copy, Clone)]
 #[pin_project::pin_project]
 pub struct OptionalTransport<T>(#[pin] Option<T>);

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -20,31 +20,43 @@
 
 //! Configuration of transport protocol upgrades.
 
-pub use crate::upgrade::Version;
-
-use crate::transport::DialOpts;
-use crate::{
-    connection::ConnectedPoint,
-    muxing::{StreamMuxer, StreamMuxerBox},
-    transport::{
-        and_then::AndThen, boxed::boxed, timeout::TransportTimeout, ListenerId, Transport,
-        TransportError, TransportEvent,
-    },
-    upgrade::{
-        self, apply_inbound, apply_outbound, InboundConnectionUpgrade, InboundUpgradeApply,
-        OutboundConnectionUpgrade, OutboundUpgradeApply, UpgradeError,
-    },
-    Negotiated,
-};
-use futures::{prelude::*, ready};
-use libp2p_identity::PeerId;
-use multiaddr::Multiaddr;
 use std::{
     error::Error,
     fmt,
     pin::Pin,
     task::{Context, Poll},
     time::Duration,
+};
+
+use futures::{prelude::*, ready};
+use libp2p_identity::PeerId;
+use multiaddr::Multiaddr;
+
+pub use crate::upgrade::Version;
+use crate::{
+    connection::ConnectedPoint,
+    muxing::{StreamMuxer, StreamMuxerBox},
+    transport::{
+        and_then::AndThen,
+        boxed::boxed,
+        timeout::TransportTimeout,
+        DialOpts,
+        ListenerId,
+        Transport,
+        TransportError,
+        TransportEvent,
+    },
+    upgrade::{
+        self,
+        apply_inbound,
+        apply_outbound,
+        InboundConnectionUpgrade,
+        InboundUpgradeApply,
+        OutboundConnectionUpgrade,
+        OutboundUpgradeApply,
+        UpgradeError,
+    },
+    Negotiated,
 };
 
 /// A `Builder` facilitates upgrading of a [`Transport`] for use with
@@ -59,8 +71,8 @@ use std::{
 /// It thus enforces the following invariants on every transport
 /// obtained from [`multiplex`](Authenticated::multiplex):
 ///
-///   1. The transport must be [authenticated](Builder::authenticate)
-///      and [multiplexed](Authenticated::multiplex).
+///   1. The transport must be [authenticated](Builder::authenticate) and
+///      [multiplexed](Authenticated::multiplex).
 ///   2. Authentication must precede the negotiation of a multiplexer.
 ///   3. Applying a multiplexer is the last step in the upgrade process.
 ///   4. The [`Transport::Output`] conforms to the requirements of a `Swarm`,
@@ -185,7 +197,8 @@ where
     }
 }
 
-/// An transport with peer authentication, obtained from [`Builder::authenticate`].
+/// An transport with peer authentication, obtained from
+/// [`Builder::authenticate`].
 #[derive(Clone)]
 pub struct Authenticated<T>(Builder<T>);
 
@@ -222,8 +235,8 @@ where
     /// Upgrades the transport with a (sub)stream multiplexer.
     ///
     /// The supplied upgrade receives the I/O resource `C` and must
-    /// produce a [`StreamMuxer`] `M`. The transport must already be authenticated.
-    /// This ends the (regular) transport upgrade process.
+    /// produce a [`StreamMuxer`] `M`. The transport must already be
+    /// authenticated. This ends the (regular) transport upgrade process.
     ///
     /// ## Transitions
     ///
@@ -251,12 +264,13 @@ where
         }))
     }
 
-    /// Like [`Authenticated::multiplex`] but accepts a function which returns the upgrade.
+    /// Like [`Authenticated::multiplex`] but accepts a function which returns
+    /// the upgrade.
     ///
     /// The supplied function is applied to [`PeerId`] and [`ConnectedPoint`]
     /// and returns an upgrade which receives the I/O resource `C` and must
-    /// produce a [`StreamMuxer`] `M`. The transport must already be authenticated.
-    /// This ends the (regular) transport upgrade process.
+    /// produce a [`StreamMuxer`] `M`. The transport must already be
+    /// authenticated. This ends the (regular) transport upgrade process.
     ///
     /// ## Transitions
     ///
@@ -499,8 +513,8 @@ where
     type Output = Result<(PeerId, D), TransportUpgradeError<F::Error, U::Error>>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // We use a `this` variable because the compiler can't mutably borrow multiple times
-        // across a `Deref`.
+        // We use a `this` variable because the compiler can't mutably borrow multiple
+        // times across a `Deref`.
         let this = &mut *self;
 
         loop {
@@ -558,8 +572,8 @@ where
     type Output = Result<(PeerId, D), TransportUpgradeError<F::Error, U::Error>>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // We use a `this` variable because the compiler can't mutably borrow multiple times
-        // across a `Deref`.
+        // We use a `this` variable because the compiler can't mutably borrow multiple
+        // times across a `Deref`.
         let this = &mut *self;
 
         loop {

--- a/core/src/upgrade.rs
+++ b/core/src/upgrade.rs
@@ -18,44 +18,51 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! Contains everything related to upgrading a connection or a substream to use a protocol.
+//! Contains everything related to upgrading a connection or a substream to use
+//! a protocol.
 //!
-//! After a connection with a remote has been successfully established or a substream successfully
-//! opened, the next step is to *upgrade* this connection or substream to use a protocol.
+//! After a connection with a remote has been successfully established or a
+//! substream successfully opened, the next step is to *upgrade* this connection
+//! or substream to use a protocol.
 //!
-//! This is where the `UpgradeInfo`, `InboundUpgrade` and `OutboundUpgrade` traits come into play.
-//! The `InboundUpgrade` and `OutboundUpgrade` traits are implemented on types that represent a
-//! collection of one or more possible protocols for respectively an ingoing or outgoing
-//! connection or substream.
+//! This is where the `UpgradeInfo`, `InboundUpgrade` and `OutboundUpgrade`
+//! traits come into play. The `InboundUpgrade` and `OutboundUpgrade` traits are
+//! implemented on types that represent a collection of one or more possible
+//! protocols for respectively an ingoing or outgoing connection or substream.
 //!
-//! > **Note**: Multiple versions of the same protocol are treated as different protocols.
-//! >           For example, `/foo/1.0.0` and `/foo/1.1.0` are totally unrelated as far as
-//! >           upgrading is concerned.
+//! > **Note**: Multiple versions of the same protocol are treated as different
+//! > protocols.
+//! > For example, `/foo/1.0.0` and `/foo/1.1.0` are totally unrelated as far as
+//! > upgrading is concerned.
 //!
 //! # Upgrade process
 //!
 //! An upgrade is performed in two steps:
 //!
-//! - A protocol negotiation step. The `UpgradeInfo::protocol_info` method is called to determine
-//!   which protocols are supported by the trait implementation. The `multistream-select` protocol
-//!   is used in order to agree on which protocol to use amongst the ones supported.
+//! - A protocol negotiation step. The `UpgradeInfo::protocol_info` method is
+//!   called to determine which protocols are supported by the trait
+//!   implementation. The `multistream-select` protocol is used in order to
+//!   agree on which protocol to use amongst the ones supported.
 //!
-//! - A handshake. After a successful negotiation, the `InboundUpgrade::upgrade_inbound` or
-//!   `OutboundUpgrade::upgrade_outbound` method is called. This method will return a `Future` that
-//!   performs a handshake. This handshake is considered mandatory, however in practice it is
-//!   possible for the trait implementation to return a dummy `Future` that doesn't perform any
-//!   action and immediately succeeds.
+//! - A handshake. After a successful negotiation, the
+//!   `InboundUpgrade::upgrade_inbound` or `OutboundUpgrade::upgrade_outbound`
+//!   method is called. This method will return a `Future` that performs a
+//!   handshake. This handshake is considered mandatory, however in practice it
+//!   is possible for the trait implementation to return a dummy `Future` that
+//!   doesn't perform any action and immediately succeeds.
 //!
-//! After an upgrade is successful, an object of type `InboundUpgrade::Output` or
-//! `OutboundUpgrade::Output` is returned. The actual object depends on the implementation and
-//! there is no constraint on the traits that it should implement, however it is expected that it
-//! can be used by the user to control the behaviour of the protocol.
+//! After an upgrade is successful, an object of type `InboundUpgrade::Output`
+//! or `OutboundUpgrade::Output` is returned. The actual object depends on the
+//! implementation and there is no constraint on the traits that it should
+//! implement, however it is expected that it can be used by the user to control
+//! the behaviour of the protocol.
 //!
-//! > **Note**: You can use the `apply_inbound` or `apply_outbound` methods to try upgrade a
+//! > **Note**: You can use the `apply_inbound` or `apply_outbound` methods to
+//! > try upgrade a
 //! > connection or substream. However if you use the recommended `Swarm` or
-//! > `ConnectionHandler` APIs, the upgrade is automatically handled for you and you don't
+//! > `ConnectionHandler` APIs, the upgrade is automatically handled for you and
+//! > you don't
 //! > need to use these methods.
-//!
 
 mod apply;
 mod denied;
@@ -66,89 +73,105 @@ mod ready;
 mod select;
 
 pub(crate) use apply::{
-    apply, apply_inbound, apply_outbound, InboundUpgradeApply, OutboundUpgradeApply,
+    apply,
+    apply_inbound,
+    apply_outbound,
+    InboundUpgradeApply,
+    OutboundUpgradeApply,
 };
 pub(crate) use error::UpgradeError;
 use futures::future::Future;
-
-pub use self::{
-    denied::DeniedUpgrade, pending::PendingUpgrade, ready::ReadyUpgrade, select::SelectUpgrade,
-};
-pub use crate::Negotiated;
 pub use multistream_select::{NegotiatedComplete, NegotiationError, ProtocolError, Version};
 
-/// Common trait for upgrades that can be applied on inbound substreams, outbound substreams,
-/// or both.
+pub use self::{
+    denied::DeniedUpgrade,
+    pending::PendingUpgrade,
+    ready::ReadyUpgrade,
+    select::SelectUpgrade,
+};
+pub use crate::Negotiated;
+
+/// Common trait for upgrades that can be applied on inbound substreams,
+/// outbound substreams, or both.
 pub trait UpgradeInfo {
     /// Opaque type representing a negotiable protocol.
     type Info: AsRef<str> + Clone;
     /// Iterator returned by `protocol_info`.
     type InfoIter: IntoIterator<Item = Self::Info>;
 
-    /// Returns the list of protocols that are supported. Used during the negotiation process.
+    /// Returns the list of protocols that are supported. Used during the
+    /// negotiation process.
     fn protocol_info(&self) -> Self::InfoIter;
 }
 
 /// Possible upgrade on an inbound connection or substream.
 pub trait InboundUpgrade<C>: UpgradeInfo {
-    /// Output after the upgrade has been successfully negotiated and the handshake performed.
+    /// Output after the upgrade has been successfully negotiated and the
+    /// handshake performed.
     type Output;
     /// Possible error during the handshake.
     type Error;
     /// Future that performs the handshake with the remote.
     type Future: Future<Output = Result<Self::Output, Self::Error>>;
 
-    /// After we have determined that the remote supports one of the protocols we support, this
-    /// method is called to start the handshake.
+    /// After we have determined that the remote supports one of the protocols
+    /// we support, this method is called to start the handshake.
     ///
-    /// The `info` is the identifier of the protocol, as produced by `protocol_info`.
+    /// The `info` is the identifier of the protocol, as produced by
+    /// `protocol_info`.
     fn upgrade_inbound(self, socket: C, info: Self::Info) -> Self::Future;
 }
 
 /// Possible upgrade on an outbound connection or substream.
 pub trait OutboundUpgrade<C>: UpgradeInfo {
-    /// Output after the upgrade has been successfully negotiated and the handshake performed.
+    /// Output after the upgrade has been successfully negotiated and the
+    /// handshake performed.
     type Output;
     /// Possible error during the handshake.
     type Error;
     /// Future that performs the handshake with the remote.
     type Future: Future<Output = Result<Self::Output, Self::Error>>;
 
-    /// After we have determined that the remote supports one of the protocols we support, this
-    /// method is called to start the handshake.
+    /// After we have determined that the remote supports one of the protocols
+    /// we support, this method is called to start the handshake.
     ///
-    /// The `info` is the identifier of the protocol, as produced by `protocol_info`.
+    /// The `info` is the identifier of the protocol, as produced by
+    /// `protocol_info`.
     fn upgrade_outbound(self, socket: C, info: Self::Info) -> Self::Future;
 }
 
 /// Possible upgrade on an inbound connection
 pub trait InboundConnectionUpgrade<T>: UpgradeInfo {
-    /// Output after the upgrade has been successfully negotiated and the handshake performed.
+    /// Output after the upgrade has been successfully negotiated and the
+    /// handshake performed.
     type Output;
     /// Possible error during the handshake.
     type Error;
     /// Future that performs the handshake with the remote.
     type Future: Future<Output = Result<Self::Output, Self::Error>>;
 
-    /// After we have determined that the remote supports one of the protocols we support, this
-    /// method is called to start the handshake.
+    /// After we have determined that the remote supports one of the protocols
+    /// we support, this method is called to start the handshake.
     ///
-    /// The `info` is the identifier of the protocol, as produced by `protocol_info`.
+    /// The `info` is the identifier of the protocol, as produced by
+    /// `protocol_info`.
     fn upgrade_inbound(self, socket: T, info: Self::Info) -> Self::Future;
 }
 
 /// Possible upgrade on an outbound connection
 pub trait OutboundConnectionUpgrade<T>: UpgradeInfo {
-    /// Output after the upgrade has been successfully negotiated and the handshake performed.
+    /// Output after the upgrade has been successfully negotiated and the
+    /// handshake performed.
     type Output;
     /// Possible error during the handshake.
     type Error;
     /// Future that performs the handshake with the remote.
     type Future: Future<Output = Result<Self::Output, Self::Error>>;
 
-    /// After we have determined that the remote supports one of the protocols we support, this
-    /// method is called to start the handshake.
+    /// After we have determined that the remote supports one of the protocols
+    /// we support, this method is called to start the handshake.
     ///
-    /// The `info` is the identifier of the protocol, as produced by `protocol_info`.
+    /// The `info` is the identifier of the protocol, as produced by
+    /// `protocol_info`.
     fn upgrade_outbound(self, socket: T, info: Self::Info) -> Self::Future;
 }

--- a/core/src/upgrade/apply.rs
+++ b/core/src/upgrade/apply.rs
@@ -18,16 +18,25 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade, UpgradeError};
-use crate::{connection::ConnectedPoint, Negotiated};
-use futures::{future::Either, prelude::*};
-use multistream_select::{DialerSelectFuture, ListenerSelectFuture};
-use std::{mem, pin::Pin, task::Context, task::Poll};
+use std::{
+    mem,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
+use futures::{future::Either, prelude::*};
 pub(crate) use multistream_select::Version;
+use multistream_select::{DialerSelectFuture, ListenerSelectFuture};
+
+use crate::{
+    connection::ConnectedPoint,
+    upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade, UpgradeError},
+    Negotiated,
+};
 
 // TODO: Still needed?
-/// Applies an upgrade to the inbound and outbound direction of a connection or substream.
+/// Applies an upgrade to the inbound and outbound direction of a connection or
+/// substream.
 pub(crate) fn apply<C, U>(
     conn: C,
     up: U,

--- a/core/src/upgrade/denied.rs
+++ b/core/src/upgrade/denied.rs
@@ -18,13 +18,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
-use futures::future;
-use std::convert::Infallible;
-use std::iter;
+use std::{convert::Infallible, iter};
 
-/// Dummy implementation of `UpgradeInfo`/`InboundUpgrade`/`OutboundUpgrade` that doesn't support
-/// any protocol.
+use futures::future;
+
+use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
+
+/// Dummy implementation of `UpgradeInfo`/`InboundUpgrade`/`OutboundUpgrade`
+/// that doesn't support any protocol.
 #[derive(Debug, Copy, Clone)]
 pub struct DeniedUpgrade;
 

--- a/core/src/upgrade/either.rs
+++ b/core/src/upgrade/either.rs
@@ -18,13 +18,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::iter::Map;
+
+use either::Either;
+use futures::future;
+
 use crate::{
     either::EitherFuture,
     upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo},
 };
-use either::Either;
-use futures::future;
-use std::iter::Map;
 
 impl<A, B> UpgradeInfo for Either<A, B>
 where

--- a/core/src/upgrade/error.rs
+++ b/core/src/upgrade/error.rs
@@ -18,10 +18,12 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use multistream_select::NegotiationError;
 use std::fmt;
 
-/// Error that can happen when upgrading a connection or substream to use a protocol.
+use multistream_select::NegotiationError;
+
+/// Error that can happen when upgrading a connection or substream to use a
+/// protocol.
 #[derive(Debug)]
 pub enum UpgradeError<E> {
     /// Error during the negotiation process.

--- a/core/src/upgrade/pending.rs
+++ b/core/src/upgrade/pending.rs
@@ -19,13 +19,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
-use futures::future;
-use std::convert::Infallible;
-use std::iter;
+use std::{convert::Infallible, iter};
 
-/// Implementation of [`UpgradeInfo`], [`InboundUpgrade`] and [`OutboundUpgrade`] that always
-/// returns a pending upgrade.
+use futures::future;
+
+use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
+
+/// Implementation of [`UpgradeInfo`], [`InboundUpgrade`] and
+/// [`OutboundUpgrade`] that always returns a pending upgrade.
 #[derive(Debug, Copy, Clone)]
 pub struct PendingUpgrade<P> {
     protocol_name: P,

--- a/core/src/upgrade/ready.rs
+++ b/core/src/upgrade/ready.rs
@@ -19,12 +19,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
-use futures::future;
-use std::convert::Infallible;
-use std::iter;
+use std::{convert::Infallible, iter};
 
-/// Implementation of [`UpgradeInfo`], [`InboundUpgrade`] and [`OutboundUpgrade`] that directly yields the substream.
+use futures::future;
+
+use crate::upgrade::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
+
+/// Implementation of [`UpgradeInfo`], [`InboundUpgrade`] and
+/// [`OutboundUpgrade`] that directly yields the substream.
 #[derive(Debug, Copy, Clone)]
 pub struct ReadyUpgrade<P> {
     protocol_name: P,

--- a/core/src/upgrade/select.rs
+++ b/core/src/upgrade/select.rs
@@ -18,17 +18,24 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::either::EitherFuture;
-use crate::upgrade::{
-    InboundConnectionUpgrade, InboundUpgrade, OutboundConnectionUpgrade, OutboundUpgrade,
-    UpgradeInfo,
-};
-use either::Either;
-use futures::future;
 use std::iter::{Chain, Map};
 
-/// Upgrade that combines two upgrades into one. Supports all the protocols supported by either
-/// sub-upgrade.
+use either::Either;
+use futures::future;
+
+use crate::{
+    either::EitherFuture,
+    upgrade::{
+        InboundConnectionUpgrade,
+        InboundUpgrade,
+        OutboundConnectionUpgrade,
+        OutboundUpgrade,
+        UpgradeInfo,
+    },
+};
+
+/// Upgrade that combines two upgrades into one. Supports all the protocols
+/// supported by either sub-upgrade.
 ///
 /// The protocols supported by the first element have a higher priority.
 #[derive(Debug, Clone)]

--- a/core/tests/transport_upgrade.rs
+++ b/core/tests/transport_upgrade.rs
@@ -18,18 +18,19 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::{io, pin::Pin};
+
 use futures::prelude::*;
-use libp2p_core::transport::{DialOpts, ListenerId, MemoryTransport, PortUse, Transport};
-use libp2p_core::upgrade::{
-    self, InboundConnectionUpgrade, OutboundConnectionUpgrade, UpgradeInfo,
+use libp2p_core::{
+    transport::{DialOpts, ListenerId, MemoryTransport, PortUse, Transport},
+    upgrade::{self, InboundConnectionUpgrade, OutboundConnectionUpgrade, UpgradeInfo},
+    Endpoint,
 };
-use libp2p_core::Endpoint;
 use libp2p_identity as identity;
 use libp2p_mplex::MplexConfig;
 use libp2p_noise as noise;
 use multiaddr::{Multiaddr, Protocol};
 use rand::random;
-use std::{io, pin::Pin};
 
 #[derive(Clone)]
 struct HelloUpgrade {}

--- a/examples/autonat/src/bin/autonat_client.rs
+++ b/examples/autonat/src/bin/autonat_client.rs
@@ -20,15 +20,21 @@
 
 #![doc = include_str!("../../README.md")]
 
+use std::{error::Error, net::Ipv4Addr, time::Duration};
+
 use clap::Parser;
 use futures::StreamExt;
-use libp2p::core::multiaddr::Protocol;
-use libp2p::core::Multiaddr;
-use libp2p::swarm::{NetworkBehaviour, SwarmEvent};
-use libp2p::{autonat, identify, identity, noise, tcp, yamux, PeerId};
-use std::error::Error;
-use std::net::Ipv4Addr;
-use std::time::Duration;
+use libp2p::{
+    autonat,
+    core::{multiaddr::Protocol, Multiaddr},
+    identify,
+    identity,
+    noise,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    tcp,
+    yamux,
+    PeerId,
+};
 use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]

--- a/examples/autonat/src/bin/autonat_server.rs
+++ b/examples/autonat/src/bin/autonat_server.rs
@@ -20,14 +20,20 @@
 
 #![doc = include_str!("../../README.md")]
 
+use std::{error::Error, net::Ipv4Addr, time::Duration};
+
 use clap::Parser;
 use futures::StreamExt;
-use libp2p::core::{multiaddr::Protocol, Multiaddr};
-use libp2p::swarm::{NetworkBehaviour, SwarmEvent};
-use libp2p::{autonat, identify, identity, noise, tcp, yamux};
-use std::error::Error;
-use std::net::Ipv4Addr;
-use std::time::Duration;
+use libp2p::{
+    autonat,
+    core::{multiaddr::Protocol, Multiaddr},
+    identify,
+    identity,
+    noise,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    tcp,
+    yamux,
+};
 use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]

--- a/examples/autonatv2/src/bin/autonatv2_client.rs
+++ b/examples/autonatv2/src/bin/autonatv2_client.rs
@@ -4,11 +4,15 @@ use clap::Parser;
 use libp2p::{
     autonat,
     futures::StreamExt,
-    identify, identity,
+    identify,
+    identity,
     multiaddr::Protocol,
     noise,
     swarm::{dial_opts::DialOpts, NetworkBehaviour, SwarmEvent},
-    tcp, yamux, Multiaddr, SwarmBuilder,
+    tcp,
+    yamux,
+    Multiaddr,
+    SwarmBuilder,
 };
 use rand::rngs::OsRng;
 use tracing_subscriber::EnvFilter;
@@ -73,7 +77,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 bytes_sent,
                 result: Ok(()),
             })) => {
-                println!("Tested {tested_addr} with {server}. Sent {bytes_sent} bytes for verification. Everything Ok and verified.");
+                println!(
+                    "Tested {tested_addr} with {server}. Sent {bytes_sent} bytes for \
+                     verification. Everything Ok and verified."
+                );
             }
             SwarmEvent::Behaviour(BehaviourEvent::Autonat(autonat::v2::client::Event {
                 server,
@@ -81,7 +88,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 bytes_sent,
                 result: Err(e),
             })) => {
-                println!("Tested {tested_addr} with {server}. Sent {bytes_sent} bytes for verification. Failed with {e:?}.");
+                println!(
+                    "Tested {tested_addr} with {server}. Sent {bytes_sent} bytes for \
+                     verification. Failed with {e:?}."
+                );
             }
             SwarmEvent::ExternalAddrConfirmed { address } => {
                 println!("External address confirmed: {address}");

--- a/examples/autonatv2/src/bin/autonatv2_server.rs
+++ b/examples/autonatv2/src/bin/autonatv2_server.rs
@@ -5,11 +5,15 @@ use clap::Parser;
 use libp2p::{
     autonat,
     futures::StreamExt,
-    identify, identity,
+    identify,
+    identity,
     multiaddr::Protocol,
     noise,
     swarm::{NetworkBehaviour, SwarmEvent},
-    tcp, yamux, Multiaddr, SwarmBuilder,
+    tcp,
+    yamux,
+    Multiaddr,
+    SwarmBuilder,
 };
 use rand::rngs::OsRng;
 

--- a/examples/browser-webrtc/src/lib.rs
+++ b/examples/browser-webrtc/src/lib.rs
@@ -1,13 +1,11 @@
 #![cfg(target_arch = "wasm32")]
 
+use std::{io, time::Duration};
+
 use futures::StreamExt;
 use js_sys::Date;
-use libp2p::core::Multiaddr;
-use libp2p::ping;
-use libp2p::swarm::SwarmEvent;
+use libp2p::{core::Multiaddr, ping, swarm::SwarmEvent};
 use libp2p_webrtc_websys as webrtc_websys;
-use std::io;
-use std::time::Duration;
 use wasm_bindgen::prelude::*;
 use web_sys::{Document, HtmlElement};
 

--- a/examples/browser-webrtc/src/main.rs
+++ b/examples/browser-webrtc/src/main.rs
@@ -1,23 +1,27 @@
 #![allow(non_upper_case_globals)]
 
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    time::Duration,
+};
+
 use anyhow::Result;
-use axum::extract::{Path, State};
-use axum::http::header::CONTENT_TYPE;
-use axum::http::StatusCode;
-use axum::response::{Html, IntoResponse};
-use axum::{http::Method, routing::get, Router};
+use axum::{
+    extract::{Path, State},
+    http::{header::CONTENT_TYPE, Method, StatusCode},
+    response::{Html, IntoResponse},
+    routing::get,
+    Router,
+};
 use futures::StreamExt;
 use libp2p::{
-    core::muxing::StreamMuxerBox,
-    core::Transport,
+    core::{muxing::StreamMuxerBox, Transport},
     multiaddr::{Multiaddr, Protocol},
     ping,
     swarm::SwarmEvent,
 };
 use libp2p_webrtc as webrtc;
 use rand::thread_rng;
-use std::net::{Ipv4Addr, SocketAddr};
-use std::time::Duration;
 use tokio::net::TcpListener;
 use tower_http::cors::{Any, CorsLayer};
 
@@ -127,7 +131,8 @@ struct Libp2pEndpoint(Multiaddr);
 /// Serves the index.html file for our client.
 ///
 /// Our server listens on a random UDP port for the WebRTC transport.
-/// To allow the client to connect, we replace the `__LIBP2P_ENDPOINT__` placeholder with the actual address.
+/// To allow the client to connect, we replace the `__LIBP2P_ENDPOINT__`
+/// placeholder with the actual address.
 async fn get_index(
     State(Libp2pEndpoint(libp2p_endpoint)): State<Libp2pEndpoint>,
 ) -> Result<Html<String>, StatusCode> {

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -20,12 +20,22 @@
 
 #![doc = include_str!("../README.md")]
 
+use std::{
+    collections::hash_map::DefaultHasher,
+    error::Error,
+    hash::{Hash, Hasher},
+    time::Duration,
+};
+
 use futures::stream::StreamExt;
-use libp2p::{gossipsub, mdns, noise, swarm::NetworkBehaviour, swarm::SwarmEvent, tcp, yamux};
-use std::collections::hash_map::DefaultHasher;
-use std::error::Error;
-use std::hash::{Hash, Hasher};
-use std::time::Duration;
+use libp2p::{
+    gossipsub,
+    mdns,
+    noise,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    tcp,
+    yamux,
+};
 use tokio::{io, io::AsyncBufReadExt, select};
 use tracing_subscriber::EnvFilter;
 
@@ -51,7 +61,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         )?
         .with_quic()
         .with_behaviour(|key| {
-            // To content-address message, we can take the hash of message and use it as an ID.
+            // To content-address message, we can take the hash of message and use it as an
+            // ID.
             let message_id_fn = |message: &gossipsub::Message| {
                 let mut s = DefaultHasher::new();
                 message.data.hash(&mut s);
@@ -61,7 +72,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
             // Set a custom gossipsub configuration
             let gossipsub_config = gossipsub::ConfigBuilder::default()
                 .heartbeat_interval(Duration::from_secs(10)) // This is set to aid debugging by not cluttering the log space
-                .validation_mode(gossipsub::ValidationMode::Strict) // This sets the kind of message validation. The default is Strict (enforce message signing)
+                .validation_mode(gossipsub::ValidationMode::Strict) // This sets the kind of message validation. The default is Strict (enforce message
+                // signing)
                 .message_id_fn(message_id_fn) // content-address messages. No two messages of the same content will be propagated.
                 .build()
                 .map_err(|msg| io::Error::new(io::ErrorKind::Other, msg))?; // Temporary hack because `build` does not return a proper `std::error::Error`.

--- a/examples/dcutr/src/main.rs
+++ b/examples/dcutr/src/main.rs
@@ -20,16 +20,23 @@
 
 #![doc = include_str!("../README.md")]
 
+use std::{error::Error, str::FromStr, time::Duration};
+
 use clap::Parser;
 use futures::{executor::block_on, future::FutureExt, stream::StreamExt};
 use libp2p::{
     core::multiaddr::{Multiaddr, Protocol},
-    dcutr, identify, identity, noise, ping, relay,
+    dcutr,
+    identify,
+    identity,
+    noise,
+    ping,
+    relay,
     swarm::{NetworkBehaviour, SwarmEvent},
-    tcp, yamux, PeerId,
+    tcp,
+    yamux,
+    PeerId,
 };
-use std::str::FromStr;
-use std::{error::Error, time::Duration};
 use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]
@@ -136,8 +143,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
     });
 
-    // Connect to the relay server. Not for the reservation or relayed connection, but to (a) learn
-    // our local public address and (b) enable a freshly started relay to learn its public address.
+    // Connect to the relay server. Not for the reservation or relayed connection,
+    // but to (a) learn our local public address and (b) enable a freshly
+    // started relay to learn its public address.
     swarm.dial(opts.relay_address.clone()).unwrap();
     block_on(async {
         let mut learned_observed_addr = false;

--- a/examples/distributed-key-value-store/src/main.rs
+++ b/examples/distributed-key-value-store/src/main.rs
@@ -20,17 +20,18 @@
 
 #![doc = include_str!("../README.md")]
 
+use std::{error::Error, time::Duration};
+
 use futures::stream::StreamExt;
-use libp2p::kad;
-use libp2p::kad::store::MemoryStore;
-use libp2p::kad::Mode;
 use libp2p::{
-    mdns, noise,
+    kad,
+    kad::{store::MemoryStore, Mode},
+    mdns,
+    noise,
     swarm::{NetworkBehaviour, SwarmEvent},
-    tcp, yamux,
+    tcp,
+    yamux,
 };
-use std::error::Error;
-use std::time::Duration;
 use tokio::{
     io::{self, AsyncBufReadExt},
     select,

--- a/examples/file-sharing/src/main.rs
+++ b/examples/file-sharing/src/main.rs
@@ -22,15 +22,12 @@
 
 mod network;
 
-use clap::Parser;
-use tokio::task::spawn;
+use std::{error::Error, io::Write, path::PathBuf};
 
-use futures::prelude::*;
-use futures::StreamExt;
+use clap::Parser;
+use futures::{prelude::*, StreamExt};
 use libp2p::{core::Multiaddr, multiaddr::Protocol};
-use std::error::Error;
-use std::io::Write;
-use std::path::PathBuf;
+use tokio::task::spawn;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]

--- a/examples/file-sharing/src/network.rs
+++ b/examples/file-sharing/src/network.rs
@@ -1,27 +1,33 @@
-use futures::channel::{mpsc, oneshot};
-use futures::prelude::*;
-use futures::StreamExt;
+use std::{
+    collections::{hash_map, HashMap, HashSet},
+    error::Error,
+    time::Duration,
+};
 
+use futures::{
+    channel::{mpsc, oneshot},
+    prelude::*,
+    StreamExt,
+};
 use libp2p::{
     core::Multiaddr,
-    identity, kad,
+    identity,
+    kad,
     multiaddr::Protocol,
     noise,
     request_response::{self, OutboundRequestId, ProtocolSupport, ResponseChannel},
     swarm::{NetworkBehaviour, Swarm, SwarmEvent},
-    tcp, yamux, PeerId,
+    tcp,
+    yamux,
+    PeerId,
+    StreamProtocol,
 };
-
-use libp2p::StreamProtocol;
 use serde::{Deserialize, Serialize};
-use std::collections::{hash_map, HashMap, HashSet};
-use std::error::Error;
-use std::time::Duration;
 
 /// Creates the network components, namely:
 ///
-/// - The network client to interact with the network layer from anywhere
-///   within your application.
+/// - The network client to interact with the network layer from anywhere within
+///   your application.
 ///
 /// - The network event stream, e.g. for incoming requests.
 ///

--- a/examples/identify/src/main.rs
+++ b/examples/identify/src/main.rs
@@ -20,9 +20,10 @@
 
 #![doc = include_str!("../README.md")]
 
+use std::{error::Error, time::Duration};
+
 use futures::StreamExt;
 use libp2p::{core::multiaddr::Multiaddr, identify, noise, swarm::SwarmEvent, tcp, yamux};
-use std::{error::Error, time::Duration};
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]

--- a/examples/ipfs-kad/src/main.rs
+++ b/examples/ipfs-kad/src/main.rs
@@ -20,15 +20,25 @@
 
 #![doc = include_str!("../README.md")]
 
-use std::num::NonZeroUsize;
-use std::ops::Add;
-use std::time::{Duration, Instant};
+use std::{
+    num::NonZeroUsize,
+    ops::Add,
+    time::{Duration, Instant},
+};
 
 use anyhow::{bail, Result};
 use clap::Parser;
 use futures::StreamExt;
-use libp2p::swarm::{StreamProtocol, SwarmEvent};
-use libp2p::{bytes::BufMut, identity, kad, noise, tcp, yamux, PeerId};
+use libp2p::{
+    bytes::BufMut,
+    identity,
+    kad,
+    noise,
+    swarm::{StreamProtocol, SwarmEvent},
+    tcp,
+    yamux,
+    PeerId,
+};
 use tracing_subscriber::EnvFilter;
 
 const BOOTNODES: [&str; 4] = [

--- a/examples/ipfs-private/src/main.rs
+++ b/examples/ipfs-private/src/main.rs
@@ -20,23 +20,29 @@
 
 #![doc = include_str!("../README.md")]
 
+use std::{env, error::Error, fs, path::Path, str::FromStr, time::Duration};
+
 use either::Either;
 use futures::prelude::*;
 use libp2p::{
     core::transport::upgrade::Version,
-    gossipsub, identify,
+    gossipsub,
+    identify,
     multiaddr::Protocol,
-    noise, ping,
+    noise,
+    ping,
     pnet::{PnetConfig, PreSharedKey},
     swarm::{NetworkBehaviour, SwarmEvent},
-    tcp, yamux, Multiaddr, Transport,
+    tcp,
+    yamux,
+    Multiaddr,
+    Transport,
 };
-use std::{env, error::Error, fs, path::Path, str::FromStr, time::Duration};
 use tokio::{io, io::AsyncBufReadExt, select};
 use tracing_subscriber::EnvFilter;
 
-/// Get the current ipfs repo path, either from the IPFS_PATH environment variable or
-/// from the default $HOME/.ipfs
+/// Get the current ipfs repo path, either from the IPFS_PATH environment
+/// variable or from the default $HOME/.ipfs
 fn get_ipfs_path() -> Box<Path> {
     env::var("IPFS_PATH")
         .map(|ipfs_path| Path::new(&ipfs_path).into())
@@ -58,8 +64,9 @@ fn get_psk(path: &Path) -> std::io::Result<Option<String>> {
     }
 }
 
-/// for a multiaddr that ends with a peer id, this strips this suffix. Rust-libp2p
-/// only supports dialing to an address without providing the peer id.
+/// for a multiaddr that ends with a peer id, this strips this suffix.
+/// Rust-libp2p only supports dialing to an address without providing the peer
+/// id.
 fn strip_peer_id(addr: &mut Multiaddr) {
     let last = addr.pop();
     match last {
@@ -105,7 +112,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Create a Gosspipsub topic
     let gossipsub_topic = gossipsub::IdentTopic::new("chat");
 
-    // We create a custom network behaviour that combines gossipsub, ping and identify.
+    // We create a custom network behaviour that combines gossipsub, ping and
+    // identify.
     #[derive(NetworkBehaviour)]
     struct MyBehaviour {
         gossipsub: gossipsub::Behaviour,

--- a/examples/metrics/src/http_service.rs
+++ b/examples/metrics/src/http_service.rs
@@ -18,15 +18,13 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use axum::extract::State;
-use axum::http::StatusCode;
-use axum::response::IntoResponse;
-use axum::routing::get;
-use axum::Router;
-use prometheus_client::encoding::text::encode;
-use prometheus_client::registry::Registry;
-use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
+use std::{
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
+
+use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::get, Router};
+use prometheus_client::{encoding::text::encode, registry::Registry};
 use tokio::net::TcpListener;
 
 const METRICS_CONTENT_TYPE: &str = "application/openmetrics-text;charset=utf-8;version=1.0.0";

--- a/examples/metrics/src/main.rs
+++ b/examples/metrics/src/main.rs
@@ -20,18 +20,23 @@
 
 #![doc = include_str!("../README.md")]
 
+use std::{error::Error, time::Duration};
+
 use futures::StreamExt;
-use libp2p::core::Multiaddr;
-use libp2p::metrics::{Metrics, Recorder};
-use libp2p::swarm::{NetworkBehaviour, SwarmEvent};
-use libp2p::{identify, identity, noise, ping, tcp, yamux};
+use libp2p::{
+    core::Multiaddr,
+    identify,
+    identity,
+    metrics::{Metrics, Recorder},
+    noise,
+    ping,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    tcp,
+    yamux,
+};
 use opentelemetry::{trace::TracerProvider, KeyValue};
 use prometheus_client::registry::Registry;
-use std::error::Error;
-use std::time::Duration;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{EnvFilter, Layer};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 
 mod http_service;
 

--- a/examples/ping/src/main.rs
+++ b/examples/ping/src/main.rs
@@ -20,9 +20,10 @@
 
 #![doc = include_str!("../README.md")]
 
+use std::{error::Error, time::Duration};
+
 use futures::prelude::*;
 use libp2p::{noise, ping, swarm::SwarmEvent, tcp, yamux, Multiaddr};
-use std::{error::Error, time::Duration};
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]

--- a/examples/relay-server/src/main.rs
+++ b/examples/relay-server/src/main.rs
@@ -21,17 +21,24 @@
 
 #![doc = include_str!("../README.md")]
 
+use std::{
+    error::Error,
+    net::{Ipv4Addr, Ipv6Addr},
+};
+
 use clap::Parser;
 use futures::StreamExt;
 use libp2p::{
-    core::multiaddr::Protocol,
-    core::Multiaddr,
-    identify, identity, noise, ping, relay,
+    core::{multiaddr::Protocol, Multiaddr},
+    identify,
+    identity,
+    noise,
+    ping,
+    relay,
     swarm::{NetworkBehaviour, SwarmEvent},
-    tcp, yamux,
+    tcp,
+    yamux,
 };
-use std::error::Error;
-use std::net::{Ipv4Addr, Ipv6Addr};
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -119,7 +126,8 @@ fn generate_ed25519(secret_key_seed: u8) -> identity::Keypair {
 #[derive(Debug, Parser)]
 #[clap(name = "libp2p relay")]
 struct Opt {
-    /// Determine if the relay listen on ipv6 or ipv4 loopback address. the default is ipv4
+    /// Determine if the relay listen on ipv6 or ipv4 loopback address. the
+    /// default is ipv4
     #[clap(long)]
     use_ipv6: Option<bool>,
 

--- a/examples/rendezvous/src/bin/rzv-discover.rs
+++ b/examples/rendezvous/src/bin/rzv-discover.rs
@@ -18,15 +18,19 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::{error::Error, time::Duration};
+
 use futures::StreamExt;
 use libp2p::{
     multiaddr::Protocol,
-    noise, ping, rendezvous,
+    noise,
+    ping,
+    rendezvous,
     swarm::{NetworkBehaviour, SwarmEvent},
-    tcp, yamux, Multiaddr,
+    tcp,
+    yamux,
+    Multiaddr,
 };
-use std::error::Error;
-use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 
 const NAMESPACE: &str = "rendezvous";

--- a/examples/rendezvous/src/bin/rzv-identify.rs
+++ b/examples/rendezvous/src/bin/rzv-identify.rs
@@ -18,13 +18,19 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::time::Duration;
+
 use futures::StreamExt;
 use libp2p::{
-    identify, noise, ping, rendezvous,
+    identify,
+    noise,
+    ping,
+    rendezvous,
     swarm::{NetworkBehaviour, SwarmEvent},
-    tcp, yamux, Multiaddr,
+    tcp,
+    yamux,
+    Multiaddr,
 };
-use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]

--- a/examples/rendezvous/src/bin/rzv-register.rs
+++ b/examples/rendezvous/src/bin/rzv-register.rs
@@ -18,13 +18,18 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::time::Duration;
+
 use futures::StreamExt;
 use libp2p::{
-    noise, ping, rendezvous,
+    noise,
+    ping,
+    rendezvous,
     swarm::{NetworkBehaviour, SwarmEvent},
-    tcp, yamux, Multiaddr,
+    tcp,
+    yamux,
+    Multiaddr,
 };
-use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -54,8 +59,9 @@ async fn main() {
         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(5)))
         .build();
 
-    // In production the external address should be the publicly facing IP address of the rendezvous point.
-    // This address is recorded in the registration entry by the rendezvous point.
+    // In production the external address should be the publicly facing IP address
+    // of the rendezvous point. This address is recorded in the registration
+    // entry by the rendezvous point.
     let external_address = "/ip4/127.0.0.1/tcp/0".parse::<Multiaddr>().unwrap();
     swarm.add_external_address(external_address);
 

--- a/examples/rendezvous/src/main.rs
+++ b/examples/rendezvous/src/main.rs
@@ -20,14 +20,18 @@
 
 #![doc = include_str!("../README.md")]
 
+use std::{error::Error, time::Duration};
+
 use futures::StreamExt;
 use libp2p::{
-    identify, noise, ping, rendezvous,
+    identify,
+    noise,
+    ping,
+    rendezvous,
     swarm::{NetworkBehaviour, SwarmEvent},
-    tcp, yamux,
+    tcp,
+    yamux,
 };
-use std::error::Error;
-use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -36,8 +40,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
 
-    // Results in PeerID 12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN which is
-    // used as the rendezvous point by the other peer examples.
+    // Results in PeerID 12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN which
+    // is used as the rendezvous point by the other peer examples.
     let keypair = libp2p::identity::Keypair::ed25519_from_bytes([0; 32]).unwrap();
 
     let mut swarm = libp2p::SwarmBuilder::with_existing_identity(keypair)

--- a/examples/stream/src/main.rs
+++ b/examples/stream/src/main.rs
@@ -43,13 +43,15 @@ async fn main() -> Result<()> {
 
     // Deal with incoming streams.
     // Spawning a dedicated task is just one way of doing this.
-    // libp2p doesn't care how you handle incoming streams but you _must_ handle them somehow.
-    // To mitigate DoS attacks, libp2p will internally drop incoming streams if your application cannot keep up processing them.
+    // libp2p doesn't care how you handle incoming streams but you _must_ handle
+    // them somehow. To mitigate DoS attacks, libp2p will internally drop
+    // incoming streams if your application cannot keep up processing them.
     tokio::spawn(async move {
-        // This loop handles incoming streams _sequentially_ but that doesn't have to be the case.
-        // You can also spawn a dedicated task per stream if you want to.
-        // Be aware that this breaks backpressure though as spawning new tasks is equivalent to an unbounded buffer.
-        // Each task needs memory meaning an aggressive remote peer may force you OOM this way.
+        // This loop handles incoming streams _sequentially_ but that doesn't have to be
+        // the case. You can also spawn a dedicated task per stream if you want
+        // to. Be aware that this breaks backpressure though as spawning new
+        // tasks is equivalent to an unbounded buffer. Each task needs memory
+        // meaning an aggressive remote peer may force you OOM this way.
 
         while let Some((peer, stream)) = incoming_streams.next().await {
             match echo(stream).await {
@@ -89,7 +91,8 @@ async fn main() -> Result<()> {
     }
 }
 
-/// A very simple, `async fn`-based connection handler for our custom echo protocol.
+/// A very simple, `async fn`-based connection handler for our custom echo
+/// protocol.
 async fn connection_handler(peer: PeerId, mut control: stream::Control) {
     loop {
         tokio::time::sleep(Duration::from_secs(1)).await; // Wait a second between echos.
@@ -102,7 +105,8 @@ async fn connection_handler(peer: PeerId, mut control: stream::Control) {
             }
             Err(error) => {
                 // Other errors may be temporary.
-                // In production, something like an exponential backoff / circuit-breaker may be more appropriate.
+                // In production, something like an exponential backoff / circuit-breaker may be
+                // more appropriate.
                 tracing::debug!(%peer, %error);
                 continue;
             }

--- a/examples/upnp/src/main.rs
+++ b/examples/upnp/src/main.rs
@@ -20,9 +20,10 @@
 
 #![doc = include_str!("../README.md")]
 
+use std::error::Error;
+
 use futures::prelude::*;
 use libp2p::{noise, swarm::SwarmEvent, upnp, yamux, Multiaddr};
-use std::error::Error;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -64,7 +65,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 break;
             }
             SwarmEvent::Behaviour(upnp::Event::NonRoutableGateway) => {
-                println!("Gateway is not exposed directly to the public Internet, i.e. it itself has a private IP address.");
+                println!(
+                    "Gateway is not exposed directly to the public Internet, i.e. it itself has a \
+                     private IP address."
+                );
                 break;
             }
             _ => {}

--- a/hole-punching-tests/src/main.rs
+++ b/hole-punching-tests/src/main.rs
@@ -18,24 +18,34 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::{
+    collections::HashMap,
+    fmt,
+    io,
+    net::{IpAddr, Ipv4Addr},
+    str::FromStr,
+    time::Duration,
+};
+
 use anyhow::{Context, Result};
 use either::Either;
 use futures::stream::StreamExt;
-use libp2p::core::transport::ListenerId;
-use libp2p::swarm::dial_opts::DialOpts;
-use libp2p::swarm::ConnectionId;
 use libp2p::{
-    core::multiaddr::{Multiaddr, Protocol},
-    dcutr, identify, noise, ping, relay,
-    swarm::{NetworkBehaviour, SwarmEvent},
-    tcp, yamux, Swarm,
+    core::{
+        multiaddr::{Multiaddr, Protocol},
+        transport::ListenerId,
+    },
+    dcutr,
+    identify,
+    noise,
+    ping,
+    relay,
+    swarm::{dial_opts::DialOpts, ConnectionId, NetworkBehaviour, SwarmEvent},
+    tcp,
+    yamux,
+    Swarm,
 };
 use redis::AsyncCommands;
-use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr};
-use std::str::FromStr;
-use std::time::Duration;
-use std::{fmt, io};
 
 /// The redis key we push the relay's TCP listen address to.
 const RELAY_TCP_ADDRESS: &str = "RELAY_TCP_ADDRESS";
@@ -47,7 +57,10 @@ const LISTEN_CLIENT_PEER_ID: &str = "LISTEN_CLIENT_PEER_ID";
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::builder()
-        .parse_filters("debug,netlink_proto=warn,rustls=warn,multistream_select=warn,libp2p_core::transport::choice=off,libp2p_swarm::connection=warn,libp2p_quic=trace")
+        .parse_filters(
+            "debug,netlink_proto=warn,rustls=warn,multistream_select=warn,\
+             libp2p_core::transport::choice=off,libp2p_swarm::connection=warn,libp2p_quic=trace",
+        )
         .parse_default_env()
         .init();
 
@@ -214,7 +227,8 @@ async fn client_listen_on_transport(
 
     let mut listen_addresses = 0;
 
-    // We should have at least two listen addresses, one for localhost and the actual interface.
+    // We should have at least two listen addresses, one for localhost and the
+    // actual interface.
     while listen_addresses < 2 {
         if let SwarmEvent::NewListenAddr {
             listener_id,

--- a/identity/CHANGELOG.md
+++ b/identity/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## 0.2.8
 
-- Bump `ring` to `0.17.5`.
+- Bump `ring` to `0.17.5.
   See [PR 4779](https://github.com/libp2p/rust-libp2p/pull/4779).
 
 ## 0.2.7

--- a/identity/src/ed25519.rs
+++ b/identity/src/ed25519.rs
@@ -20,12 +20,12 @@
 
 //! Ed25519 keys.
 
-use super::error::DecodingError;
-use core::cmp;
-use core::fmt;
-use core::hash;
+use core::{cmp, fmt, hash};
+
 use ed25519_dalek::{self as ed25519, Signer as _, Verifier as _};
 use zeroize::Zeroize;
+
+use super::error::DecodingError;
 
 /// An Ed25519 keypair.
 #[derive(Clone)]
@@ -48,7 +48,8 @@ impl Keypair {
     /// Try to parse a keypair from the [binary format](https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.5)
     /// produced by [`Keypair::to_bytes`], zeroing the input on success.
     ///
-    /// Note that this binary format is the same as `ed25519_dalek`'s and `ed25519_zebra`'s.
+    /// Note that this binary format is the same as `ed25519_dalek`'s and
+    /// `ed25519_zebra`'s.
     pub fn try_from_bytes(kp: &mut [u8]) -> Result<Keypair, DecodingError> {
         let bytes = <[u8; 64]>::try_from(&*kp)
             .map_err(|e| DecodingError::failed_to_parse("Ed25519 keypair", e))?;
@@ -152,7 +153,8 @@ impl PublicKey {
         self.0.to_bytes()
     }
 
-    /// Try to parse a public key from a byte array containing the actual key as produced by `to_bytes`.
+    /// Try to parse a public key from a byte array containing the actual key as
+    /// produced by `to_bytes`.
     pub fn try_from_bytes(k: &[u8]) -> Result<PublicKey, DecodingError> {
         let k = <[u8; 32]>::try_from(k)
             .map_err(|e| DecodingError::failed_to_parse("Ed25519 public key", e))?;
@@ -206,8 +208,9 @@ impl SecretKey {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use quickcheck::*;
+
+    use super::*;
 
     fn eq_keypairs(kp1: &Keypair, kp2: &Keypair) -> bool {
         kp1.public() == kp2.public() && kp1.0.to_bytes() == kp2.0.to_bytes()

--- a/identity/src/error.rs
+++ b/identity/src/error.rs
@@ -20,8 +20,7 @@
 
 //! Errors during identity key operations.
 
-use std::error::Error;
-use std::fmt;
+use std::{error::Error, fmt};
 
 use crate::KeyType;
 
@@ -136,7 +135,8 @@ impl Error for SigningError {
     }
 }
 
-/// Error produced when failing to convert [`Keypair`](crate::Keypair) to a more concrete keypair.
+/// Error produced when failing to convert [`Keypair`](crate::Keypair) to a more
+/// concrete keypair.
 #[derive(Debug)]
 pub struct OtherVariantError {
     actual: KeyType,

--- a/identity/src/keypair.rs
+++ b/identity/src/keypair.rs
@@ -24,6 +24,16 @@
     feature = "ed25519",
     feature = "rsa"
 ))]
+use quick_protobuf::{BytesReader, Writer};
+
+#[cfg(feature = "ecdsa")]
+use crate::ecdsa;
+#[cfg(any(
+    feature = "ecdsa",
+    feature = "secp256k1",
+    feature = "ed25519",
+    feature = "rsa"
+))]
 #[cfg(feature = "ed25519")]
 use crate::ed25519;
 #[cfg(any(
@@ -33,7 +43,6 @@ use crate::ed25519;
     feature = "rsa"
 ))]
 use crate::error::OtherVariantError;
-use crate::error::{DecodingError, SigningError};
 #[cfg(any(
     feature = "ecdsa",
     feature = "secp256k1",
@@ -41,23 +50,14 @@ use crate::error::{DecodingError, SigningError};
     feature = "rsa"
 ))]
 use crate::proto;
-#[cfg(any(
-    feature = "ecdsa",
-    feature = "secp256k1",
-    feature = "ed25519",
-    feature = "rsa"
-))]
-use quick_protobuf::{BytesReader, Writer};
-
 #[cfg(all(feature = "rsa", not(target_arch = "wasm32")))]
 use crate::rsa;
-
 #[cfg(feature = "secp256k1")]
 use crate::secp256k1;
-
-#[cfg(feature = "ecdsa")]
-use crate::ecdsa;
-use crate::KeyType;
+use crate::{
+    error::{DecodingError, SigningError},
+    KeyType,
+};
 
 /// Identity keypair of a node.
 ///
@@ -75,7 +75,6 @@ use crate::KeyType;
 /// let mut bytes = std::fs::read("private.pk8").unwrap();
 /// let keypair = Keypair::rsa_from_pkcs8(&mut bytes);
 /// ```
-///
 #[derive(Debug, Clone)]
 pub struct Keypair {
     keypair: KeyPairInner,
@@ -154,8 +153,8 @@ impl Keypair {
         })
     }
 
-    /// Decode a keypair from a DER-encoded Secp256k1 secret key in an ECPrivateKey
-    /// structure as defined in [RFC5915].
+    /// Decode a keypair from a DER-encoded Secp256k1 secret key in an
+    /// ECPrivateKey structure as defined in [RFC5915].
     ///
     /// [RFC5915]: https://tools.ietf.org/html/rfc5915
     #[cfg(feature = "secp256k1")]
@@ -258,7 +257,8 @@ impl Keypair {
         unreachable!()
     }
 
-    /// Decode a private key from a protobuf structure and parse it as a [`Keypair`].
+    /// Decode a private key from a protobuf structure and parse it as a
+    /// [`Keypair`].
     #[allow(unused_variables)]
     pub fn from_protobuf_encoding(bytes: &[u8]) -> Result<Keypair, DecodingError> {
         #[cfg(any(
@@ -341,7 +341,8 @@ impl Keypair {
         }
     }
 
-    /// Deterministically derive a new secret from this [`Keypair`], taking into account the provided domain.
+    /// Deterministically derive a new secret from this [`Keypair`], taking into
+    /// account the provided domain.
     ///
     /// This works for all key types except RSA where it returns `None`.
     ///
@@ -352,10 +353,11 @@ impl Keypair {
     /// # use libp2p_identity as identity;
     /// let key = identity::Keypair::generate_ed25519();
     ///
-    /// let new_key = key.derive_secret(b"my encryption key").expect("can derive secret for ed25519");
+    /// let new_key = key
+    ///     .derive_secret(b"my encryption key")
+    ///     .expect("can derive secret for ed25519");
     /// # }
     /// ```
-    ///
     #[cfg(any(
         feature = "ecdsa",
         feature = "secp256k1",
@@ -904,8 +906,9 @@ mod tests {
 
     #[test]
     fn public_key_implements_hash() {
-        use crate::PublicKey;
         use std::hash::Hash;
+
+        use crate::PublicKey;
 
         fn assert_implements_hash<T: Hash>() {}
 
@@ -914,8 +917,9 @@ mod tests {
 
     #[test]
     fn public_key_implements_ord() {
-        use crate::PublicKey;
         use std::cmp::Ord;
+
+        use crate::PublicKey;
 
         fn assert_implements_ord<T: Ord>() {}
 

--- a/identity/src/lib.rs
+++ b/identity/src/lib.rs
@@ -31,7 +31,8 @@
 //! Instead, loading fixed keys must use the standard, thus more portable
 //! binary representation of the specific key type
 //! (e.g. [ed25519 binary format](https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.5)).
-//! All key types have functions to enable conversion to/from their binary representations.
+//! All key types have functions to enable conversion to/from their binary
+//! representations.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![allow(unreachable_pub)]

--- a/identity/src/peer_id.rs
+++ b/identity/src/peer_id.rs
@@ -18,17 +18,19 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::{fmt, str::FromStr};
+
 #[cfg(feature = "rand")]
 use rand::Rng;
 use sha2::Digest as _;
-use std::{fmt, str::FromStr};
 use thiserror::Error;
 
 /// Local type-alias for multihash.
 ///
 /// Must be big enough to accommodate for `MAX_INLINE_KEY_LENGTH`.
-/// 64 satisfies that and can hold 512 bit hashes which is what the ecosystem typically uses.
-/// Given that this appears in our type-signature, using a "common" number here makes us more compatible.
+/// 64 satisfies that and can hold 512 bit hashes which is what the ecosystem
+/// typically uses. Given that this appears in our type-signature, using a
+/// "common" number here makes us more compatible.
 type Multihash = multihash::Multihash<64>;
 
 #[cfg(feature = "serde")]
@@ -43,8 +45,8 @@ const MULTIHASH_SHA256_CODE: u64 = 0x12;
 
 /// Identifier of a peer of the network.
 ///
-/// The data is a CIDv0 compatible multihash of the protobuf encoded public key of the peer
-/// as specified in [specs/peer-ids](https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md).
+/// The data is a CIDv0 compatible multihash of the protobuf encoded public key
+/// of the peer as specified in [specs/peer-ids](https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md).
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct PeerId {
     multihash: Multihash,

--- a/identity/src/rsa.rs
+++ b/identity/src/rsa.rs
@@ -20,14 +20,23 @@
 
 //! RSA keys.
 
-use super::error::*;
-use asn1_der::typed::{DerDecodable, DerEncodable, DerTypeView, Sequence};
-use asn1_der::{Asn1DerError, Asn1DerErrorVariant, DerObject, Sink, VecBacking};
-use ring::rand::SystemRandom;
-use ring::signature::KeyPair;
-use ring::signature::{self, RsaKeyPair, RSA_PKCS1_2048_8192_SHA256, RSA_PKCS1_SHA256};
 use std::{fmt, sync::Arc};
+
+use asn1_der::{
+    typed::{DerDecodable, DerEncodable, DerTypeView, Sequence},
+    Asn1DerError,
+    Asn1DerErrorVariant,
+    DerObject,
+    Sink,
+    VecBacking,
+};
+use ring::{
+    rand::SystemRandom,
+    signature::{self, KeyPair, RsaKeyPair, RSA_PKCS1_2048_8192_SHA256, RSA_PKCS1_SHA256},
+};
 use zeroize::Zeroize;
+
+use super::error::*;
 
 /// An RSA keypair.
 #[derive(Clone)]
@@ -42,8 +51,8 @@ impl std::fmt::Debug for Keypair {
 }
 
 impl Keypair {
-    /// Decode an RSA keypair from a DER-encoded private key in PKCS#1 RSAPrivateKey
-    /// format (i.e. unencrypted) as defined in [RFC3447].
+    /// Decode an RSA keypair from a DER-encoded private key in PKCS#1
+    /// RSAPrivateKey format (i.e. unencrypted) as defined in [RFC3447].
     ///
     /// [RFC3447]: https://tools.ietf.org/html/rfc3447#appendix-A.1.2
     pub fn try_decode_pkcs1(der: &mut [u8]) -> Result<Keypair, DecodingError> {
@@ -53,8 +62,8 @@ impl Keypair {
         Ok(Keypair(Arc::new(kp)))
     }
 
-    /// Decode an RSA keypair from a DER-encoded private key in PKCS#8 PrivateKeyInfo
-    /// format (i.e. unencrypted) as defined in [RFC5208].
+    /// Decode an RSA keypair from a DER-encoded private key in PKCS#8
+    /// PrivateKeyInfo format (i.e. unencrypted) as defined in [RFC5208].
     ///
     /// [RFC5208]: https://tools.ietf.org/html/rfc5208#section-5
     pub fn try_decode_pkcs8(der: &mut [u8]) -> Result<Keypair, DecodingError> {
@@ -100,8 +109,8 @@ impl PublicKey {
         self.0.clone()
     }
 
-    /// Encode the RSA public key in DER as a X.509 SubjectPublicKeyInfo structure,
-    /// as defined in [RFC5280].
+    /// Encode the RSA public key in DER as a X.509 SubjectPublicKeyInfo
+    /// structure, as defined in [RFC5280].
     ///
     /// [RFC5280]: https://tools.ietf.org/html/rfc5280#section-4.1
     pub fn encode_x509(&self) -> Vec<u8> {
@@ -315,8 +324,9 @@ impl DerDecodable<'_> for Asn1SubjectPublicKeyInfo {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use quickcheck::*;
+
+    use super::*;
 
     const KEY1: &[u8] = include_bytes!("test/rsa-2048.pk8");
     const KEY2: &[u8] = include_bytes!("test/rsa-3072.pk8");

--- a/interop-tests/src/arch.rs
+++ b/interop-tests/src/arch.rs
@@ -1,7 +1,6 @@
 // Native re-exports
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) use native::{build_swarm, init_logger, sleep, Instant, RedisClient};
-
 // Wasm re-exports
 #[cfg(target_arch = "wasm32")]
 pub(crate) use wasm::{build_swarm, init_logger, sleep, Instant, RedisClient};
@@ -11,11 +10,15 @@ pub(crate) mod native {
     use std::time::Duration;
 
     use anyhow::{bail, Context, Result};
-    use futures::future::BoxFuture;
-    use futures::FutureExt;
-    use libp2p::identity::Keypair;
-    use libp2p::swarm::{NetworkBehaviour, Swarm};
-    use libp2p::{noise, tcp, tls, yamux};
+    use futures::{future::BoxFuture, FutureExt};
+    use libp2p::{
+        identity::Keypair,
+        noise,
+        swarm::{NetworkBehaviour, Swarm},
+        tcp,
+        tls,
+        yamux,
+    };
     use libp2p_mplex as mplex;
     use libp2p_webrtc as webrtc;
     use redis::AsyncCommands;
@@ -186,15 +189,22 @@ pub(crate) mod native {
 
 #[cfg(target_arch = "wasm32")]
 pub(crate) mod wasm {
+    use std::time::Duration;
+
     use anyhow::{bail, Context, Result};
     use futures::future::{BoxFuture, FutureExt};
-    use libp2p::core::upgrade::Version;
-    use libp2p::identity::Keypair;
-    use libp2p::swarm::{NetworkBehaviour, Swarm};
-    use libp2p::{noise, websocket_websys, webtransport_websys, yamux, Transport as _};
+    use libp2p::{
+        core::upgrade::Version,
+        identity::Keypair,
+        noise,
+        swarm::{NetworkBehaviour, Swarm},
+        websocket_websys,
+        webtransport_websys,
+        yamux,
+        Transport as _,
+    };
     use libp2p_mplex as mplex;
     use libp2p_webrtc_websys as webrtc_websys;
-    use std::time::Duration;
 
     use crate::{BlpopRequest, Muxer, SecProtocol, Transport};
 

--- a/interop-tests/src/bin/wasm_ping.rs
+++ b/interop-tests/src/bin/wasm_ping.rs
@@ -1,25 +1,27 @@
 #![allow(non_upper_case_globals)]
 
-use std::future::IntoFuture;
-use std::process::Stdio;
-use std::time::Duration;
+use std::{future::IntoFuture, process::Stdio, time::Duration};
 
 use anyhow::{bail, Context, Result};
-use axum::http::{header, Uri};
-use axum::response::{Html, IntoResponse, Response};
-use axum::routing::get;
-use axum::{extract::State, http::StatusCode, routing::post, Json, Router};
+use axum::{
+    extract::State,
+    http::{header, StatusCode, Uri},
+    response::{Html, IntoResponse, Response},
+    routing::{get, post},
+    Json,
+    Router,
+};
+use interop_tests::{BlpopRequest, Report};
 use redis::{AsyncCommands, Client};
 use thirtyfour::prelude::*;
-use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::net::TcpListener;
-use tokio::process::Child;
-use tokio::sync::mpsc;
-use tower_http::cors::CorsLayer;
-use tower_http::trace::TraceLayer;
+use tokio::{
+    io::{AsyncBufReadExt, BufReader},
+    net::TcpListener,
+    process::Child,
+    sync::mpsc,
+};
+use tower_http::{cors::CorsLayer, trace::TraceLayer};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
-
-use interop_tests::{BlpopRequest, Report};
 
 mod config;
 

--- a/interop-tests/src/lib.rs
+++ b/interop-tests/src/lib.rs
@@ -1,11 +1,14 @@
-use std::str::FromStr;
-use std::time::Duration;
+use std::{str::FromStr, time::Duration};
 
 use anyhow::{bail, Context, Result};
 use futures::{FutureExt, StreamExt};
-use libp2p::identity::Keypair;
-use libp2p::swarm::SwarmEvent;
-use libp2p::{identify, ping, swarm::NetworkBehaviour, Multiaddr};
+use libp2p::{
+    identify,
+    identity::Keypair,
+    ping,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    Multiaddr,
+};
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
@@ -60,8 +63,8 @@ pub async fn run_test(
     let maybe_id = None;
 
     // Run a ping interop test. Based on `is_dialer`, either dial the address
-    // retrieved via `listenAddr` key over the redis connection. Or wait to be pinged and have
-    // `dialerDone` key ready on the redis connection.
+    // retrieved via `listenAddr` key over the redis connection. Or wait to be
+    // pinged and have `dialerDone` key ready on the redis connection.
     match is_dialer {
         true => {
             let result: Vec<String> = redis_client

--- a/libp2p/src/bandwidth.rs
+++ b/libp2p/src/bandwidth.rs
@@ -20,13 +20,6 @@
 
 #![allow(deprecated)]
 
-use crate::core::muxing::{StreamMuxer, StreamMuxerEvent};
-
-use futures::{
-    io::{IoSlice, IoSliceMut},
-    prelude::*,
-    ready,
-};
 use std::{
     convert::TryFrom as _,
     io,
@@ -38,8 +31,16 @@ use std::{
     task::{Context, Poll},
 };
 
-/// Wraps around a [`StreamMuxer`] and counts the number of bytes that go through all the opened
-/// streams.
+use futures::{
+    io::{IoSlice, IoSliceMut},
+    prelude::*,
+    ready,
+};
+
+use crate::core::muxing::{StreamMuxer, StreamMuxerEvent};
+
+/// Wraps around a [`StreamMuxer`] and counts the number of bytes that go
+/// through all the opened streams.
 #[derive(Clone)]
 #[pin_project::pin_project]
 pub(crate) struct BandwidthLogging<SMInner> {
@@ -103,9 +104,8 @@ where
 }
 
 /// Allows obtaining the average bandwidth of the streams.
-#[deprecated(
-    note = "Use `libp2p::SwarmBuilder::with_bandwidth_metrics` or `libp2p_metrics::BandwidthTransport` instead."
-)]
+#[deprecated(note = "Use `libp2p::SwarmBuilder::with_bandwidth_metrics` or \
+                     `libp2p_metrics::BandwidthTransport` instead.")]
 pub struct BandwidthSinks {
     inbound: AtomicU64,
     outbound: AtomicU64,
@@ -120,24 +120,29 @@ impl BandwidthSinks {
         })
     }
 
-    /// Returns the total number of bytes that have been downloaded on all the streams.
+    /// Returns the total number of bytes that have been downloaded on all the
+    /// streams.
     ///
-    /// > **Note**: This method is by design subject to race conditions. The returned value should
-    /// >           only ever be used for statistics purposes.
+    /// > **Note**: This method is by design subject to race conditions. The
+    /// > returned value should
+    /// > only ever be used for statistics purposes.
     pub fn total_inbound(&self) -> u64 {
         self.inbound.load(Ordering::Relaxed)
     }
 
-    /// Returns the total number of bytes that have been uploaded on all the streams.
+    /// Returns the total number of bytes that have been uploaded on all the
+    /// streams.
     ///
-    /// > **Note**: This method is by design subject to race conditions. The returned value should
-    /// >           only ever be used for statistics purposes.
+    /// > **Note**: This method is by design subject to race conditions. The
+    /// > returned value should
+    /// > only ever be used for statistics purposes.
     pub fn total_outbound(&self) -> u64 {
         self.outbound.load(Ordering::Relaxed)
     }
 }
 
-/// Wraps around an [`AsyncRead`] + [`AsyncWrite`] and logs the bandwidth that goes through it.
+/// Wraps around an [`AsyncRead`] + [`AsyncWrite`] and logs the bandwidth that
+/// goes through it.
 #[pin_project::pin_project]
 pub(crate) struct InstrumentedStream<SMInner> {
     #[pin]

--- a/libp2p/src/builder.rs
+++ b/libp2p/src/builder.rs
@@ -33,31 +33,31 @@ mod select_security;
 /// #         relay: libp2p_relay::client::Behaviour,
 /// #     }
 ///
-///  let swarm = SwarmBuilder::with_new_identity()
-///      .with_tokio()
-///      .with_tcp(
-///          Default::default(),
-///          (libp2p_tls::Config::new, libp2p_noise::Config::new),
-///          libp2p_yamux::Config::default,
-///      )?
-///      .with_quic()
-///      .with_other_transport(|_key| DummyTransport::<(PeerId, StreamMuxerBox)>::new())?
-///      .with_dns()?
-///      .with_websocket(
-///          (libp2p_tls::Config::new, libp2p_noise::Config::new),
-///          libp2p_yamux::Config::default,
-///      )
-///      .await?
-///      .with_relay_client(
-///          (libp2p_tls::Config::new, libp2p_noise::Config::new),
-///          libp2p_yamux::Config::default,
-///      )?
-///      .with_behaviour(|_key, relay| MyBehaviour { relay })?
-///      .with_swarm_config(|cfg| {
-///          // Edit cfg here.
-///          cfg
-///      })
-///      .build();
+/// let swarm = SwarmBuilder::with_new_identity()
+///     .with_tokio()
+///     .with_tcp(
+///         Default::default(),
+///         (libp2p_tls::Config::new, libp2p_noise::Config::new),
+///         libp2p_yamux::Config::default,
+///     )?
+///     .with_quic()
+///     .with_other_transport(|_key| DummyTransport::<(PeerId, StreamMuxerBox)>::new())?
+///     .with_dns()?
+///     .with_websocket(
+///         (libp2p_tls::Config::new, libp2p_noise::Config::new),
+///         libp2p_yamux::Config::default,
+///     )
+///     .await?
+///     .with_relay_client(
+///         (libp2p_tls::Config::new, libp2p_noise::Config::new),
+///         libp2p_yamux::Config::default,
+///     )?
+///     .with_behaviour(|_key, relay| MyBehaviour { relay })?
+///     .with_swarm_config(|cfg| {
+///         // Edit cfg here.
+///         cfg
+///     })
+///     .build();
 /// #
 /// #     Ok(())
 /// # }
@@ -70,10 +70,11 @@ pub struct SwarmBuilder<Provider, Phase> {
 
 #[cfg(test)]
 mod tests {
-    use crate::SwarmBuilder;
     use libp2p_core::{muxing::StreamMuxerBox, transport::dummy::DummyTransport};
     use libp2p_identity::PeerId;
     use libp2p_swarm::NetworkBehaviour;
+
+    use crate::SwarmBuilder;
 
     #[test]
     #[cfg(all(
@@ -460,7 +461,8 @@ mod tests {
             .build();
     }
 
-    /// Showcases how to provide custom transports unknown to the libp2p crate, e.g. WebRTC.
+    /// Showcases how to provide custom transports unknown to the libp2p crate,
+    /// e.g. WebRTC.
     #[test]
     #[cfg(feature = "tokio")]
     fn other_transport() -> Result<(), Box<dyn std::error::Error>> {

--- a/libp2p/src/builder/phase.rs
+++ b/libp2p/src/builder/phase.rs
@@ -19,6 +19,8 @@ use bandwidth_metrics::*;
 use behaviour::*;
 use build::*;
 use dns::*;
+use libp2p_core::{muxing::StreamMuxerBox, Transport};
+use libp2p_identity::Keypair;
 use other_transport::*;
 use provider::*;
 use quic::*;
@@ -27,12 +29,11 @@ use swarm::*;
 use tcp::*;
 use websocket::*;
 
-use super::select_muxer::SelectMuxerUpgrade;
-use super::select_security::SelectSecurityUpgrade;
-use super::SwarmBuilder;
-
-use libp2p_core::{muxing::StreamMuxerBox, Transport};
-use libp2p_identity::Keypair;
+use super::{
+    select_muxer::SelectMuxerUpgrade,
+    select_security::SelectSecurityUpgrade,
+    SwarmBuilder,
+};
 
 #[allow(unreachable_pub)]
 pub trait IntoSecurityUpgrade<C> {

--- a/libp2p/src/builder/phase/bandwidth_logging.rs
+++ b/libp2p/src/builder/phase/bandwidth_logging.rs
@@ -1,10 +1,9 @@
+use std::{marker::PhantomData, sync::Arc};
+
 use super::*;
 #[allow(deprecated)]
 use crate::bandwidth::BandwidthSinks;
-use crate::transport_ext::TransportExt;
-use crate::SwarmBuilder;
-use std::marker::PhantomData;
-use std::sync::Arc;
+use crate::{transport_ext::TransportExt, SwarmBuilder};
 
 pub struct BandwidthLoggingPhase<T, R> {
     pub(crate) relay_behaviour: R,

--- a/libp2p/src/builder/phase/bandwidth_metrics.rs
+++ b/libp2p/src/builder/phase/bandwidth_metrics.rs
@@ -1,10 +1,9 @@
+use std::{marker::PhantomData, sync::Arc};
+
 use super::*;
 #[allow(deprecated)]
 use crate::bandwidth::BandwidthSinks;
-use crate::transport_ext::TransportExt;
-use crate::SwarmBuilder;
-use std::marker::PhantomData;
-use std::sync::Arc;
+use crate::{transport_ext::TransportExt, SwarmBuilder};
 
 pub struct BandwidthMetricsPhase<T, R> {
     pub(crate) relay_behaviour: R,

--- a/libp2p/src/builder/phase/behaviour.rs
+++ b/libp2p/src/builder/phase/behaviour.rs
@@ -1,8 +1,9 @@
+use std::{convert::Infallible, marker::PhantomData};
+
+use libp2p_swarm::NetworkBehaviour;
+
 use super::*;
 use crate::SwarmBuilder;
-use libp2p_swarm::NetworkBehaviour;
-use std::convert::Infallible;
-use std::marker::PhantomData;
 
 pub struct BehaviourPhase<T, R> {
     pub(crate) relay_behaviour: R,

--- a/libp2p/src/builder/phase/build.rs
+++ b/libp2p/src/builder/phase/build.rs
@@ -1,9 +1,9 @@
-#[allow(unused_imports)]
-use super::*;
-
-use crate::SwarmBuilder;
 use libp2p_core::Transport;
 use libp2p_swarm::Swarm;
+
+#[allow(unused_imports)]
+use super::*;
+use crate::SwarmBuilder;
 
 pub struct BuildPhase<T, B> {
     pub(crate) behaviour: B,

--- a/libp2p/src/builder/phase/dns.rs
+++ b/libp2p/src/builder/phase/dns.rs
@@ -1,6 +1,7 @@
+use std::marker::PhantomData;
+
 use super::*;
 use crate::SwarmBuilder;
-use std::marker::PhantomData;
 
 pub struct DnsPhase<T> {
     pub(crate) transport: T,

--- a/libp2p/src/builder/phase/identity.rs
+++ b/libp2p/src/builder/phase/identity.rs
@@ -1,6 +1,7 @@
+use std::marker::PhantomData;
+
 use super::*;
 use crate::SwarmBuilder;
-use std::marker::PhantomData;
 
 pub struct IdentityPhase {}
 

--- a/libp2p/src/builder/phase/other_transport.rs
+++ b/libp2p/src/builder/phase/other_transport.rs
@@ -1,19 +1,18 @@
-use std::convert::Infallible;
-use std::marker::PhantomData;
-use std::sync::Arc;
+use std::{convert::Infallible, marker::PhantomData, sync::Arc};
 
-use libp2p_core::upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade};
-use libp2p_core::Transport;
+use libp2p_core::{
+    upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade},
+    Transport,
+};
 #[cfg(feature = "relay")]
 use libp2p_core::{Negotiated, UpgradeInfo};
 #[cfg(feature = "relay")]
 use libp2p_identity::PeerId;
 
+use super::*;
 #[allow(deprecated)]
 use crate::bandwidth::BandwidthSinks;
 use crate::SwarmBuilder;
-
-use super::*;
 
 pub struct OtherTransportPhase<T> {
     pub(crate) transport: T,

--- a/libp2p/src/builder/phase/provider.rs
+++ b/libp2p/src/builder/phase/provider.rs
@@ -1,13 +1,16 @@
+use std::marker::PhantomData;
+
 #[allow(unused_imports)]
 use super::*;
 use crate::SwarmBuilder;
-use std::marker::PhantomData;
 /// Represents the phase where a provider is not yet specified.
-/// This is a marker type used in the type-state pattern to ensure compile-time checks of the builder's state.
+/// This is a marker type used in the type-state pattern to ensure compile-time
+/// checks of the builder's state.
 pub enum NoProviderSpecified {}
 
-// Define enums for each of the possible runtime environments. These are used as markers in the type-state pattern,
-// allowing compile-time checks for the appropriate environment configuration.
+// Define enums for each of the possible runtime environments. These are used as
+// markers in the type-state pattern, allowing compile-time checks for the
+// appropriate environment configuration.
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "async-std"))]
 /// Represents the AsyncStd runtime environment.
@@ -21,12 +24,14 @@ pub enum Tokio {}
 /// Represents the WasmBindgen environment for WebAssembly.
 pub enum WasmBindgen {}
 
-/// Represents a phase in the SwarmBuilder where a provider has been chosen but not yet specified.
+/// Represents a phase in the SwarmBuilder where a provider has been chosen but
+/// not yet specified.
 pub struct ProviderPhase {}
 
 impl SwarmBuilder<NoProviderSpecified, ProviderPhase> {
     /// Configures the SwarmBuilder to use the AsyncStd runtime.
-    /// This method is only available when compiling for non-Wasm targets with the `async-std` feature enabled.
+    /// This method is only available when compiling for non-Wasm targets with
+    /// the `async-std` feature enabled.
     #[cfg(all(not(target_arch = "wasm32"), feature = "async-std"))]
     pub fn with_async_std(self) -> SwarmBuilder<AsyncStd, TcpPhase> {
         SwarmBuilder {
@@ -37,7 +42,8 @@ impl SwarmBuilder<NoProviderSpecified, ProviderPhase> {
     }
 
     /// Configures the SwarmBuilder to use the Tokio runtime.
-    /// This method is only available when compiling for non-Wasm targets with the `tokio` feature enabled
+    /// This method is only available when compiling for non-Wasm targets with
+    /// the `tokio` feature enabled
     #[cfg(all(not(target_arch = "wasm32"), feature = "tokio"))]
     pub fn with_tokio(self) -> SwarmBuilder<Tokio, TcpPhase> {
         SwarmBuilder {

--- a/libp2p/src/builder/phase/quic.rs
+++ b/libp2p/src/builder/phase/quic.rs
@@ -1,5 +1,5 @@
-use super::*;
-use crate::SwarmBuilder;
+use std::{marker::PhantomData, sync::Arc};
+
 #[cfg(all(not(target_arch = "wasm32"), feature = "websocket"))]
 use libp2p_core::muxing::StreamMuxer;
 use libp2p_core::upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade};
@@ -8,7 +8,9 @@ use libp2p_core::upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade};
     all(not(target_arch = "wasm32"), feature = "websocket")
 ))]
 use libp2p_core::{InboundUpgrade, Negotiated, OutboundUpgrade, UpgradeInfo};
-use std::{marker::PhantomData, sync::Arc};
+
+use super::*;
+use crate::SwarmBuilder;
 
 pub struct QuicPhase<T> {
     pub(crate) transport: T,

--- a/libp2p/src/builder/phase/relay.rs
+++ b/libp2p/src/builder/phase/relay.rs
@@ -10,9 +10,8 @@ use libp2p_core::{InboundUpgrade, Negotiated, OutboundUpgrade, StreamMuxer, Upgr
 #[cfg(feature = "relay")]
 use libp2p_identity::PeerId;
 
-use crate::SwarmBuilder;
-
 use super::*;
+use crate::SwarmBuilder;
 
 pub struct RelayPhase<T> {
     pub(crate) transport: T,
@@ -22,9 +21,10 @@ pub struct RelayPhase<T> {
 impl<Provider, T: AuthenticatedMultiplexedTransport> SwarmBuilder<Provider, RelayPhase<T>> {
     /// Adds a relay client transport.
     ///
-    /// Note that both `security_upgrade` and `multiplexer_upgrade` take function pointers,
-    /// i.e. they take the function themselves (without the invocation via `()`), not the
-    /// result of the function invocation. See example below.
+    /// Note that both `security_upgrade` and `multiplexer_upgrade` take
+    /// function pointers, i.e. they take the function themselves (without
+    /// the invocation via `()`), not the result of the function invocation.
+    /// See example below.
     ///
     /// ``` rust
     /// # use libp2p::SwarmBuilder;

--- a/libp2p/src/builder/phase/tcp.rs
+++ b/libp2p/src/builder/phase/tcp.rs
@@ -1,5 +1,5 @@
-use super::*;
-use crate::SwarmBuilder;
+use std::marker::PhantomData;
+
 #[cfg(all(
     not(target_arch = "wasm32"),
     any(feature = "tcp", feature = "websocket")
@@ -12,9 +12,14 @@ use libp2p_core::Transport;
     any(feature = "tcp", feature = "websocket")
 ))]
 use libp2p_core::{
-    upgrade::InboundConnectionUpgrade, upgrade::OutboundConnectionUpgrade, Negotiated, UpgradeInfo,
+    upgrade::InboundConnectionUpgrade,
+    upgrade::OutboundConnectionUpgrade,
+    Negotiated,
+    UpgradeInfo,
 };
-use std::marker::PhantomData;
+
+use super::*;
+use crate::SwarmBuilder;
 
 pub struct TcpPhase {}
 

--- a/libp2p/src/builder/phase/websocket.rs
+++ b/libp2p/src/builder/phase/websocket.rs
@@ -1,5 +1,5 @@
-use super::*;
-use crate::SwarmBuilder;
+use std::marker::PhantomData;
+
 #[cfg(all(not(target_arch = "wasm32"), feature = "websocket"))]
 use libp2p_core::muxing::{StreamMuxer, StreamMuxerBox};
 use libp2p_core::upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade};
@@ -15,7 +15,9 @@ use libp2p_core::{InboundUpgrade, Negotiated, OutboundUpgrade, UpgradeInfo};
     feature = "relay"
 ))]
 use libp2p_identity::PeerId;
-use std::marker::PhantomData;
+
+use super::*;
+use crate::SwarmBuilder;
 
 pub struct WebsocketPhase<T> {
     pub(crate) transport: T,
@@ -126,8 +128,8 @@ impl_websocket_builder!(
 impl_websocket_builder!(
     "tokio",
     super::provider::Tokio,
-    // Note this is an unnecessary await for Tokio Websocket (i.e. tokio dns) in order to be consistent
-    // with above AsyncStd construction.
+    // Note this is an unnecessary await for Tokio Websocket (i.e. tokio dns) in order to be
+    // consistent with above AsyncStd construction.
     futures::future::ready(libp2p_dns::tokio::Transport::system(
         libp2p_tcp::tokio::Transport::new(libp2p_tcp::Config::default())
     )),

--- a/libp2p/src/builder/select_muxer.rs
+++ b/libp2p/src/builder/select_muxer.rs
@@ -20,12 +20,15 @@
 
 #![allow(unreachable_pub)]
 
+use std::iter::{Chain, Map};
+
 use either::Either;
 use futures::future;
-use libp2p_core::either::EitherFuture;
-use libp2p_core::upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade};
-use libp2p_core::UpgradeInfo;
-use std::iter::{Chain, Map};
+use libp2p_core::{
+    either::EitherFuture,
+    upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade},
+    UpgradeInfo,
+};
 
 #[derive(Debug, Clone)]
 pub struct SelectMuxerUpgrade<A, B>(A, B);

--- a/libp2p/src/builder/select_security.rs
+++ b/libp2p/src/builder/select_security.rs
@@ -21,16 +21,18 @@
 
 #![allow(unreachable_pub)]
 
-use either::Either;
-use futures::future::MapOk;
-use futures::{future, TryFutureExt};
-use libp2p_core::either::EitherFuture;
-use libp2p_core::upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade, UpgradeInfo};
-use libp2p_identity::PeerId;
 use std::iter::{Chain, Map};
 
-/// Upgrade that combines two upgrades into one. Supports all the protocols supported by either
-/// sub-upgrade.
+use either::Either;
+use futures::{future, future::MapOk, TryFutureExt};
+use libp2p_core::{
+    either::EitherFuture,
+    upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade, UpgradeInfo},
+};
+use libp2p_identity::PeerId;
+
+/// Upgrade that combines two upgrades into one. Supports all the protocols
+/// supported by either sub-upgrade.
 ///
 /// The protocols supported by the first element have a higher priority.
 #[derive(Debug, Clone)]

--- a/libp2p/src/lib.rs
+++ b/libp2p/src/lib.rs
@@ -35,11 +35,6 @@
 pub use bytes;
 pub use futures;
 #[doc(inline)]
-pub use libp2p_core::multihash;
-#[doc(inline)]
-pub use multiaddr;
-
-#[doc(inline)]
 pub use libp2p_allow_block_list as allow_block_list;
 #[cfg(feature = "autonat")]
 #[doc(inline)]
@@ -48,6 +43,8 @@ pub use libp2p_autonat as autonat;
 pub use libp2p_connection_limits as connection_limits;
 #[doc(inline)]
 pub use libp2p_core as core;
+#[doc(inline)]
+pub use libp2p_core::multihash;
 #[cfg(feature = "dcutr")]
 #[doc(inline)]
 pub use libp2p_dcutr as dcutr;
@@ -140,6 +137,8 @@ pub use libp2p_webtransport_websys as webtransport_websys;
 #[cfg(feature = "yamux")]
 #[doc(inline)]
 pub use libp2p_yamux as yamux;
+#[doc(inline)]
+pub use multiaddr;
 
 mod builder;
 mod transport_ext;
@@ -149,15 +148,18 @@ pub mod bandwidth;
 #[cfg(doc)]
 pub mod tutorials;
 
-pub use self::builder::SwarmBuilder;
-pub use self::core::{
-    transport::TransportError,
-    upgrade::{InboundUpgrade, OutboundUpgrade},
-    Transport,
-};
-pub use self::multiaddr::{multiaddr as build_multiaddr, Multiaddr};
-pub use self::swarm::Swarm;
-pub use self::transport_ext::TransportExt;
 pub use libp2p_identity as identity;
 pub use libp2p_identity::PeerId;
 pub use libp2p_swarm::{Stream, StreamProtocol};
+
+pub use self::{
+    builder::SwarmBuilder,
+    core::{
+        transport::TransportError,
+        upgrade::{InboundUpgrade, OutboundUpgrade},
+        Transport,
+    },
+    multiaddr::{multiaddr as build_multiaddr, Multiaddr},
+    swarm::Swarm,
+    transport_ext::TransportExt,
+};

--- a/libp2p/src/transport_ext.rs
+++ b/libp2p/src/transport_ext.rs
@@ -20,45 +20,43 @@
 
 //! Provides the `TransportExt` trait.
 
-#[allow(deprecated)]
-use crate::bandwidth::{BandwidthLogging, BandwidthSinks};
-use crate::core::{
-    muxing::{StreamMuxer, StreamMuxerBox},
-    transport::Boxed,
-};
-use crate::Transport;
-use libp2p_identity::PeerId;
 use std::sync::Arc;
 
-/// Trait automatically implemented on all objects that implement `Transport`. Provides some
-/// additional utilities.
+use libp2p_identity::PeerId;
+
+#[allow(deprecated)]
+use crate::bandwidth::{BandwidthLogging, BandwidthSinks};
+use crate::{
+    core::{
+        muxing::{StreamMuxer, StreamMuxerBox},
+        transport::Boxed,
+    },
+    Transport,
+};
+
+/// Trait automatically implemented on all objects that implement `Transport`.
+/// Provides some additional utilities.
 pub trait TransportExt: Transport {
-    /// Adds a layer on the `Transport` that logs all traffic that passes through the streams
-    /// created by it.
+    /// Adds a layer on the `Transport` that logs all traffic that passes
+    /// through the streams created by it.
     ///
-    /// This method returns an `Arc<BandwidthSinks>` that can be used to retrieve the total number
-    /// of bytes transferred through the streams.
+    /// This method returns an `Arc<BandwidthSinks>` that can be used to
+    /// retrieve the total number of bytes transferred through the streams.
     ///
     /// # Example
     ///
     /// ```
-    /// use libp2p_yamux as yamux;
+    /// use libp2p::{core::upgrade, identity, Transport, TransportExt};
     /// use libp2p_noise as noise;
     /// use libp2p_tcp as tcp;
-    /// use libp2p::{
-    ///     core::upgrade,
-    ///     identity,
-    ///     TransportExt,
-    ///     Transport,
-    /// };
+    /// use libp2p_yamux as yamux;
     ///
     /// let id_keys = identity::Keypair::generate_ed25519();
     ///
     /// let transport = tcp::tokio::Transport::new(tcp::Config::default().nodelay(true))
     ///     .upgrade(upgrade::Version::V1)
     ///     .authenticate(
-    ///         noise::Config::new(&id_keys)
-    ///             .expect("Signing libp2p-noise static DH keypair failed."),
+    ///         noise::Config::new(&id_keys).expect("Signing libp2p-noise static DH keypair failed."),
     ///     )
     ///     .multiplex(yamux::Config::default())
     ///     .boxed();
@@ -66,9 +64,8 @@ pub trait TransportExt: Transport {
     /// let (transport, sinks) = transport.with_bandwidth_logging();
     /// ```
     #[allow(deprecated)]
-    #[deprecated(
-        note = "Use `libp2p::SwarmBuilder::with_bandwidth_metrics` or `libp2p_metrics::BandwidthTransport` instead."
-    )]
+    #[deprecated(note = "Use `libp2p::SwarmBuilder::with_bandwidth_metrics` or \
+                         `libp2p_metrics::BandwidthTransport` instead.")]
     fn with_bandwidth_logging<S>(self) -> (Boxed<(PeerId, StreamMuxerBox)>, Arc<BandwidthSinks>)
     where
         Self: Sized + Send + Unpin + 'static,

--- a/libp2p/src/tutorials/hole_punching.rs
+++ b/libp2p/src/tutorials/hole_punching.rs
@@ -20,45 +20,49 @@
 
 //! # Hole Punching Tutorial
 //!
-//! This tutorial shows hands-on how to overcome firewalls and NATs with libp2p's hole punching
-//! mechanism. Before we get started, please read the [blog
-//! post](https://blog.ipfs.io/2022-01-20-libp2p-hole-punching/) to familiarize yourself with libp2p's hole
+//! This tutorial shows hands-on how to overcome firewalls and NATs with
+//! libp2p's hole punching mechanism. Before we get started, please read the
+//! [blog post](https://blog.ipfs.io/2022-01-20-libp2p-hole-punching/) to familiarize yourself with libp2p's hole
 //! punching mechanism on a conceptual level.
 //!
-//! We will be using the [Circuit Relay](crate::relay) and the [Direct Connection
-//! Upgrade through Relay (DCUtR)](crate::dcutr) protocol.
+//! We will be using the [Circuit Relay](crate::relay) and the [Direct
+//! Connection Upgrade through Relay (DCUtR)](crate::dcutr) protocol.
 //!
 //! You will need 3 machines for this tutorial:
 //!
 //! - A relay server:
 //!    - Any public server will do, e.g. a cloud provider VM.
 //! - A listening client:
-//!    - Any computer connected to the internet, but not reachable from outside its own network,
-//!      works.
-//!    - This can e.g. be your friends laptop behind their router (firewall + NAT).
-//!    - This can e.g. be some cloud provider VM, shielded from incoming connections e.g. via
-//!      Linux's UFW on the same machine.
-//!    - Don't use a machine that is in the same network as the dialing client. (This would require
-//!      NAT hairpinning.)
+//!    - Any computer connected to the internet, but not reachable from outside
+//!      its own network, works.
+//!    - This can e.g. be your friends laptop behind their router (firewall +
+//!      NAT).
+//!    - This can e.g. be some cloud provider VM, shielded from incoming
+//!      connections e.g. via Linux's UFW on the same machine.
+//!    - Don't use a machine that is in the same network as the dialing client.
+//!      (This would require NAT hairpinning.)
 //! - A dialing client:
-//!    - Like the above, any computer connected to the internet, but not reachable from the outside.
+//!    - Like the above, any computer connected to the internet, but not
+//!      reachable from the outside.
 //!    - Your local machine will likely fulfill these requirements.
 //!
 //! ## Setting up the relay server
 //!
-//! Hole punching requires a public relay node for the two private nodes to coordinate their hole
-//! punch via. For that we need a public server somewhere in the Internet. In case you don't have
-//! one already, any cloud provider VM will do.
+//! Hole punching requires a public relay node for the two private nodes to
+//! coordinate their hole punch via. For that we need a public server somewhere
+//! in the Internet. In case you don't have one already, any cloud provider VM
+//! will do.
 //!
-//! Either on the server directly, or on your local machine, compile the example relay server:
+//! Either on the server directly, or on your local machine, compile the example
+//! relay server:
 //!
 //! ``` bash
 //! ## Inside the rust-libp2p repository.
 //! cargo build --bin relay-server-example
 //! ```
 //!
-//! You can find the binary at `target/debug/relay-server-example`. In case you built it locally, copy
-//! it to your server.
+//! You can find the binary at `target/debug/relay-server-example`. In case you
+//! built it locally, copy it to your server.
 //!
 //! On your server, start the relay server binary:
 //!
@@ -66,9 +70,10 @@
 //! ./relay-server-example --port 4001 --secret-key-seed 0
 //! ```
 //!
-//! Now let's make sure that the server is public, in other words let's make sure one can reach it
-//! through the Internet. First, either manually replace `$RELAY_SERVER_IP` in the following
-//! commands or `export RELAY_SERVER_IP=ipaddr` with the appropriate relay server `ipaddr` in
+//! Now let's make sure that the server is public, in other words let's make
+//! sure one can reach it through the Internet. First, either manually replace
+//! `$RELAY_SERVER_IP` in the following commands or `export
+//! RELAY_SERVER_IP=ipaddr` with the appropriate relay server `ipaddr` in
 //! the dialing client and listening client.
 //!
 //! Now, from the dialing client:
@@ -98,7 +103,8 @@
 //!
 //!    ``` bash
 //!    $ libp2p-lookup direct --address /ip4/111.11.111.111/tcp/4001
-//!    Lookup for peer with id PeerId("12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN") succeeded.
+//!    Lookup for peer with id
+//! PeerId("12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN") succeeded.
 //!
 //!    Protocol version: "/TODO/0.0.1"
 //!    Agent version: "rust-libp2p/0.36.0"
@@ -117,16 +123,16 @@
 //!
 //! ## Setting up the listening client
 //!
-//! Either on the listening client machine directly, or on your local machine, compile the example
-//! DCUtR client:
+//! Either on the listening client machine directly, or on your local machine,
+//! compile the example DCUtR client:
 //!
 //! ``` bash
 //! ## Inside the rust-libp2p repository.
 //! cargo build --bin dcutr-example
 //! ```
 //!
-//! You can find the binary at `target/debug/dcutr-example`. In case you built it locally, copy
-//! it to your listening client machine.
+//! You can find the binary at `target/debug/dcutr-example`. In case you built
+//! it locally, copy it to your listening client machine.
 //!
 //! On the listening client machine:
 //!
@@ -142,9 +148,9 @@
 //! [2022-05-11T10:38:54Z INFO  client] Listening on "/ip4/$RELAY_SERVER_IP/tcp/4001/p2p/12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN/p2p-circuit/p2p/XXX"
 //! ```
 //!
-//! Now let's make sure that the listening client is not public, in other words let's make sure one
-//! can not reach it directly through the Internet. From the dialing client test that you can not
-//! connect on Layer 4 (TCP):
+//! Now let's make sure that the listening client is not public, in other words
+//! let's make sure one can not reach it directly through the Internet. From the
+//! dialing client test that you can not connect on Layer 4 (TCP):
 //!
 //! ``` bash
 //! telnet $LISTENING_CLIENT_IP_OBSERVED_BY_RELAY 53160
@@ -158,17 +164,26 @@
 //!
 //! You should see the following logs appear:
 //!
-//! 1. The dialing client establishing a relayed connection to the listening client via the relay
-//!    server. Note the [`/p2p-circuit` protocol](crate::multiaddr::Protocol::P2pCircuit) in the
+//! 1. The dialing client establishing a relayed connection to the listening
+//!    client via the relay server. Note the [`/p2p-circuit`
+//!    protocol](crate::multiaddr::Protocol::P2pCircuit) in the
 //!    [`Multiaddr`](crate::Multiaddr).
 //!
 //!    ``` ignore
-//!    [2022-01-30T12:54:10Z INFO  client] Established connection to PeerId("12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X") via Dialer { address: "/ip4/$RELAY_PEER_ID/tcp/4001/p2p/12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN/p2p-circuit/p2p/12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X", role_override: Dialer }
-//!    ```
+//!    [2022-01-30T12:54:10Z INFO  client] Established connection to
+//! PeerId("12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X") via Dialer {
+//! address: "/ip4/$RELAY_PEER_ID/tcp/4001/p2p/
+//! 12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN/p2p-circuit/p2p/
+//! 12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X", role_override: Dialer
+//! }    ```
 //!
 //! 2. The direct connection upgrade, also known as hole punch, succeeding.
-//!    Reported by [`dcutr`](crate::dcutr) through [`Event`](crate::dcutr::Event) containing [`Result::Ok`] with the [`ConnectionId`](libp2p_swarm::ConnectionId) of the new direct connection.
+//!    Reported by [`dcutr`](crate::dcutr) through
+//!    [`Event`](crate::dcutr::Event) containing [`Result::Ok`] with the
+//!    [`ConnectionId`](libp2p_swarm::ConnectionId) of the new direct
+//!    connection.
 //!
 //!    ``` ignore
-//!    [2022-01-30T12:54:11Z INFO  client] Event { remote_peer_id: PeerId("12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X"), result: Ok(2) }
-//!    ```
+//!    [2022-01-30T12:54:11Z INFO  client] Event { remote_peer_id:
+//! PeerId("12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X"), result:
+//! Ok(2) }    ```

--- a/libp2p/src/tutorials/ping.rs
+++ b/libp2p/src/tutorials/ping.rs
@@ -55,8 +55,8 @@
 //!        edition = "2021"
 //!
 //!    [dependencies]
-//!        libp2p = { version = "0.54", features = ["noise", "ping", "tcp", "tokio", "yamux"] }
-//!        futures = "0.3.30"
+//!        libp2p = { version = "0.54", features = ["noise", "ping", "tcp",
+//! "tokio", "yamux"] }        futures = "0.3.30"
 //!        tokio = { version = "1.37.0", features = ["full"] }
 //!        tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 //!    ```
@@ -72,6 +72,7 @@
 //!
 //! ```rust
 //! use std::error::Error;
+//!
 //! use tracing_subscriber::EnvFilter;
 //!
 //! #[tokio::main]
@@ -86,20 +87,23 @@
 //! }
 //! ```
 //!
-//! Go ahead and build and run the above code with: `cargo run`. Nothing happening thus far.
+//! Go ahead and build and run the above code with: `cargo run`. Nothing
+//! happening thus far.
 //!
 //! ## Transport
 //!
-//! Next up we need to construct a transport. Each transport in libp2p provides encrypted streams.
-//! E.g. combining TCP to establish connections, NOISE to encrypt these connections and Yamux to run
-//! one or more streams on a connection. Another libp2p transport is QUIC, providing encrypted
-//! streams out-of-the-box. We will stick to TCP for now. Each of these implement the [`Transport`]
-//! trait.
+//! Next up we need to construct a transport. Each transport in libp2p provides
+//! encrypted streams. E.g. combining TCP to establish connections, NOISE to
+//! encrypt these connections and Yamux to run one or more streams on a
+//! connection. Another libp2p transport is QUIC, providing encrypted
+//! streams out-of-the-box. We will stick to TCP for now. Each of these
+//! implement the [`Transport`] trait.
 //!
 //! ```rust
 //! use std::error::Error;
-//! use tracing_subscriber::EnvFilter;
+//!
 //! use libp2p::{noise, tcp, yamux};
+//! use tracing_subscriber::EnvFilter;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn Error>> {
@@ -127,24 +131,28 @@
 //! _what_ bytes and to _whom_ to send on the network.
 //!
 //! To make this more concrete, let's take a look at a simple implementation of
-//! the [`NetworkBehaviour`] trait: the [`ping::Behaviour`](crate::ping::Behaviour).
-//! As you might have guessed, similar to the good old ICMP `ping` network tool,
-//! libp2p [`ping::Behaviour`](crate::ping::Behaviour) sends a ping to a peer and expects
-//! to receive a pong in turn. The [`ping::Behaviour`](crate::ping::Behaviour) does not care _how_
-//! the ping and pong messages are sent on the network, whether they are sent via
+//! the [`NetworkBehaviour`] trait: the
+//! [`ping::Behaviour`](crate::ping::Behaviour). As you might have guessed,
+//! similar to the good old ICMP `ping` network tool,
+//! libp2p [`ping::Behaviour`](crate::ping::Behaviour) sends a ping to a peer
+//! and expects to receive a pong in turn. The
+//! [`ping::Behaviour`](crate::ping::Behaviour) does not care _how_ the ping and
+//! pong messages are sent on the network, whether they are sent via
 //! TCP, whether they are encrypted via [noise](crate::noise) or just in
-//! [plaintext](crate::plaintext). It only cares about _what_ messages and to _whom_ to sent on the
-//! network.
+//! [plaintext](crate::plaintext). It only cares about _what_ messages and to
+//! _whom_ to sent on the network.
 //!
 //! The two traits [`Transport`] and [`NetworkBehaviour`] allow us to cleanly
 //! separate _how_ to send bytes from _what_ bytes and to _whom_ to send.
 //!
-//! With the above in mind, let's extend our example, creating a [`ping::Behaviour`](crate::ping::Behaviour) at the end:
+//! With the above in mind, let's extend our example, creating a
+//! [`ping::Behaviour`](crate::ping::Behaviour) at the end:
 //!
 //! ```rust
 //! use std::error::Error;
-//! use tracing_subscriber::EnvFilter;
+//!
 //! use libp2p::{noise, ping, tcp, yamux};
+//! use tracing_subscriber::EnvFilter;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn Error>> {
@@ -167,15 +175,17 @@
 //!
 //! ## Swarm
 //!
-//! Now that we have a [`Transport`] and a [`NetworkBehaviour`], we can build the [`Swarm`]
-//! which connects the two, allowing both to make progress. Put simply, a [`Swarm`] drives both a
-//! [`Transport`] and a [`NetworkBehaviour`] forward, passing commands from the [`NetworkBehaviour`]
-//! to the [`Transport`] as well as events from the [`Transport`] to the [`NetworkBehaviour`].
+//! Now that we have a [`Transport`] and a [`NetworkBehaviour`], we can build
+//! the [`Swarm`] which connects the two, allowing both to make progress. Put
+//! simply, a [`Swarm`] drives both a [`Transport`] and a [`NetworkBehaviour`]
+//! forward, passing commands from the [`NetworkBehaviour`] to the [`Transport`]
+//! as well as events from the [`Transport`] to the [`NetworkBehaviour`].
 //!
 //! ```rust
 //! use std::error::Error;
-//! use tracing_subscriber::EnvFilter;
+//!
 //! use libp2p::{noise, ping, tcp, yamux};
+//! use tracing_subscriber::EnvFilter;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn Error>> {
@@ -199,18 +209,20 @@
 //!
 //! ## Idle connection timeout
 //!
-//! Now, for this example in particular, we need set the idle connection timeout.
-//! Otherwise, the connection will be closed immediately.
+//! Now, for this example in particular, we need set the idle connection
+//! timeout. Otherwise, the connection will be closed immediately.
 //!
-//! Whether you need to set this in your application too depends on your usecase.
-//! Typically, connections are kept alive if they are "in use" by a certain protocol.
-//! The ping protocol however is only an "auxiliary" kind of protocol.
-//! Thus, without any other behaviour in place, we would not be able to observe the pings.
+//! Whether you need to set this in your application too depends on your
+//! usecase. Typically, connections are kept alive if they are "in use" by a
+//! certain protocol. The ping protocol however is only an "auxiliary" kind of
+//! protocol. Thus, without any other behaviour in place, we would not be able
+//! to observe the pings.
 //!
 //! ```rust
 //! use std::{error::Error, time::Duration};
-//! use tracing_subscriber::EnvFilter;
+//!
 //! use libp2p::{noise, ping, tcp, yamux};
+//! use tracing_subscriber::EnvFilter;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn Error>> {
@@ -226,7 +238,9 @@
 //!             yamux::Config::default,
 //!         )?
 //!         .with_behaviour(|_| ping::Behaviour::default())?
-//!         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX)))
+//!         .with_swarm_config(|cfg| {
+//!             cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX))
+//!         })
 //!         .build();
 //!
 //!     Ok(())
@@ -249,20 +263,21 @@
 //! [github.com/multiformats/multiaddr](https://github.com/multiformats/multiaddr/).
 //!
 //! Let's make our local node listen on a new socket.
-//! This socket is listening on multiple network interfaces at the same time. For
-//! each network interface, a new listening address is created. These may change
-//! over time as interfaces become available or unavailable.
-//! For example, in case of our TCP transport it may (among others) listen on the
-//! loopback interface (localhost) `/ip4/127.0.0.1/tcp/24915` as well as the local
-//! network `/ip4/192.168.178.25/tcp/24915`.
+//! This socket is listening on multiple network interfaces at the same time.
+//! For each network interface, a new listening address is created. These may
+//! change over time as interfaces become available or unavailable.
+//! For example, in case of our TCP transport it may (among others) listen on
+//! the loopback interface (localhost) `/ip4/127.0.0.1/tcp/24915` as well as the
+//! local network `/ip4/192.168.178.25/tcp/24915`.
 //!
 //! In addition, if provided on the CLI, let's instruct our local node to dial a
 //! remote peer.
 //!
 //! ```rust
 //! use std::{error::Error, time::Duration};
-//! use tracing_subscriber::EnvFilter;
+//!
 //! use libp2p::{noise, ping, tcp, yamux, Multiaddr};
+//! use tracing_subscriber::EnvFilter;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn Error>> {
@@ -278,7 +293,9 @@
 //!             yamux::Config::default,
 //!         )?
 //!         .with_behaviour(|_| ping::Behaviour::default())?
-//!         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX)))
+//!         .with_swarm_config(|cfg| {
+//!             cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX))
+//!         })
 //!         .build();
 //!
 //!     // Tell the swarm to listen on all interfaces and a random, OS-assigned
@@ -305,9 +322,10 @@
 //!
 //! ```no_run
 //! use std::{error::Error, time::Duration};
-//! use tracing_subscriber::EnvFilter;
-//! use libp2p::{noise, ping, tcp, yamux, Multiaddr, swarm::SwarmEvent};
+//!
 //! use futures::prelude::*;
+//! use libp2p::{noise, ping, swarm::SwarmEvent, tcp, yamux, Multiaddr};
+//! use tracing_subscriber::EnvFilter;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn Error>> {
@@ -323,7 +341,9 @@
 //!             yamux::Config::default,
 //!         )?
 //!         .with_behaviour(|_| ping::Behaviour::default())?
-//!         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX)))
+//!         .with_swarm_config(|cfg| {
+//!             cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX))
+//!         })
 //!         .build();
 //!
 //!     // Tell the swarm to listen on all interfaces and a random, OS-assigned
@@ -378,9 +398,9 @@
 //!
 //! Note: The [`Multiaddr`] at the end being one of the [`Multiaddr`] printed
 //! earlier in terminal window one.
-//! Both peers have to be in the same network with which the address is associated.
-//! In our case any printed addresses can be used, as both peers run on the same
-//! device.
+//! Both peers have to be in the same network with which the address is
+//! associated. In our case any printed addresses can be used, as both peers run
+//! on the same device.
 //!
 //! The two nodes will establish a connection and send each other ping and pong
 //! messages every 15 seconds.

--- a/misc/allow-block-list/src/lib.rs
+++ b/misc/allow-block-list/src/lib.rs
@@ -31,12 +31,12 @@
 //! #[derive(NetworkBehaviour)]
 //! # #[behaviour(prelude = "libp2p_swarm::derive_prelude")]
 //! struct MyBehaviour {
-//!    allowed_peers: allow_block_list::Behaviour<AllowedPeers>,
+//!     allowed_peers: allow_block_list::Behaviour<AllowedPeers>,
 //! }
 //!
 //! # fn main() {
 //! let behaviour = MyBehaviour {
-//!     allowed_peers: allow_block_list::Behaviour::default()
+//!     allowed_peers: allow_block_list::Behaviour::default(),
 //! };
 //! # }
 //! ```
@@ -51,27 +51,37 @@
 //! #[derive(NetworkBehaviour)]
 //! # #[behaviour(prelude = "libp2p_swarm::derive_prelude")]
 //! struct MyBehaviour {
-//!    blocked_peers: allow_block_list::Behaviour<BlockedPeers>,
+//!     blocked_peers: allow_block_list::Behaviour<BlockedPeers>,
 //! }
 //!
 //! # fn main() {
 //! let behaviour = MyBehaviour {
-//!     blocked_peers: allow_block_list::Behaviour::default()
+//!     blocked_peers: allow_block_list::Behaviour::default(),
 //! };
 //! # }
 //! ```
 
-use libp2p_core::transport::PortUse;
-use libp2p_core::{Endpoint, Multiaddr};
+use std::{
+    collections::{HashSet, VecDeque},
+    convert::Infallible,
+    fmt,
+    task::{Context, Poll, Waker},
+};
+
+use libp2p_core::{transport::PortUse, Endpoint, Multiaddr};
 use libp2p_identity::PeerId;
 use libp2p_swarm::{
-    dummy, CloseConnection, ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour, THandler,
-    THandlerInEvent, THandlerOutEvent, ToSwarm,
+    dummy,
+    CloseConnection,
+    ConnectionDenied,
+    ConnectionId,
+    FromSwarm,
+    NetworkBehaviour,
+    THandler,
+    THandlerInEvent,
+    THandlerOutEvent,
+    ToSwarm,
 };
-use std::collections::{HashSet, VecDeque};
-use std::convert::Infallible;
-use std::fmt;
-use std::task::{Context, Poll, Waker};
 
 /// A [`NetworkBehaviour`] that can act as an allow or block list.
 #[derive(Default, Debug)]
@@ -101,7 +111,8 @@ impl Behaviour<AllowedPeers> {
 
     /// Allow connections to the given peer.
     ///
-    /// Returns whether the peer was newly inserted. Does nothing if the peer was already present in the set.
+    /// Returns whether the peer was newly inserted. Does nothing if the peer
+    /// was already present in the set.
     pub fn allow_peer(&mut self, peer: PeerId) -> bool {
         let inserted = self.state.peers.insert(peer);
         if inserted {
@@ -116,7 +127,8 @@ impl Behaviour<AllowedPeers> {
     ///
     /// All active connections to this peer will be closed immediately.
     ///
-    /// Returns whether the peer was present in the set. Does nothing if the peer was not present in the set.
+    /// Returns whether the peer was present in the set. Does nothing if the
+    /// peer was not present in the set.
     pub fn disallow_peer(&mut self, peer: PeerId) -> bool {
         let removed = self.state.peers.remove(&peer);
         if removed {
@@ -139,7 +151,8 @@ impl Behaviour<BlockedPeers> {
     ///
     /// All active connections to this peer will be closed immediately.
     ///
-    /// Returns whether the peer was newly inserted. Does nothing if the peer was already present in the set.
+    /// Returns whether the peer was newly inserted. Does nothing if the peer
+    /// was already present in the set.
     pub fn block_peer(&mut self, peer: PeerId) -> bool {
         let inserted = self.state.peers.insert(peer);
         if inserted {
@@ -153,7 +166,8 @@ impl Behaviour<BlockedPeers> {
 
     /// Unblock connections to a given peer.
     ///
-    /// Returns whether the peer was present in the set. Does nothing if the peer was not present in the set.
+    /// Returns whether the peer was present in the set. Does nothing if the
+    /// peer was not present in the set.
     pub fn unblock_peer(&mut self, peer: PeerId) -> bool {
         let removed = self.state.peers.remove(&peer);
         if removed {
@@ -165,7 +179,8 @@ impl Behaviour<BlockedPeers> {
     }
 }
 
-/// A connection to this peer is not explicitly allowed and was thus [`denied`](ConnectionDenied).
+/// A connection to this peer is not explicitly allowed and was thus
+/// [`denied`](ConnectionDenied).
 #[derive(Debug)]
 pub struct NotAllowed {
     peer: PeerId,
@@ -179,7 +194,8 @@ impl fmt::Display for NotAllowed {
 
 impl std::error::Error for NotAllowed {}
 
-/// A connection to this peer was explicitly blocked and was thus [`denied`](ConnectionDenied).
+/// A connection to this peer was explicitly blocked and was thus
+/// [`denied`](ConnectionDenied).
 #[derive(Debug)]
 pub struct Blocked {
     peer: PeerId,
@@ -294,9 +310,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use libp2p_swarm::{dial_opts::DialOpts, DialError, ListenError, Swarm, SwarmEvent};
     use libp2p_swarm_test::SwarmExt;
+
+    use super::*;
 
     #[async_std::test]
     async fn cannot_dial_blocked_peer() {

--- a/misc/keygen/src/config.rs
+++ b/misc/keygen/src/config.rs
@@ -1,10 +1,8 @@
-use base64::prelude::*;
-use serde::{Deserialize, Serialize};
-use std::error::Error;
-use std::path::Path;
+use std::{error::Error, path::Path};
 
-use libp2p_identity::Keypair;
-use libp2p_identity::PeerId;
+use base64::prelude::*;
+use libp2p_identity::{Keypair, PeerId};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/misc/keygen/src/main.rs
+++ b/misc/keygen/src/main.rs
@@ -1,9 +1,12 @@
+use std::{
+    error::Error,
+    path::PathBuf,
+    str::{self, FromStr},
+    sync::mpsc,
+    thread,
+};
+
 use base64::prelude::*;
-use std::error::Error;
-use std::path::PathBuf;
-use std::str::{self, FromStr};
-use std::sync::mpsc;
-use std::thread;
 
 mod config;
 
@@ -39,8 +42,8 @@ enum Command {
     },
 }
 
-// Due to the fact that a peer id uses a SHA-256 multihash, it always starts with the
-// bytes 0x1220, meaning that only some characters are valid.
+// Due to the fact that a peer id uses a SHA-256 multihash, it always starts
+// with the bytes 0x1220, meaning that only some characters are valid.
 const ALLOWED_FIRST_BYTE: &[u8] = b"NPQRSTUVWXYZ";
 
 // The base58 alphabet is not necessarily obvious.
@@ -60,10 +63,11 @@ fn main() -> Result<(), Box<dyn Error>> {
 
             let peer_id = keypair.public().into();
             assert_eq!(
-                    PeerId::from_str(&config.identity.peer_id)?,
-                    peer_id,
-                    "Expect peer id derived from private key and peer id retrieved from config to match."
-                );
+                PeerId::from_str(&config.identity.peer_id)?,
+                peer_id,
+                "Expect peer id derived from private key and peer id retrieved from config to \
+                 match."
+            );
 
             (peer_id, keypair)
         }

--- a/misc/memory-connection-limits/src/lib.rs
+++ b/misc/memory-connection-limits/src/lib.rs
@@ -18,35 +18,48 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use libp2p_core::{transport::PortUse, Endpoint, Multiaddr};
-use libp2p_identity::PeerId;
-use libp2p_swarm::{
-    dummy, ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour, THandler, THandlerInEvent,
-    THandlerOutEvent, ToSwarm,
-};
-use std::convert::Infallible;
-
 use std::{
+    convert::Infallible,
     fmt,
     task::{Context, Poll},
     time::{Duration, Instant},
+};
+
+use libp2p_core::{transport::PortUse, Endpoint, Multiaddr};
+use libp2p_identity::PeerId;
+use libp2p_swarm::{
+    dummy,
+    ConnectionDenied,
+    ConnectionId,
+    FromSwarm,
+    NetworkBehaviour,
+    THandler,
+    THandlerInEvent,
+    THandlerOutEvent,
+    ToSwarm,
 };
 use sysinfo::MemoryRefreshKind;
 
 /// A [`NetworkBehaviour`] that enforces a set of memory usage based limits.
 ///
-/// For these limits to take effect, this needs to be composed into the behaviour tree of your application.
+/// For these limits to take effect, this needs to be composed into the
+/// behaviour tree of your application.
 ///
-/// If a connection is denied due to a limit, either a [`SwarmEvent::IncomingConnectionError`](libp2p_swarm::SwarmEvent::IncomingConnectionError)
+/// If a connection is denied due to a limit, either a
+/// [`SwarmEvent::IncomingConnectionError`](libp2p_swarm::SwarmEvent::IncomingConnectionError)
 /// or [`SwarmEvent::OutgoingConnectionError`](libp2p_swarm::SwarmEvent::OutgoingConnectionError) will be emitted.
-/// The [`ListenError::Denied`](libp2p_swarm::ListenError::Denied) and respectively the [`DialError::Denied`](libp2p_swarm::DialError::Denied) variant
-/// contain a [`ConnectionDenied`] type that can be downcast to [`MemoryUsageLimitExceeded`] error if (and only if) **this**
+/// The [`ListenError::Denied`](libp2p_swarm::ListenError::Denied) and
+/// respectively the [`DialError::Denied`](libp2p_swarm::DialError::Denied)
+/// variant contain a [`ConnectionDenied`] type that can be downcast to
+/// [`MemoryUsageLimitExceeded`] error if (and only if) **this**
 /// behaviour denied the connection.
 ///
-/// If you employ multiple [`NetworkBehaviour`]s that manage connections, it may also be a different error.
+/// If you employ multiple [`NetworkBehaviour`]s that manage connections, it may
+/// also be a different error.
 ///
-/// [Behaviour::with_max_bytes] and [Behaviour::with_max_percentage] are mutually exclusive.
-/// If you need to employ both of them, compose two instances of [Behaviour] into your custom behaviour.
+/// [Behaviour::with_max_bytes] and [Behaviour::with_max_percentage] are
+/// mutually exclusive. If you need to employ both of them, compose two
+/// instances of [Behaviour] into your custom behaviour.
 ///
 /// # Example
 ///
@@ -58,8 +71,8 @@ use sysinfo::MemoryRefreshKind;
 /// #[derive(NetworkBehaviour)]
 /// # #[behaviour(prelude = "libp2p_swarm::derive_prelude")]
 /// struct MyBehaviour {
-///   identify: identify::Behaviour,
-///   limits: memory_connection_limits::Behaviour
+///     identify: identify::Behaviour,
+///     limits: memory_connection_limits::Behaviour,
 /// }
 /// ```
 pub struct Behaviour {
@@ -68,7 +81,8 @@ pub struct Behaviour {
     last_refreshed: Instant,
 }
 
-/// The maximum duration for which the retrieved memory-stats of the process are allowed to be stale.
+/// The maximum duration for which the retrieved memory-stats of the process are
+/// allowed to be stale.
 ///
 /// Once exceeded, we will retrieve new stats.
 const MAX_STALE_DURATION: Duration = Duration::from_millis(100);
@@ -76,7 +90,8 @@ const MAX_STALE_DURATION: Duration = Duration::from_millis(100);
 impl Behaviour {
     /// Sets the process memory usage threshold in absolute bytes.
     ///
-    /// New inbound and outbound connections will be denied when the threshold is reached.
+    /// New inbound and outbound connections will be denied when the threshold
+    /// is reached.
     pub fn with_max_bytes(max_allowed_bytes: usize) -> Self {
         Self {
             max_allowed_bytes,
@@ -87,9 +102,11 @@ impl Behaviour {
         }
     }
 
-    /// Sets the process memory usage threshold in the percentage of the total physical memory.
+    /// Sets the process memory usage threshold in the percentage of the total
+    /// physical memory.
     ///
-    /// New inbound and outbound connections will be denied when the threshold is reached.
+    /// New inbound and outbound connections will be denied when the threshold
+    /// is reached.
     pub fn with_max_percentage(percentage: f64) -> Self {
         use sysinfo::{RefreshKind, System};
 
@@ -223,9 +240,9 @@ impl fmt::Display for MemoryUsageLimitExceeded {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "process physical memory usage limit exceeded: process memory: {} bytes, max allowed: {} bytes",
-            self.process_physical_memory_bytes,
-            self.max_allowed_bytes,
+            "process physical memory usage limit exceeded: process memory: {} bytes, max allowed: \
+             {} bytes",
+            self.process_physical_memory_bytes, self.max_allowed_bytes,
         )
     }
 }

--- a/misc/memory-connection-limits/tests/max_bytes.rs
+++ b/misc/memory-connection-limits/tests/max_bytes.rs
@@ -20,14 +20,14 @@
 
 mod util;
 
+use std::time::Duration;
+
 use libp2p_core::Multiaddr;
 use libp2p_identity::PeerId;
 use libp2p_memory_connection_limits::*;
-use std::time::Duration;
-use util::*;
-
 use libp2p_swarm::{dial_opts::DialOpts, DialError, Swarm};
 use libp2p_swarm_test::SwarmExt;
+use util::*;
 
 #[test]
 fn max_bytes() {
@@ -69,7 +69,8 @@ fn max_bytes() {
             .expect("Unexpected connection limit.");
     }
 
-    std::thread::sleep(Duration::from_millis(100)); // Memory stats are only updated every 100ms internally, ensure they are up-to-date when we try to exceed it.
+    std::thread::sleep(Duration::from_millis(100)); // Memory stats are only updated every 100ms internally, ensure they are
+                                                    // up-to-date when we try to exceed it.
 
     match network
         .dial(

--- a/misc/memory-connection-limits/tests/max_percentage.rs
+++ b/misc/memory-connection-limits/tests/max_percentage.rs
@@ -20,18 +20,19 @@
 
 mod util;
 
+use std::time::Duration;
+
 use libp2p_core::Multiaddr;
 use libp2p_identity::PeerId;
 use libp2p_memory_connection_limits::*;
-use std::time::Duration;
-use sysinfo::{MemoryRefreshKind, RefreshKind};
-use util::*;
-
 use libp2p_swarm::{
     dial_opts::{DialOpts, PeerCondition},
-    DialError, Swarm,
+    DialError,
+    Swarm,
 };
 use libp2p_swarm_test::SwarmExt;
+use sysinfo::{MemoryRefreshKind, RefreshKind};
+use util::*;
 
 #[test]
 fn max_percentage() {
@@ -76,7 +77,8 @@ fn max_percentage() {
             .expect("Unexpected connection limit.");
     }
 
-    std::thread::sleep(Duration::from_millis(100)); // Memory stats are only updated every 100ms internally, ensure they are up-to-date when we try to exceed it.
+    std::thread::sleep(Duration::from_millis(100)); // Memory stats are only updated every 100ms internally, ensure they are
+                                                    // up-to-date when we try to exceed it.
 
     match network
         .dial(

--- a/misc/memory-connection-limits/tests/util/mod.rs
+++ b/misc/memory-connection-limits/tests/util/mod.rs
@@ -18,15 +18,24 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::task::{Context, Poll};
+use std::{
+    convert::Infallible,
+    task::{Context, Poll},
+};
 
 use libp2p_core::{transport::PortUse, Endpoint, Multiaddr};
 use libp2p_identity::PeerId;
 use libp2p_swarm::{
-    dummy, ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour, THandler, THandlerInEvent,
-    THandlerOutEvent, ToSwarm,
+    dummy,
+    ConnectionDenied,
+    ConnectionId,
+    FromSwarm,
+    NetworkBehaviour,
+    THandler,
+    THandlerInEvent,
+    THandlerOutEvent,
+    ToSwarm,
 };
-use std::convert::Infallible;
 
 #[derive(libp2p_swarm_derive::NetworkBehaviour)]
 #[behaviour(prelude = "libp2p_swarm::derive_prelude")]

--- a/misc/metrics/src/bandwidth.rs
+++ b/misc/metrics/src/bandwidth.rs
@@ -1,4 +1,10 @@
-use crate::protocol_stack;
+use std::{
+    convert::TryFrom as _,
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
 use futures::{
     future::{MapOk, TryFutureExt},
     io::{IoSlice, IoSliceMut},
@@ -16,12 +22,8 @@ use prometheus_client::{
     metrics::{counter::Counter, family::Family},
     registry::{Registry, Unit},
 };
-use std::{
-    convert::TryFrom as _,
-    io,
-    pin::Pin,
-    task::{Context, Poll},
-};
+
+use crate::protocol_stack;
 
 #[derive(Debug, Clone)]
 #[pin_project::pin_project]
@@ -160,8 +162,8 @@ impl ConnectionMetrics {
     }
 }
 
-/// Wraps around a [`StreamMuxer`] and counts the number of bytes that go through all the opened
-/// streams.
+/// Wraps around a [`StreamMuxer`] and counts the number of bytes that go
+/// through all the opened streams.
 #[derive(Clone)]
 #[pin_project::pin_project]
 pub struct Muxer<SMInner> {
@@ -224,7 +226,8 @@ where
     }
 }
 
-/// Wraps around an [`AsyncRead`] + [`AsyncWrite`] and logs the bandwidth that goes through it.
+/// Wraps around an [`AsyncRead`] + [`AsyncWrite`] and logs the bandwidth that
+/// goes through it.
 #[pin_project::pin_project]
 pub struct InstrumentedStream<SMInner> {
     #[pin]

--- a/misc/metrics/src/dcutr.rs
+++ b/misc/metrics/src/dcutr.rs
@@ -18,10 +18,11 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
-use prometheus_client::metrics::counter::Counter;
-use prometheus_client::metrics::family::Family;
-use prometheus_client::registry::Registry;
+use prometheus_client::{
+    encoding::{EncodeLabelSet, EncodeLabelValue},
+    metrics::{counter::Counter, family::Family},
+    registry::Registry,
+};
 
 pub(crate) struct Metrics {
     events: Family<EventLabels, Counter>,

--- a/misc/metrics/src/gossipsub.rs
+++ b/misc/metrics/src/gossipsub.rs
@@ -18,8 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use prometheus_client::metrics::counter::Counter;
-use prometheus_client::registry::Registry;
+use prometheus_client::{metrics::counter::Counter, registry::Registry};
 
 pub(crate) struct Metrics {
     messages: Counter,

--- a/misc/metrics/src/identify.rs
+++ b/misc/metrics/src/identify.rs
@@ -18,17 +18,21 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::protocol_stack;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
 use libp2p_identity::PeerId;
 use libp2p_swarm::StreamProtocol;
-use prometheus_client::collector::Collector;
-use prometheus_client::encoding::{DescriptorEncoder, EncodeMetric};
-use prometheus_client::metrics::counter::Counter;
-use prometheus_client::metrics::gauge::ConstGauge;
-use prometheus_client::metrics::MetricType;
-use prometheus_client::registry::Registry;
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use prometheus_client::{
+    collector::Collector,
+    encoding::{DescriptorEncoder, EncodeMetric},
+    metrics::{counter::Counter, gauge::ConstGauge, MetricType},
+    registry::Registry,
+};
+
+use crate::protocol_stack;
 
 const ALLOWED_PROTOCOLS: &[StreamProtocol] = &[
     #[cfg(feature = "dcutr")]
@@ -72,24 +76,23 @@ impl Metrics {
         let pushed = Counter::default();
         sub_registry.register(
             "pushed",
-            "Number of times identification information of the local node has \
-             been actively pushed to a peer.",
+            "Number of times identification information of the local node has been actively \
+             pushed to a peer.",
             pushed.clone(),
         );
 
         let received = Counter::default();
         sub_registry.register(
             "received",
-            "Number of times identification information has been received from \
-             a peer",
+            "Number of times identification information has been received from a peer",
             received.clone(),
         );
 
         let sent = Counter::default();
         sub_registry.register(
             "sent",
-            "Number of times identification information of the local node has \
-             been sent to a peer in response to an identification request",
+            "Number of times identification information of the local node has been sent to a peer \
+             in response to an identification request",
             sent.clone(),
         );
 
@@ -205,7 +208,8 @@ impl Collector for Peers {
         {
             let mut family_encoder = encoder.encode_descriptor(
                 "remote_protocols",
-                "Number of connected nodes supporting a specific protocol, with \"unrecognized\" for each peer supporting one or more unrecognized protocols",
+                "Number of connected nodes supporting a specific protocol, with \"unrecognized\" \
+                 for each peer supporting one or more unrecognized protocols",
                 None,
                 MetricType::Gauge,
             )?;

--- a/misc/metrics/src/kad.rs
+++ b/misc/metrics/src/kad.rs
@@ -18,11 +18,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
-use prometheus_client::metrics::counter::Counter;
-use prometheus_client::metrics::family::Family;
-use prometheus_client::metrics::histogram::{exponential_buckets, Histogram};
-use prometheus_client::registry::{Registry, Unit};
+use prometheus_client::{
+    encoding::{EncodeLabelSet, EncodeLabelValue},
+    metrics::{
+        counter::Counter,
+        family::Family,
+        histogram::{exponential_buckets, Histogram},
+    },
+    registry::{Registry, Unit},
+};
 
 pub(crate) struct Metrics {
     query_result_get_record_ok: Counter,
@@ -126,7 +130,8 @@ impl Metrics {
         let routing_updated = Family::default();
         sub_registry.register(
             "routing_updated",
-            "Number of peers added, updated or evicted to, in or from a specific kbucket in the routing table",
+            "Number of peers added, updated or evicted to, in or from a specific kbucket in the \
+             routing table",
             routing_updated.clone(),
         );
 

--- a/misc/metrics/src/lib.rs
+++ b/misc/metrics/src/lib.rs
@@ -67,8 +67,8 @@ impl Metrics {
     /// Create a new set of Swarm and protocol [`Metrics`].
     ///
     /// ```
-    /// use prometheus_client::registry::Registry;
     /// use libp2p_metrics::Metrics;
+    /// use prometheus_client::registry::Registry;
     /// let mut registry = Registry::default();
     /// let metrics = Metrics::new(&mut registry);
     /// ```

--- a/misc/metrics/src/ping.rs
+++ b/misc/metrics/src/ping.rs
@@ -18,11 +18,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
-use prometheus_client::metrics::counter::Counter;
-use prometheus_client::metrics::family::Family;
-use prometheus_client::metrics::histogram::{exponential_buckets, Histogram};
-use prometheus_client::registry::{Registry, Unit};
+use prometheus_client::{
+    encoding::{EncodeLabelSet, EncodeLabelValue},
+    metrics::{
+        counter::Counter,
+        family::Family,
+        histogram::{exponential_buckets, Histogram},
+    },
+    registry::{Registry, Unit},
+};
 
 #[derive(Clone, Hash, PartialEq, Eq, EncodeLabelSet, Debug)]
 struct FailureLabels {

--- a/misc/metrics/src/protocol_stack.rs
+++ b/misc/metrics/src/protocol_stack.rs
@@ -18,13 +18,21 @@ mod tests {
 
     #[test]
     fn ip6_tcp_wss_p2p() {
-        let ma = Multiaddr::try_from("/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/wss/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC").expect("testbad");
+        let ma = Multiaddr::try_from(
+            "/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/wss/p2p/\
+             QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+        )
+        .expect("testbad");
 
         let protocol_stack = as_string(&ma);
 
         assert_eq!(protocol_stack, "/ip6/tcp/wss/p2p");
 
-        let ma = Multiaddr::try_from("/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/tls/ws/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC").expect("testbad");
+        let ma = Multiaddr::try_from(
+            "/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/tls/ws/p2p/\
+             QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+        )
+        .expect("testbad");
 
         let protocol_stack = as_string(&ma);
 

--- a/misc/metrics/src/relay.rs
+++ b/misc/metrics/src/relay.rs
@@ -18,10 +18,11 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
-use prometheus_client::metrics::counter::Counter;
-use prometheus_client::metrics::family::Family;
-use prometheus_client::registry::Registry;
+use prometheus_client::{
+    encoding::{EncodeLabelSet, EncodeLabelValue},
+    metrics::{counter::Counter, family::Family},
+    registry::Registry,
+};
 
 pub(crate) struct Metrics {
     events: Family<EventLabels, Counter>,

--- a/misc/metrics/src/swarm.rs
+++ b/misc/metrics/src/swarm.rs
@@ -18,17 +18,24 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use libp2p_swarm::{ConnectionId, DialError, SwarmEvent};
+use prometheus_client::{
+    encoding::{EncodeLabelSet, EncodeLabelValue},
+    metrics::{
+        counter::Counter,
+        family::Family,
+        histogram::{exponential_buckets, Histogram},
+    },
+    registry::{Registry, Unit},
+};
+use web_time::Instant;
 
 use crate::protocol_stack;
-use libp2p_swarm::{ConnectionId, DialError, SwarmEvent};
-use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
-use prometheus_client::metrics::counter::Counter;
-use prometheus_client::metrics::family::Family;
-use prometheus_client::metrics::histogram::{exponential_buckets, Histogram};
-use prometheus_client::registry::{Registry, Unit};
-use web_time::Instant;
 
 pub(crate) struct Metrics {
     connections_incoming: Family<AddressLabels, Counter>,

--- a/misc/multistream-select/src/dialer_select.rs
+++ b/misc/multistream-select/src/dialer_select.rs
@@ -20,15 +20,21 @@
 
 //! Protocol negotiation strategies for the peer acting as the dialer.
 
-use crate::protocol::{HeaderLine, Message, MessageIO, Protocol, ProtocolError};
-use crate::{Negotiated, NegotiationError, Version};
-
-use futures::prelude::*;
 use std::{
     convert::TryFrom as _,
-    iter, mem,
+    iter,
+    mem,
     pin::Pin,
     task::{Context, Poll},
+};
+
+use futures::prelude::*;
+
+use crate::{
+    protocol::{HeaderLine, Message, MessageIO, Protocol, ProtocolError},
+    Negotiated,
+    NegotiationError,
+    Version,
 };
 
 /// Returns a `Future` that negotiates a protocol on the given I/O stream
@@ -84,8 +90,9 @@ enum State<R, N> {
 
 impl<R, I> Future for DialerSelectFuture<R, I>
 where
-    // The Unpin bound here is required because we produce a `Negotiated<R>` as the output.
-    // It also makes the implementation considerably easier to write.
+    // The Unpin bound here is required because we produce
+    // a `Negotiated<R>` as the output. It also makes
+    // the implementation considerably easier to write.
     R: AsyncRead + AsyncWrite + Unpin,
     I: Iterator,
     I::Item: AsRef<str>,
@@ -204,14 +211,18 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::listener_select_proto;
-    use async_std::future::timeout;
-    use async_std::net::{TcpListener, TcpStream};
-    use quickcheck::{Arbitrary, Gen, GenRange};
     use std::time::Duration;
+
+    use async_std::{
+        future::timeout,
+        net::{TcpListener, TcpStream},
+    };
+    use quickcheck::{Arbitrary, Gen, GenRange};
     use tracing::metadata::LevelFilter;
     use tracing_subscriber::EnvFilter;
+
+    use super::*;
+    use crate::listener_select_proto;
 
     #[test]
     fn select_proto_basic() {
@@ -353,8 +364,8 @@ mod tests {
                 .unwrap();
             assert_eq!(proto, "/proto1");
 
-            // client can close the connection even though protocol negotiation is not yet done, i.e.
-            // `_server_connection` had been untouched.
+            // client can close the connection even though protocol negotiation is not yet
+            // done, i.e. `_server_connection` had been untouched.
             io.close().await.unwrap();
         });
 

--- a/misc/multistream-select/src/length_delimited.rs
+++ b/misc/multistream-select/src/length_delimited.rs
@@ -18,14 +18,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use bytes::{Buf as _, BufMut as _, Bytes, BytesMut};
-use futures::{io::IoSlice, prelude::*};
 use std::{
     convert::TryFrom as _,
     io,
     pin::Pin,
     task::{Context, Poll},
 };
+
+use bytes::{Buf as _, BufMut as _, Bytes, BytesMut};
+use futures::{io::IoSlice, prelude::*};
 
 const MAX_LEN_BYTES: u16 = 2;
 const MAX_FRAME_SIZE: u16 = (1 << (MAX_LEN_BYTES * 8 - MAX_LEN_BYTES)) - 1;
@@ -35,15 +36,16 @@ const DEFAULT_BUFFER_SIZE: usize = 64;
 /// wrapping an underlying `AsyncRead + AsyncWrite` I/O resource.
 ///
 /// We purposely only support a frame sizes up to 16KiB (2 bytes unsigned varint
-/// frame length). Frames mostly consist in a short protocol name, which is highly
-/// unlikely to be more than 16KiB long.
+/// frame length). Frames mostly consist in a short protocol name, which is
+/// highly unlikely to be more than 16KiB long.
 #[pin_project::pin_project]
 #[derive(Debug)]
 pub(crate) struct LengthDelimited<R> {
     /// The inner I/O resource.
     #[pin]
     inner: R,
-    /// Read buffer for a single incoming unsigned-varint length-delimited frame.
+    /// Read buffer for a single incoming unsigned-varint length-delimited
+    /// frame.
     read_buffer: BytesMut,
     /// Write buffer for outgoing unsigned-varint length-delimited frames.
     write_buffer: BytesMut,
@@ -84,7 +86,8 @@ impl<R> LengthDelimited<R> {
         }
     }
 
-    /// Drops the [`LengthDelimited`] resource, yielding the underlying I/O stream.
+    /// Drops the [`LengthDelimited`] resource, yielding the underlying I/O
+    /// stream.
     ///
     /// # Panic
     ///
@@ -98,9 +101,9 @@ impl<R> LengthDelimited<R> {
         self.inner
     }
 
-    /// Converts the [`LengthDelimited`] into a [`LengthDelimitedReader`], dropping the
-    /// uvi-framed `Sink` in favour of direct `AsyncWrite` access to the underlying
-    /// I/O stream.
+    /// Converts the [`LengthDelimited`] into a [`LengthDelimitedReader`],
+    /// dropping the uvi-framed `Sink` in favour of direct `AsyncWrite`
+    /// access to the underlying I/O stream.
     ///
     /// This is typically done if further uvi-framed messages are expected to be
     /// received but no more such messages are written, allowing the writing of
@@ -293,7 +296,8 @@ where
 }
 
 /// A `LengthDelimitedReader` implements a `Stream` of uvi-length-delimited
-/// frames on an underlying I/O resource combined with direct `AsyncWrite` access.
+/// frames on an underlying I/O resource combined with direct `AsyncWrite`
+/// access.
 #[pin_project::pin_project]
 #[derive(Debug)]
 pub(crate) struct LengthDelimitedReader<R> {
@@ -302,7 +306,8 @@ pub(crate) struct LengthDelimitedReader<R> {
 }
 
 impl<R> LengthDelimitedReader<R> {
-    /// Destroys the `LengthDelimitedReader` and returns the underlying I/O stream.
+    /// Destroys the `LengthDelimitedReader` and returns the underlying I/O
+    /// stream.
     ///
     /// This method is guaranteed not to drop any data read from or not yet
     /// submitted to the underlying I/O stream.
@@ -311,9 +316,10 @@ impl<R> LengthDelimitedReader<R> {
     ///
     /// Will panic if called while there is data in the read or write buffer.
     /// The read buffer is guaranteed to be empty whenever [`Stream::poll_next`]
-    /// yield a new `Message`. The write buffer is guaranteed to be empty whenever
-    /// [`LengthDelimited::poll_write_buffer`] yields [`Poll::Ready`] or after
-    /// the [`Sink`] has been completely flushed via [`Sink::poll_flush`].
+    /// yield a new `Message`. The write buffer is guaranteed to be empty
+    /// whenever [`LengthDelimited::poll_write_buffer`] yields
+    /// [`Poll::Ready`] or after the [`Sink`] has been completely flushed
+    /// via [`Sink::poll_flush`].
     pub(crate) fn into_inner(self) -> R {
         self.inner.into_inner()
     }
@@ -383,10 +389,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::length_delimited::LengthDelimited;
+    use std::io::ErrorKind;
+
     use futures::{io::Cursor, prelude::*};
     use quickcheck::*;
-    use std::io::ErrorKind;
+
+    use crate::length_delimited::LengthDelimited;
 
     #[test]
     fn basic_read() {

--- a/misc/multistream-select/src/lib.rs
+++ b/misc/multistream-select/src/lib.rs
@@ -20,28 +20,29 @@
 
 //! # Multistream-select Protocol Negotiation
 //!
-//! This crate implements the `multistream-select` protocol, which is the protocol
-//! used by libp2p to negotiate which application-layer protocol to use with the
-//! remote on a connection or substream.
+//! This crate implements the `multistream-select` protocol, which is the
+//! protocol used by libp2p to negotiate which application-layer protocol to use
+//! with the remote on a connection or substream.
 //!
-//! > **Note**: This crate is used primarily by core components of *libp2p* and it
+//! > **Note**: This crate is used primarily by core components of *libp2p* and
+//! > it
 //! > is usually not used directly on its own.
 //!
 //! ## Roles
 //!
 //! Two peers using the multistream-select negotiation protocol on an I/O stream
-//! are distinguished by their role as a _dialer_ (or _initiator_) or as a _listener_
-//! (or _responder_). Thereby the dialer plays the active part, driving the protocol,
-//! whereas the listener reacts to the messages received.
+//! are distinguished by their role as a _dialer_ (or _initiator_) or as a
+//! _listener_ (or _responder_). Thereby the dialer plays the active part,
+//! driving the protocol, whereas the listener reacts to the messages received.
 //!
-//! The dialer has two options: it can either pick a protocol from the complete list
-//! of protocols that the listener supports, or it can directly suggest a protocol.
-//! Either way, a selected protocol is sent to the listener who can either accept (by
-//! echoing the same protocol) or reject (by responding with a message stating
-//! "not available"). If a suggested protocol is not available, the dialer may
-//! suggest another protocol. This process continues until a protocol is agreed upon,
-//! yielding a [`Negotiated`] stream, or the dialer has run out of
-//! alternatives.
+//! The dialer has two options: it can either pick a protocol from the complete
+//! list of protocols that the listener supports, or it can directly suggest a
+//! protocol. Either way, a selected protocol is sent to the listener who can
+//! either accept (by echoing the same protocol) or reject (by responding with a
+//! message stating "not available"). If a suggested protocol is not available,
+//! the dialer may suggest another protocol. This process continues until a
+//! protocol is agreed upon, yielding a [`Negotiated`] stream, or the dialer has
+//! run out of alternatives.
 //!
 //! See [`dialer_select_proto`] and [`listener_select_proto`].
 //!
@@ -57,12 +58,13 @@
 //! [`Negotiated`] I/O stream before the negotiation
 //! data has been flushed. It is then expecting confirmation for that protocol
 //! as the first messages read from the stream. This behaviour allows the dialer
-//! to immediately send data relating to the negotiated protocol together with the
-//! remaining negotiation message(s). Note, however, that a dialer that performs
-//! multiple 0-RTT negotiations in sequence for different protocols layered on
-//! top of each other may trigger undesirable behaviour for a listener not
-//! supporting one of the intermediate protocols. See
-//! [`dialer_select_proto`] and the documentation of [`Version::V1Lazy`] for further details.
+//! to immediately send data relating to the negotiated protocol together with
+//! the remaining negotiation message(s). Note, however, that a dialer that
+//! performs multiple 0-RTT negotiations in sequence for different protocols
+//! layered on top of each other may trigger undesirable behaviour for a
+//! listener not supporting one of the intermediate protocols. See
+//! [`dialer_select_proto`] and the documentation of [`Version::V1Lazy`] for
+//! further details.
 //!
 //! ## Examples
 //!
@@ -70,20 +72,21 @@
 //!
 //! ```no_run
 //! use async_std::net::TcpStream;
-//! use multistream_select::{dialer_select_proto, Version};
 //! use futures::prelude::*;
+//! use multistream_select::{dialer_select_proto, Version};
 //!
 //! async_std::task::block_on(async move {
 //!     let socket = TcpStream::connect("127.0.0.1:10333").await.unwrap();
 //!
 //!     let protos = vec!["/echo/1.0.0", "/echo/2.5.0"];
-//!     let (protocol, _io) = dialer_select_proto(socket, protos, Version::V1).await.unwrap();
+//!     let (protocol, _io) = dialer_select_proto(socket, protos, Version::V1)
+//!         .await
+//!         .unwrap();
 //!
 //!     println!("Negotiated protocol: {:?}", protocol);
 //!     // You can now use `_io` to communicate with the remote.
 //! });
 //! ```
-//!
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
@@ -93,10 +96,12 @@ mod listener_select;
 mod negotiated;
 mod protocol;
 
-pub use self::dialer_select::{dialer_select_proto, DialerSelectFuture};
-pub use self::listener_select::{listener_select_proto, ListenerSelectFuture};
-pub use self::negotiated::{Negotiated, NegotiatedComplete, NegotiationError};
-pub use self::protocol::ProtocolError;
+pub use self::{
+    dialer_select::{dialer_select_proto, DialerSelectFuture},
+    listener_select::{listener_select_proto, ListenerSelectFuture},
+    negotiated::{Negotiated, NegotiatedComplete, NegotiationError},
+    protocol::ProtocolError,
+};
 
 /// Supported multistream-select versions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -118,21 +123,31 @@ pub enum Version {
     /// with the first round of application protocol data (or an attempt
     /// is made to read from the `Negotiated` I/O stream).
     ///
-    /// A listener will behave identically to `V1`. This ensures interoperability with `V1`.
-    /// Notably, it will immediately send the multistream header as well as the protocol
-    /// confirmation, resulting in multiple frames being sent on the underlying transport.
-    /// Nevertheless, if the listener supports the protocol that the dialer optimistically
-    /// settled on, it can be a 0-RTT negotiation.
+    /// A listener will behave identically to `V1`. This ensures
+    /// interoperability with `V1`. Notably, it will immediately send the
+    /// multistream header as well as the protocol confirmation, resulting
+    /// in multiple frames being sent on the underlying transport.
+    /// Nevertheless, if the listener supports the protocol that the dialer
+    /// optimistically settled on, it can be a 0-RTT negotiation.
     ///
-    /// > **Note**: `V1Lazy` is specific to `rust-libp2p`. The wire protocol is identical to `V1`
-    /// > and generally interoperable with peers only supporting `V1`. Nevertheless, there is a
-    /// > pitfall that is rarely encountered: When nesting multiple protocol negotiations, the
-    /// > listener should either be known to support all of the dialer's optimistically chosen
-    /// > protocols or there is must be no intermediate protocol without a payload and none of
-    /// > the protocol payloads must have the potential for being mistaken for a multistream-select
-    /// > protocol message. This avoids rare edge-cases whereby the listener may not recognize
-    /// > upgrade boundaries and erroneously process a request despite not supporting one of
-    /// > the intermediate protocols that the dialer committed to. See [1] and [2].
+    /// > **Note**: `V1Lazy` is specific to `rust-libp2p`. The wire protocol is
+    /// > identical to `V1`
+    /// > and generally interoperable with peers only supporting `V1`.
+    /// > Nevertheless, there is a
+    /// > pitfall that is rarely encountered: When nesting multiple protocol
+    /// > negotiations, the
+    /// > listener should either be known to support all of the dialer's
+    /// > optimistically chosen
+    /// > protocols or there is must be no intermediate protocol without a
+    /// > payload and none of
+    /// > the protocol payloads must have the potential for being mistaken for a
+    /// > multistream-select
+    /// > protocol message. This avoids rare edge-cases whereby the listener may
+    /// > not recognize
+    /// > upgrade boundaries and erroneously process a request despite not
+    /// > supporting one of
+    /// > the intermediate protocols that the dialer committed to. See [1] and
+    /// > [2].
     ///
     /// [1]: https://github.com/multiformats/go-multistream/issues/20
     /// [2]: https://github.com/libp2p/rust-libp2p/pull/1212

--- a/misc/multistream-select/src/listener_select.rs
+++ b/misc/multistream-select/src/listener_select.rs
@@ -21,16 +21,20 @@
 //! Protocol negotiation strategies for the peer acting as the listener
 //! in a multistream-select protocol negotiation.
 
-use crate::protocol::{HeaderLine, Message, MessageIO, Protocol, ProtocolError};
-use crate::{Negotiated, NegotiationError};
-
-use futures::prelude::*;
-use smallvec::SmallVec;
 use std::{
     convert::TryFrom as _,
     mem,
     pin::Pin,
     task::{Context, Poll},
+};
+
+use futures::prelude::*;
+use smallvec::SmallVec;
+
+use crate::{
+    protocol::{HeaderLine, Message, MessageIO, Protocol, ProtocolError},
+    Negotiated,
+    NegotiationError,
 };
 
 /// Returns a `Future` that negotiates a protocol on the given I/O stream
@@ -109,8 +113,10 @@ enum State<R, N> {
 
 impl<R, N> Future for ListenerSelectFuture<R, N>
 where
-    // The Unpin bound here is required because we produce a `Negotiated<R>` as the output.
-    // It also makes the implementation considerably easier to write.
+    // The Unpin bound here is required because we
+    // produce a `Negotiated<R>` as the output.
+    // It also makes the implementation considerably
+    // easier to write.
     R: AsyncRead + AsyncWrite + Unpin,
     N: AsRef<str> + Clone,
 {
@@ -186,16 +192,16 @@ where
                                 // reading the `N/A` response.
                                 if let ProtocolError::InvalidMessage = &err {
                                     tracing::trace!(
-                                        "Listener: Negotiation failed with invalid \
-                                        message after protocol rejection."
+                                        "Listener: Negotiation failed with invalid message after \
+                                         protocol rejection."
                                     );
                                     return Poll::Ready(Err(NegotiationError::Failed));
                                 }
                                 if let ProtocolError::IoError(e) = &err {
                                     if e.kind() == std::io::ErrorKind::UnexpectedEof {
                                         tracing::trace!(
-                                            "Listener: Negotiation failed with EOF \
-                                            after protocol rejection."
+                                            "Listener: Negotiation failed with EOF after protocol \
+                                             rejection."
                                         );
                                         return Poll::Ready(Err(NegotiationError::Failed));
                                     }

--- a/misc/multistream-select/src/protocol.rs
+++ b/misc/multistream-select/src/protocol.rs
@@ -25,18 +25,22 @@
 //! `Stream` and `Sink` implementations of `MessageIO` and
 //! `MessageReader`.
 
-use crate::length_delimited::{LengthDelimited, LengthDelimitedReader};
-use crate::Version;
-
-use bytes::{BufMut, Bytes, BytesMut};
-use futures::{io::IoSlice, prelude::*, ready};
 use std::{
     error::Error,
-    fmt, io,
+    fmt,
+    io,
     pin::Pin,
     task::{Context, Poll},
 };
+
+use bytes::{BufMut, Bytes, BytesMut};
+use futures::{io::IoSlice, prelude::*, ready};
 use unsigned_varint as uvi;
+
+use crate::{
+    length_delimited::{LengthDelimited, LengthDelimitedReader},
+    Version,
+};
 
 /// The maximum number of supported protocols that can be processed.
 const MAX_PROTOCOLS: usize = 1000;
@@ -248,9 +252,9 @@ impl<R> MessageIO<R> {
     /// [`Message`]-oriented `Sink` in favour of direct `AsyncWrite` access
     /// to the underlying I/O stream.
     ///
-    /// This is typically done if further negotiation messages are expected to be
-    /// received but no more messages are written, allowing the writing of
-    /// follow-up protocol data to commence.
+    /// This is typically done if further negotiation messages are expected to
+    /// be received but no more messages are written, allowing the writing
+    /// of follow-up protocol data to commence.
     pub(crate) fn into_reader(self) -> MessageReader<R> {
         MessageReader {
             inner: self.inner.into_reader(),
@@ -261,11 +265,12 @@ impl<R> MessageIO<R> {
     ///
     /// # Panics
     ///
-    /// Panics if the read buffer or write buffer is not empty, meaning that an incoming
-    /// protocol negotiation frame has been partially read or an outgoing frame
-    /// has not yet been flushed. The read buffer is guaranteed to be empty whenever
-    /// `MessageIO::poll` returned a message. The write buffer is guaranteed to be empty
-    /// when the sink has been flushed.
+    /// Panics if the read buffer or write buffer is not empty, meaning that an
+    /// incoming protocol negotiation frame has been partially read or an
+    /// outgoing frame has not yet been flushed. The read buffer is
+    /// guaranteed to be empty whenever `MessageIO::poll` returned a
+    /// message. The write buffer is guaranteed to be empty when the sink
+    /// has been flushed.
     pub(crate) fn into_inner(self) -> R {
         self.inner.into_inner()
     }
@@ -331,11 +336,12 @@ impl<R> MessageReader<R> {
     ///
     /// # Panics
     ///
-    /// Panics if the read buffer or write buffer is not empty, meaning that either
-    /// an incoming protocol negotiation frame has been partially read, or an
-    /// outgoing frame has not yet been flushed. The read buffer is guaranteed to
-    /// be empty whenever `MessageReader::poll` returned a message. The write
-    /// buffer is guaranteed to be empty whenever the sink has been flushed.
+    /// Panics if the read buffer or write buffer is not empty, meaning that
+    /// either an incoming protocol negotiation frame has been partially
+    /// read, or an outgoing frame has not yet been flushed. The read buffer
+    /// is guaranteed to be empty whenever `MessageReader::poll` returned a
+    /// message. The write buffer is guaranteed to be empty whenever the
+    /// sink has been flushed.
     pub(crate) fn into_inner(self) -> R {
         self.inner.into_inner()
     }
@@ -461,9 +467,11 @@ impl fmt::Display for ProtocolError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use quickcheck::*;
     use std::iter;
+
+    use quickcheck::*;
+
+    use super::*;
 
     impl Arbitrary for Protocol {
         fn arbitrary(g: &mut Gen) -> Protocol {

--- a/misc/quick-protobuf-codec/src/lib.rs
+++ b/misc/quick-protobuf-codec/src/lib.rs
@@ -1,10 +1,10 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+use std::{io, marker::PhantomData};
+
 use asynchronous_codec::{Decoder, Encoder};
 use bytes::{Buf, BufMut, BytesMut};
 use quick_protobuf::{BytesReader, MessageRead, MessageWrite, Writer, WriterBackend};
-use std::io;
-use std::marker::PhantomData;
 
 mod generated;
 
@@ -13,8 +13,9 @@ pub use generated::test as proto;
 
 /// [`Codec`] implements [`Encoder`] and [`Decoder`], uses [`unsigned_varint`]
 ///
-/// to prefix messages with their length and uses [`quick_protobuf`] and a provided
-/// `struct` implementing [`MessageRead`] and [`MessageWrite`] to do the encoding.
+/// to prefix messages with their length and uses [`quick_protobuf`] and a
+/// provided `struct` implementing [`MessageRead`] and [`MessageWrite`] to do
+/// the encoding.
 pub struct Codec<In, Out = In> {
     max_message_len_bytes: usize,
     phantom: PhantomData<(In, Out)>,
@@ -46,7 +47,8 @@ impl<In: MessageWrite, Out> Encoder for Codec<In, Out> {
     }
 }
 
-/// Write the message's length (i.e. `size`) to `dst` as a variable-length integer.
+/// Write the message's length (i.e. `size`) to `dst` as a variable-length
+/// integer.
 fn write_length(message: &impl MessageWrite, dst: &mut BytesMut) {
     let message_length = message.get_size();
 
@@ -182,12 +184,13 @@ impl From<Error> for io::Error {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use asynchronous_codec::FramedRead;
-    use futures::io::Cursor;
-    use futures::{FutureExt, StreamExt};
-    use quickcheck::{Arbitrary, Gen, QuickCheck};
     use std::error::Error;
+
+    use asynchronous_codec::FramedRead;
+    use futures::{io::Cursor, FutureExt, StreamExt};
+    use quickcheck::{Arbitrary, Gen, QuickCheck};
+
+    use super::*;
 
     #[test]
     fn honors_max_message_length() {
@@ -244,7 +247,8 @@ mod tests {
         QuickCheck::new().quickcheck(prop as fn(_, _) -> _)
     }
 
-    /// Constructs a [`BytesMut`] of the provided length where the message is all zeros.
+    /// Constructs a [`BytesMut`] of the provided length where the message is
+    /// all zeros.
     fn varint_zeroes(length: usize) -> BytesMut {
         let mut buf = unsigned_varint::encode::usize_buffer();
         let encoded_length = unsigned_varint::encode::usize(length, &mut buf);

--- a/misc/quick-protobuf-codec/tests/large_message.rs
+++ b/misc/quick-protobuf-codec/tests/large_message.rs
@@ -1,7 +1,6 @@
 use asynchronous_codec::Encoder;
 use bytes::BytesMut;
-use quick_protobuf_codec::proto;
-use quick_protobuf_codec::Codec;
+use quick_protobuf_codec::{proto, Codec};
 
 #[test]
 fn encode_large_message() {

--- a/misc/quickcheck-ext/src/lib.rs
+++ b/misc/quickcheck-ext/src/lib.rs
@@ -1,9 +1,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-pub use quickcheck::*;
-
 use core::ops::Range;
+
 use num_traits::sign::Unsigned;
+pub use quickcheck::*;
 
 pub trait GenRange {
     fn gen_range<T: Unsigned + Arbitrary + Copy>(&mut self, _range: Range<T>) -> T;

--- a/misc/rw-stream-sink/src/lib.rs
+++ b/misc/rw-stream-sink/src/lib.rs
@@ -23,17 +23,19 @@
 //! [`AsyncRead`] and [`AsyncWrite`].
 //!
 //! Each call to [`AsyncWrite::poll_write`] will send one packet to the sink.
-//! Calls to [`AsyncRead::poll_read`] will read from the stream's incoming packets.
+//! Calls to [`AsyncRead::poll_read`] will read from the stream's incoming
+//! packets.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use futures::{prelude::*, ready};
 use std::{
     io::{self, Read},
     mem,
     pin::Pin,
     task::{Context, Poll},
 };
+
+use futures::{prelude::*, ready};
 
 static_assertions::const_assert!(mem::size_of::<usize>() <= mem::size_of::<u64>());
 
@@ -115,13 +117,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::RwStreamSink;
-    use async_std::task;
-    use futures::{channel::mpsc, prelude::*};
     use std::{
         pin::Pin,
         task::{Context, Poll},
     };
+
+    use async_std::task;
+    use futures::{channel::mpsc, prelude::*};
+
+    use super::RwStreamSink;
 
     // This struct merges a stream and a sink and is quite useful for tests.
     struct Wrapper<St, Si>(St, Si);

--- a/misc/server/src/behaviour.rs
+++ b/misc/server/src/behaviour.rs
@@ -1,13 +1,16 @@
-use libp2p::autonat;
-use libp2p::identify;
-use libp2p::kad;
-use libp2p::ping;
-use libp2p::relay;
-use libp2p::swarm::behaviour::toggle::Toggle;
-use libp2p::swarm::{NetworkBehaviour, StreamProtocol};
-use libp2p::{identity, Multiaddr, PeerId};
-use std::str::FromStr;
-use std::time::Duration;
+use std::{str::FromStr, time::Duration};
+
+use libp2p::{
+    autonat,
+    identify,
+    identity,
+    kad,
+    ping,
+    relay,
+    swarm::{behaviour::toggle::Toggle, NetworkBehaviour, StreamProtocol},
+    Multiaddr,
+    PeerId,
+};
 
 const BOOTNODES: [&str; 4] = [
     "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",

--- a/misc/server/src/config.rs
+++ b/misc/server/src/config.rs
@@ -1,7 +1,7 @@
+use std::{error::Error, path::Path};
+
 use libp2p::Multiaddr;
 use serde_derive::Deserialize;
-use std::error::Error;
-use std::path::Path;
 
 #[derive(Clone, Deserialize)]
 #[serde(rename_all = "PascalCase")]

--- a/misc/server/src/http_service.rs
+++ b/misc/server/src/http_service.rs
@@ -18,15 +18,13 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use axum::extract::State;
-use axum::http::StatusCode;
-use axum::response::IntoResponse;
-use axum::routing::get;
-use axum::Router;
-use prometheus_client::encoding::text::encode;
-use prometheus_client::registry::Registry;
-use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
+use std::{
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
+
+use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::get, Router};
+use prometheus_client::{encoding::text::encode, registry::Registry};
 use tokio::net::TcpListener;
 
 const METRICS_CONTENT_TYPE: &str = "application/openmetrics-text;charset=utf-8;version=1.0.0";

--- a/misc/server/src/main.rs
+++ b/misc/server/src/main.rs
@@ -1,18 +1,20 @@
+use std::{error::Error, path::PathBuf, str::FromStr};
+
 use base64::Engine;
 use clap::Parser;
 use futures::stream::StreamExt;
-use libp2p::identity;
-use libp2p::identity::PeerId;
-use libp2p::kad;
-use libp2p::metrics::{Metrics, Recorder};
-use libp2p::swarm::SwarmEvent;
-use libp2p::tcp;
-use libp2p::{identify, noise, yamux};
-use prometheus_client::metrics::info::Info;
-use prometheus_client::registry::Registry;
-use std::error::Error;
-use std::path::PathBuf;
-use std::str::FromStr;
+use libp2p::{
+    identify,
+    identity,
+    identity::PeerId,
+    kad,
+    metrics::{Metrics, Recorder},
+    noise,
+    swarm::SwarmEvent,
+    tcp,
+    yamux,
+};
+use prometheus_client::{metrics::info::Info, registry::Registry};
 use tracing_subscriber::EnvFilter;
 use zeroize::Zeroizing;
 

--- a/misc/webrtc-utils/src/fingerprint.rs
+++ b/misc/webrtc-utils/src/fingerprint.rs
@@ -19,16 +19,18 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::fmt;
+
 use libp2p_core::multihash;
 use sha2::Digest as _;
-use std::fmt;
 
 pub const SHA256: &str = "sha-256";
 const MULTIHASH_SHA256_CODE: u64 = 0x12;
 
 type Multihash = multihash::Multihash<64>;
 
-/// A certificate fingerprint that is assumed to be created using the SHA256 hash algorithm.
+/// A certificate fingerprint that is assumed to be created using the SHA256
+/// hash algorithm.
 #[derive(Eq, PartialEq, Copy, Clone)]
 pub struct Fingerprint([u8; 32]);
 
@@ -39,7 +41,8 @@ impl Fingerprint {
         Fingerprint(digest)
     }
 
-    /// Creates a new [Fingerprint] from a raw certificate by hashing the given bytes with SHA256.
+    /// Creates a new [Fingerprint] from a raw certificate by hashing the given
+    /// bytes with SHA256.
     pub fn from_certificate(bytes: &[u8]) -> Self {
         Fingerprint(sha2::Sha256::digest(bytes).into())
     }
@@ -85,7 +88,8 @@ impl fmt::Debug for Fingerprint {
 mod tests {
     use super::*;
 
-    const SDP_FORMAT: &str = "7D:E3:D8:3F:81:A6:80:59:2A:47:1E:6B:6A:BB:07:47:AB:D3:53:85:A8:09:3F:DF:E1:12:C1:EE:BB:6C:C6:AC";
+    const SDP_FORMAT: &str = "7D:E3:D8:3F:81:A6:80:59:2A:47:1E:6B:6A:BB:07:47:AB:D3:53:85:A8:09:\
+                              3F:DF:E1:12:C1:EE:BB:6C:C6:AC";
     const REGULAR_FORMAT: [u8; 32] =
         hex_literal::hex!("7DE3D83F81A680592A471E6B6ABB0747ABD35385A8093FDFE112C1EEBB6CC6AC");
 

--- a/misc/webrtc-utils/src/noise.rs
+++ b/misc/webrtc-utils/src/noise.rs
@@ -19,15 +19,16 @@
 // DEALINGS IN THE SOFTWARE.
 
 use futures::{AsyncRead, AsyncWrite, AsyncWriteExt};
-use libp2p_core::upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade};
-use libp2p_core::UpgradeInfo;
+use libp2p_core::{
+    upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade},
+    UpgradeInfo,
+};
 use libp2p_identity as identity;
 use libp2p_identity::PeerId;
 use libp2p_noise as noise;
+pub use noise::Error;
 
 use crate::fingerprint::Fingerprint;
-
-pub use noise::Error;
 
 pub async fn inbound<T>(
     id_keys: identity::Keypair,
@@ -42,8 +43,8 @@ where
         .unwrap()
         .with_prologue(noise_prologue(client_fingerprint, server_fingerprint));
     let info = noise.protocol_info().next().unwrap();
-    // Note the roles are reversed because it allows the server (webrtc connection responder) to
-    // send application data 0.5 RTT earlier.
+    // Note the roles are reversed because it allows the server (webrtc connection
+    // responder) to send application data 0.5 RTT earlier.
     let (peer_id, mut channel) = noise.upgrade_outbound(stream, info).await?;
 
     channel.close().await?;
@@ -64,8 +65,8 @@ where
         .unwrap()
         .with_prologue(noise_prologue(client_fingerprint, server_fingerprint));
     let info = noise.protocol_info().next().unwrap();
-    // Note the roles are reversed because it allows the server (webrtc connection responder) to
-    // send application data 0.5 RTT earlier.
+    // Note the roles are reversed because it allows the server (webrtc connection
+    // responder) to send application data 0.5 RTT earlier.
     let (peer_id, mut channel) = noise.upgrade_inbound(stream, info).await?;
 
     channel.close().await?;
@@ -89,8 +90,9 @@ pub(crate) fn noise_prologue(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use hex_literal::hex;
+
+    use super::*;
 
     #[test]
     fn noise_prologue_tests() {

--- a/misc/webrtc-utils/src/sdp.rs
+++ b/misc/webrtc-utils/src/sdp.rs
@@ -18,13 +18,13 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
-use crate::fingerprint::Fingerprint;
-use serde::Serialize;
 use std::net::{IpAddr, SocketAddr};
+
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use serde::Serialize;
 use tinytemplate::TinyTemplate;
 
-use rand::distributions::Alphanumeric;
-use rand::{thread_rng, Rng};
+use crate::fingerprint::Fingerprint;
 
 pub fn answer(addr: SocketAddr, server_fingerprint: Fingerprint, client_ufrag: &str) -> String {
     let answer = render_description(
@@ -43,37 +43,41 @@ pub fn answer(addr: SocketAddr, server_fingerprint: Fingerprint, client_ufrag: &
 //
 // a=ice-lite
 //
-//     A lite implementation is only appropriate for devices that will *always* be connected to
-//     the public Internet and have a public IP address at which it can receive packets from any
-//     correspondent. ICE will not function when a lite implementation is placed behind a NAT
-//     (RFC8445).
+//     A lite implementation is only appropriate for devices that will *always*
+// be connected to     the public Internet and have a public IP address at which
+// it can receive packets from any     correspondent. ICE will not function when
+// a lite implementation is placed behind a NAT     (RFC8445).
 //
 // a=tls-id:<id>
 //
 //     "TLS ID" uniquely identifies a TLS association.
-//     The ICE protocol uses a "TLS ID" system to indicate whether a fresh DTLS connection
-//     must be reopened in case of ICE renegotiation. Considering that ICE renegotiations
-//     never happen in our use case, we can simply put a random value and not care about
-//     it. Note however that the TLS ID in the answer must be present if and only if the
-//     offer contains one. (RFC8842)
-//     TODO: is it true that renegotiations never happen? what about a connection closing?
-//     "tls-id" attribute MUST be present in the initial offer and respective answer (RFC8839).
-//     XXX: but right now browsers don't send it.
+//     The ICE protocol uses a "TLS ID" system to indicate whether a fresh DTLS
+// connection     must be reopened in case of ICE renegotiation. Considering
+// that ICE renegotiations     never happen in our use case, we can simply put a
+// random value and not care about     it. Note however that the TLS ID in the
+// answer must be present if and only if the     offer contains one. (RFC8842)
+//     TODO: is it true that renegotiations never happen? what about a
+// connection closing?     "tls-id" attribute MUST be present in the initial
+// offer and respective answer (RFC8839).     XXX: but right now browsers don't
+// send it.
 //
 // a=setup:passive
 //
-//     "passive" indicates that the remote DTLS server will only listen for incoming
-//     connections. (RFC5763)
+//     "passive" indicates that the remote DTLS server will only listen for
+// incoming     connections. (RFC5763)
 //     The answerer (server) MUST not be located behind a NAT (RFC6135).
 //
-//     The answerer MUST use either a setup attribute value of setup:active or setup:passive.
-//     Note that if the answerer uses setup:passive, then the DTLS handshake will not begin until
-//     the answerer is received, which adds additional latency. setup:active allows the answer and
-//     the DTLS handshake to occur in parallel. Thus, setup:active is RECOMMENDED.
+//     The answerer MUST use either a setup attribute value of setup:active or
+// setup:passive.     Note that if the answerer uses setup:passive, then the
+// DTLS handshake will not begin until     the answerer is received, which adds
+// additional latency. setup:active allows the answer and     the DTLS handshake
+// to occur in parallel. Thus, setup:active is RECOMMENDED.
 //
-// a=candidate:<foundation> <component-id> <transport> <priority> <connection-address> <port> <cand-type>
+// a=candidate:<foundation> <component-id> <transport> <priority>
+// <connection-address> <port> <cand-type>
 //
-//     A transport address for a candidate that can be used for connectivity checks (RFC8839).
+//     A transport address for a candidate that can be used for connectivity
+// checks (RFC8839).
 //
 // a=end-of-candidates
 const SERVER_SESSION_DESCRIPTION: &str = "v=0
@@ -102,8 +106,8 @@ enum IpVersion {
     IP6,
 }
 
-/// Context passed to the templating engine, which replaces the above placeholders (e.g.
-/// `{IP_VERSION}`) with real values.
+/// Context passed to the templating engine, which replaces the above
+/// placeholders (e.g. `{IP_VERSION}`) with real values.
 #[derive(Serialize)]
 struct DescriptionContext {
     pub(crate) ip_version: IpVersion,

--- a/misc/webrtc-utils/src/stream/drop_listener.rs
+++ b/misc/webrtc-utils/src/stream/drop_listener.rs
@@ -18,17 +18,25 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures::channel::oneshot;
-use futures::channel::oneshot::Canceled;
-use futures::{AsyncRead, AsyncWrite, FutureExt, SinkExt};
+use std::{
+    future::Future,
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
-use std::future::Future;
-use std::io;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use futures::{
+    channel::{oneshot, oneshot::Canceled},
+    AsyncRead,
+    AsyncWrite,
+    FutureExt,
+    SinkExt,
+};
 
-use crate::proto::{Flag, Message};
-use crate::stream::framed_dc::FramedDc;
+use crate::{
+    proto::{Flag, Message},
+    stream::framed_dc::FramedDc,
+};
 
 #[must_use]
 pub struct DropListener<T> {

--- a/misc/webrtc-utils/src/stream/framed_dc.rs
+++ b/misc/webrtc-utils/src/stream/framed_dc.rs
@@ -21,8 +21,10 @@
 use asynchronous_codec::Framed;
 use futures::{AsyncRead, AsyncWrite};
 
-use crate::proto::Message;
-use crate::stream::{MAX_DATA_LEN, MAX_MSG_LEN, VARINT_LEN};
+use crate::{
+    proto::Message,
+    stream::{MAX_DATA_LEN, MAX_MSG_LEN, VARINT_LEN},
+};
 
 pub(crate) type FramedDc<T> = Framed<T, quick_protobuf_codec::Codec<Message>>;
 pub(crate) fn new<T>(inner: T) -> FramedDc<T>
@@ -30,8 +32,8 @@ where
     T: AsyncRead + AsyncWrite,
 {
     let mut framed = Framed::new(inner, codec());
-    // If not set, `Framed` buffers up to 131kB of data before sending, which leads to "outbound
-    // packet larger than maximum message size" error in webrtc-rs.
+    // If not set, `Framed` buffers up to 131kB of data before sending, which leads
+    // to "outbound packet larger than maximum message size" error in webrtc-rs.
     framed.set_send_high_water_mark(MAX_DATA_LEN);
     framed
 }

--- a/misc/webrtc-utils/src/stream/state.rs
+++ b/misc/webrtc-utils/src/stream/state.rs
@@ -18,9 +18,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use bytes::Bytes;
-
 use std::io;
+
+use bytes::Bytes;
 
 use crate::proto::Flag;
 
@@ -44,10 +44,11 @@ pub(crate) enum State {
     },
 }
 
-/// Represents the state of closing one half (either read or write) of the connection.
+/// Represents the state of closing one half (either read or write) of the
+/// connection.
 ///
-/// Gracefully closing the read or write requires sending the `STOP_SENDING` or `FIN` flag respectively
-/// and flushing the underlying connection.
+/// Gracefully closing the read or write requires sending the `STOP_SENDING` or
+/// `FIN` flag respectively and flushing the underlying connection.
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum Closing {
     Requested,
@@ -179,10 +180,11 @@ impl State {
         }
     }
 
-    /// Whether we should read from the stream in the [`futures::AsyncWrite`] implementation.
+    /// Whether we should read from the stream in the [`futures::AsyncWrite`]
+    /// implementation.
     ///
-    /// This is necessary for read-closed streams because we would otherwise not read any more flags from
-    /// the socket.
+    /// This is necessary for read-closed streams because we would otherwise not
+    /// read any more flags from the socket.
     pub(crate) fn read_flags_in_async_write(&self) -> bool {
         matches!(self, Self::ReadClosed)
     }
@@ -277,7 +279,8 @@ impl State {
         }
     }
 
-    /// Acts as a "barrier" for [`Stream::poll_close_read`](super::Stream::poll_close_read).
+    /// Acts as a "barrier" for
+    /// [`Stream::poll_close_read`](super::Stream::poll_close_read).
     pub(crate) fn close_read_barrier(&mut self) -> io::Result<Option<Closing>> {
         loop {
             match self {
@@ -324,8 +327,9 @@ impl State {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::io::ErrorKind;
+
+    use super::*;
 
     #[test]
     fn cannot_read_after_receiving_fin() {

--- a/misc/webrtc-utils/src/transport.rs
+++ b/misc/webrtc-utils/src/transport.rs
@@ -1,8 +1,11 @@
-use crate::fingerprint::Fingerprint;
-use libp2p_core::{multiaddr::Protocol, Multiaddr};
 use std::net::{IpAddr, SocketAddr};
 
-/// Parse the given [`Multiaddr`] into a [`SocketAddr`] and a [`Fingerprint`] for dialing.
+use libp2p_core::{multiaddr::Protocol, Multiaddr};
+
+use crate::fingerprint::Fingerprint;
+
+/// Parse the given [`Multiaddr`] into a [`SocketAddr`] and a [`Fingerprint`]
+/// for dialing.
 pub fn parse_webrtc_dial_addr(addr: &Multiaddr) -> Option<(SocketAddr, Fingerprint)> {
     let mut iter = addr.iter();
 
@@ -38,12 +41,15 @@ pub fn parse_webrtc_dial_addr(addr: &Multiaddr) -> Option<(SocketAddr, Fingerpri
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::net::{Ipv4Addr, Ipv6Addr};
+
+    use super::*;
 
     #[test]
     fn parse_valid_address_with_certhash_and_p2p() {
-        let addr = "/ip4/127.0.0.1/udp/39901/webrtc-direct/certhash/uEiDikp5KVUgkLta1EjUN-IKbHk-dUBg8VzKgf5nXxLK46w/p2p/12D3KooWNpDk9w6WrEEcdsEH1y47W71S36yFjw4sd3j7omzgCSMS"
+        let addr = "/ip4/127.0.0.1/udp/39901/webrtc-direct/certhash/\
+                    uEiDikp5KVUgkLta1EjUN-IKbHk-dUBg8VzKgf5nXxLK46w/p2p/\
+                    12D3KooWNpDk9w6WrEEcdsEH1y47W71S36yFjw4sd3j7omzgCSMS"
             .parse()
             .unwrap();
 
@@ -62,7 +68,8 @@ mod tests {
 
     #[test]
     fn peer_id_is_not_required() {
-        let addr = "/ip4/127.0.0.1/udp/39901/webrtc-direct/certhash/uEiDikp5KVUgkLta1EjUN-IKbHk-dUBg8VzKgf5nXxLK46w"
+        let addr = "/ip4/127.0.0.1/udp/39901/webrtc-direct/certhash/\
+                    uEiDikp5KVUgkLta1EjUN-IKbHk-dUBg8VzKgf5nXxLK46w"
             .parse()
             .unwrap();
 
@@ -81,10 +88,11 @@ mod tests {
 
     #[test]
     fn parse_ipv6() {
-        let addr =
-            "/ip6/::1/udp/12345/webrtc-direct/certhash/uEiDikp5KVUgkLta1EjUN-IKbHk-dUBg8VzKgf5nXxLK46w/p2p/12D3KooWNpDk9w6WrEEcdsEH1y47W71S36yFjw4sd3j7omzgCSMS"
-                .parse()
-                .unwrap();
+        let addr = "/ip6/::1/udp/12345/webrtc-direct/certhash/\
+                    uEiDikp5KVUgkLta1EjUN-IKbHk-dUBg8VzKgf5nXxLK46w/p2p/\
+                    12D3KooWNpDk9w6WrEEcdsEH1y47W71S36yFjw4sd3j7omzgCSMS"
+            .parse()
+            .unwrap();
 
         let maybe_parsed = parse_webrtc_dial_addr(&addr);
 

--- a/muxers/mplex/benches/split_send_size.rs
+++ b/muxers/mplex/benches/split_send_size.rs
@@ -21,21 +21,30 @@
 //! A benchmark for the `split_send_size` configuration option
 //! using different transports.
 
+use std::{pin::Pin, time::Duration};
+
 use async_std::task;
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use futures::future::poll_fn;
-use futures::prelude::*;
-use futures::{channel::oneshot, future::join};
-use libp2p_core::muxing::StreamMuxerExt;
-use libp2p_core::transport::ListenerId;
-use libp2p_core::Endpoint;
-use libp2p_core::{multiaddr::multiaddr, muxing, transport, upgrade, Multiaddr, Transport};
+use futures::{
+    channel::oneshot,
+    future::{join, poll_fn},
+    prelude::*,
+};
+use libp2p_core::{
+    multiaddr::multiaddr,
+    muxing,
+    muxing::StreamMuxerExt,
+    transport,
+    transport::ListenerId,
+    upgrade,
+    Endpoint,
+    Multiaddr,
+    Transport,
+};
 use libp2p_identity as identity;
 use libp2p_identity::PeerId;
 use libp2p_mplex as mplex;
 use libp2p_plaintext as plaintext;
-use std::pin::Pin;
-use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 
 type BenchTransport = transport::Boxed<(PeerId, muxing::StreamMuxerBox)>;
@@ -120,7 +129,8 @@ fn run(
                 }
                 transport::TransportEvent::Incoming { upgrade, .. } => {
                     let (_peer, mut conn) = upgrade.await.unwrap();
-                    // Just calling `poll_inbound` without `poll` is fine here because mplex makes progress through all `poll_` functions. It is hacky though.
+                    // Just calling `poll_inbound` without `poll` is fine here because mplex makes
+                    // progress through all `poll_` functions. It is hacky though.
                     let mut s = poll_fn(|cx| conn.poll_inbound_unpin(cx))
                         .await
                         .expect("unexpected error");
@@ -158,7 +168,8 @@ fn run(
             .unwrap()
             .await
             .unwrap();
-        // Just calling `poll_outbound` without `poll` is fine here because mplex makes progress through all `poll_` functions. It is hacky though.
+        // Just calling `poll_outbound` without `poll` is fine here because mplex makes
+        // progress through all `poll_` functions. It is hacky though.
         let mut stream = poll_fn(|cx| conn.poll_outbound_unpin(cx)).await.unwrap();
         let mut off = 0;
         loop {

--- a/muxers/mplex/src/codec.rs
+++ b/muxers/mplex/src/codec.rs
@@ -18,19 +18,22 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use asynchronous_codec::{Decoder, Encoder};
-use bytes::{BufMut, Bytes, BytesMut};
-use libp2p_core::Endpoint;
 use std::{
     fmt,
     hash::{Hash, Hasher},
-    io, mem,
+    io,
+    mem,
 };
+
+use asynchronous_codec::{Decoder, Encoder};
+use bytes::{BufMut, Bytes, BytesMut};
+use libp2p_core::Endpoint;
 use unsigned_varint::{codec, encode};
 
 // Maximum size for a packet: 1MB as per the spec.
-// Since data is entirely buffered before being dispatched, we need a limit or remotes could just
-// send a 4 TB-long packet full of zeroes that we kill our process with an OOM error.
+// Since data is entirely buffered before being dispatched, we need a limit or
+// remotes could just send a 4 TB-long packet full of zeroes that we kill our
+// process with an OOM error.
 pub(crate) const MAX_FRAME_SIZE: usize = 1024 * 1024;
 
 /// A unique identifier used by the local node for a substream.
@@ -41,13 +44,18 @@ pub(crate) const MAX_FRAME_SIZE: usize = 1024 * 1024;
 /// > **Note**: Streams are identified by a number and a role encoded as a flag
 /// > on each frame that is either odd (for receivers) or even (for initiators).
 /// > `Open` frames do not have a flag, but are sent unidirectionally. As a
-/// > consequence, we need to remember if a stream was initiated by us or remotely
+/// > consequence, we need to remember if a stream was initiated by us or
+/// > remotely
 /// > and we store the information from our point of view as a `LocalStreamId`,
-/// > i.e. receiving an `Open` frame results in a local ID with role `Endpoint::Listener`,
-/// > whilst sending an `Open` frame results in a local ID with role `Endpoint::Dialer`.
-/// > Receiving a frame with a flag identifying the remote as a "receiver" means that
+/// > i.e. receiving an `Open` frame results in a local ID with role
+/// > `Endpoint::Listener`,
+/// > whilst sending an `Open` frame results in a local ID with role
+/// > `Endpoint::Dialer`.
+/// > Receiving a frame with a flag identifying the remote as a "receiver" means
+/// > that
 /// > we initiated the stream, so the local ID has the role `Endpoint::Dialer`.
-/// > Conversely, when receiving a frame with a flag identifying the remote as a "sender",
+/// > Conversely, when receiving a frame with a flag identifying the remote as a
+/// > "sender",
 /// > the corresponding local ID has the role `Endpoint::Listener`.
 #[derive(Copy, Clone, Eq, Debug)]
 pub(crate) struct LocalStreamId {
@@ -66,11 +74,11 @@ impl fmt::Display for LocalStreamId {
 
 /// Manual implementation of [`PartialEq`].
 ///
-/// This is equivalent to the derived one but we purposely don't derive it because it triggers the
-/// `clippy::derive_hash_xor_eq` lint.
+/// This is equivalent to the derived one but we purposely don't derive it
+/// because it triggers the `clippy::derive_hash_xor_eq` lint.
 ///
-/// This [`PartialEq`] implementation satisfies the rule of v1 == v2 -> hash(v1) == hash(v2).
-/// The inverse is not true but does not have to be.
+/// This [`PartialEq`] implementation satisfies the rule of v1 == v2 -> hash(v1)
+/// == hash(v2). The inverse is not true but does not have to be.
 impl PartialEq for LocalStreamId {
     fn eq(&self, other: &Self) -> bool {
         self.num.eq(&other.num) && self.role.eq(&other.role)

--- a/muxers/mplex/src/config.rs
+++ b/muxers/mplex/src/config.rs
@@ -18,8 +18,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::codec::MAX_FRAME_SIZE;
 use std::cmp;
+
+use crate::codec::MAX_FRAME_SIZE;
 
 pub(crate) const DEFAULT_MPLEX_PROTOCOL_NAME: &str = "/mplex/6.7.0";
 

--- a/muxers/mplex/src/io.rs
+++ b/muxers/mplex/src/io.rs
@@ -18,23 +18,34 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::codec::{Codec, Frame, LocalStreamId, RemoteStreamId};
-use crate::{MaxBufferBehaviour, MplexConfig};
-use asynchronous_codec::Framed;
-use bytes::Bytes;
-use futures::task::{waker_ref, ArcWake, AtomicWaker, WakerRef};
-use futures::{prelude::*, ready, stream::Fuse};
-use nohash_hasher::{IntMap, IntSet};
-use parking_lot::Mutex;
-use smallvec::SmallVec;
-use std::collections::VecDeque;
+pub(crate) use std::io::{Error, Result};
 use std::{
-    cmp, fmt, io, mem,
+    cmp,
+    collections::VecDeque,
+    fmt,
+    io,
+    mem,
     sync::Arc,
     task::{Context, Poll, Waker},
 };
 
-pub(crate) use std::io::{Error, Result};
+use asynchronous_codec::Framed;
+use bytes::Bytes;
+use futures::{
+    prelude::*,
+    ready,
+    stream::Fuse,
+    task::{waker_ref, ArcWake, AtomicWaker, WakerRef},
+};
+use nohash_hasher::{IntMap, IntSet};
+use parking_lot::Mutex;
+use smallvec::SmallVec;
+
+use crate::{
+    codec::{Codec, Frame, LocalStreamId, RemoteStreamId},
+    MaxBufferBehaviour,
+    MplexConfig,
+};
 /// A connection identifier.
 ///
 /// Randomly generated and mainly intended to improve log output
@@ -194,7 +205,8 @@ where
         }
     }
 
-    /// Waits for a new inbound substream, returning the corresponding `LocalStreamId`.
+    /// Waits for a new inbound substream, returning the corresponding
+    /// `LocalStreamId`.
     ///
     /// If the number of already used substreams (i.e. substreams that have not
     /// yet been dropped via `drop_substream`) reaches the configured
@@ -302,13 +314,13 @@ where
     /// reading and writing immediately. The remote is informed
     /// based on the current state of the substream:
     ///
-    /// * If the substream was open, a `Reset` frame is sent at
-    ///   the next opportunity.
-    /// * If the substream was half-closed, i.e. a `Close` frame
-    ///   has already been sent, nothing further happens.
-    /// * If the substream was half-closed by the remote, i.e.
-    ///   a `Close` frame has already been received, a `Close`
-    ///   frame is sent at the next opportunity.
+    /// * If the substream was open, a `Reset` frame is sent at the next
+    ///   opportunity.
+    /// * If the substream was half-closed, i.e. a `Close` frame has already
+    ///   been sent, nothing further happens.
+    /// * If the substream was half-closed by the remote, i.e. a `Close` frame
+    ///   has already been received, a `Close` frame is sent at the next
+    ///   opportunity.
     ///
     /// If the multiplexed stream is closed or encountered
     /// an error earlier, or there is no known substream with
@@ -424,7 +436,8 @@ where
     /// this method call are buffered up to the configured `max_substreams`
     /// and under consideration of the number of already used substreams,
     /// thereby waking the task that last called `poll_next_stream`, if any.
-    /// Inbound substreams received in excess of that limit are immediately reset.
+    /// Inbound substreams received in excess of that limit are immediately
+    /// reset.
     pub(crate) fn poll_read_stream(
         &mut self,
         cx: &Context<'_>,
@@ -669,8 +682,8 @@ where
                 // reading `Data` frames from the current stream when unblocked.
                 debug_assert!(
                     blocked_id != &id,
-                    "Unexpected attempt at reading a new \
-                    frame from a substream with a full buffer."
+                    "Unexpected attempt at reading a new frame from a substream with a full \
+                     buffer."
                 );
                 let _ = NotifierRead::register_read_stream(&self.notifier_read, cx.waker(), id);
             } else {
@@ -1146,15 +1159,14 @@ const EXTRA_PENDING_FRAMES: usize = 1000;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::{collections::HashSet, num::NonZeroU8, ops::DerefMut, pin::Pin};
+
     use async_std::task;
     use asynchronous_codec::{Decoder, Encoder};
     use bytes::BytesMut;
     use quickcheck::*;
-    use std::collections::HashSet;
-    use std::num::NonZeroU8;
-    use std::ops::DerefMut;
-    use std::pin::Pin;
+
+    use super::*;
 
     impl Arbitrary for MaxBufferBehaviour {
         fn arbitrary(g: &mut Gen) -> MaxBufferBehaviour {

--- a/muxers/mplex/src/lib.rs
+++ b/muxers/mplex/src/lib.rs
@@ -26,15 +26,23 @@ mod codec;
 mod config;
 mod io;
 
-pub use config::{MaxBufferBehaviour, MplexConfig};
+use std::{
+    cmp,
+    iter,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 use bytes::Bytes;
 use codec::LocalStreamId;
+pub use config::{MaxBufferBehaviour, MplexConfig};
 use futures::{prelude::*, ready};
-use libp2p_core::muxing::{StreamMuxer, StreamMuxerEvent};
-use libp2p_core::upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade, UpgradeInfo};
+use libp2p_core::{
+    muxing::{StreamMuxer, StreamMuxerEvent},
+    upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade, UpgradeInfo},
+};
 use parking_lot::Mutex;
-use std::{cmp, iter, pin::Pin, sync::Arc, task::Context, task::Poll};
 
 impl UpgradeInfo for MplexConfig {
     type Info = &'static str;

--- a/muxers/test-harness/src/lib.rs
+++ b/muxers/test-harness/src/lib.rs
@@ -1,15 +1,21 @@
+use std::{
+    fmt,
+    future::Future,
+    mem,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use futures::{future, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, Stream, StreamExt};
+use libp2p_core::{
+    muxing::StreamMuxerExt,
+    upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade},
+    StreamMuxer,
+    UpgradeInfo,
+};
+
 use crate::future::{BoxFuture, Either, FutureExt};
-use futures::{future, AsyncRead, AsyncWrite};
-use futures::{AsyncReadExt, Stream};
-use futures::{AsyncWriteExt, StreamExt};
-use libp2p_core::muxing::StreamMuxerExt;
-use libp2p_core::upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade};
-use libp2p_core::{StreamMuxer, UpgradeInfo};
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::Duration;
-use std::{fmt, mem};
 
 pub async fn connected_muxers_on_memory_ring_buffer<MC, M, E>() -> (M, M)
 where
@@ -41,7 +47,8 @@ where
         .unwrap()
 }
 
-/// Verifies that Alice can send a message and immediately close the stream afterwards and Bob can use `read_to_end` to read the entire message.
+/// Verifies that Alice can send a message and immediately close the stream
+/// afterwards and Bob can use `read_to_end` to read the entire message.
 pub async fn close_implies_flush<A, B, S, E>(alice: A, bob: B)
 where
     A: StreamMuxer<Substream = S, Error = E> + Unpin,
@@ -99,7 +106,8 @@ where
     .await;
 }
 
-/// Runs the given protocol between the two parties, ensuring commutativity, i.e. either party can be the dialer and listener.
+/// Runs the given protocol between the two parties, ensuring commutativity,
+/// i.e. either party can be the dialer and listener.
 async fn run_commutative<A, B, S, E, F1, F2>(
     mut alice: A,
     mut bob: B,
@@ -119,8 +127,10 @@ async fn run_commutative<A, B, S, E, F1, F2>(
 
 /// Runs a given protocol between the two parties.
 ///
-/// The first party will open a new substream and the second party will wait for this.
-/// The [`StreamMuxer`] is polled until both parties have completed the protocol to ensure that the underlying connection can make progress at all times.
+/// The first party will open a new substream and the second party will wait for
+/// this. The [`StreamMuxer`] is polled until both parties have completed the
+/// protocol to ensure that the underlying connection can make progress at all
+/// times.
 async fn run<A, B, S, E, F1, F2>(
     dialer: &mut A,
     listener: &mut B,

--- a/protocols/autonat/src/v1.rs
+++ b/protocols/autonat/src/v1.rs
@@ -21,22 +21,30 @@
 //! Implementation of the [AutoNAT](https://github.com/libp2p/specs/blob/master/autonat/README.md) protocol.
 //!
 //! ## Eventual Deprecation
-//! This version of the protocol will eventually be deprecated in favor of [v2](crate::v2).
-//! We recommend using v2 for new projects.
+//! This version of the protocol will eventually be deprecated in favor of
+//! [v2](crate::v2). We recommend using v2 for new projects.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub(crate) mod behaviour;
 pub(crate) mod protocol;
 
+pub use libp2p_request_response::{InboundFailure, OutboundFailure};
+
 pub use self::{
     behaviour::{
-        Behaviour, Config, Event, InboundProbeError, InboundProbeEvent, NatStatus,
-        OutboundProbeError, OutboundProbeEvent, ProbeId,
+        Behaviour,
+        Config,
+        Event,
+        InboundProbeError,
+        InboundProbeEvent,
+        NatStatus,
+        OutboundProbeError,
+        OutboundProbeEvent,
+        ProbeId,
     },
     protocol::{ResponseError, DEFAULT_PROTOCOL_NAME},
 };
-pub use libp2p_request_response::{InboundFailure, OutboundFailure};
 
 pub(crate) mod proto {
     #![allow(unreachable_pub)]

--- a/protocols/autonat/src/v1/behaviour/as_server.rs
+++ b/protocols/autonat/src/v1/behaviour/as_server.rs
@@ -17,24 +17,38 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
-use super::{
-    Action, AutoNatCodec, Config, DialRequest, DialResponse, Event, HandleInnerEvent, ProbeId,
-    ResponseError,
-};
-use libp2p_core::{multiaddr::Protocol, Multiaddr};
-use libp2p_identity::PeerId;
-use libp2p_request_response::{
-    self as request_response, InboundFailure, InboundRequestId, ResponseChannel,
-};
-use libp2p_swarm::{
-    dial_opts::{DialOpts, PeerCondition},
-    ConnectionId, DialError, ToSwarm,
-};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     num::NonZeroU8,
 };
+
+use libp2p_core::{multiaddr::Protocol, Multiaddr};
+use libp2p_identity::PeerId;
+use libp2p_request_response::{
+    self as request_response,
+    InboundFailure,
+    InboundRequestId,
+    ResponseChannel,
+};
+use libp2p_swarm::{
+    dial_opts::{DialOpts, PeerCondition},
+    ConnectionId,
+    DialError,
+    ToSwarm,
+};
 use web_time::Instant;
+
+use super::{
+    Action,
+    AutoNatCodec,
+    Config,
+    DialRequest,
+    DialResponse,
+    Event,
+    HandleInnerEvent,
+    ProbeId,
+    ResponseError,
+};
 
 /// Inbound probe failed.
 #[derive(Debug)]
@@ -379,9 +393,9 @@ impl AsServer<'_> {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-
     use std::net::Ipv4Addr;
+
+    use super::*;
 
     fn random_ip<'a>() -> Protocol<'a> {
         Protocol::Ip4(Ipv4Addr::new(

--- a/protocols/autonat/src/v1/protocol.rs
+++ b/protocols/autonat/src/v1/protocol.rs
@@ -18,16 +18,21 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::proto;
+use std::io;
+
 use async_trait::async_trait;
 use asynchronous_codec::{FramedRead, FramedWrite};
-use futures::io::{AsyncRead, AsyncWrite};
-use futures::{SinkExt, StreamExt};
+use futures::{
+    io::{AsyncRead, AsyncWrite},
+    SinkExt,
+    StreamExt,
+};
 use libp2p_core::Multiaddr;
 use libp2p_identity::PeerId;
 use libp2p_request_response::{self as request_response};
 use libp2p_swarm::StreamProtocol;
-use std::io;
+
+use crate::proto;
 
 /// The protocol name used for negotiating with multistream-select.
 pub const DEFAULT_PROTOCOL_NAME: StreamProtocol = StreamProtocol::new("/libp2p/autonat/1.0.0");

--- a/protocols/autonat/src/v2.rs
+++ b/protocols/autonat/src/v2.rs
@@ -3,18 +3,19 @@
 //! The implementation follows the [libp2p spec](https://github.com/libp2p/specs/blob/03718ef0f2dea4a756a85ba716ee33f97e4a6d6c/autonat/autonat-v2.md).
 //!
 //! The new version fixes the issues of the first version:
-//! - The server now always dials back over a newly allocated port. This greatly reduces the risk of
-//!     false positives that often occurred in the first version, when the clinet-server connection
-//!     occurred over a hole-punched port.
-//! - The server protects against DoS attacks by requiring the client to send more data to the
-//!     server then the dial back puts on the client, thus making the protocol unatractive for an
-//!     attacker.
+//! - The server now always dials back over a newly allocated port. This greatly
+//!   reduces the risk of false positives that often occurred in the first
+//!   version, when the clinet-server connection occurred over a hole-punched
+//!   port.
+//! - The server protects against DoS attacks by requiring the client to send
+//!   more data to the server then the dial back puts on the client, thus making
+//!   the protocol unatractive for an attacker.
 //!
 //! The protocol is separated into two parts:
-//! - The client part, which is implemented in the `client` module. (The client is the party that
-//!     wants to check if it is reachable from the outside.)
-//! - The server part, which is implemented in the `server` module. (The server is the party
-//!     performing reachability checks on behalf of the client.)
+//! - The client part, which is implemented in the `client` module. (The client
+//!   is the party that wants to check if it is reachable from the outside.)
+//! - The server part, which is implemented in the `server` module. (The server
+//!   is the party performing reachability checks on behalf of the client.)
 //!
 //! The two can be used together.
 

--- a/protocols/autonat/src/v2/client.rs
+++ b/protocols/autonat/src/v2/client.rs
@@ -1,5 +1,4 @@
 mod behaviour;
 mod handler;
 
-pub use behaviour::Event;
-pub use behaviour::{Behaviour, Config};
+pub use behaviour::{Behaviour, Config, Event};

--- a/protocols/autonat/src/v2/client/behaviour.rs
+++ b/protocols/autonat/src/v2/client/behaviour.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, VecDeque},
+    fmt::{Debug, Display, Formatter},
     task::{Context, Poll},
     time::Duration,
 };
@@ -10,26 +11,33 @@ use futures_timer::Delay;
 use libp2p_core::{transport::PortUse, Endpoint, Multiaddr};
 use libp2p_identity::PeerId;
 use libp2p_swarm::{
-    behaviour::ConnectionEstablished, ConnectionClosed, ConnectionDenied, ConnectionHandler,
-    ConnectionId, FromSwarm, NetworkBehaviour, NewExternalAddrCandidate, NotifyHandler, ToSwarm,
+    behaviour::ConnectionEstablished,
+    ConnectionClosed,
+    ConnectionDenied,
+    ConnectionHandler,
+    ConnectionId,
+    FromSwarm,
+    NetworkBehaviour,
+    NewExternalAddrCandidate,
+    NotifyHandler,
+    ToSwarm,
 };
 use rand::prelude::*;
 use rand_core::OsRng;
-use std::fmt::{Debug, Display, Formatter};
-
-use crate::v2::{protocol::DialRequest, Nonce};
 
 use super::handler::{
     dial_back::{self, IncomingNonce},
     dial_request,
 };
+use crate::v2::{protocol::DialRequest, Nonce};
 
 #[derive(Debug, Clone, Copy)]
 pub struct Config {
     /// How many candidates we will test at most.
     pub(crate) max_candidates: usize,
 
-    /// The interval at which we will attempt to confirm candidates as external addresses.
+    /// The interval at which we will attempt to confirm candidates as external
+    /// addresses.
     pub(crate) probe_interval: Duration,
 }
 
@@ -281,10 +289,13 @@ where
         }
     }
 
-    /// Issues dial requests to random AutoNAT servers for the most frequently reported, untested candidates.
+    /// Issues dial requests to random AutoNAT servers for the most frequently
+    /// reported, untested candidates.
     ///
-    /// In the current implementation, we only send a single address to each AutoNAT server.
-    /// This spreads our candidates out across all servers we are connected to which should give us pretty fast feedback on all of them.
+    /// In the current implementation, we only send a single address to each
+    /// AutoNAT server. This spreads our candidates out across all servers
+    /// we are connected to which should give us pretty fast feedback on all of
+    /// them.
     fn issue_dial_requests_for_untested_candidates(&mut self) {
         for addr in self.untested_candidates() {
             let Some((conn_id, peer_id)) = self.random_autonat_server() else {
@@ -309,9 +320,11 @@ where
         }
     }
 
-    /// Returns all untested candidates, sorted by the frequency they were reported at.
+    /// Returns all untested candidates, sorted by the frequency they were
+    /// reported at.
     ///
-    /// More frequently reported candidates are considered to more likely be external addresses and thus tested first.
+    /// More frequently reported candidates are considered to more likely be
+    /// external addresses and thus tested first.
     fn untested_candidates(&self) -> impl Iterator<Item = Multiaddr> {
         let mut entries = self
             .address_candidates
@@ -333,7 +346,9 @@ where
             .map(|(addr, _)| addr)
     }
 
-    /// Chooses an active connection to one of our peers that reported support for the [`DIAL_REQUEST_PROTOCOL`](crate::v2::DIAL_REQUEST_PROTOCOL) protocol.
+    /// Chooses an active connection to one of our peers that reported support
+    /// for the [`DIAL_REQUEST_PROTOCOL`](crate::v2::DIAL_REQUEST_PROTOCOL)
+    /// protocol.
     fn random_autonat_server(&mut self) -> Option<(ConnectionId, PeerId)> {
         let (conn_id, info) = self
             .peer_info

--- a/protocols/autonat/src/v2/client/handler/dial_back.rs
+++ b/protocols/autonat/src/v2/client/handler/dial_back.rs
@@ -1,4 +1,5 @@
 use std::{
+    convert::Infallible,
     io,
     task::{Context, Poll},
     time::Duration,
@@ -9,9 +10,11 @@ use futures_bounded::StreamSet;
 use libp2p_core::upgrade::{DeniedUpgrade, ReadyUpgrade};
 use libp2p_swarm::{
     handler::{ConnectionEvent, FullyNegotiatedInbound, ListenUpgradeError},
-    ConnectionHandler, ConnectionHandlerEvent, StreamProtocol, SubstreamProtocol,
+    ConnectionHandler,
+    ConnectionHandlerEvent,
+    StreamProtocol,
+    SubstreamProtocol,
 };
-use std::convert::Infallible;
 
 use crate::v2::{protocol, Nonce, DIAL_BACK_PROTOCOL};
 
@@ -83,7 +86,8 @@ impl ConnectionHandler for Handler {
                     tracing::warn!("Dial back request dropped, too many requests in flight");
                 }
             }
-            // TODO: remove when Rust 1.82 is MSRVprotocols/autonat/src/v2/client/handler/dial_back.rs
+            // TODO: remove when Rust 1.82 is
+            // MSRVprotocols/autonat/src/v2/client/handler/dial_back.rs
             #[allow(unreachable_patterns)]
             ConnectionEvent::ListenUpgradeError(ListenUpgradeError { error, .. }) => {
                 libp2p_core::util::unreachable(error);

--- a/protocols/autonat/src/v2/client/handler/dial_request.rs
+++ b/protocols/autonat/src/v2/client/handler/dial_request.rs
@@ -1,18 +1,3 @@
-use futures::{channel::oneshot, AsyncWrite};
-use futures_bounded::FuturesMap;
-use libp2p_core::{
-    upgrade::{DeniedUpgrade, ReadyUpgrade},
-    Multiaddr,
-};
-
-use libp2p_swarm::{
-    handler::{
-        ConnectionEvent, DialUpgradeError, FullyNegotiatedOutbound, OutboundUpgradeSend,
-        ProtocolsChange,
-    },
-    ConnectionHandler, ConnectionHandlerEvent, Stream, StreamProtocol, StreamUpgradeError,
-    SubstreamProtocol,
-};
 use std::{
     collections::VecDeque,
     convert::Infallible,
@@ -22,13 +7,42 @@ use std::{
     time::Duration,
 };
 
+use futures::{channel::oneshot, AsyncWrite};
+use futures_bounded::FuturesMap;
+use libp2p_core::{
+    upgrade::{DeniedUpgrade, ReadyUpgrade},
+    Multiaddr,
+};
+use libp2p_swarm::{
+    handler::{
+        ConnectionEvent,
+        DialUpgradeError,
+        FullyNegotiatedOutbound,
+        OutboundUpgradeSend,
+        ProtocolsChange,
+    },
+    ConnectionHandler,
+    ConnectionHandlerEvent,
+    Stream,
+    StreamProtocol,
+    StreamUpgradeError,
+    SubstreamProtocol,
+};
+
 use crate::v2::{
     generated::structs::{mod_DialResponse::ResponseStatus, DialStatus},
     protocol::{
-        Coder, DialDataRequest, DialDataResponse, DialRequest, Response,
-        DATA_FIELD_LEN_UPPER_BOUND, DATA_LEN_LOWER_BOUND, DATA_LEN_UPPER_BOUND,
+        Coder,
+        DialDataRequest,
+        DialDataResponse,
+        DialRequest,
+        Response,
+        DATA_FIELD_LEN_UPPER_BOUND,
+        DATA_LEN_LOWER_BOUND,
+        DATA_LEN_UPPER_BOUND,
     },
-    Nonce, DIAL_REQUEST_PROTOCOL,
+    Nonce,
+    DIAL_REQUEST_PROTOCOL,
 };
 
 #[derive(Debug)]
@@ -261,8 +275,10 @@ async fn start_stream_handle(
         Ok(_) => {}
         Err(err) => {
             if err.kind() == io::ErrorKind::ConnectionReset {
-                // The AutoNAT server may have already closed the stream (this is normal because the probe is finished), in this case we have this error:
-                // Err(Custom { kind: ConnectionReset, error: Stopped(0) })
+                // The AutoNAT server may have already closed the stream (this
+                // is normal because the probe is finished), in this case we
+                // have this error: Err(Custom { kind:
+                // ConnectionReset, error: Stopped(0) })
                 // so we silently ignore this error
             } else {
                 return Err(err.into());

--- a/protocols/autonat/src/v2/protocol.rs
+++ b/protocols/autonat/src/v2/protocol.rs
@@ -1,13 +1,10 @@
 // change to quick-protobuf-codec
 
-use std::io;
-use std::io::ErrorKind;
+use std::{io, io::ErrorKind};
 
 use asynchronous_codec::{Framed, FramedRead, FramedWrite};
-
 use futures::{AsyncRead, AsyncWrite, SinkExt, StreamExt};
 use libp2p_core::Multiaddr;
-
 use quick_protobuf_codec::Codec;
 use rand::Rng;
 
@@ -103,7 +100,9 @@ impl From<DialDataResponse> for proto::Message {
         );
         proto::Message {
             msg: proto::mod_Message::OneOfmsg::dialDataResponse(proto::DialDataResponse {
-                data: vec![0; val.data_count], // One could use Cow::Borrowed here, but it will require a modification of the generated code and that will fail the CI
+                data: vec![0; val.data_count], /* One could use Cow::Borrowed here, but it will
+                                                * require a modification of the generated code
+                                                * and that will fail the CI */
             }),
         }
     }
@@ -310,7 +309,9 @@ pub(crate) async fn recv_dial_back_response(
 #[cfg(test)]
 mod tests {
     use crate::v2::generated::structs::{
-        mod_Message::OneOfmsg, DialDataResponse as GenDialDataResponse, Message,
+        mod_Message::OneOfmsg,
+        DialDataResponse as GenDialDataResponse,
+        Message,
     };
 
     #[test]

--- a/protocols/autonat/src/v2/server.rs
+++ b/protocols/autonat/src/v2/server.rs
@@ -1,5 +1,4 @@
 mod behaviour;
 mod handler;
 
-pub use behaviour::Behaviour;
-pub use behaviour::Event;
+pub use behaviour::{Behaviour, Event};

--- a/protocols/autonat/src/v2/server/behaviour.rs
+++ b/protocols/autonat/src/v2/server/behaviour.rs
@@ -4,20 +4,25 @@ use std::{
     task::{Context, Poll},
 };
 
-use crate::v2::server::handler::dial_request::DialBackStatus;
 use either::Either;
 use libp2p_core::{transport::PortUse, Endpoint, Multiaddr};
 use libp2p_identity::PeerId;
-use libp2p_swarm::dial_opts::PeerCondition;
 use libp2p_swarm::{
-    dial_opts::DialOpts, dummy, ConnectionDenied, ConnectionHandler, ConnectionId, DialFailure,
-    FromSwarm, NetworkBehaviour, ToSwarm,
+    dial_opts::{DialOpts, PeerCondition},
+    dummy,
+    ConnectionDenied,
+    ConnectionHandler,
+    ConnectionId,
+    DialFailure,
+    FromSwarm,
+    NetworkBehaviour,
+    ToSwarm,
 };
 use rand_core::{OsRng, RngCore};
 
 use crate::v2::server::handler::{
     dial_back,
-    dial_request::{self, DialBackCommand},
+    dial_request::{self, DialBackCommand, DialBackStatus},
     Handler,
 };
 

--- a/protocols/autonat/src/v2/server/handler/dial_back.rs
+++ b/protocols/autonat/src/v2/server/handler/dial_back.rs
@@ -10,16 +10,18 @@ use futures_bounded::FuturesSet;
 use libp2p_core::upgrade::{DeniedUpgrade, ReadyUpgrade};
 use libp2p_swarm::{
     handler::{ConnectionEvent, DialUpgradeError, FullyNegotiatedOutbound},
-    ConnectionHandler, ConnectionHandlerEvent, StreamProtocol, StreamUpgradeError,
+    ConnectionHandler,
+    ConnectionHandlerEvent,
+    StreamProtocol,
+    StreamUpgradeError,
     SubstreamProtocol,
 };
 
+use super::dial_request::{DialBackCommand, DialBackStatus as DialBackRes};
 use crate::v2::{
     protocol::{dial_back, recv_dial_back_response},
     DIAL_BACK_PROTOCOL,
 };
-
-use super::dial_request::{DialBackCommand, DialBackStatus as DialBackRes};
 
 pub(crate) type ToBehaviour = io::Result<()>;
 

--- a/protocols/autonat/src/v2/server/handler/dial_request.rs
+++ b/protocols/autonat/src/v2/server/handler/dial_request.rs
@@ -8,7 +8,10 @@ use std::{
 use either::Either;
 use futures::{
     channel::{mpsc, oneshot},
-    AsyncRead, AsyncWrite, SinkExt, StreamExt,
+    AsyncRead,
+    AsyncWrite,
+    SinkExt,
+    StreamExt,
 };
 use futures_bounded::FuturesSet;
 use libp2p_core::{
@@ -18,7 +21,10 @@ use libp2p_core::{
 use libp2p_identity::PeerId;
 use libp2p_swarm::{
     handler::{ConnectionEvent, FullyNegotiatedInbound, ListenUpgradeError},
-    ConnectionHandler, ConnectionHandlerEvent, StreamProtocol, SubstreamProtocol,
+    ConnectionHandler,
+    ConnectionHandlerEvent,
+    StreamProtocol,
+    SubstreamProtocol,
 };
 use rand_core::RngCore;
 
@@ -26,7 +32,8 @@ use crate::v2::{
     generated::structs::{mod_DialResponse::ResponseStatus, DialStatus},
     protocol::{Coder, DialDataRequest, DialRequest, DialResponse, Request, Response},
     server::behaviour::Event,
-    Nonce, DIAL_REQUEST_PROTOCOL,
+    Nonce,
+    DIAL_REQUEST_PROTOCOL,
 };
 
 #[derive(Debug, PartialEq)]
@@ -225,7 +232,8 @@ async fn handle_request(
             data_amount,
             result: Err(io::Error::new(
                 io::ErrorKind::Other,
-                "client is not conformint to protocol. the tested address is not the observed address",
+                "client is not conformint to protocol. the tested address is not the observed \
+                 address",
             )),
         };
     };

--- a/protocols/autonat/tests/autonatv2.rs
+++ b/protocols/autonat/tests/autonatv2.rs
@@ -1,15 +1,20 @@
-use libp2p_autonat::v2::client::{self, Config};
-use libp2p_autonat::v2::server;
-use libp2p_core::multiaddr::Protocol;
-use libp2p_core::transport::TransportError;
-use libp2p_core::Multiaddr;
+use std::{sync::Arc, time::Duration};
+
+use libp2p_autonat::v2::{
+    client::{self, Config},
+    server,
+};
+use libp2p_core::{multiaddr::Protocol, transport::TransportError, Multiaddr};
 use libp2p_swarm::{
-    DialError, FromSwarm, NetworkBehaviour, NewExternalAddrCandidate, Swarm, SwarmEvent,
+    DialError,
+    FromSwarm,
+    NetworkBehaviour,
+    NewExternalAddrCandidate,
+    Swarm,
+    SwarmEvent,
 };
 use libp2p_swarm_test::SwarmExt;
 use rand_core::OsRng;
-use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::oneshot;
 use tracing_subscriber::EnvFilter;
 

--- a/protocols/autonat/tests/test_client.rs
+++ b/protocols/autonat/tests/test_client.rs
@@ -18,14 +18,21 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::time::Duration;
+
 use libp2p_autonat::{
-    Behaviour, Config, Event, NatStatus, OutboundProbeError, OutboundProbeEvent, ResponseError,
+    Behaviour,
+    Config,
+    Event,
+    NatStatus,
+    OutboundProbeError,
+    OutboundProbeEvent,
+    ResponseError,
 };
 use libp2p_core::Multiaddr;
 use libp2p_identity::PeerId;
 use libp2p_swarm::{Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt as _;
-use std::time::Duration;
 use tokio::task::JoinHandle;
 
 const MAX_CONFIDENCE: usize = 3;
@@ -115,8 +122,9 @@ async fn test_auto_probe() {
     }
 
     // It can happen that the server observed the established connection and
-    // returned a response before the inbound established connection was reported at the client.
-    // In this (rare) case the `ConnectionEstablished` event occurs after the `OutboundProbeEvent::Response`.
+    // returned a response before the inbound established connection was reported at
+    // the client. In this (rare) case the `ConnectionEstablished` event occurs
+    // after the `OutboundProbeEvent::Response`.
     if !had_connection_event {
         match client.next_swarm_event().await {
             SwarmEvent::ConnectionEstablished {

--- a/protocols/autonat/tests/test_server.rs
+++ b/protocols/autonat/tests/test_server.rs
@@ -18,15 +18,20 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::{num::NonZeroU32, time::Duration};
+
 use libp2p_autonat::{
-    Behaviour, Config, Event, InboundProbeError, InboundProbeEvent, ResponseError,
+    Behaviour,
+    Config,
+    Event,
+    InboundProbeError,
+    InboundProbeEvent,
+    ResponseError,
 };
 use libp2p_core::{multiaddr::Protocol, ConnectedPoint, Endpoint, Multiaddr};
 use libp2p_identity::PeerId;
-use libp2p_swarm::DialError;
-use libp2p_swarm::{Swarm, SwarmEvent};
+use libp2p_swarm::{DialError, Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt as _;
-use std::{num::NonZeroU32, time::Duration};
 
 #[tokio::test]
 async fn test_dial_back() {
@@ -340,7 +345,8 @@ async fn test_global_ips_config() {
     client.listen().await;
     tokio::spawn(client.loop_on_next());
 
-    // Expect the probe to be refused as both peers run on the same machine and thus in the same local network.
+    // Expect the probe to be refused as both peers run on the same machine and thus
+    // in the same local network.
     match server.next_behaviour_event().await {
         Event::InboundProbe(InboundProbeEvent::Error { error, .. }) => assert!(matches!(
             error,

--- a/protocols/dcutr/src/behaviour.rs
+++ b/protocols/dcutr/src/behaviour.rs
@@ -18,28 +18,44 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! [`NetworkBehaviour`] to act as a direct connection upgrade through relay node.
+//! [`NetworkBehaviour`] to act as a direct connection upgrade through relay
+//! node.
+
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    convert::Infallible,
+    num::NonZeroUsize,
+    task::{Context, Poll},
+};
+
+use either::Either;
+use libp2p_core::{
+    connection::ConnectedPoint,
+    multiaddr::Protocol,
+    transport::PortUse,
+    Endpoint,
+    Multiaddr,
+};
+use libp2p_identity::PeerId;
+use libp2p_swarm::{
+    behaviour::{ConnectionClosed, DialFailure, FromSwarm},
+    dial_opts::{self, DialOpts},
+    dummy,
+    ConnectionDenied,
+    ConnectionHandler,
+    ConnectionId,
+    NetworkBehaviour,
+    NewExternalAddrCandidate,
+    NotifyHandler,
+    THandler,
+    THandlerInEvent,
+    THandlerOutEvent,
+    ToSwarm,
+};
+use lru::LruCache;
+use thiserror::Error;
 
 use crate::{handler, protocol};
-use either::Either;
-use libp2p_core::connection::ConnectedPoint;
-use libp2p_core::multiaddr::Protocol;
-use libp2p_core::transport::PortUse;
-use libp2p_core::{Endpoint, Multiaddr};
-use libp2p_identity::PeerId;
-use libp2p_swarm::behaviour::{ConnectionClosed, DialFailure, FromSwarm};
-use libp2p_swarm::dial_opts::{self, DialOpts};
-use libp2p_swarm::{
-    dummy, ConnectionDenied, ConnectionHandler, ConnectionId, NewExternalAddrCandidate, THandler,
-    THandlerOutEvent,
-};
-use libp2p_swarm::{NetworkBehaviour, NotifyHandler, THandlerInEvent, ToSwarm};
-use lru::LruCache;
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::convert::Infallible;
-use std::num::NonZeroUsize;
-use std::task::{Context, Poll};
-use thiserror::Error;
 
 pub(crate) const MAX_NUMBER_OF_UPGRADE_ATTEMPTS: u8 = 3;
 
@@ -184,7 +200,9 @@ impl NetworkBehaviour for Behaviour {
                 handler::relayed::Handler::new(connected_point, self.observed_addresses());
             handler.on_behaviour_event(handler::relayed::Command::Connect);
 
-            return Ok(Either::Left(handler)); // TODO: We could make two `handler::relayed::Handler` here, one inbound one outbound.
+            return Ok(Either::Left(handler)); // TODO: We could make two
+                                              // `handler::relayed::Handler`
+                                              // here, one inbound one outbound.
         }
         self.direct_connections
             .entry(peer)
@@ -217,7 +235,8 @@ impl NetworkBehaviour for Behaviour {
                     port_use,
                 },
                 self.observed_addresses(),
-            ))); // TODO: We could make two `handler::relayed::Handler` here, one inbound one outbound.
+            ))); // TODO: We could make two `handler::relayed::Handler` here,
+                 // one inbound one outbound.
         }
 
         self.direct_connections
@@ -255,7 +274,8 @@ impl NetworkBehaviour for Behaviour {
             Either::Left(_) => connection_id,
             Either::Right(_) => match self.direct_to_relayed_connections.get(&connection_id) {
                 None => {
-                    // If the connection ID is unknown to us, it means we didn't create it so ignore any event coming from it.
+                    // If the connection ID is unknown to us, it means we didn't create it so ignore
+                    // any event coming from it.
                     return;
                 }
                 Some(relayed_connection_id) => *relayed_connection_id,
@@ -347,8 +367,9 @@ impl NetworkBehaviour for Behaviour {
 ///
 /// We use an [`LruCache`] to favor addresses that are reported more often.
 /// When attempting a hole-punch, we will try more frequent addresses first.
-/// Most of these addresses will come from observations by other nodes (via e.g. the identify protocol).
-/// More common observations mean a more likely stable port-mapping and thus a higher chance of a successful hole-punch.
+/// Most of these addresses will come from observations by other nodes (via e.g.
+/// the identify protocol). More common observations mean a more likely stable
+/// port-mapping and thus a higher chance of a successful hole-punch.
 struct Candidates {
     inner: LruCache<Multiaddr, ()>,
     me: PeerId,

--- a/protocols/dcutr/src/protocol/inbound.rs
+++ b/protocols/dcutr/src/protocol/inbound.rs
@@ -18,13 +18,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::proto;
+use std::io;
+
 use asynchronous_codec::Framed;
 use futures::prelude::*;
 use libp2p_core::{multiaddr::Protocol, Multiaddr};
 use libp2p_swarm::Stream;
-use std::io;
 use thiserror::Error;
+
+use crate::proto;
 
 pub(crate) async fn handshake(
     stream: Stream,

--- a/protocols/dcutr/src/protocol/outbound.rs
+++ b/protocols/dcutr/src/protocol/outbound.rs
@@ -18,16 +18,17 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::proto;
-use crate::PROTOCOL_NAME;
+use std::io;
+
 use asynchronous_codec::Framed;
 use futures::prelude::*;
 use futures_timer::Delay;
 use libp2p_core::{multiaddr::Protocol, Multiaddr};
 use libp2p_swarm::Stream;
-use std::io;
 use thiserror::Error;
 use web_time::Instant;
+
+use crate::{proto, PROTOCOL_NAME};
 
 pub(crate) async fn handshake(
     stream: Stream,

--- a/protocols/dcutr/tests/lib.rs
+++ b/protocols/dcutr/tests/lib.rs
@@ -18,9 +18,12 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use libp2p_core::multiaddr::{Multiaddr, Protocol};
-use libp2p_core::transport::upgrade::Version;
-use libp2p_core::transport::{MemoryTransport, Transport};
+use std::time::Duration;
+
+use libp2p_core::{
+    multiaddr::{Multiaddr, Protocol},
+    transport::{upgrade::Version, MemoryTransport, Transport},
+};
 use libp2p_dcutr as dcutr;
 use libp2p_identify as identify;
 use libp2p_identity as identity;
@@ -29,7 +32,6 @@ use libp2p_plaintext as plaintext;
 use libp2p_relay as relay;
 use libp2p_swarm::{Config, NetworkBehaviour, Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt as _;
-use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::test]

--- a/protocols/floodsub/src/lib.rs
+++ b/protocols/floodsub/src/lib.rs
@@ -35,18 +35,21 @@ mod proto {
     pub(crate) use self::floodsub::pb::{mod_RPC::SubOpts, Message, RPC};
 }
 
-pub use self::layer::{Floodsub, FloodsubEvent};
-pub use self::protocol::{FloodsubMessage, FloodsubRpc};
-pub use self::topic::Topic;
+pub use self::{
+    layer::{Floodsub, FloodsubEvent},
+    protocol::{FloodsubMessage, FloodsubRpc},
+    topic::Topic,
+};
 
 /// Configuration options for the Floodsub protocol.
 #[derive(Debug, Clone)]
 pub struct FloodsubConfig {
-    /// Peer id of the local node. Used for the source of the messages that we publish.
+    /// Peer id of the local node. Used for the source of the messages that we
+    /// publish.
     pub local_peer_id: PeerId,
 
-    /// `true` if messages published by local node should be propagated as messages received from
-    /// the network, `false` by default.
+    /// `true` if messages published by local node should be propagated as
+    /// messages received from the network, `false` by default.
     pub subscribe_local_messages: bool,
 }
 

--- a/protocols/floodsub/src/protocol.rs
+++ b/protocols/floodsub/src/protocol.rs
@@ -18,19 +18,21 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::proto;
-use crate::topic::Topic;
+use std::{io, iter, pin::Pin};
+
 use asynchronous_codec::Framed;
 use bytes::Bytes;
 use futures::{
     io::{AsyncRead, AsyncWrite},
     Future,
+    SinkExt,
+    StreamExt,
 };
-use futures::{SinkExt, StreamExt};
 use libp2p_core::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use libp2p_identity::PeerId;
 use libp2p_swarm::StreamProtocol;
-use std::{io, iter, pin::Pin};
+
+use crate::{proto, topic::Topic};
 
 const MAX_MESSAGE_LEN_BYTES: usize = 2048;
 

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -20,16 +20,20 @@
 
 // Collection of tests for the gossipsub network behaviour
 
-use super::*;
-use crate::rpc::Receiver;
-use crate::subscription_filter::WhitelistSubscriptionFilter;
-use crate::{config::ConfigBuilder, types::Rpc, IdentTopic as Topic};
+use std::{future, net::Ipv4Addr, thread::sleep};
+
 use byteorder::{BigEndian, ByteOrder};
 use libp2p_core::ConnectedPoint;
 use rand::Rng;
-use std::future;
-use std::net::Ipv4Addr;
-use std::thread::sleep;
+
+use super::*;
+use crate::{
+    config::ConfigBuilder,
+    rpc::Receiver,
+    subscription_filter::WhitelistSubscriptionFilter,
+    types::Rpc,
+    IdentTopic as Topic,
+};
 
 #[derive(Default, Debug)]
 struct InjectNodes<D, F>
@@ -302,7 +306,8 @@ where
     }
 }
 
-// Converts a protobuf message into a gossipsub message for reading the Gossipsub event queue.
+// Converts a protobuf message into a gossipsub message for reading the
+// Gossipsub event queue.
 fn proto_to_message(rpc: &proto::RPC) -> Rpc {
     // Store valid messages.
     let mut messages = Vec::with_capacity(rpc.publish.len());
@@ -311,7 +316,8 @@ fn proto_to_message(rpc: &proto::RPC) -> Rpc {
         messages.push(RawMessage {
             source: message.from.map(|x| PeerId::from_bytes(&x).unwrap()),
             data: message.data.unwrap_or_default(),
-            sequence_number: message.seqno.map(|x| BigEndian::read_u64(&x)), // don't inform the application
+            sequence_number: message.seqno.map(|x| BigEndian::read_u64(&x)), /* don't inform the
+                                                                              * application */
             topic: TopicHash::from_raw(message.topic),
             signature: message.signature, // don't inform the application
             key: None,
@@ -677,7 +683,7 @@ fn test_publish_without_flood_publishing() {
     // - Send publish message to all peers
     // - Insert message into gs.mcache and gs.received
 
-    //turn off flood publish to test old behaviour
+    // turn off flood publish to test old behaviour
     let config = ConfigBuilder::default()
         .flood_publish(false)
         .build()
@@ -757,7 +763,7 @@ fn test_fanout() {
     // - Send publish message to fanout peers
     // - Insert message into gs.mcache and gs.received
 
-    //turn off flood publish to test fanout behaviour
+    // turn off flood publish to test fanout behaviour
     let config = ConfigBuilder::default()
         .flood_publish(false)
         .build()
@@ -869,7 +875,8 @@ fn test_inject_connected() {
     // check that there are 20 send events created
     assert_eq!(subscriptions.len(), 20);
 
-    // should add the new peers to `peer_topics` with an empty vec as a gossipsub node
+    // should add the new peers to `peer_topics` with an empty vec as a gossipsub
+    // node
     for peer in peers {
         let peer = gs.connected_peers.get(&peer).unwrap();
         assert!(
@@ -1047,7 +1054,8 @@ fn test_get_random_peers() {
     assert!(random_peers.len() == 10, "Expected 10 peers to be returned");
 }
 
-/// Tests that the correct message is sent when a peer asks for a message in our cache.
+/// Tests that the correct message is sent when a peer asks for a message in our
+/// cache.
 #[test]
 fn test_handle_iwant_msg_cached() {
     let (mut gs, peers, receivers, _) = inject_nodes1()
@@ -1099,7 +1107,8 @@ fn test_handle_iwant_msg_cached() {
     );
 }
 
-/// Tests that messages are sent correctly depending on the shifting of the message cache.
+/// Tests that messages are sent correctly depending on the shifting of the
+/// message cache.
 #[test]
 fn test_handle_iwant_msg_cached_shifted() {
     let (mut gs, peers, mut receivers, _) = inject_nodes1()
@@ -1173,7 +1182,8 @@ fn test_handle_iwant_msg_cached_shifted() {
     }
 }
 
-/// tests that an event is not created when a peers asks for a message not in our cache
+/// tests that an event is not created when a peers asks for a message not in
+/// our cache
 #[test]
 fn test_handle_iwant_msg_not_cached() {
     let (mut gs, peers, _, _) = inject_nodes1()
@@ -1192,7 +1202,8 @@ fn test_handle_iwant_msg_not_cached() {
     );
 }
 
-/// tests that an event is created when a peer shares that it has a message we want
+/// tests that an event is created when a peer shares that it has a message we
+/// want
 #[test]
 fn test_handle_ihave_subscribed_and_msg_not_cached() {
     let (mut gs, peers, mut receivers, topic_hashes) = inject_nodes1()
@@ -1228,8 +1239,8 @@ fn test_handle_ihave_subscribed_and_msg_not_cached() {
     );
 }
 
-/// tests that an event is not created when a peer shares that it has a message that
-/// we already have
+/// tests that an event is not created when a peer shares that it has a message
+/// that we already have
 #[test]
 fn test_handle_ihave_subscribed_and_msg_cached() {
     let (mut gs, peers, _, topic_hashes) = inject_nodes1()
@@ -1250,8 +1261,8 @@ fn test_handle_ihave_subscribed_and_msg_cached() {
     )
 }
 
-/// test that an event is not created when a peer shares that it has a message in
-/// a topic that we are not subscribed to
+/// test that an event is not created when a peer shares that it has a message
+/// in a topic that we are not subscribed to
 #[test]
 fn test_handle_ihave_not_subscribed() {
     let (mut gs, peers, _, _) = inject_nodes1()
@@ -1447,10 +1458,10 @@ fn test_explicit_peer_gets_connected() {
         .to_subscribe(true)
         .create_network();
 
-    //create new peer
+    // create new peer
     let peer = PeerId::random();
 
-    //add peer as explicit peer
+    // add peer as explicit peer
     gs.add_explicit_peer(&peer);
 
     let num_events = gs
@@ -1483,17 +1494,18 @@ fn test_explicit_peer_reconnects() {
 
     let peer = others.first().unwrap();
 
-    //add peer as explicit peer
+    // add peer as explicit peer
     gs.add_explicit_peer(peer);
 
     flush_events(&mut gs, receivers);
 
-    //disconnect peer
+    // disconnect peer
     disconnect_peer(&mut gs, peer);
 
     gs.heartbeat();
 
-    //check that no reconnect after first heartbeat since `explicit_peer_ticks == 2`
+    // check that no reconnect after first heartbeat since `explicit_peer_ticks ==
+    // 2`
     assert_eq!(
         gs.events
             .iter()
@@ -1508,7 +1520,7 @@ fn test_explicit_peer_reconnects() {
 
     gs.heartbeat();
 
-    //check that there is a reconnect after second heartbeat
+    // check that there is a reconnect after second heartbeat
     assert!(
         gs.events
             .iter()
@@ -1536,11 +1548,11 @@ fn test_handle_graft_explicit_peer() {
 
     gs.handle_graft(peer, topic_hashes.clone());
 
-    //peer got not added to mesh
+    // peer got not added to mesh
     assert!(gs.mesh[&topic_hashes[0]].is_empty());
     assert!(gs.mesh[&topic_hashes[1]].is_empty());
 
-    //check prunes
+    // check prunes
     let (control_msgs, _) = count_control_msgs(receivers, |peer_id, m| {
         peer_id == peer
             && match m {
@@ -1566,13 +1578,13 @@ fn explicit_peers_not_added_to_mesh_on_receiving_subscription() {
         .explicit(1)
         .create_network();
 
-    //only peer 1 is in the mesh not peer 0 (which is an explicit peer)
+    // only peer 1 is in the mesh not peer 0 (which is an explicit peer)
     assert_eq!(
         gs.mesh[&topic_hashes[0]],
         vec![peers[1]].into_iter().collect()
     );
 
-    //assert that graft gets created to non-explicit peer
+    // assert that graft gets created to non-explicit peer
     let (control_msgs, receivers) = count_control_msgs(receivers, |peer_id, m| {
         peer_id == &peers[1] && matches!(m, RpcOut::Graft { .. })
     });
@@ -1581,7 +1593,7 @@ fn explicit_peers_not_added_to_mesh_on_receiving_subscription() {
         "No graft message got created to non-explicit peer"
     );
 
-    //assert that no graft gets created to explicit peer
+    // assert that no graft gets created to explicit peer
     let (control_msgs, _) = count_control_msgs(receivers, |peer_id, m| {
         peer_id == &peers[0] && matches!(m, RpcOut::Graft { .. })
     });
@@ -1603,10 +1615,10 @@ fn do_not_graft_explicit_peer() {
 
     gs.heartbeat();
 
-    //mesh stays empty
+    // mesh stays empty
     assert_eq!(gs.mesh[&topic_hashes[0]], BTreeSet::new());
 
-    //assert that no graft gets created to explicit peer
+    // assert that no graft gets created to explicit peer
     let (control_msgs, _) = count_control_msgs(receivers, |peer_id, m| {
         peer_id == &others[0] && matches!(m, RpcOut::Graft { .. })
     });
@@ -1663,7 +1675,7 @@ fn explicit_peers_not_added_to_mesh_on_subscribe() {
         .explicit(1)
         .create_network();
 
-    //create new topic, both peers subscribing to it but we do not subscribe to it
+    // create new topic, both peers subscribing to it but we do not subscribe to it
     let topic = Topic::new(String::from("t"));
     let topic_hash = topic.hash();
     for peer in peers.iter().take(2) {
@@ -1676,13 +1688,13 @@ fn explicit_peers_not_added_to_mesh_on_subscribe() {
         );
     }
 
-    //subscribe now to topic
+    // subscribe now to topic
     gs.subscribe(&topic).unwrap();
 
-    //only peer 1 is in the mesh not peer 0 (which is an explicit peer)
+    // only peer 1 is in the mesh not peer 0 (which is an explicit peer)
     assert_eq!(gs.mesh[&topic_hash], vec![peers[1]].into_iter().collect());
 
-    //assert that graft gets created to non-explicit peer
+    // assert that graft gets created to non-explicit peer
     let (control_msgs, receivers) = count_control_msgs(receivers, |peer_id, m| {
         peer_id == &peers[1] && matches!(m, RpcOut::Graft { .. })
     });
@@ -1691,7 +1703,7 @@ fn explicit_peers_not_added_to_mesh_on_subscribe() {
         "No graft message got created to non-explicit peer"
     );
 
-    //assert that no graft gets created to explicit peer
+    // assert that no graft gets created to explicit peer
     let (control_msgs, _) = count_control_msgs(receivers, |peer_id, m| {
         peer_id == &peers[0] && matches!(m, RpcOut::Graft { .. })
     });
@@ -1711,7 +1723,7 @@ fn explicit_peers_not_added_to_mesh_from_fanout_on_subscribe() {
         .explicit(1)
         .create_network();
 
-    //create new topic, both peers subscribing to it but we do not subscribe to it
+    // create new topic, both peers subscribing to it but we do not subscribe to it
     let topic = Topic::new(String::from("t"));
     let topic_hash = topic.hash();
     for peer in peers.iter().take(2) {
@@ -1724,16 +1736,16 @@ fn explicit_peers_not_added_to_mesh_from_fanout_on_subscribe() {
         );
     }
 
-    //we send a message for this topic => this will initialize the fanout
+    // we send a message for this topic => this will initialize the fanout
     gs.publish(topic.clone(), vec![1, 2, 3]).unwrap();
 
-    //subscribe now to topic
+    // subscribe now to topic
     gs.subscribe(&topic).unwrap();
 
-    //only peer 1 is in the mesh not peer 0 (which is an explicit peer)
+    // only peer 1 is in the mesh not peer 0 (which is an explicit peer)
     assert_eq!(gs.mesh[&topic_hash], vec![peers[1]].into_iter().collect());
 
-    //assert that graft gets created to non-explicit peer
+    // assert that graft gets created to non-explicit peer
     let (control_msgs, receivers) = count_control_msgs(receivers, |peer_id, m| {
         peer_id == &peers[1] && matches!(m, RpcOut::Graft { .. })
     });
@@ -1742,7 +1754,7 @@ fn explicit_peers_not_added_to_mesh_from_fanout_on_subscribe() {
         "No graft message got created to non-explicit peer"
     );
 
-    //assert that no graft gets created to explicit peer
+    // assert that no graft gets created to explicit peer
     let (control_msgs, _) = count_control_msgs(receivers, |peer_id, m| {
         peer_id == &peers[0] && matches!(m, RpcOut::Graft { .. })
     });
@@ -1774,15 +1786,15 @@ fn no_gossip_gets_sent_to_explicit_peers() {
         validated: true,
     };
 
-    //forward the message
+    // forward the message
     gs.handle_received_message(message, &local_id);
 
-    //simulate multiple gossip calls (for randomness)
+    // simulate multiple gossip calls (for randomness)
     for _ in 0..3 {
         gs.emit_gossip();
     }
 
-    //assert that no gossip gets sent to explicit peer
+    // assert that no gossip gets sent to explicit peer
     let receiver = receivers.remove(&peers[0]).unwrap();
     let mut gossips = 0;
     let non_priority = receiver.non_priority.get_ref();
@@ -1835,7 +1847,7 @@ fn test_mesh_subtraction() {
 
     // Adds mesh_low peers and PRUNE 2 giving us a deficit.
     let n = config.mesh_n_high() + 10;
-    //make all outbound connections so that we allow grafting to all
+    // make all outbound connections so that we allow grafting to all
     let (mut gs, peers, _receivers, topics) = inject_nodes1()
         .peer_no(n)
         .topics(vec!["test".into()])
@@ -1866,10 +1878,10 @@ fn test_connect_to_px_peers_on_handle_prune() {
         .to_subscribe(true)
         .create_network();
 
-    //handle prune from single peer with px peers
+    // handle prune from single peer with px peers
 
     let mut px = Vec::new();
-    //propose more px peers than config.prune_peers()
+    // propose more px peers than config.prune_peers()
     for _ in 0..config.prune_peers() + 5 {
         px.push(PeerInfo {
             peer_id: Some(PeerId::random()),
@@ -1885,7 +1897,7 @@ fn test_connect_to_px_peers_on_handle_prune() {
         )],
     );
 
-    //Check DialPeer events for px peers
+    // Check DialPeer events for px peers
     let dials: Vec<_> = gs
         .events
         .iter()
@@ -1903,7 +1915,7 @@ fn test_connect_to_px_peers_on_handle_prune() {
     // No duplicates
     assert_eq!(dials_set.len(), config.prune_peers());
 
-    //all dial peers must be in px
+    // all dial peers must be in px
     assert!(dials_set.is_subset(
         &px.iter()
             .map(|i| *i.peer_id.as_ref().unwrap())
@@ -1915,14 +1927,14 @@ fn test_connect_to_px_peers_on_handle_prune() {
 fn test_send_px_and_backoff_in_prune() {
     let config: Config = Config::default();
 
-    //build mesh with enough peers for px
+    // build mesh with enough peers for px
     let (mut gs, peers, receivers, topics) = inject_nodes1()
         .peer_no(config.prune_peers() + 1)
         .topics(vec!["test".into()])
         .to_subscribe(true)
         .create_network();
 
-    //send prune to peer
+    // send prune to peer
     gs.send_graft_prune(
         HashMap::new(),
         vec![(peers[0], vec![topics[0].clone()])]
@@ -1931,7 +1943,7 @@ fn test_send_px_and_backoff_in_prune() {
         HashSet::new(),
     );
 
-    //check prune message
+    // check prune message
     let (control_msgs, _) = count_control_msgs(receivers, |peer_id, m| {
         peer_id == &peers[0]
             && match m {
@@ -1957,14 +1969,15 @@ fn test_send_px_and_backoff_in_prune() {
 fn test_prune_backoffed_peer_on_graft() {
     let config: Config = Config::default();
 
-    //build mesh with enough peers for px
+    // build mesh with enough peers for px
     let (mut gs, peers, receivers, topics) = inject_nodes1()
         .peer_no(config.prune_peers() + 1)
         .topics(vec!["test".into()])
         .to_subscribe(true)
         .create_network();
 
-    //remove peer from mesh and send prune to peer => this adds a backoff for this peer
+    // remove peer from mesh and send prune to peer => this adds a backoff for this
+    // peer
     gs.mesh.get_mut(&topics[0]).unwrap().remove(&peers[0]);
     gs.send_graft_prune(
         HashMap::new(),
@@ -1974,13 +1987,13 @@ fn test_prune_backoffed_peer_on_graft() {
         HashSet::new(),
     );
 
-    //ignore all messages until now
+    // ignore all messages until now
     let receivers = flush_events(&mut gs, receivers);
 
-    //handle graft
+    // handle graft
     gs.handle_graft(&peers[0], vec![topics[0].clone()]);
 
-    //check prune message
+    // check prune message
     let (control_msgs, _) = count_control_msgs(receivers, |peer_id, m| {
         peer_id == &peers[0]
             && match m {
@@ -2007,7 +2020,7 @@ fn test_do_not_graft_within_backoff_period() {
         .heartbeat_interval(Duration::from_millis(100))
         .build()
         .unwrap();
-    //only one peer => mesh too small and will try to regraft as early as possible
+    // only one peer => mesh too small and will try to regraft as early as possible
     let (mut gs, peers, receivers, topics) = inject_nodes1()
         .peer_no(1)
         .topics(vec!["test".into()])
@@ -2015,23 +2028,23 @@ fn test_do_not_graft_within_backoff_period() {
         .gs_config(config)
         .create_network();
 
-    //handle prune from peer with backoff of one second
+    // handle prune from peer with backoff of one second
     gs.handle_prune(&peers[0], vec![(topics[0].clone(), Vec::new(), Some(1))]);
 
-    //forget all events until now
+    // forget all events until now
     let receivers = flush_events(&mut gs, receivers);
 
-    //call heartbeat
+    // call heartbeat
     gs.heartbeat();
 
-    //Sleep for one second and apply 10 regular heartbeats (interval = 100ms).
+    // Sleep for one second and apply 10 regular heartbeats (interval = 100ms).
     for _ in 0..10 {
         sleep(Duration::from_millis(100));
         gs.heartbeat();
     }
 
-    //Check that no graft got created (we have backoff_slack = 1 therefore one more heartbeat
-    // is needed).
+    // Check that no graft got created (we have backoff_slack = 1 therefore one more
+    // heartbeat is needed).
     let (control_msgs, receivers) =
         count_control_msgs(receivers, |_, m| matches!(m, RpcOut::Graft { .. }));
     assert_eq!(
@@ -2039,11 +2052,11 @@ fn test_do_not_graft_within_backoff_period() {
         "Graft message created too early within backoff period"
     );
 
-    //Heartbeat one more time this should graft now
+    // Heartbeat one more time this should graft now
     sleep(Duration::from_millis(100));
     gs.heartbeat();
 
-    //check that graft got created
+    // check that graft got created
     let (control_msgs, _) = count_control_msgs(receivers, |_, m| matches!(m, RpcOut::Graft { .. }));
     assert!(
         control_msgs > 0,
@@ -2053,14 +2066,14 @@ fn test_do_not_graft_within_backoff_period() {
 
 #[test]
 fn test_do_not_graft_within_default_backoff_period_after_receiving_prune_without_backoff() {
-    //set default backoff period to 1 second
+    // set default backoff period to 1 second
     let config = ConfigBuilder::default()
         .prune_backoff(Duration::from_millis(90))
         .backoff_slack(1)
         .heartbeat_interval(Duration::from_millis(100))
         .build()
         .unwrap();
-    //only one peer => mesh too small and will try to regraft as early as possible
+    // only one peer => mesh too small and will try to regraft as early as possible
     let (mut gs, peers, receivers, topics) = inject_nodes1()
         .peer_no(1)
         .topics(vec!["test".into()])
@@ -2068,21 +2081,21 @@ fn test_do_not_graft_within_default_backoff_period_after_receiving_prune_without
         .gs_config(config)
         .create_network();
 
-    //handle prune from peer without a specified backoff
+    // handle prune from peer without a specified backoff
     gs.handle_prune(&peers[0], vec![(topics[0].clone(), Vec::new(), None)]);
 
-    //forget all events until now
+    // forget all events until now
     let receivers = flush_events(&mut gs, receivers);
 
-    //call heartbeat
+    // call heartbeat
     gs.heartbeat();
 
-    //Apply one more heartbeat
+    // Apply one more heartbeat
     sleep(Duration::from_millis(100));
     gs.heartbeat();
 
-    //Check that no graft got created (we have backoff_slack = 1 therefore one more heartbeat
-    // is needed).
+    // Check that no graft got created (we have backoff_slack = 1 therefore one more
+    // heartbeat is needed).
     let (control_msgs, receivers) =
         count_control_msgs(receivers, |_, m| matches!(m, RpcOut::Graft { .. }));
     assert_eq!(
@@ -2090,11 +2103,11 @@ fn test_do_not_graft_within_default_backoff_period_after_receiving_prune_without
         "Graft message created too early within backoff period"
     );
 
-    //Heartbeat one more time this should graft now
+    // Heartbeat one more time this should graft now
     sleep(Duration::from_millis(100));
     gs.heartbeat();
 
-    //check that graft got created
+    // check that graft got created
     let (control_msgs, _) = count_control_msgs(receivers, |_, m| matches!(m, RpcOut::Graft { .. }));
     assert!(
         control_msgs > 0,
@@ -2148,8 +2161,8 @@ fn test_unsubscribe_backoff() {
         gs.heartbeat();
     }
 
-    // Check that no graft got created (we have backoff_slack = 1 therefore one more heartbeat
-    // is needed).
+    // Check that no graft got created (we have backoff_slack = 1 therefore one more
+    // heartbeat is needed).
     let (control_msgs, receivers) =
         count_control_msgs(receivers, |_, m| matches!(m, RpcOut::Graft { .. }));
     assert_eq!(
@@ -2181,7 +2194,7 @@ fn test_flood_publish() {
         .to_subscribe(true)
         .create_network();
 
-    //publish message
+    // publish message
     let publish_data = vec![0; 42];
     gs.publish(Topic::new(topic), publish_data).unwrap();
 
@@ -2228,15 +2241,15 @@ fn test_flood_publish() {
 fn test_gossip_to_at_least_gossip_lazy_peers() {
     let config: Config = Config::default();
 
-    //add more peers than in mesh to test gossipping
-    //by default only mesh_n_low peers will get added to mesh
+    // add more peers than in mesh to test gossipping
+    // by default only mesh_n_low peers will get added to mesh
     let (mut gs, _, receivers, topic_hashes) = inject_nodes1()
         .peer_no(config.mesh_n_low() + config.gossip_lazy() + 1)
         .topics(vec!["topic".into()])
         .to_subscribe(true)
         .create_network();
 
-    //receive message
+    // receive message
     let raw_message = RawMessage {
         source: Some(PeerId::random()),
         data: vec![],
@@ -2248,7 +2261,7 @@ fn test_gossip_to_at_least_gossip_lazy_peers() {
     };
     gs.handle_received_message(raw_message.clone(), &PeerId::random());
 
-    //emit gossip
+    // emit gossip
     gs.emit_gossip();
 
     // Transform the inbound message
@@ -2256,7 +2269,7 @@ fn test_gossip_to_at_least_gossip_lazy_peers() {
 
     let msg_id = gs.config.message_id(message);
 
-    //check that exactly config.gossip_lazy() many gossip messages were sent.
+    // check that exactly config.gossip_lazy() many gossip messages were sent.
     let (control_msgs, _) = count_control_msgs(receivers, |_, action| match action {
         RpcOut::IHave(IHave {
             topic_hash,
@@ -2271,7 +2284,7 @@ fn test_gossip_to_at_least_gossip_lazy_peers() {
 fn test_gossip_to_at_most_gossip_factor_peers() {
     let config: Config = Config::default();
 
-    //add a lot of peers
+    // add a lot of peers
     let m = config.mesh_n_low() + config.gossip_lazy() * (2.0 / config.gossip_factor()) as usize;
     let (mut gs, _, receivers, topic_hashes) = inject_nodes1()
         .peer_no(m)
@@ -2279,7 +2292,7 @@ fn test_gossip_to_at_most_gossip_factor_peers() {
         .to_subscribe(true)
         .create_network();
 
-    //receive message
+    // receive message
     let raw_message = RawMessage {
         source: Some(PeerId::random()),
         data: vec![],
@@ -2291,14 +2304,14 @@ fn test_gossip_to_at_most_gossip_factor_peers() {
     };
     gs.handle_received_message(raw_message.clone(), &PeerId::random());
 
-    //emit gossip
+    // emit gossip
     gs.emit_gossip();
 
     // Transform the inbound message
     let message = &gs.data_transform.inbound_transform(raw_message).unwrap();
 
     let msg_id = gs.config.message_id(message);
-    //check that exactly config.gossip_lazy() many gossip messages were sent.
+    // check that exactly config.gossip_lazy() many gossip messages were sent.
     let (control_msgs, _) = count_control_msgs(receivers, |_, action| match action {
         RpcOut::IHave(IHave {
             topic_hash,
@@ -2316,7 +2329,7 @@ fn test_gossip_to_at_most_gossip_factor_peers() {
 fn test_accept_only_outbound_peer_grafts_when_mesh_full() {
     let config: Config = Config::default();
 
-    //enough peers to fill the mesh
+    // enough peers to fill the mesh
     let (mut gs, peers, _, topics) = inject_nodes1()
         .peer_no(config.mesh_n_high())
         .topics(vec!["test".into()])
@@ -2328,30 +2341,30 @@ fn test_accept_only_outbound_peer_grafts_when_mesh_full() {
         gs.handle_graft(&peer, topics.clone());
     }
 
-    //assert current mesh size
+    // assert current mesh size
     assert_eq!(gs.mesh[&topics[0]].len(), config.mesh_n_high());
 
-    //create an outbound and an inbound peer
+    // create an outbound and an inbound peer
     let (inbound, _in_reciver) = add_peer(&mut gs, &topics, false, false);
     let (outbound, _out_receiver) = add_peer(&mut gs, &topics, true, false);
 
-    //send grafts
+    // send grafts
     gs.handle_graft(&inbound, vec![topics[0].clone()]);
     gs.handle_graft(&outbound, vec![topics[0].clone()]);
 
-    //assert mesh size
+    // assert mesh size
     assert_eq!(gs.mesh[&topics[0]].len(), config.mesh_n_high() + 1);
 
-    //inbound is not in mesh
+    // inbound is not in mesh
     assert!(!gs.mesh[&topics[0]].contains(&inbound));
 
-    //outbound is in mesh
+    // outbound is in mesh
     assert!(gs.mesh[&topics[0]].contains(&outbound));
 }
 
 #[test]
 fn test_do_not_remove_too_many_outbound_peers() {
-    //use an extreme case to catch errors with high probability
+    // use an extreme case to catch errors with high probability
     let m = 50;
     let n = 2 * m;
     let config = ConfigBuilder::default()
@@ -2362,7 +2375,7 @@ fn test_do_not_remove_too_many_outbound_peers() {
         .build()
         .unwrap();
 
-    //fill the mesh with inbound connections
+    // fill the mesh with inbound connections
     let (mut gs, peers, _receivers, topics) = inject_nodes1()
         .peer_no(n)
         .topics(vec!["test".into()])
@@ -2375,7 +2388,7 @@ fn test_do_not_remove_too_many_outbound_peers() {
         gs.handle_graft(&peer, topics.clone());
     }
 
-    //create m outbound connections and graft (we will accept the graft)
+    // create m outbound connections and graft (we will accept the graft)
     let mut outbound = HashSet::new();
     for _ in 0..m {
         let (peer, _) = add_peer(&mut gs, &topics, true, false);
@@ -2383,7 +2396,7 @@ fn test_do_not_remove_too_many_outbound_peers() {
         gs.handle_graft(&peer, topics.clone());
     }
 
-    //mesh is overly full
+    // mesh is overly full
     assert_eq!(gs.mesh.get(&topics[0]).unwrap().len(), n + m);
 
     // run a heartbeat
@@ -2392,7 +2405,7 @@ fn test_do_not_remove_too_many_outbound_peers() {
     // Peers should be removed to reach n
     assert_eq!(gs.mesh.get(&topics[0]).unwrap().len(), n);
 
-    //all outbound peers are still in the mesh
+    // all outbound peers are still in the mesh
     assert!(outbound.iter().all(|p| gs.mesh[&topics[0]].contains(p)));
 }
 
@@ -2412,7 +2425,7 @@ fn test_add_outbound_peers_if_min_is_not_satisfied() {
         gs.handle_graft(&peer, topics.clone());
     }
 
-    //create config.mesh_outbound_min() many outbound connections without grafting
+    // create config.mesh_outbound_min() many outbound connections without grafting
     let mut peers = vec![];
     for _ in 0..config.mesh_outbound_min() {
         peers.push(add_peer(&mut gs, &topics, true, false));
@@ -2435,7 +2448,7 @@ fn test_add_outbound_peers_if_min_is_not_satisfied() {
 fn test_prune_negative_scored_peers() {
     let config = Config::default();
 
-    //build mesh with one peer
+    // build mesh with one peer
     let (mut gs, peers, receivers, topics) = inject_nodes1()
         .peer_no(1)
         .topics(vec!["test".into()])
@@ -2449,16 +2462,16 @@ fn test_prune_negative_scored_peers() {
         )))
         .create_network();
 
-    //add penalty to peer
+    // add penalty to peer
     gs.peer_score.as_mut().unwrap().0.add_penalty(&peers[0], 1);
 
-    //execute heartbeat
+    // execute heartbeat
     gs.heartbeat();
 
-    //peer should not be in mesh anymore
+    // peer should not be in mesh anymore
     assert!(gs.mesh[&topics[0]].is_empty());
 
-    //check prune message
+    // check prune message
     let (control_msgs, _) = count_control_msgs(receivers, |peer_id, m| {
         peer_id == &peers[0]
             && match m {
@@ -2481,7 +2494,7 @@ fn test_prune_negative_scored_peers() {
 #[test]
 fn test_dont_graft_to_negative_scored_peers() {
     let config = Config::default();
-    //init full mesh
+    // init full mesh
     let (mut gs, peers, _, topics) = inject_nodes1()
         .peer_no(config.mesh_n_high())
         .topics(vec!["test".into()])
@@ -2493,34 +2506,35 @@ fn test_dont_graft_to_negative_scored_peers() {
         )))
         .create_network();
 
-    //add two additional peers that will not be part of the mesh
+    // add two additional peers that will not be part of the mesh
     let (p1, _receiver1) = add_peer(&mut gs, &topics, false, false);
     let (p2, _receiver2) = add_peer(&mut gs, &topics, false, false);
 
-    //reduce score of p1 to negative
+    // reduce score of p1 to negative
     gs.peer_score.as_mut().unwrap().0.add_penalty(&p1, 1);
 
-    //handle prunes of all other peers
+    // handle prunes of all other peers
     for p in peers {
         gs.handle_prune(&p, vec![(topics[0].clone(), Vec::new(), None)]);
     }
 
-    //heartbeat
+    // heartbeat
     gs.heartbeat();
 
-    //assert that mesh only contains p2
+    // assert that mesh only contains p2
     assert_eq!(gs.mesh.get(&topics[0]).unwrap().len(), 1);
     assert!(gs.mesh.get(&topics[0]).unwrap().contains(&p2));
 }
 
-///Note that in this test also without a penalty the px would be ignored because of the
-/// acceptPXThreshold, but the spec still explicitly states the rule that px from negative
-/// peers should get ignored, therefore we test it here.
+/// Note that in this test also without a penalty the px would be ignored
+/// because of the acceptPXThreshold, but the spec still explicitly states the
+/// rule that px from negative peers should get ignored, therefore we test it
+/// here.
 #[test]
 fn test_ignore_px_from_negative_scored_peer() {
     let config = Config::default();
 
-    //build mesh with one peer
+    // build mesh with one peer
     let (mut gs, peers, _, topics) = inject_nodes1()
         .peer_no(1)
         .topics(vec!["test".into()])
@@ -2532,10 +2546,10 @@ fn test_ignore_px_from_negative_scored_peer() {
         )))
         .create_network();
 
-    //penalize peer
+    // penalize peer
     gs.peer_score.as_mut().unwrap().0.add_penalty(&peers[0], 1);
 
-    //handle prune from single peer with px peers
+    // handle prune from single peer with px peers
     let px = vec![PeerInfo {
         peer_id: Some(PeerId::random()),
     }];
@@ -2549,7 +2563,7 @@ fn test_ignore_px_from_negative_scored_peer() {
         )],
     );
 
-    //assert no dials
+    // assert no dials
     assert_eq!(
         gs.events
             .iter()
@@ -2646,7 +2660,8 @@ fn test_do_not_gossip_to_peers_below_gossip_threshold() {
     // 4 * peer_score_params.behaviour_penalty_weight.
     gs.peer_score.as_mut().unwrap().0.add_penalty(&p1, 2);
 
-    // Reduce score of p2 below 0 but not below peer_score_thresholds.gossip_threshold
+    // Reduce score of p2 below 0 but not below
+    // peer_score_thresholds.gossip_threshold
     gs.peer_score.as_mut().unwrap().0.add_penalty(&p2, 1);
 
     // Receive message
@@ -2723,7 +2738,8 @@ fn test_iwant_msg_from_peer_below_gossip_threshold_gets_ignored() {
     // 4 * peer_score_params.behaviour_penalty_weight.
     gs.peer_score.as_mut().unwrap().0.add_penalty(&p1, 2);
 
-    // Reduce score of p2 below 0 but not below peer_score_thresholds.gossip_threshold
+    // Reduce score of p2 below 0 but not below
+    // peer_score_thresholds.gossip_threshold
     gs.peer_score.as_mut().unwrap().0.add_penalty(&p2, 1);
 
     // Receive message
@@ -2760,7 +2776,7 @@ fn test_iwant_msg_from_peer_below_gossip_threshold_gets_ignored() {
                 collected_messages
             });
 
-    //the message got sent to p2
+    // the message got sent to p2
     assert!(sent_messages
         .iter()
         .map(|(peer_id, msg)| (
@@ -2768,7 +2784,7 @@ fn test_iwant_msg_from_peer_below_gossip_threshold_gets_ignored() {
             gs.data_transform.inbound_transform(msg.clone()).unwrap()
         ))
         .any(|(peer_id, msg)| peer_id == &p2 && gs.config.message_id(&msg) == msg_id));
-    //the message got not sent to p1
+    // the message got not sent to p1
     assert!(sent_messages
         .iter()
         .map(|(peer_id, msg)| (
@@ -2786,7 +2802,7 @@ fn test_ihave_msg_from_peer_below_gossip_threshold_gets_ignored() {
         gossip_threshold: 3.0 * peer_score_params.behaviour_penalty_weight,
         ..PeerScoreThresholds::default()
     };
-    //build full mesh
+    // build full mesh
     let (mut gs, peers, mut receivers, topics) = inject_nodes1()
         .peer_no(config.mesh_n_high())
         .topics(vec!["test".into()])
@@ -2802,21 +2818,22 @@ fn test_ihave_msg_from_peer_below_gossip_threshold_gets_ignored() {
         gs.handle_graft(&peer, topics.clone());
     }
 
-    //add two additional peers that will not be part of the mesh
+    // add two additional peers that will not be part of the mesh
     let (p1, receiver1) = add_peer(&mut gs, &topics, false, false);
     receivers.insert(p1, receiver1);
     let (p2, receiver2) = add_peer(&mut gs, &topics, false, false);
     receivers.insert(p2, receiver2);
 
-    //reduce score of p1 below peer_score_thresholds.gossip_threshold
-    //note that penalties get squared so two penalties means a score of
+    // reduce score of p1 below peer_score_thresholds.gossip_threshold
+    // note that penalties get squared so two penalties means a score of
     // 4 * peer_score_params.behaviour_penalty_weight.
     gs.peer_score.as_mut().unwrap().0.add_penalty(&p1, 2);
 
-    //reduce score of p2 below 0 but not below peer_score_thresholds.gossip_threshold
+    // reduce score of p2 below 0 but not below
+    // peer_score_thresholds.gossip_threshold
     gs.peer_score.as_mut().unwrap().0.add_penalty(&p2, 1);
 
-    //message that other peers have
+    // message that other peers have
     let raw_message = RawMessage {
         source: Some(PeerId::random()),
         data: vec![],
@@ -2863,31 +2880,32 @@ fn test_do_not_publish_to_peer_below_publish_threshold() {
         ..PeerScoreThresholds::default()
     };
 
-    //build mesh with no peers and no subscribed topics
+    // build mesh with no peers and no subscribed topics
     let (mut gs, _, mut receivers, _) = inject_nodes1()
         .gs_config(config)
         .scoring(Some((peer_score_params, peer_score_thresholds)))
         .create_network();
 
-    //create a new topic for which we are not subscribed
+    // create a new topic for which we are not subscribed
     let topic = Topic::new("test");
     let topics = vec![topic.hash()];
 
-    //add two additional peers that will be added to the mesh
+    // add two additional peers that will be added to the mesh
     let (p1, receiver1) = add_peer(&mut gs, &topics, false, false);
     receivers.insert(p1, receiver1);
     let (p2, receiver2) = add_peer(&mut gs, &topics, false, false);
     receivers.insert(p2, receiver2);
 
-    //reduce score of p1 below peer_score_thresholds.publish_threshold
-    //note that penalties get squared so two penalties means a score of
+    // reduce score of p1 below peer_score_thresholds.publish_threshold
+    // note that penalties get squared so two penalties means a score of
     // 4 * peer_score_params.behaviour_penalty_weight.
     gs.peer_score.as_mut().unwrap().0.add_penalty(&p1, 2);
 
-    //reduce score of p2 below 0 but not below peer_score_thresholds.publish_threshold
+    // reduce score of p2 below 0 but not below
+    // peer_score_thresholds.publish_threshold
     gs.peer_score.as_mut().unwrap().0.add_penalty(&p2, 1);
 
-    //a heartbeat will remove the peers from the mesh
+    // a heartbeat will remove the peers from the mesh
     gs.heartbeat();
 
     // publish on topic
@@ -2907,7 +2925,7 @@ fn test_do_not_publish_to_peer_below_publish_threshold() {
             collected_publish
         });
 
-    //assert only published to p2
+    // assert only published to p2
     assert_eq!(publishes.len(), 1);
     assert_eq!(publishes[0].0, p2);
 }
@@ -2921,28 +2939,29 @@ fn test_do_not_flood_publish_to_peer_below_publish_threshold() {
         publish_threshold: 3.0 * peer_score_params.behaviour_penalty_weight,
         ..PeerScoreThresholds::default()
     };
-    //build mesh with no peers
+    // build mesh with no peers
     let (mut gs, _, mut receivers, topics) = inject_nodes1()
         .topics(vec!["test".into()])
         .gs_config(config)
         .scoring(Some((peer_score_params, peer_score_thresholds)))
         .create_network();
 
-    //add two additional peers that will be added to the mesh
+    // add two additional peers that will be added to the mesh
     let (p1, receiver1) = add_peer(&mut gs, &topics, false, false);
     receivers.insert(p1, receiver1);
     let (p2, receiver2) = add_peer(&mut gs, &topics, false, false);
     receivers.insert(p2, receiver2);
 
-    //reduce score of p1 below peer_score_thresholds.publish_threshold
-    //note that penalties get squared so two penalties means a score of
+    // reduce score of p1 below peer_score_thresholds.publish_threshold
+    // note that penalties get squared so two penalties means a score of
     // 4 * peer_score_params.behaviour_penalty_weight.
     gs.peer_score.as_mut().unwrap().0.add_penalty(&p1, 2);
 
-    //reduce score of p2 below 0 but not below peer_score_thresholds.publish_threshold
+    // reduce score of p2 below 0 but not below
+    // peer_score_thresholds.publish_threshold
     gs.peer_score.as_mut().unwrap().0.add_penalty(&p2, 1);
 
-    //a heartbeat will remove the peers from the mesh
+    // a heartbeat will remove the peers from the mesh
     gs.heartbeat();
 
     // publish on topic
@@ -2962,7 +2981,7 @@ fn test_do_not_flood_publish_to_peer_below_publish_threshold() {
             collected_publish
         });
 
-    //assert only published to p2
+    // assert only published to p2
     assert_eq!(publishes.len(), 1);
     assert!(publishes[0].0 == p2);
 }
@@ -2978,23 +2997,23 @@ fn test_ignore_rpc_from_peers_below_graylist_threshold() {
         ..PeerScoreThresholds::default()
     };
 
-    //build mesh with no peers
+    // build mesh with no peers
     let (mut gs, _, _, topics) = inject_nodes1()
         .topics(vec!["test".into()])
         .gs_config(config.clone())
         .scoring(Some((peer_score_params, peer_score_thresholds)))
         .create_network();
 
-    //add two additional peers that will be added to the mesh
+    // add two additional peers that will be added to the mesh
     let (p1, _receiver1) = add_peer(&mut gs, &topics, false, false);
     let (p2, _receiver2) = add_peer(&mut gs, &topics, false, false);
 
-    //reduce score of p1 below peer_score_thresholds.graylist_threshold
-    //note that penalties get squared so two penalties means a score of
+    // reduce score of p1 below peer_score_thresholds.graylist_threshold
+    // note that penalties get squared so two penalties means a score of
     // 4 * peer_score_params.behaviour_penalty_weight.
     gs.peer_score.as_mut().unwrap().0.add_penalty(&p1, 2);
 
-    //reduce score of p2 below publish_threshold but not below graylist_threshold
+    // reduce score of p2 below publish_threshold but not below graylist_threshold
     gs.peer_score.as_mut().unwrap().0.add_penalty(&p2, 1);
 
     let raw_message1 = RawMessage {
@@ -3053,10 +3072,10 @@ fn test_ignore_rpc_from_peers_below_graylist_threshold() {
         message_ids: vec![config.message_id(message2)],
     });
 
-    //clear events
+    // clear events
     gs.events.clear();
 
-    //receive from p1
+    // receive from p1
     gs.on_connection_handler_event(
         p1,
         ConnectionId::new_unchecked(0),
@@ -3070,7 +3089,7 @@ fn test_ignore_rpc_from_peers_below_graylist_threshold() {
         },
     );
 
-    //only the subscription event gets processed, the rest is dropped
+    // only the subscription event gets processed, the rest is dropped
     assert_eq!(gs.events.len(), 1);
     assert!(matches!(
         gs.events[0],
@@ -3082,7 +3101,7 @@ fn test_ignore_rpc_from_peers_below_graylist_threshold() {
         message_ids: vec![config.message_id(message4)],
     });
 
-    //receive from p2
+    // receive from p2
     gs.on_connection_handler_event(
         p2,
         ConnectionId::new_unchecked(0),
@@ -3096,7 +3115,7 @@ fn test_ignore_rpc_from_peers_below_graylist_threshold() {
         },
     );
 
-    //events got processed
+    // events got processed
     assert!(gs.events.len() > 1);
 }
 
@@ -3145,7 +3164,7 @@ fn test_ignore_px_from_peers_below_accept_px_threshold() {
         0
     );
 
-    //handle prune from peer peers[1] with px peers
+    // handle prune from peer peers[1] with px peers
     let px = vec![PeerInfo {
         peer_id: Some(PeerId::random()),
     }];
@@ -3158,7 +3177,7 @@ fn test_ignore_px_from_peers_below_accept_px_threshold() {
         )],
     );
 
-    //assert there are dials now
+    // assert there are dials now
     assert!(
         gs.events
             .iter()
@@ -3178,7 +3197,7 @@ fn test_keep_best_scoring_peers_on_oversubscription() {
         .build()
         .unwrap();
 
-    //build mesh with more peers than mesh can hold
+    // build mesh with more peers than mesh can hold
     let n = config.mesh_n_high() + 1;
     let (mut gs, peers, _receivers, topics) = inject_nodes1()
         .peer_no(n)
@@ -3198,21 +3217,21 @@ fn test_keep_best_scoring_peers_on_oversubscription() {
         gs.handle_graft(peer, topics.clone());
     }
 
-    //assign scores to peers equalling their index
+    // assign scores to peers equalling their index
 
-    //set random positive scores
+    // set random positive scores
     for (index, peer) in peers.iter().enumerate() {
         gs.set_application_score(peer, index as f64);
     }
 
     assert_eq!(gs.mesh[&topics[0]].len(), n);
 
-    //heartbeat to prune some peers
+    // heartbeat to prune some peers
     gs.heartbeat();
 
     assert_eq!(gs.mesh[&topics[0]].len(), config.mesh_n());
 
-    //mesh contains retain_scores best peers
+    // mesh contains retain_scores best peers
     assert!(gs.mesh[&topics[0]].is_superset(
         &peers[(n - config.retain_scores())..]
             .iter()
@@ -3239,7 +3258,7 @@ fn test_scoring_p1() {
         .insert(topic_hash, topic_params.clone());
     let peer_score_thresholds = PeerScoreThresholds::default();
 
-    //build mesh with one peer
+    // build mesh with one peer
     let (mut gs, peers, _, _) = inject_nodes1()
         .peer_no(1)
         .topics(vec!["test".into()])
@@ -3250,9 +3269,9 @@ fn test_scoring_p1() {
         .scoring(Some((peer_score_params, peer_score_thresholds)))
         .create_network();
 
-    //sleep for 2 times the mesh_quantum
+    // sleep for 2 times the mesh_quantum
     sleep(topic_params.time_in_mesh_quantum * 2);
-    //refresh scores
+    // refresh scores
     gs.peer_score.as_mut().unwrap().0.refresh_scores();
     assert!(
         gs.peer_score.as_ref().unwrap().0.score(&peers[0])
@@ -3265,9 +3284,9 @@ fn test_scoring_p1() {
         "score should be less than 3 * time_in_mesh_weight * topic_weight"
     );
 
-    //sleep again for 2 times the mesh_quantum
+    // sleep again for 2 times the mesh_quantum
     sleep(topic_params.time_in_mesh_quantum * 2);
-    //refresh scores
+    // refresh scores
     gs.peer_score.as_mut().unwrap().0.refresh_scores();
     assert!(
         gs.peer_score.as_ref().unwrap().0.score(&peers[0])
@@ -3275,9 +3294,9 @@ fn test_scoring_p1() {
         "score should be at least 4 * time_in_mesh_weight * topic_weight"
     );
 
-    //sleep for enough periods to reach maximum
+    // sleep for enough periods to reach maximum
     sleep(topic_params.time_in_mesh_quantum * (topic_params.time_in_mesh_cap - 3.0) as u32);
-    //refresh scores
+    // refresh scores
     gs.peer_score.as_mut().unwrap().0.refresh_scores();
     assert_eq!(
         gs.peer_score.as_ref().unwrap().0.score(&peers[0]),
@@ -3309,7 +3328,7 @@ fn test_scoring_p2() {
     let topic = Topic::new("test");
     let topic_hash = topic.hash();
     let topic_params = TopicScoreParams {
-        time_in_mesh_weight: 0.0, //deactivate time in mesh
+        time_in_mesh_weight: 0.0, // deactivate time in mesh
         first_message_deliveries_weight: 2.0,
         first_message_deliveries_cap: 10.0,
         first_message_deliveries_decay: 0.9,
@@ -3321,7 +3340,7 @@ fn test_scoring_p2() {
         .insert(topic_hash, topic_params.clone());
     let peer_score_thresholds = PeerScoreThresholds::default();
 
-    //build mesh with one peer
+    // build mesh with one peer
     let (mut gs, peers, _, topics) = inject_nodes1()
         .peer_no(2)
         .topics(vec!["test".into()])
@@ -3338,9 +3357,9 @@ fn test_scoring_p2() {
     };
 
     let m1 = random_message(&mut seq, &topics);
-    //peer 0 delivers message first
+    // peer 0 delivers message first
     deliver_message(&mut gs, 0, m1.clone());
-    //peer 1 delivers message second
+    // peer 1 delivers message second
     deliver_message(&mut gs, 1, m1);
 
     assert_eq!(
@@ -3355,7 +3374,7 @@ fn test_scoring_p2() {
         "there should be no score for second message deliveries * topic_weight"
     );
 
-    //peer 2 delivers two new messages
+    // peer 2 delivers two new messages
     deliver_message(&mut gs, 1, random_message(&mut seq, &topics));
     deliver_message(&mut gs, 1, random_message(&mut seq, &topics));
     assert_eq!(
@@ -3364,7 +3383,7 @@ fn test_scoring_p2() {
         "score should be exactly 2 * first_message_deliveries_weight * topic_weight"
     );
 
-    //test decaying
+    // test decaying
     gs.peer_score.as_mut().unwrap().0.refresh_scores();
 
     assert_eq!(
@@ -3372,8 +3391,8 @@ fn test_scoring_p2() {
         1.0 * topic_params.first_message_deliveries_decay
             * topic_params.first_message_deliveries_weight
             * topic_params.topic_weight,
-        "score should be exactly first_message_deliveries_decay * \
-               first_message_deliveries_weight * topic_weight"
+        "score should be exactly first_message_deliveries_decay * first_message_deliveries_weight \
+         * topic_weight"
     );
 
     assert_eq!(
@@ -3382,10 +3401,10 @@ fn test_scoring_p2() {
             * topic_params.first_message_deliveries_weight
             * topic_params.topic_weight,
         "score should be exactly 2 * first_message_deliveries_decay * \
-               first_message_deliveries_weight * topic_weight"
+         first_message_deliveries_weight * topic_weight"
     );
 
-    //test cap
+    // test cap
     for _ in 0..topic_params.first_message_deliveries_cap as u64 {
         deliver_message(&mut gs, 1, random_message(&mut seq, &topics));
     }
@@ -3395,8 +3414,8 @@ fn test_scoring_p2() {
         topic_params.first_message_deliveries_cap
             * topic_params.first_message_deliveries_weight
             * topic_params.topic_weight,
-        "score should be exactly first_message_deliveries_cap * \
-               first_message_deliveries_weight * topic_weight"
+        "score should be exactly first_message_deliveries_cap * first_message_deliveries_weight * \
+         topic_weight"
     );
 }
 
@@ -3407,8 +3426,8 @@ fn test_scoring_p3() {
     let topic = Topic::new("test");
     let topic_hash = topic.hash();
     let topic_params = TopicScoreParams {
-        time_in_mesh_weight: 0.0,             //deactivate time in mesh
-        first_message_deliveries_weight: 0.0, //deactivate first time deliveries
+        time_in_mesh_weight: 0.0,             // deactivate time in mesh
+        first_message_deliveries_weight: 0.0, // deactivate first time deliveries
         mesh_message_deliveries_weight: -2.0,
         mesh_message_deliveries_decay: 0.9,
         mesh_message_deliveries_cap: 10.0,
@@ -3421,7 +3440,7 @@ fn test_scoring_p3() {
     peer_score_params.topics.insert(topic_hash, topic_params);
     let peer_score_thresholds = PeerScoreThresholds::default();
 
-    //build mesh with two peers
+    // build mesh with two peers
     let (mut gs, peers, _, topics) = inject_nodes1()
         .peer_no(2)
         .topics(vec!["test".into()])
@@ -3439,42 +3458,43 @@ fn test_scoring_p3() {
 
     let mut expected_message_deliveries = 0.0;
 
-    //messages used to test window
+    // messages used to test window
     let m1 = random_message(&mut seq, &topics);
     let m2 = random_message(&mut seq, &topics);
 
-    //peer 1 delivers m1
+    // peer 1 delivers m1
     deliver_message(&mut gs, 1, m1.clone());
 
-    //peer 0 delivers two message
+    // peer 0 delivers two message
     deliver_message(&mut gs, 0, random_message(&mut seq, &topics));
     deliver_message(&mut gs, 0, random_message(&mut seq, &topics));
     expected_message_deliveries += 2.0;
 
     sleep(Duration::from_millis(60));
 
-    //peer 1 delivers m2
+    // peer 1 delivers m2
     deliver_message(&mut gs, 1, m2.clone());
 
     sleep(Duration::from_millis(70));
-    //peer 0 delivers m1 and m2 only m2 gets counted
+    // peer 0 delivers m1 and m2 only m2 gets counted
     deliver_message(&mut gs, 0, m1);
     deliver_message(&mut gs, 0, m2);
     expected_message_deliveries += 1.0;
 
     sleep(Duration::from_millis(900));
 
-    //message deliveries penalties get activated, peer 0 has only delivered 3 messages and
-    // therefore gets a penalty
+    // message deliveries penalties get activated, peer 0 has only delivered 3
+    // messages and therefore gets a penalty
     gs.peer_score.as_mut().unwrap().0.refresh_scores();
-    expected_message_deliveries *= 0.9; //decay
+    expected_message_deliveries *= 0.9; // decay
 
     assert_eq!(
         gs.peer_score.as_ref().unwrap().0.score(&peers[0]),
         (5f64 - expected_message_deliveries).powi(2) * -2.0 * 0.7
     );
 
-    // peer 0 delivers a lot of messages => message_deliveries should be capped at 10
+    // peer 0 delivers a lot of messages => message_deliveries should be capped at
+    // 10
     for _ in 0..20 {
         deliver_message(&mut gs, 0, random_message(&mut seq, &topics));
     }
@@ -3483,10 +3503,10 @@ fn test_scoring_p3() {
 
     assert_eq!(gs.peer_score.as_ref().unwrap().0.score(&peers[0]), 0.0);
 
-    //apply 10 decays
+    // apply 10 decays
     for _ in 0..10 {
         gs.peer_score.as_mut().unwrap().0.refresh_scores();
-        expected_message_deliveries *= 0.9; //decay
+        expected_message_deliveries *= 0.9; // decay
     }
 
     assert_eq!(
@@ -3505,8 +3525,8 @@ fn test_scoring_p3b() {
     let topic = Topic::new("test");
     let topic_hash = topic.hash();
     let topic_params = TopicScoreParams {
-        time_in_mesh_weight: 0.0,             //deactivate time in mesh
-        first_message_deliveries_weight: 0.0, //deactivate first time deliveries
+        time_in_mesh_weight: 0.0,             // deactivate time in mesh
+        first_message_deliveries_weight: 0.0, // deactivate first time deliveries
         mesh_message_deliveries_weight: -2.0,
         mesh_message_deliveries_decay: 0.9,
         mesh_message_deliveries_cap: 10.0,
@@ -3522,7 +3542,7 @@ fn test_scoring_p3b() {
     peer_score_params.app_specific_weight = 1.0;
     let peer_score_thresholds = PeerScoreThresholds::default();
 
-    //build mesh with one peer
+    // build mesh with one peer
     let (mut gs, peers, _, topics) = inject_nodes1()
         .peer_no(1)
         .topics(vec!["test".into()])
@@ -3540,49 +3560,49 @@ fn test_scoring_p3b() {
 
     let mut expected_message_deliveries = 0.0;
 
-    //add some positive score
+    // add some positive score
     gs.peer_score
         .as_mut()
         .unwrap()
         .0
         .set_application_score(&peers[0], 100.0);
 
-    //peer 0 delivers two message
+    // peer 0 delivers two message
     deliver_message(&mut gs, 0, random_message(&mut seq, &topics));
     deliver_message(&mut gs, 0, random_message(&mut seq, &topics));
     expected_message_deliveries += 2.0;
 
     sleep(Duration::from_millis(1050));
 
-    //activation kicks in
+    // activation kicks in
     gs.peer_score.as_mut().unwrap().0.refresh_scores();
-    expected_message_deliveries *= 0.9; //decay
+    expected_message_deliveries *= 0.9; // decay
 
-    //prune peer
+    // prune peer
     gs.handle_prune(&peers[0], vec![(topics[0].clone(), vec![], None)]);
 
-    //wait backoff
+    // wait backoff
     sleep(Duration::from_millis(130));
 
-    //regraft peer
+    // regraft peer
     gs.handle_graft(&peers[0], topics.clone());
 
-    //the score should now consider p3b
+    // the score should now consider p3b
     let mut expected_b3 = (5f64 - expected_message_deliveries).powi(2);
     assert_eq!(
         gs.peer_score.as_ref().unwrap().0.score(&peers[0]),
         100.0 + expected_b3 * -3.0 * 0.7
     );
 
-    //we can also add a new p3 to the score
+    // we can also add a new p3 to the score
 
-    //peer 0 delivers one message
+    // peer 0 delivers one message
     deliver_message(&mut gs, 0, random_message(&mut seq, &topics));
     expected_message_deliveries += 1.0;
 
     sleep(Duration::from_millis(1050));
     gs.peer_score.as_mut().unwrap().0.refresh_scores();
-    expected_message_deliveries *= 0.9; //decay
+    expected_message_deliveries *= 0.9; // decay
     expected_b3 *= 0.95;
 
     assert_eq!(
@@ -3601,10 +3621,10 @@ fn test_scoring_p4_valid_message() {
     let topic = Topic::new("test");
     let topic_hash = topic.hash();
     let topic_params = TopicScoreParams {
-        time_in_mesh_weight: 0.0,             //deactivate time in mesh
-        first_message_deliveries_weight: 0.0, //deactivate first time deliveries
-        mesh_message_deliveries_weight: 0.0,  //deactivate message deliveries
-        mesh_failure_penalty_weight: 0.0,     //deactivate mesh failure penalties
+        time_in_mesh_weight: 0.0,             // deactivate time in mesh
+        first_message_deliveries_weight: 0.0, // deactivate first time deliveries
+        mesh_message_deliveries_weight: 0.0,  // deactivate message deliveries
+        mesh_failure_penalty_weight: 0.0,     // deactivate mesh failure penalties
         invalid_message_deliveries_weight: -2.0,
         invalid_message_deliveries_decay: 0.9,
         topic_weight: 0.7,
@@ -3614,7 +3634,7 @@ fn test_scoring_p4_valid_message() {
     peer_score_params.app_specific_weight = 1.0;
     let peer_score_thresholds = PeerScoreThresholds::default();
 
-    //build mesh with two peers
+    // build mesh with two peers
     let (mut gs, peers, _, topics) = inject_nodes1()
         .peer_no(1)
         .topics(vec!["test".into()])
@@ -3630,7 +3650,7 @@ fn test_scoring_p4_valid_message() {
         gs.handle_received_message(msg, &peers[index]);
     };
 
-    //peer 0 delivers valid message
+    // peer 0 delivers valid message
     let m1 = random_message(&mut seq, &topics);
     deliver_message(&mut gs, 0, m1.clone());
 
@@ -3639,7 +3659,7 @@ fn test_scoring_p4_valid_message() {
 
     assert_eq!(gs.peer_score.as_ref().unwrap().0.score(&peers[0]), 0.0);
 
-    //message m1 gets validated
+    // message m1 gets validated
     gs.report_message_validation_result(
         &config.message_id(message1),
         &peers[0],
@@ -3659,10 +3679,10 @@ fn test_scoring_p4_invalid_signature() {
     let topic = Topic::new("test");
     let topic_hash = topic.hash();
     let topic_params = TopicScoreParams {
-        time_in_mesh_weight: 0.0,             //deactivate time in mesh
-        first_message_deliveries_weight: 0.0, //deactivate first time deliveries
-        mesh_message_deliveries_weight: 0.0,  //deactivate message deliveries
-        mesh_failure_penalty_weight: 0.0,     //deactivate mesh failure penalties
+        time_in_mesh_weight: 0.0,             // deactivate time in mesh
+        first_message_deliveries_weight: 0.0, // deactivate first time deliveries
+        mesh_message_deliveries_weight: 0.0,  // deactivate message deliveries
+        mesh_failure_penalty_weight: 0.0,     // deactivate mesh failure penalties
         invalid_message_deliveries_weight: -2.0,
         invalid_message_deliveries_decay: 0.9,
         topic_weight: 0.7,
@@ -3672,7 +3692,7 @@ fn test_scoring_p4_invalid_signature() {
     peer_score_params.app_specific_weight = 1.0;
     let peer_score_thresholds = PeerScoreThresholds::default();
 
-    //build mesh with one peer
+    // build mesh with one peer
     let (mut gs, peers, _, topics) = inject_nodes1()
         .peer_no(1)
         .topics(vec!["test".into()])
@@ -3685,7 +3705,7 @@ fn test_scoring_p4_invalid_signature() {
 
     let mut seq = 0;
 
-    //peer 0 delivers message with invalid signature
+    // peer 0 delivers message with invalid signature
     let m = random_message(&mut seq, &topics);
 
     gs.on_connection_handler_event(
@@ -3717,10 +3737,10 @@ fn test_scoring_p4_message_from_self() {
     let topic = Topic::new("test");
     let topic_hash = topic.hash();
     let topic_params = TopicScoreParams {
-        time_in_mesh_weight: 0.0,             //deactivate time in mesh
-        first_message_deliveries_weight: 0.0, //deactivate first time deliveries
-        mesh_message_deliveries_weight: 0.0,  //deactivate message deliveries
-        mesh_failure_penalty_weight: 0.0,     //deactivate mesh failure penalties
+        time_in_mesh_weight: 0.0,             // deactivate time in mesh
+        first_message_deliveries_weight: 0.0, // deactivate first time deliveries
+        mesh_message_deliveries_weight: 0.0,  // deactivate message deliveries
+        mesh_failure_penalty_weight: 0.0,     // deactivate mesh failure penalties
         invalid_message_deliveries_weight: -2.0,
         invalid_message_deliveries_decay: 0.9,
         topic_weight: 0.7,
@@ -3730,7 +3750,7 @@ fn test_scoring_p4_message_from_self() {
     peer_score_params.app_specific_weight = 1.0;
     let peer_score_thresholds = PeerScoreThresholds::default();
 
-    //build mesh with two peers
+    // build mesh with two peers
     let (mut gs, peers, _, topics) = inject_nodes1()
         .peer_no(1)
         .topics(vec!["test".into()])
@@ -3746,7 +3766,7 @@ fn test_scoring_p4_message_from_self() {
         gs.handle_received_message(msg, &peers[index]);
     };
 
-    //peer 0 delivers invalid message from self
+    // peer 0 delivers invalid message from self
     let mut m = random_message(&mut seq, &topics);
     m.source = Some(*gs.publish_config.get_own_id().unwrap());
 
@@ -3767,10 +3787,10 @@ fn test_scoring_p4_ignored_message() {
     let topic = Topic::new("test");
     let topic_hash = topic.hash();
     let topic_params = TopicScoreParams {
-        time_in_mesh_weight: 0.0,             //deactivate time in mesh
-        first_message_deliveries_weight: 0.0, //deactivate first time deliveries
-        mesh_message_deliveries_weight: 0.0,  //deactivate message deliveries
-        mesh_failure_penalty_weight: 0.0,     //deactivate mesh failure penalties
+        time_in_mesh_weight: 0.0,             // deactivate time in mesh
+        first_message_deliveries_weight: 0.0, // deactivate first time deliveries
+        mesh_message_deliveries_weight: 0.0,  // deactivate message deliveries
+        mesh_failure_penalty_weight: 0.0,     // deactivate mesh failure penalties
         invalid_message_deliveries_weight: -2.0,
         invalid_message_deliveries_decay: 0.9,
         topic_weight: 0.7,
@@ -3780,7 +3800,7 @@ fn test_scoring_p4_ignored_message() {
     peer_score_params.app_specific_weight = 1.0;
     let peer_score_thresholds = PeerScoreThresholds::default();
 
-    //build mesh with two peers
+    // build mesh with two peers
     let (mut gs, peers, _, topics) = inject_nodes1()
         .peer_no(1)
         .topics(vec!["test".into()])
@@ -3796,7 +3816,7 @@ fn test_scoring_p4_ignored_message() {
         gs.handle_received_message(msg, &peers[index]);
     };
 
-    //peer 0 delivers ignored message
+    // peer 0 delivers ignored message
     let m1 = random_message(&mut seq, &topics);
     deliver_message(&mut gs, 0, m1.clone());
 
@@ -3805,7 +3825,7 @@ fn test_scoring_p4_ignored_message() {
     // Transform the inbound message
     let message1 = &gs.data_transform.inbound_transform(m1).unwrap();
 
-    //message m1 gets ignored
+    // message m1 gets ignored
     gs.report_message_validation_result(
         &config.message_id(message1),
         &peers[0],
@@ -3825,10 +3845,10 @@ fn test_scoring_p4_application_invalidated_message() {
     let topic = Topic::new("test");
     let topic_hash = topic.hash();
     let topic_params = TopicScoreParams {
-        time_in_mesh_weight: 0.0,             //deactivate time in mesh
-        first_message_deliveries_weight: 0.0, //deactivate first time deliveries
-        mesh_message_deliveries_weight: 0.0,  //deactivate message deliveries
-        mesh_failure_penalty_weight: 0.0,     //deactivate mesh failure penalties
+        time_in_mesh_weight: 0.0,             // deactivate time in mesh
+        first_message_deliveries_weight: 0.0, // deactivate first time deliveries
+        mesh_message_deliveries_weight: 0.0,  // deactivate message deliveries
+        mesh_failure_penalty_weight: 0.0,     // deactivate mesh failure penalties
         invalid_message_deliveries_weight: -2.0,
         invalid_message_deliveries_decay: 0.9,
         topic_weight: 0.7,
@@ -3838,7 +3858,7 @@ fn test_scoring_p4_application_invalidated_message() {
     peer_score_params.app_specific_weight = 1.0;
     let peer_score_thresholds = PeerScoreThresholds::default();
 
-    //build mesh with two peers
+    // build mesh with two peers
     let (mut gs, peers, _, topics) = inject_nodes1()
         .peer_no(1)
         .topics(vec!["test".into()])
@@ -3854,7 +3874,7 @@ fn test_scoring_p4_application_invalidated_message() {
         gs.handle_received_message(msg, &peers[index]);
     };
 
-    //peer 0 delivers invalid message
+    // peer 0 delivers invalid message
     let m1 = random_message(&mut seq, &topics);
     deliver_message(&mut gs, 0, m1.clone());
 
@@ -3863,7 +3883,7 @@ fn test_scoring_p4_application_invalidated_message() {
     // Transform the inbound message
     let message1 = &gs.data_transform.inbound_transform(m1).unwrap();
 
-    //message m1 gets rejected
+    // message m1 gets rejected
     gs.report_message_validation_result(
         &config.message_id(message1),
         &peers[0],
@@ -3886,10 +3906,10 @@ fn test_scoring_p4_application_invalid_message_from_two_peers() {
     let topic = Topic::new("test");
     let topic_hash = topic.hash();
     let topic_params = TopicScoreParams {
-        time_in_mesh_weight: 0.0,             //deactivate time in mesh
-        first_message_deliveries_weight: 0.0, //deactivate first time deliveries
-        mesh_message_deliveries_weight: 0.0,  //deactivate message deliveries
-        mesh_failure_penalty_weight: 0.0,     //deactivate mesh failure penalties
+        time_in_mesh_weight: 0.0,             // deactivate time in mesh
+        first_message_deliveries_weight: 0.0, // deactivate first time deliveries
+        mesh_message_deliveries_weight: 0.0,  // deactivate message deliveries
+        mesh_failure_penalty_weight: 0.0,     // deactivate mesh failure penalties
         invalid_message_deliveries_weight: -2.0,
         invalid_message_deliveries_decay: 0.9,
         topic_weight: 0.7,
@@ -3899,7 +3919,7 @@ fn test_scoring_p4_application_invalid_message_from_two_peers() {
     peer_score_params.app_specific_weight = 1.0;
     let peer_score_thresholds = PeerScoreThresholds::default();
 
-    //build mesh with two peers
+    // build mesh with two peers
     let (mut gs, peers, _, topics) = inject_nodes1()
         .peer_no(2)
         .topics(vec!["test".into()])
@@ -3915,20 +3935,20 @@ fn test_scoring_p4_application_invalid_message_from_two_peers() {
         gs.handle_received_message(msg, &peers[index]);
     };
 
-    //peer 0 delivers invalid message
+    // peer 0 delivers invalid message
     let m1 = random_message(&mut seq, &topics);
     deliver_message(&mut gs, 0, m1.clone());
 
     // Transform the inbound message
     let message1 = &gs.data_transform.inbound_transform(m1.clone()).unwrap();
 
-    //peer 1 delivers same message
+    // peer 1 delivers same message
     deliver_message(&mut gs, 1, m1);
 
     assert_eq!(gs.peer_score.as_ref().unwrap().0.score(&peers[0]), 0.0);
     assert_eq!(gs.peer_score.as_ref().unwrap().0.score(&peers[1]), 0.0);
 
-    //message m1 gets rejected
+    // message m1 gets rejected
     gs.report_message_validation_result(
         &config.message_id(message1),
         &peers[0],
@@ -3955,10 +3975,10 @@ fn test_scoring_p4_three_application_invalid_messages() {
     let topic = Topic::new("test");
     let topic_hash = topic.hash();
     let topic_params = TopicScoreParams {
-        time_in_mesh_weight: 0.0,             //deactivate time in mesh
-        first_message_deliveries_weight: 0.0, //deactivate first time deliveries
-        mesh_message_deliveries_weight: 0.0,  //deactivate message deliveries
-        mesh_failure_penalty_weight: 0.0,     //deactivate mesh failure penalties
+        time_in_mesh_weight: 0.0,             // deactivate time in mesh
+        first_message_deliveries_weight: 0.0, // deactivate first time deliveries
+        mesh_message_deliveries_weight: 0.0,  // deactivate message deliveries
+        mesh_failure_penalty_weight: 0.0,     // deactivate mesh failure penalties
         invalid_message_deliveries_weight: -2.0,
         invalid_message_deliveries_decay: 0.9,
         topic_weight: 0.7,
@@ -3968,7 +3988,7 @@ fn test_scoring_p4_three_application_invalid_messages() {
     peer_score_params.app_specific_weight = 1.0;
     let peer_score_thresholds = PeerScoreThresholds::default();
 
-    //build mesh with one peer
+    // build mesh with one peer
     let (mut gs, peers, _, topics) = inject_nodes1()
         .peer_no(1)
         .topics(vec!["test".into()])
@@ -3984,7 +4004,7 @@ fn test_scoring_p4_three_application_invalid_messages() {
         gs.handle_received_message(msg, &peers[index]);
     };
 
-    //peer 0 delivers two invalid message
+    // peer 0 delivers two invalid message
     let m1 = random_message(&mut seq, &topics);
     let m2 = random_message(&mut seq, &topics);
     let m3 = random_message(&mut seq, &topics);
@@ -4002,7 +4022,7 @@ fn test_scoring_p4_three_application_invalid_messages() {
 
     assert_eq!(gs.peer_score.as_ref().unwrap().0.score(&peers[0]), 0.0);
 
-    //messages gets rejected
+    // messages gets rejected
     gs.report_message_validation_result(
         &config.message_id(message1),
         &peers[0],
@@ -4021,7 +4041,7 @@ fn test_scoring_p4_three_application_invalid_messages() {
         MessageAcceptance::Reject,
     );
 
-    //number of invalid messages gets squared
+    // number of invalid messages gets squared
     assert_eq!(
         gs.peer_score.as_ref().unwrap().0.score(&peers[0]),
         9.0 * -2.0 * 0.7
@@ -4038,10 +4058,10 @@ fn test_scoring_p4_decay() {
     let topic = Topic::new("test");
     let topic_hash = topic.hash();
     let topic_params = TopicScoreParams {
-        time_in_mesh_weight: 0.0,             //deactivate time in mesh
-        first_message_deliveries_weight: 0.0, //deactivate first time deliveries
-        mesh_message_deliveries_weight: 0.0,  //deactivate message deliveries
-        mesh_failure_penalty_weight: 0.0,     //deactivate mesh failure penalties
+        time_in_mesh_weight: 0.0,             // deactivate time in mesh
+        first_message_deliveries_weight: 0.0, // deactivate first time deliveries
+        mesh_message_deliveries_weight: 0.0,  // deactivate message deliveries
+        mesh_failure_penalty_weight: 0.0,     // deactivate mesh failure penalties
         invalid_message_deliveries_weight: -2.0,
         invalid_message_deliveries_decay: 0.9,
         topic_weight: 0.7,
@@ -4051,7 +4071,7 @@ fn test_scoring_p4_decay() {
     peer_score_params.app_specific_weight = 1.0;
     let peer_score_thresholds = PeerScoreThresholds::default();
 
-    //build mesh with one peer
+    // build mesh with one peer
     let (mut gs, peers, _, topics) = inject_nodes1()
         .peer_no(1)
         .topics(vec!["test".into()])
@@ -4067,7 +4087,7 @@ fn test_scoring_p4_decay() {
         gs.handle_received_message(msg, &peers[index]);
     };
 
-    //peer 0 delivers invalid message
+    // peer 0 delivers invalid message
     let m1 = random_message(&mut seq, &topics);
     deliver_message(&mut gs, 0, m1.clone());
 
@@ -4075,7 +4095,7 @@ fn test_scoring_p4_decay() {
     let message1 = &gs.data_transform.inbound_transform(m1).unwrap();
     assert_eq!(gs.peer_score.as_ref().unwrap().0.score(&peers[0]), 0.0);
 
-    //message m1 gets rejected
+    // message m1 gets rejected
     gs.report_message_validation_result(
         &config.message_id(message1),
         &peers[0],
@@ -4087,7 +4107,7 @@ fn test_scoring_p4_decay() {
         -2.0 * 0.7
     );
 
-    //we decay
+    // we decay
     gs.peer_score.as_mut().unwrap().0.refresh_scores();
 
     // the number of invalids gets decayed to 0.9 and then squared in the score
@@ -4104,7 +4124,7 @@ fn test_scoring_p5() {
         ..PeerScoreParams::default()
     };
 
-    //build mesh with one peer
+    // build mesh with one peer
     let (mut gs, peers, _, _) = inject_nodes1()
         .peer_no(1)
         .topics(vec!["test".into()])
@@ -4141,7 +4161,7 @@ fn test_scoring_p6() {
         .scoring(Some((peer_score_params, PeerScoreThresholds::default())))
         .create_network();
 
-    //create 5 peers with the same ip
+    // create 5 peers with the same ip
     let addr = Multiaddr::from(Ipv4Addr::new(10, 1, 2, 3));
     let peers = vec![
         add_peer_with_addr(&mut gs, &[], false, false, addr.clone()).0,
@@ -4151,7 +4171,7 @@ fn test_scoring_p6() {
         add_peer_with_addr(&mut gs, &[], true, true, addr.clone()).0,
     ];
 
-    //create 4 other peers with other ip
+    // create 4 other peers with other ip
     let addr2 = Multiaddr::from(Ipv4Addr::new(10, 1, 2, 4));
     let others = vec![
         add_peer_with_addr(&mut gs, &[], false, false, addr2.clone()).0,
@@ -4160,12 +4180,12 @@ fn test_scoring_p6() {
         add_peer_with_addr(&mut gs, &[], true, false, addr2.clone()).0,
     ];
 
-    //no penalties yet
+    // no penalties yet
     for peer in peers.iter().chain(others.iter()) {
         assert_eq!(gs.peer_score.as_ref().unwrap().0.score(peer), 0.0);
     }
 
-    //add additional connection for 3 others with addr
+    // add additional connection for 3 others with addr
     for id in others.iter().take(3) {
         gs.on_swarm_event(FromSwarm::ConnectionEstablished(ConnectionEstablished {
             peer_id: *id,
@@ -4180,14 +4200,14 @@ fn test_scoring_p6() {
         }));
     }
 
-    //penalties apply squared
+    // penalties apply squared
     for peer in peers.iter().chain(others.iter().take(3)) {
         assert_eq!(gs.peer_score.as_ref().unwrap().0.score(peer), 9.0 * -2.0);
     }
-    //fourth other peer still no penalty
+    // fourth other peer still no penalty
     assert_eq!(gs.peer_score.as_ref().unwrap().0.score(&others[3]), 0.0);
 
-    //add additional connection for 3 of the peers to addr2
+    // add additional connection for 3 of the peers to addr2
     for peer in peers.iter().take(3) {
         gs.on_swarm_event(FromSwarm::ConnectionEstablished(ConnectionEstablished {
             peer_id: *peer,
@@ -4202,7 +4222,7 @@ fn test_scoring_p6() {
         }));
     }
 
-    //double penalties for the first three of each
+    // double penalties for the first three of each
     for peer in peers.iter().take(3).chain(others.iter().take(3)) {
         assert_eq!(
             gs.peer_score.as_ref().unwrap().0.score(peer),
@@ -4210,7 +4230,7 @@ fn test_scoring_p6() {
         );
     }
 
-    //single penalties for the rest
+    // single penalties for the rest
     for peer in peers.iter().skip(3) {
         assert_eq!(gs.peer_score.as_ref().unwrap().0.score(peer), 9.0 * -2.0);
     }
@@ -4219,7 +4239,7 @@ fn test_scoring_p6() {
         4.0 * -2.0
     );
 
-    //two times same ip doesn't count twice
+    // two times same ip doesn't count twice
     gs.on_swarm_event(FromSwarm::ConnectionEstablished(ConnectionEstablished {
         peer_id: peers[0],
         connection_id: ConnectionId::new_unchecked(0),
@@ -4232,8 +4252,8 @@ fn test_scoring_p6() {
         other_established: 2,
     }));
 
-    //nothing changed
-    //double penalties for the first three of each
+    // nothing changed
+    // double penalties for the first three of each
     for peer in peers.iter().take(3).chain(others.iter().take(3)) {
         assert_eq!(
             gs.peer_score.as_ref().unwrap().0.score(peer),
@@ -4241,7 +4261,7 @@ fn test_scoring_p6() {
         );
     }
 
-    //single penalties for the rest
+    // single penalties for the rest
     for peer in peers.iter().skip(3) {
         assert_eq!(gs.peer_score.as_ref().unwrap().0.score(peer), 9.0 * -2.0);
     }
@@ -4274,7 +4294,8 @@ fn test_scoring_p7_grafts_before_backoff() {
         .scoring(Some((peer_score_params, PeerScoreThresholds::default())))
         .create_network();
 
-    //remove peers from mesh and send prune to them => this adds a backoff for the peers
+    // remove peers from mesh and send prune to them => this adds a backoff for the
+    // peers
     for peer in peers.iter().take(2) {
         gs.mesh.get_mut(&topics[0]).unwrap().remove(peer);
         gs.send_graft_prune(
@@ -4284,31 +4305,31 @@ fn test_scoring_p7_grafts_before_backoff() {
         );
     }
 
-    //wait 50 millisecs
+    // wait 50 millisecs
     sleep(Duration::from_millis(50));
 
-    //first peer tries to graft
+    // first peer tries to graft
     gs.handle_graft(&peers[0], vec![topics[0].clone()]);
 
-    //double behaviour penalty for first peer (squared)
+    // double behaviour penalty for first peer (squared)
     assert_eq!(
         gs.peer_score.as_ref().unwrap().0.score(&peers[0]),
         4.0 * -2.0
     );
 
-    //wait 100 millisecs
+    // wait 100 millisecs
     sleep(Duration::from_millis(100));
 
-    //second peer tries to graft
+    // second peer tries to graft
     gs.handle_graft(&peers[1], vec![topics[0].clone()]);
 
-    //single behaviour penalty for second peer
+    // single behaviour penalty for second peer
     assert_eq!(
         gs.peer_score.as_ref().unwrap().0.score(&peers[1]),
         1.0 * -2.0
     );
 
-    //test decay
+    // test decay
     gs.peer_score.as_mut().unwrap().0.refresh_scores();
 
     assert_eq!(
@@ -4327,7 +4348,7 @@ fn test_opportunistic_grafting() {
         .mesh_n_low(3)
         .mesh_n(5)
         .mesh_n_high(7)
-        .mesh_outbound_min(0) //deactivate outbound handling
+        .mesh_outbound_min(0) // deactivate outbound handling
         .opportunistic_graft_ticks(2)
         .opportunistic_graft_peers(2)
         .build()
@@ -4351,30 +4372,30 @@ fn test_opportunistic_grafting() {
         .scoring(Some((peer_score_params, thresholds)))
         .create_network();
 
-    //fill mesh with 5 peers
+    // fill mesh with 5 peers
     for peer in &peers {
         gs.handle_graft(peer, topics.clone());
     }
 
-    //add additional 5 peers
+    // add additional 5 peers
     let others: Vec<_> = (0..5)
         .map(|_| add_peer(&mut gs, &topics, false, false))
         .collect();
 
-    //currently mesh equals peers
+    // currently mesh equals peers
     assert_eq!(gs.mesh[&topics[0]], peers.iter().cloned().collect());
 
-    //give others high scores (but the first two have not high enough scores)
+    // give others high scores (but the first two have not high enough scores)
     for (i, peer) in peers.iter().enumerate().take(5) {
         gs.set_application_score(peer, 0.0 + i as f64);
     }
 
-    //set scores for peers in the mesh
+    // set scores for peers in the mesh
     for (i, (peer, _receiver)) in others.iter().enumerate().take(5) {
         gs.set_application_score(peer, 0.0 + i as f64);
     }
 
-    //this gives a median of exactly 2.0 => should not apply opportunistic grafting
+    // this gives a median of exactly 2.0 => should not apply opportunistic grafting
     gs.heartbeat();
     gs.heartbeat();
 
@@ -4384,10 +4405,10 @@ fn test_opportunistic_grafting() {
         "should not apply opportunistic grafting"
     );
 
-    //reduce middle score to 1.0 giving a median of 1.0
+    // reduce middle score to 1.0 giving a median of 1.0
     gs.set_application_score(&peers[2], 1.0);
 
-    //opportunistic grafting after two heartbeats
+    // opportunistic grafting after two heartbeats
 
     gs.heartbeat();
     assert_eq!(
@@ -4417,17 +4438,17 @@ fn test_opportunistic_grafting() {
 
 #[test]
 fn test_ignore_graft_from_unknown_topic() {
-    //build gossipsub without subscribing to any topics
+    // build gossipsub without subscribing to any topics
     let (mut gs, peers, receivers, _) = inject_nodes1()
         .peer_no(1)
         .topics(vec![])
         .to_subscribe(false)
         .create_network();
 
-    //handle an incoming graft for some topic
+    // handle an incoming graft for some topic
     gs.handle_graft(&peers[0], vec![Topic::new("test").hash()]);
 
-    //assert that no prune got created
+    // assert that no prune got created
     let (control_msgs, _) = count_control_msgs(receivers, |_, a| matches!(a, RpcOut::Prune { .. }));
     assert_eq!(
         control_msgs, 0,
@@ -4438,18 +4459,18 @@ fn test_ignore_graft_from_unknown_topic() {
 #[test]
 fn test_ignore_too_many_iwants_from_same_peer_for_same_message() {
     let config = Config::default();
-    //build gossipsub with full mesh
+    // build gossipsub with full mesh
     let (mut gs, _, mut receivers, topics) = inject_nodes1()
         .peer_no(config.mesh_n_high())
         .topics(vec!["test".into()])
         .to_subscribe(false)
         .create_network();
 
-    //add another peer not in the mesh
+    // add another peer not in the mesh
     let (peer, receiver) = add_peer(&mut gs, &topics, false, false);
     receivers.insert(peer, receiver);
 
-    //receive a message
+    // receive a message
     let mut seq = 0;
     let m1 = random_message(&mut seq, &topics);
 
@@ -4460,11 +4481,11 @@ fn test_ignore_too_many_iwants_from_same_peer_for_same_message() {
 
     gs.handle_received_message(m1, &PeerId::random());
 
-    //clear events
+    // clear events
     let receivers = flush_events(&mut gs, receivers);
 
-    //the first gossip_retransimission many iwants return the valid message, all others are
-    // ignored.
+    // the first gossip_retransimission many iwants return the valid message, all
+    // others are ignored.
     for _ in 0..(2 * config.gossip_retransimission() + 10) {
         gs.handle_iwant(&peer, vec![id.clone()]);
     }
@@ -4490,7 +4511,7 @@ fn test_ignore_too_many_ihaves() {
         .max_ihave_messages(10)
         .build()
         .unwrap();
-    //build gossipsub with full mesh
+    // build gossipsub with full mesh
     let (mut gs, _, mut receivers, topics) = inject_nodes1()
         .peer_no(config.mesh_n_high())
         .topics(vec!["test".into()])
@@ -4498,15 +4519,15 @@ fn test_ignore_too_many_ihaves() {
         .gs_config(config.clone())
         .create_network();
 
-    //add another peer not in the mesh
+    // add another peer not in the mesh
     let (peer, receiver) = add_peer(&mut gs, &topics, false, false);
     receivers.insert(peer, receiver);
 
-    //peer has 20 messages
+    // peer has 20 messages
     let mut seq = 0;
     let messages: Vec<_> = (0..20).map(|_| random_message(&mut seq, &topics)).collect();
 
-    //peer sends us one ihave for each message in order
+    // peer sends us one ihave for each message in order
     for raw_message in &messages {
         // Transform the inbound message
         let message = &gs
@@ -4527,7 +4548,7 @@ fn test_ignore_too_many_ihaves() {
         .map(|m| config.message_id(&m))
         .collect();
 
-    //we send iwant only for the first 10 messages
+    // we send iwant only for the first 10 messages
     let (control_msgs, receivers) = count_control_msgs(receivers, |p, action| {
         p == &peer
             && matches!(action, RpcOut::IWant(IWant { message_ids }) if message_ids.len() == 1 && first_ten.contains(&message_ids[0]))
@@ -4537,7 +4558,7 @@ fn test_ignore_too_many_ihaves() {
         "exactly the first ten ihaves should be processed and one iwant for each created"
     );
 
-    //after a heartbeat everything is forgotten
+    // after a heartbeat everything is forgotten
     gs.heartbeat();
 
     for raw_message in messages[10..].iter() {
@@ -4553,7 +4574,7 @@ fn test_ignore_too_many_ihaves() {
         );
     }
 
-    //we sent iwant for all 10 messages
+    // we sent iwant for all 10 messages
     let (control_msgs, _) = count_control_msgs(receivers, |p, action| {
         p == &peer
             && matches!(action, RpcOut::IWant(IWant { message_ids }) if message_ids.len() == 1)
@@ -4568,7 +4589,7 @@ fn test_ignore_too_many_messages_in_ihave() {
         .max_ihave_length(10)
         .build()
         .unwrap();
-    //build gossipsub with full mesh
+    // build gossipsub with full mesh
     let (mut gs, _, mut receivers, topics) = inject_nodes1()
         .peer_no(config.mesh_n_high())
         .topics(vec!["test".into()])
@@ -4576,11 +4597,11 @@ fn test_ignore_too_many_messages_in_ihave() {
         .gs_config(config.clone())
         .create_network();
 
-    //add another peer not in the mesh
+    // add another peer not in the mesh
     let (peer, receiver) = add_peer(&mut gs, &topics, false, false);
     receivers.insert(peer, receiver);
 
-    //peer has 20 messages
+    // peer has 20 messages
     let mut seq = 0;
     let message_ids: Vec<_> = (0..20)
         .map(|_| random_message(&mut seq, &topics))
@@ -4588,7 +4609,7 @@ fn test_ignore_too_many_messages_in_ihave() {
         .map(|msg| config.message_id(&msg))
         .collect();
 
-    //peer sends us three ihaves
+    // peer sends us three ihaves
     gs.handle_ihave(&peer, vec![(topics[0].clone(), message_ids[0..8].to_vec())]);
     gs.handle_ihave(
         &peer,
@@ -4601,7 +4622,7 @@ fn test_ignore_too_many_messages_in_ihave() {
 
     let first_twelve: HashSet<_> = message_ids.iter().take(12).collect();
 
-    //we send iwant only for the first 10 messages
+    // we send iwant only for the first 10 messages
     let mut sum = 0;
     let (control_msgs, receivers) = count_control_msgs(receivers, |p, rpc| match rpc {
         RpcOut::IWant(IWant { message_ids }) => {
@@ -4620,14 +4641,14 @@ fn test_ignore_too_many_messages_in_ihave() {
 
     assert_eq!(sum, 10, "exactly the first ten ihaves should be processed");
 
-    //after a heartbeat everything is forgotten
+    // after a heartbeat everything is forgotten
     gs.heartbeat();
     gs.handle_ihave(
         &peer,
         vec![(topics[0].clone(), message_ids[10..20].to_vec())],
     );
 
-    //we sent 10 iwant messages ids via a IWANT rpc.
+    // we sent 10 iwant messages ids via a IWANT rpc.
     let mut sum = 0;
     let (control_msgs, _) = count_control_msgs(receivers, |p, rpc| match rpc {
         RpcOut::IWant(IWant { message_ids }) => {
@@ -4649,7 +4670,7 @@ fn test_limit_number_of_message_ids_inside_ihave() {
         .max_ihave_length(100)
         .build()
         .unwrap();
-    //build gossipsub with full mesh
+    // build gossipsub with full mesh
     let (mut gs, peers, mut receivers, topics) = inject_nodes1()
         .peer_no(config.mesh_n_high())
         .topics(vec!["test".into()])
@@ -4657,29 +4678,30 @@ fn test_limit_number_of_message_ids_inside_ihave() {
         .gs_config(config)
         .create_network();
 
-    //graft to all peers to really fill the mesh with all the peers
+    // graft to all peers to really fill the mesh with all the peers
     for peer in peers {
         gs.handle_graft(&peer, topics.clone());
     }
 
-    //add two other peers not in the mesh
+    // add two other peers not in the mesh
     let (p1, receiver1) = add_peer(&mut gs, &topics, false, false);
     receivers.insert(p1, receiver1);
     let (p2, receiver2) = add_peer(&mut gs, &topics, false, false);
     receivers.insert(p2, receiver2);
 
-    //receive 200 messages from another peer
+    // receive 200 messages from another peer
     let mut seq = 0;
     for _ in 0..200 {
         gs.handle_received_message(random_message(&mut seq, &topics), &PeerId::random());
     }
 
-    //emit gossip
+    // emit gossip
     gs.emit_gossip();
 
-    // both peers should have gotten 100 random ihave messages, to assert the randomness, we
-    // assert that both have not gotten the same set of messages, but have an intersection
-    // (which is the case with very high probability, the probabiltity of failure is < 10^-58).
+    // both peers should have gotten 100 random ihave messages, to assert the
+    // randomness, we assert that both have not gotten the same set of messages,
+    // but have an intersection (which is the case with very high probability,
+    // the probabiltity of failure is < 10^-58).
 
     let mut ihaves1 = HashSet::new();
     let mut ihaves2 = HashSet::new();
@@ -4715,24 +4737,22 @@ fn test_limit_number_of_message_ids_inside_ihave() {
     );
     assert!(
         ihaves1 != ihaves2,
-        "should have sent different random messages to p1 and p2 \
-        (this may fail with a probability < 10^-58"
+        "should have sent different random messages to p1 and p2 (this may fail with a \
+         probability < 10^-58"
     );
     assert!(
         ihaves1.intersection(&ihaves2).count() > 0,
-        "should have sent random messages with some common messages to p1 and p2 \
-            (this may fail with a probability < 10^-58"
+        "should have sent random messages with some common messages to p1 and p2 (this may fail \
+         with a probability < 10^-58"
     );
 }
 
 #[test]
 fn test_iwant_penalties() {
-    /*
-    use tracing_subscriber::EnvFilter;
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .try_init();
-    */
+    // use tracing_subscriber::EnvFilter;
+    // let _ = tracing_subscriber::fmt()
+    // .with_env_filter(EnvFilter::from_default_env())
+    // .try_init();
     let config = ConfigBuilder::default()
         .iwant_followup_time(Duration::from_secs(4))
         .build()
@@ -4862,7 +4882,7 @@ fn test_publish_to_floodsub_peers_without_flood_publish() {
         .gs_config(config)
         .create_network();
 
-    //add two floodsub peer, one explicit, one implicit
+    // add two floodsub peer, one explicit, one implicit
     let (p1, receiver1) = add_peer_with_addr_and_kind(
         &mut gs,
         &topics,
@@ -4877,10 +4897,10 @@ fn test_publish_to_floodsub_peers_without_flood_publish() {
         add_peer_with_addr_and_kind(&mut gs, &topics, false, false, Multiaddr::empty(), None);
     receivers.insert(p2, receiver2);
 
-    //p1 and p2 are not in the mesh
+    // p1 and p2 are not in the mesh
     assert!(!gs.mesh[&topics[0]].contains(&p1) && !gs.mesh[&topics[0]].contains(&p2));
 
-    //publish a message
+    // publish a message
     let publish_data = vec![0; 42];
     gs.publish(Topic::new("test"), publish_data).unwrap();
 
@@ -4921,7 +4941,7 @@ fn test_do_not_use_floodsub_in_fanout() {
     let topic = Topic::new("test");
     let topics = vec![topic.hash()];
 
-    //add two floodsub peer, one explicit, one implicit
+    // add two floodsub peer, one explicit, one implicit
     let (p1, receiver1) = add_peer_with_addr_and_kind(
         &mut gs,
         &topics,
@@ -4936,7 +4956,7 @@ fn test_do_not_use_floodsub_in_fanout() {
         add_peer_with_addr_and_kind(&mut gs, &topics, false, false, Multiaddr::empty(), None);
 
     receivers.insert(p2, receiver2);
-    //publish a message
+    // publish a message
     let publish_data = vec![0; 42];
     gs.publish(Topic::new("test"), publish_data).unwrap();
 
@@ -4977,7 +4997,7 @@ fn test_dont_add_floodsub_peers_to_mesh_on_join() {
     let topic = Topic::new("test");
     let topics = vec![topic.hash()];
 
-    //add two floodsub peer, one explicit, one implicit
+    // add two floodsub peer, one explicit, one implicit
     let _p1 = add_peer_with_addr_and_kind(
         &mut gs,
         &topics,
@@ -5004,7 +5024,7 @@ fn test_dont_send_px_to_old_gossipsub_peers() {
         .to_subscribe(false)
         .create_network();
 
-    //add an old gossipsub peer
+    // add an old gossipsub peer
     let (p1, _receiver1) = add_peer_with_addr_and_kind(
         &mut gs,
         &topics,
@@ -5014,14 +5034,14 @@ fn test_dont_send_px_to_old_gossipsub_peers() {
         Some(PeerKind::Gossipsub),
     );
 
-    //prune the peer
+    // prune the peer
     gs.send_graft_prune(
         HashMap::new(),
         vec![(p1, topics.clone())].into_iter().collect(),
         HashSet::new(),
     );
 
-    //check that prune does not contain px
+    // check that prune does not contain px
     let (control_msgs, _) = count_control_msgs(receivers, |_, m| match m {
         RpcOut::Prune(Prune { peers: px, .. }) => !px.is_empty(),
         _ => false,
@@ -5031,14 +5051,14 @@ fn test_dont_send_px_to_old_gossipsub_peers() {
 
 #[test]
 fn test_dont_send_floodsub_peers_in_px() {
-    //build mesh with one peer
+    // build mesh with one peer
     let (mut gs, peers, receivers, topics) = inject_nodes1()
         .peer_no(1)
         .topics(vec!["test".into()])
         .to_subscribe(true)
         .create_network();
 
-    //add two floodsub peers
+    // add two floodsub peers
     let _p1 = add_peer_with_addr_and_kind(
         &mut gs,
         &topics,
@@ -5049,14 +5069,14 @@ fn test_dont_send_floodsub_peers_in_px() {
     );
     let _p2 = add_peer_with_addr_and_kind(&mut gs, &topics, false, false, Multiaddr::empty(), None);
 
-    //prune only mesh node
+    // prune only mesh node
     gs.send_graft_prune(
         HashMap::new(),
         vec![(peers[0], topics.clone())].into_iter().collect(),
         HashSet::new(),
     );
 
-    //check that px in prune message is empty
+    // check that px in prune message is empty
     let (control_msgs, _) = count_control_msgs(receivers, |_, m| match m {
         RpcOut::Prune(Prune { peers: px, .. }) => !px.is_empty(),
         _ => false,
@@ -5072,7 +5092,7 @@ fn test_dont_add_floodsub_peers_to_mesh_in_heartbeat() {
         .to_subscribe(false)
         .create_network();
 
-    //add two floodsub peer, one explicit, one implicit
+    // add two floodsub peer, one explicit, one implicit
     let _p1 = add_peer_with_addr_and_kind(
         &mut gs,
         &topics,
@@ -5139,7 +5159,7 @@ fn test_subscribe_to_invalid_topic() {
 
 #[test]
 fn test_subscribe_and_graft_with_negative_score() {
-    //simulate a communication between two gossipsub instances
+    // simulate a communication between two gossipsub instances
     let (mut gs1, _, _, topic_hashes) = inject_nodes1()
         .topics(vec!["test".into()])
         .scoring(Some((
@@ -5157,12 +5177,12 @@ fn test_subscribe_and_graft_with_negative_score() {
     let (p2, _receiver1) = add_peer(&mut gs1, &Vec::new(), true, false);
     let (p1, _receiver2) = add_peer(&mut gs2, &topic_hashes, false, false);
 
-    //add penalty to peer p2
+    // add penalty to peer p2
     gs1.peer_score.as_mut().unwrap().0.add_penalty(&p2, 1);
 
     let original_score = gs1.peer_score.as_ref().unwrap().0.score(&p2);
 
-    //subscribe to topic in gs2
+    // subscribe to topic in gs2
     gs2.subscribe(&topic).unwrap();
 
     let forward_messages_to_p1 = |gs1: &mut Behaviour<_, _>,
@@ -5191,17 +5211,17 @@ fn test_subscribe_and_graft_with_negative_score() {
         new_receivers
     };
 
-    //forward the subscribe message
+    // forward the subscribe message
     let receivers = forward_messages_to_p1(&mut gs1, p1, p2, connection_id, receivers);
 
-    //heartbeats on both
+    // heartbeats on both
     gs1.heartbeat();
     gs2.heartbeat();
 
-    //forward messages again
+    // forward messages again
     forward_messages_to_p1(&mut gs1, p1, p2, connection_id, receivers);
 
-    //nobody got penalized
+    // nobody got penalized
     assert!(gs1.peer_score.as_ref().unwrap().0.score(&p2) >= original_score);
 }
 

--- a/protocols/gossipsub/src/error.rs
+++ b/protocols/gossipsub/src/error.rs
@@ -31,13 +31,13 @@ pub enum PublishError {
     SigningError(SigningError),
     /// There were no peers to send this message to.
     InsufficientPeers,
-    /// The overall message was too large. This could be due to excessive topics or an excessive
-    /// message size.
+    /// The overall message was too large. This could be due to excessive topics
+    /// or an excessive message size.
     MessageTooLarge,
     /// The compression algorithm failed.
     TransformFailed(std::io::Error),
-    /// Messages could not be sent because the queues for all peers were full. The usize represents the
-    /// number of peers that were attempted.
+    /// Messages could not be sent because the queues for all peers were full.
+    /// The usize represents the number of peers that were attempted.
     AllQueuesFull(usize),
 }
 
@@ -131,7 +131,8 @@ pub enum ConfigBuilderError {
     MaxTransmissionSizeTooSmall,
     /// History length less than history gossip length.
     HistoryLengthTooSmall,
-    /// The ineauality doesn't hold mesh_outbound_min <= mesh_n_low <= mesh_n <= mesh_n_high
+    /// The ineauality doesn't hold mesh_outbound_min <= mesh_n_low <= mesh_n <=
+    /// mesh_n_high
     MeshParametersInvalid,
     /// The inequality doesn't hold mesh_outbound_min <= self.config.mesh_n / 2
     MeshOutboundInvalid,
@@ -149,9 +150,18 @@ impl std::fmt::Display for ConfigBuilderError {
             Self::MaxTransmissionSizeTooSmall => {
                 write!(f, "Maximum transmission size is too small")
             }
-            Self::HistoryLengthTooSmall => write!(f, "History length less than history gossip length"),
-            Self::MeshParametersInvalid => write!(f, "The ineauality doesn't hold mesh_outbound_min <= mesh_n_low <= mesh_n <= mesh_n_high"),
-            Self::MeshOutboundInvalid => write!(f, "The inequality doesn't hold mesh_outbound_min <= self.config.mesh_n / 2"),
+            Self::HistoryLengthTooSmall => {
+                write!(f, "History length less than history gossip length")
+            }
+            Self::MeshParametersInvalid => write!(
+                f,
+                "The ineauality doesn't hold mesh_outbound_min <= mesh_n_low <= mesh_n <= \
+                 mesh_n_high"
+            ),
+            Self::MeshOutboundInvalid => write!(
+                f,
+                "The inequality doesn't hold mesh_outbound_min <= self.config.mesh_n / 2"
+            ),
             Self::UnsubscribeBackoffIsZero => write!(f, "unsubscribe_backoff is zero"),
             Self::InvalidProtocol => write!(f, "Invalid protocol"),
         }

--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -20,8 +20,8 @@
 
 //! Implementation of the [Gossipsub](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/README.md) protocol.
 //!
-//! Gossipsub is a P2P pubsub (publish/subscription) routing layer designed to extend upon
-//! floodsub and meshsub routing protocols.
+//! Gossipsub is a P2P pubsub (publish/subscription) routing layer designed to
+//! extend upon floodsub and meshsub routing protocols.
 //!
 //! # Overview
 //!
@@ -29,37 +29,43 @@
 //! (<https://github.com/libp2p/specs/tree/master/pubsub/gossipsub>) provide an outline for the
 //! routing protocol. They should be consulted for further detail.*
 //!
-//! Gossipsub  is a blend of meshsub for data and randomsub for mesh metadata. It provides bounded
-//! degree and amplification factor with the meshsub construction and augments it using gossip
-//! propagation of metadata with the randomsub technique.
+//! Gossipsub  is a blend of meshsub for data and randomsub for mesh metadata.
+//! It provides bounded degree and amplification factor with the meshsub
+//! construction and augments it using gossip propagation of metadata with the
+//! randomsub technique.
 //!
-//! The router maintains an overlay mesh network of peers on which to efficiently send messages and
-//! metadata.  Peers use control messages to broadcast and request known messages and
-//! subscribe/unsubscribe from topics in the mesh network.
+//! The router maintains an overlay mesh network of peers on which to
+//! efficiently send messages and metadata.  Peers use control messages to
+//! broadcast and request known messages and subscribe/unsubscribe from topics
+//! in the mesh network.
 //!
 //! # Important Discrepancies
 //!
-//! This section outlines the current implementation's potential discrepancies from that of other
-//! implementations, due to undefined elements in the current specification.
+//! This section outlines the current implementation's potential discrepancies
+//! from that of other implementations, due to undefined elements in the current
+//! specification.
 //!
-//! - **Topics** -  In gossipsub, topics configurable by the `hash_topics` configuration parameter.
-//!   Topics are of type [`TopicHash`]. The current go implementation uses raw utf-8 strings, and this
-//!   is default configuration in rust-libp2p. Topics can be hashed (SHA256 hashed then base64
-//!   encoded) by setting the `hash_topics` configuration parameter to true.
+//! - **Topics** -  In gossipsub, topics configurable by the `hash_topics`
+//!   configuration parameter. Topics are of type [`TopicHash`]. The current go
+//!   implementation uses raw utf-8 strings, and this is default configuration
+//!   in rust-libp2p. Topics can be hashed (SHA256 hashed then base64 encoded)
+//!   by setting the `hash_topics` configuration parameter to true.
 //!
-//! - **Sequence Numbers** - A message on the gossipsub network is identified by the source
-//!   [`PeerId`](libp2p_identity::PeerId) and a nonce (sequence number) of the message. The sequence numbers in
-//!   this implementation are sent as raw bytes across the wire. They are 64-bit big-endian unsigned
-//!   integers. When messages are signed, they are monotonically increasing integers starting from a
-//!   random value and wrapping around u64::MAX. When messages are unsigned, they are chosen at random.
-//!   NOTE: These numbers are sequential in the current go implementation.
+//! - **Sequence Numbers** - A message on the gossipsub network is identified by
+//!   the source [`PeerId`](libp2p_identity::PeerId) and a nonce (sequence
+//!   number) of the message. The sequence numbers in this implementation are
+//!   sent as raw bytes across the wire. They are 64-bit big-endian unsigned
+//!   integers. When messages are signed, they are monotonically increasing
+//!   integers starting from a random value and wrapping around u64::MAX. When
+//!   messages are unsigned, they are chosen at random. NOTE: These numbers are
+//!   sequential in the current go implementation.
 //!
 //! # Peer Discovery
 //!
-//! Gossipsub does not provide peer discovery by itself. Peer discovery is the process by which
-//! peers in a p2p network exchange information about each other among other reasons to become resistant
-//! against the failure or replacement of the
-//! [boot nodes](https://docs.libp2p.io/reference/glossary/#boot-node) of the network.
+//! Gossipsub does not provide peer discovery by itself. Peer discovery is the
+//! process by which peers in a p2p network exchange information about each
+//! other among other reasons to become resistant against the failure or
+//! replacement of the [boot nodes](https://docs.libp2p.io/reference/glossary/#boot-node) of the network.
 //!
 //! Peer
 //! discovery can e.g. be implemented with the help of the [Kademlia](https://github.com/libp2p/specs/blob/master/kad-dht/README.md) protocol
@@ -70,8 +76,8 @@
 //!
 //! ## Gossipsub Config
 //!
-//! The [`Config`] struct specifies various network performance/tuning configuration
-//! parameters. Specifically it specifies:
+//! The [`Config`] struct specifies various network performance/tuning
+//! configuration parameters. Specifically it specifies:
 //!
 //! [`Config`]: struct.Config.html
 //!
@@ -81,8 +87,9 @@
 //!
 //! ## Behaviour
 //!
-//! The [`Behaviour`] struct implements the [`libp2p_swarm::NetworkBehaviour`] trait allowing it to
-//! act as the routing behaviour in a [`libp2p_swarm::Swarm`]. This struct requires an instance of
+//! The [`Behaviour`] struct implements the [`libp2p_swarm::NetworkBehaviour`]
+//! trait allowing it to act as the routing behaviour in a
+//! [`libp2p_swarm::Swarm`]. This struct requires an instance of
 //! [`PeerId`](libp2p_identity::PeerId) and [`Config`].
 //!
 //! [`Behaviour`]: struct.Behaviour.html
@@ -111,22 +118,31 @@ mod topic;
 mod transform;
 mod types;
 
-pub use self::behaviour::{Behaviour, Event, MessageAuthenticity};
-pub use self::config::{Config, ConfigBuilder, ValidationMode, Version};
-pub use self::error::{ConfigBuilderError, PublishError, SubscriptionError, ValidationError};
-pub use self::metrics::Config as MetricsConfig;
-pub use self::peer_score::{
-    score_parameter_decay, score_parameter_decay_with_base, PeerScoreParams, PeerScoreThresholds,
-    TopicScoreParams,
+pub use self::{
+    behaviour::{Behaviour, Event, MessageAuthenticity},
+    config::{Config, ConfigBuilder, ValidationMode, Version},
+    error::{ConfigBuilderError, PublishError, SubscriptionError, ValidationError},
+    metrics::Config as MetricsConfig,
+    peer_score::{
+        score_parameter_decay,
+        score_parameter_decay_with_base,
+        PeerScoreParams,
+        PeerScoreThresholds,
+        TopicScoreParams,
+    },
+    subscription_filter::{
+        AllowAllSubscriptionFilter,
+        CallbackSubscriptionFilter,
+        CombinedSubscriptionFilters,
+        MaxCountSubscriptionFilter,
+        RegexSubscriptionFilter,
+        TopicSubscriptionFilter,
+        WhitelistSubscriptionFilter,
+    },
+    topic::{Hasher, Topic, TopicHash},
+    transform::{DataTransform, IdentityTransform},
+    types::{FailedMessages, Message, MessageAcceptance, MessageId, RawMessage},
 };
-pub use self::subscription_filter::{
-    AllowAllSubscriptionFilter, CallbackSubscriptionFilter, CombinedSubscriptionFilters,
-    MaxCountSubscriptionFilter, RegexSubscriptionFilter, TopicSubscriptionFilter,
-    WhitelistSubscriptionFilter,
-};
-pub use self::topic::{Hasher, Topic, TopicHash};
-pub use self::transform::{DataTransform, IdentityTransform};
-pub use self::types::{FailedMessages, Message, MessageAcceptance, MessageId, RawMessage};
 
 #[deprecated(note = "Will be removed from the public API.")]
 pub type Rpc = self::types::Rpc;

--- a/protocols/gossipsub/src/peer_score/tests.rs
+++ b/protocols/gossipsub/src/peer_score/tests.rs
@@ -20,9 +20,7 @@
 
 /// A collection of unit tests mostly ported from the go implementation.
 use super::*;
-
-use crate::types::RawMessage;
-use crate::{IdentTopic as Topic, Message};
+use crate::{types::RawMessage, IdentTopic as Topic, Message};
 
 // estimates a value within variance
 fn within_variance(value: f64, expected: f64, variance: f64) -> bool {
@@ -325,8 +323,8 @@ fn test_score_mesh_message_deliveries() {
     // peer A always delivers the message first.
     // peer B delivers next (within the delivery window).
     // peer C delivers outside the delivery window.
-    // we expect peers A and B to have a score of zero, since all other parameter weights are zero.
-    // Peer C should have a negative score.
+    // we expect peers A and B to have a score of zero, since all other parameter
+    // weights are zero. Peer C should have a negative score.
     let peer_id_a = PeerId::random();
     let peer_id_b = PeerId::random();
     let peer_id_c = PeerId::random();
@@ -338,7 +336,8 @@ fn test_score_mesh_message_deliveries() {
         peer_score.graft(peer_id, topic.clone());
     }
 
-    // assert that nobody has been penalized yet for not delivering messages before activation time
+    // assert that nobody has been penalized yet for not delivering messages before
+    // activation time
     peer_score.refresh_scores();
     for peer_id in &peers {
         let score = peer_score.score(peer_id);
@@ -351,8 +350,8 @@ fn test_score_mesh_message_deliveries() {
     // wait for the activation time to kick in
     std::thread::sleep(topic_params.mesh_message_deliveries_activation);
 
-    // deliver a bunch of messages from peer A, with duplicates within the window from peer B,
-    // and duplicates outside the window from peer C.
+    // deliver a bunch of messages from peer A, with duplicates within the window
+    // from peer B, and duplicates outside the window from peer C.
     let messages = 100;
     let mut messages_to_send = Vec::new();
     for seq in 0..messages {
@@ -384,8 +383,9 @@ fn test_score_mesh_message_deliveries() {
         "expected non-negative score for Peer B, got score {score_b}"
     );
 
-    // the penalty is the difference between the threshold and the actual mesh deliveries, squared.
-    // since we didn't deliver anything, this is just the value of the threshold
+    // the penalty is the difference between the threshold and the actual mesh
+    // deliveries, squared. since we didn't deliver anything, this is just the
+    // value of the threshold
     let penalty = topic_params.mesh_message_deliveries_threshold
         * topic_params.mesh_message_deliveries_threshold;
     let expected =
@@ -431,7 +431,8 @@ fn test_score_mesh_message_deliveries_decay() {
         peer_score.deliver_message(&peer_id_a, &id, &msg.topic);
     }
 
-    // we should have a positive score, since we delivered more messages than the threshold
+    // we should have a positive score, since we delivered more messages than the
+    // threshold
     peer_score.refresh_scores();
 
     let score_a = peer_score.score(&peer_id_a);
@@ -447,7 +448,8 @@ fn test_score_mesh_message_deliveries_decay() {
     }
 
     let score_a = peer_score.score(&peer_id_a);
-    // the penalty is the difference between the threshold and the (decayed) mesh deliveries, squared.
+    // the penalty is the difference between the threshold and the (decayed) mesh
+    // deliveries, squared.
     let deficit = topic_params.mesh_message_deliveries_threshold - decayed_delivery_count;
     let penalty = deficit * deficit;
     let expected =
@@ -506,7 +508,8 @@ fn test_score_mesh_failure_penalty() {
         peer_score.deliver_message(&peer_id_a, &id, &msg.topic);
     }
 
-    // peers A and B should both have zero scores, since the failure penalty hasn't been applied yet
+    // peers A and B should both have zero scores, since the failure penalty hasn't
+    // been applied yet
     peer_score.refresh_scores();
     let score_a = peer_score.score(&peer_id_a);
     let score_b = peer_score.score(&peer_id_b);
@@ -526,8 +529,8 @@ fn test_score_mesh_failure_penalty() {
 
     assert_eq!(score_a, 0.0, "expected Peer A to have a 0");
 
-    // penalty calculation is the same as for mesh_message_deliveries, but multiplied by
-    // mesh_failure_penalty_weigh
+    // penalty calculation is the same as for mesh_message_deliveries, but
+    // multiplied by mesh_failure_penalty_weigh
     // instead of mesh_message_deliveries_weight
     let penalty = topic_params.mesh_message_deliveries_threshold
         * topic_params.mesh_message_deliveries_threshold;
@@ -693,8 +696,8 @@ fn test_score_reject_message_deliveries() {
     // insert a record in the message deliveries
     peer_score.validate_message(&peer_id_a, &id, &msg.topic);
 
-    // this should have no effect in the score, and subsequent duplicate messages should have no
-    // effect either
+    // this should have no effect in the score, and subsequent duplicate messages
+    // should have no effect either
     peer_score.reject_message(&peer_id_a, &id, &msg.topic, RejectReason::ValidationIgnored);
     peer_score.duplicated_message(&peer_id_b, &id, &msg.topic);
 
@@ -711,8 +714,8 @@ fn test_score_reject_message_deliveries() {
     // insert a record in the message deliveries
     peer_score.validate_message(&peer_id_a, &id, &msg.topic);
 
-    // this should have no effect in the score, and subsequent duplicate messages should have no
-    // effect either
+    // this should have no effect in the score, and subsequent duplicate messages
+    // should have no effect either
     peer_score.reject_message(&peer_id_a, &id, &msg.topic, RejectReason::ValidationIgnored);
     peer_score.duplicated_message(&peer_id_b, &id, &msg.topic);
 
@@ -837,7 +840,8 @@ fn test_score_ip_colocation() {
         peer_score.graft(peer_id, topic.clone());
     }
 
-    // peerA should have no penalty, but B, C, and D should be penalized for sharing an IP
+    // peerA should have no penalty, but B, C, and D should be penalized for sharing
+    // an IP
     peer_score.add_ip(&peer_id_a, "1.2.3.4".parse().unwrap());
     peer_score.add_ip(&peer_id_b, "2.3.4.5".parse().unwrap());
     peer_score.add_ip(&peer_id_c, "2.3.4.5".parse().unwrap());

--- a/protocols/gossipsub/src/rpc.rs
+++ b/protocols/gossipsub/src/rpc.rs
@@ -18,7 +18,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures::{stream::Peekable, Stream, StreamExt};
 use std::{
     future::Future,
     pin::Pin,
@@ -28,6 +27,8 @@ use std::{
     },
     task::{Context, Poll},
 };
+
+use futures::{stream::Peekable, Stream, StreamExt};
 
 use crate::types::RpcOut;
 
@@ -46,8 +47,8 @@ pub(crate) struct Sender {
 impl Sender {
     /// Create a RpcSender.
     pub(crate) fn new(cap: usize) -> Sender {
-        // We intentionally do not bound the channel, as we still need to send control messages
-        // such as `GRAFT`, `PRUNE`, `SUBSCRIBE`, and `UNSUBSCRIBE`.
+        // We intentionally do not bound the channel, as we still need to send control
+        // messages such as `GRAFT`, `PRUNE`, `SUBSCRIBE`, and `UNSUBSCRIBE`.
         // That's also why we define `cap` and divide it by two,
         // to ensure there is capacity for both priority and non_priority messages.
         let (priority_sender, priority_receiver) = async_channel::unbounded();
@@ -119,7 +120,8 @@ pub struct Receiver {
 
 impl Receiver {
     // Peek the next message in the queues and return it if its timeout has elapsed.
-    // Returns `None` if there aren't any more messages on the stream or none is stale.
+    // Returns `None` if there aren't any more messages on the stream or none is
+    // stale.
     pub(crate) fn poll_stale(&mut self, cx: &mut Context<'_>) -> Poll<Option<RpcOut>> {
         // Peek priority queue.
         let priority = match self.priority.as_mut().poll_peek_mut(cx) {

--- a/protocols/gossipsub/src/rpc_proto.rs
+++ b/protocols/gossipsub/src/rpc_proto.rs
@@ -26,11 +26,11 @@ pub(crate) mod proto {
 
 #[cfg(test)]
 mod test {
-    use crate::rpc_proto::proto::compat;
-    use crate::IdentTopic as Topic;
     use libp2p_identity::PeerId;
     use quick_protobuf::{BytesReader, MessageRead, MessageWrite, Writer};
     use rand::Rng;
+
+    use crate::{rpc_proto::proto::compat, IdentTopic as Topic};
 
     #[test]
     fn test_multi_topic_message_compatibility() {

--- a/protocols/gossipsub/src/subscription_filter.rs
+++ b/protocols/gossipsub/src/subscription_filter.rs
@@ -18,9 +18,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::types::Subscription;
-use crate::TopicHash;
 use std::collections::{BTreeSet, HashMap, HashSet};
+
+use crate::{types::Subscription, TopicHash};
 
 pub trait TopicSubscriptionFilter {
     /// Returns true iff the topic is of interest and we can subscribe to it.
@@ -55,7 +55,8 @@ pub trait TopicSubscriptionFilter {
     }
 
     /// Filters a set of deduplicated subscriptions
-    /// By default this filters the elements based on [`Self::allow_incoming_subscription`].
+    /// By default this filters the elements based on
+    /// [`Self::allow_incoming_subscription`].
     fn filter_incoming_subscription_set<'a>(
         &mut self,
         mut subscriptions: HashSet<&'a Subscription>,
@@ -73,16 +74,16 @@ pub trait TopicSubscriptionFilter {
     }
 
     /// Returns true iff we allow an incoming subscription.
-    /// This is used by the default implementation of filter_incoming_subscription_set to decide
-    /// whether to filter out a subscription or not.
-    /// By default this uses can_subscribe to decide the same for incoming subscriptions as for
-    /// outgoing ones.
+    /// This is used by the default implementation of
+    /// filter_incoming_subscription_set to decide whether to filter out a
+    /// subscription or not. By default this uses can_subscribe to decide
+    /// the same for incoming subscriptions as for outgoing ones.
     fn allow_incoming_subscription(&mut self, subscription: &Subscription) -> bool {
         self.can_subscribe(&subscription.topic_hash)
     }
 }
 
-//some useful implementers
+// some useful implementers
 
 /// Allows all subscriptions
 #[derive(Default, Clone)]
@@ -199,7 +200,7 @@ where
     }
 }
 
-///A subscription filter that filters topics based on a regular expression.
+/// A subscription filter that filters topics based on a regular expression.
 pub struct RegexSubscriptionFilter(pub regex::Regex);
 
 impl TopicSubscriptionFilter for RegexSubscriptionFilter {

--- a/protocols/gossipsub/src/time_cache.rs
+++ b/protocols/gossipsub/src/time_cache.rs
@@ -18,15 +18,21 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! This implements a time-based LRU cache for checking gossipsub message duplicates.
+//! This implements a time-based LRU cache for checking gossipsub message
+//! duplicates.
+
+use std::{
+    collections::{
+        hash_map::{
+            self,
+            Entry::{Occupied, Vacant},
+        },
+        VecDeque,
+    },
+    time::Duration,
+};
 
 use fnv::FnvHashMap;
-use std::collections::hash_map::{
-    self,
-    Entry::{Occupied, Vacant},
-};
-use std::collections::VecDeque;
-use std::time::Duration;
 use web_time::Instant;
 
 struct ExpiringElement<Element> {
@@ -37,8 +43,8 @@ struct ExpiringElement<Element> {
 }
 
 pub(crate) struct TimeCache<Key, Value> {
-    /// Mapping a key to its value together with its latest expire time (can be updated through
-    /// reinserts).
+    /// Mapping a key to its value together with its latest expire time (can be
+    /// updated through reinserts).
     map: FnvHashMap<Key, ExpiringElement<Value>>,
     /// An ordered list of keys by expires time.
     list: VecDeque<ExpiringElement<Key>>,
@@ -167,8 +173,8 @@ where
 
     // Inserts new elements and removes any expired elements.
     //
-    // If the key was not present this returns `true`. If the value was already present this
-    // returns `false`.
+    // If the key was not present this returns `true`. If the value was already
+    // present this returns `false`.
     pub(crate) fn insert(&mut self, key: Key) -> bool {
         if let Entry::Vacant(entry) = self.0.entry(key) {
             entry.insert(());
@@ -206,7 +212,7 @@ mod test {
         cache.insert("t");
         assert!(!cache.insert("t"));
         cache.insert("e");
-        //assert!(!cache.insert("t"));
+        // assert!(!cache.insert("t"));
         assert!(!cache.insert("e"));
         // sleep until cache expiry
         std::thread::sleep(Duration::from_millis(101));

--- a/protocols/gossipsub/src/topic.rs
+++ b/protocols/gossipsub/src/topic.rs
@@ -18,12 +18,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::rpc_proto::proto;
+use std::fmt;
+
 use base64::prelude::*;
 use prometheus_client::encoding::EncodeLabelSet;
 use quick_protobuf::Writer;
 use sha2::{Digest, Sha256};
-use std::fmt;
+
+use crate::rpc_proto::proto;
 
 /// A generic trait that can be extended for various hashing types for a topic.
 pub trait Hasher {
@@ -44,8 +46,8 @@ impl Hasher for IdentityHash {
 #[derive(Debug, Clone)]
 pub struct Sha256Hash {}
 impl Hasher for Sha256Hash {
-    /// Creates a [`TopicHash`] by SHA256 hashing the topic then base64 encoding the
-    /// hash.
+    /// Creates a [`TopicHash`] by SHA256 hashing the topic then base64 encoding
+    /// the hash.
     fn hash(topic_string: String) -> TopicHash {
         use quick_protobuf::MessageWrite;
 

--- a/protocols/gossipsub/src/transform.rs
+++ b/protocols/gossipsub/src/transform.rs
@@ -18,30 +18,34 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! This trait allows of extended user-level decoding that can apply to message-data before a
-//! message-id is calculated.
+//! This trait allows of extended user-level decoding that can apply to
+//! message-data before a message-id is calculated.
 //!
-//! This is primarily designed to allow applications to implement their own custom compression
-//! algorithms that can be topic-specific. Once the raw data is transformed the message-id is then
-//! calculated, allowing for applications to employ message-id functions post compression.
+//! This is primarily designed to allow applications to implement their own
+//! custom compression algorithms that can be topic-specific. Once the raw data
+//! is transformed the message-id is then calculated, allowing for applications
+//! to employ message-id functions post compression.
 
 use crate::{Message, RawMessage, TopicHash};
 
 /// A general trait of transforming a [`RawMessage`] into a [`Message`]. The
 ///
 /// [`RawMessage`] is obtained from the wire and the [`Message`] is used to
-/// calculate the [`crate::MessageId`] of the message and is what is sent to the application.
+/// calculate the [`crate::MessageId`] of the message and is what is sent to the
+/// application.
 ///
-/// The inbound/outbound transforms must be inverses. Applying the inbound transform and then the
-/// outbound transform MUST leave the underlying data un-modified.
+/// The inbound/outbound transforms must be inverses. Applying the inbound
+/// transform and then the outbound transform MUST leave the underlying data
+/// un-modified.
 ///
 /// By default, this is the identity transform for all fields in [`Message`].
 pub trait DataTransform {
     /// Takes a [`RawMessage`] received and converts it to a [`Message`].
     fn inbound_transform(&self, raw_message: RawMessage) -> Result<Message, std::io::Error>;
 
-    /// Takes the data to be published (a topic and associated data) transforms the data. The
-    /// transformed data will then be used to create a [`crate::RawMessage`] to be sent to peers.
+    /// Takes the data to be published (a topic and associated data) transforms
+    /// the data. The transformed data will then be used to create a
+    /// [`crate::RawMessage`] to be sent to peers.
     fn outbound_transform(
         &self,
         topic: &TopicHash,
@@ -49,7 +53,8 @@ pub trait DataTransform {
     ) -> Result<Vec<u8>, std::io::Error>;
 }
 
-/// The default transform, the raw data is propagated as is to the application layer gossipsub.
+/// The default transform, the raw data is propagated as is to the application
+/// layer gossipsub.
 #[derive(Default, Clone)]
 pub struct IdentityTransform;
 

--- a/protocols/gossipsub/tests/smoke.rs
+++ b/protocols/gossipsub/tests/smoke.rs
@@ -18,15 +18,18 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures::stream::{FuturesUnordered, SelectAll};
-use futures::StreamExt;
+use std::{task::Poll, time::Duration};
+
+use futures::{
+    stream::{FuturesUnordered, SelectAll},
+    StreamExt,
+};
 use libp2p_gossipsub as gossipsub;
 use libp2p_gossipsub::{MessageAuthenticity, ValidationMode};
 use libp2p_swarm::Swarm;
 use libp2p_swarm_test::SwarmExt as _;
 use quickcheck::{QuickCheck, TestResult};
 use rand::{seq::SliceRandom, SeedableRng};
-use std::{task::Poll, time::Duration};
 use tokio::{runtime::Runtime, time};
 use tracing_subscriber::EnvFilter;
 
@@ -65,8 +68,8 @@ impl Graph {
         }
     }
 
-    /// Polls the graph and passes each event into the provided FnMut until the closure returns
-    /// `true`.
+    /// Polls the graph and passes each event into the provided FnMut until the
+    /// closure returns `true`.
     ///
     /// Returns [`true`] on success and [`false`] on timeout.
     async fn wait_for<F: FnMut(&gossipsub::Event) -> bool>(&mut self, mut f: F) -> bool {
@@ -91,7 +94,8 @@ impl Graph {
         }
     }
 
-    /// Polls the graph until Poll::Pending is obtained, completing the underlying polls.
+    /// Polls the graph until Poll::Pending is obtained, completing the
+    /// underlying polls.
     async fn drain_events(&mut self) {
         let fut = futures::future::poll_fn(|cx| loop {
             match self.nodes.poll_next_unpin(cx) {
@@ -104,10 +108,10 @@ impl Graph {
 }
 
 async fn build_node() -> Swarm<gossipsub::Behaviour> {
-    // NOTE: The graph of created nodes can be disconnected from the mesh point of view as nodes
-    // can reach their d_lo value and not add other nodes to their mesh. To speed up this test, we
-    // reduce the default values of the heartbeat, so that all nodes will receive gossip in a
-    // timely fashion.
+    // NOTE: The graph of created nodes can be disconnected from the mesh point of
+    // view as nodes can reach their d_lo value and not add other nodes to their
+    // mesh. To speed up this test, we reduce the default values of the
+    // heartbeat, so that all nodes will receive gossip in a timely fashion.
 
     let mut swarm = Swarm::new_ephemeral(|identity| {
         let peer_id = identity.public().to_peer_id();
@@ -170,12 +174,14 @@ fn multi_hop_propagation() {
 
             if !all_subscribed {
                 return TestResult::error(format!(
-                    "Timed out waiting for all nodes to subscribe but only have {subscribed:?}/{num_nodes:?}.",
+                    "Timed out waiting for all nodes to subscribe but only have \
+                     {subscribed:?}/{num_nodes:?}.",
                 ));
             }
 
-            // It can happen that the publish occurs before all grafts have completed causing this test
-            // to fail. We drain all the poll messages before publishing.
+            // It can happen that the publish occurs before all grafts have completed
+            // causing this test to fail. We drain all the poll messages before
+            // publishing.
             graph.drain_events().await;
 
             // Publish a single message.
@@ -205,7 +211,8 @@ fn multi_hop_propagation() {
 
             if !all_received {
                 return TestResult::error(format!(
-                    "Timed out waiting for all nodes to receive the msg but only have {received_msgs:?}/{num_nodes:?}.",
+                    "Timed out waiting for all nodes to receive the msg but only have \
+                     {received_msgs:?}/{num_nodes:?}.",
                 ));
             }
 

--- a/protocols/identify/src/handler.rs
+++ b/protocols/identify/src/handler.rs
@@ -18,28 +18,45 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::protocol::{Info, PushInfo, UpgradeError};
-use crate::{protocol, PROTOCOL_NAME, PUSH_PROTOCOL_NAME};
+use std::{
+    collections::HashSet,
+    task::{Context, Poll},
+    time::Duration,
+};
+
 use either::Either;
 use futures::prelude::*;
 use futures_bounded::Timeout;
 use futures_timer::Delay;
-use libp2p_core::upgrade::{ReadyUpgrade, SelectUpgrade};
-use libp2p_core::Multiaddr;
-use libp2p_identity::PeerId;
-use libp2p_identity::PublicKey;
-use libp2p_swarm::handler::{
-    ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
-    ProtocolSupport,
+use libp2p_core::{
+    upgrade::{ReadyUpgrade, SelectUpgrade},
+    Multiaddr,
 };
+use libp2p_identity::{PeerId, PublicKey};
 use libp2p_swarm::{
-    ConnectionHandler, ConnectionHandlerEvent, StreamProtocol, StreamUpgradeError,
-    SubstreamProtocol, SupportedProtocols,
+    handler::{
+        ConnectionEvent,
+        DialUpgradeError,
+        FullyNegotiatedInbound,
+        FullyNegotiatedOutbound,
+        ProtocolSupport,
+    },
+    ConnectionHandler,
+    ConnectionHandlerEvent,
+    StreamProtocol,
+    StreamUpgradeError,
+    SubstreamProtocol,
+    SupportedProtocols,
 };
 use smallvec::SmallVec;
-use std::collections::HashSet;
-use std::{task::Context, task::Poll, time::Duration};
 use tracing::Level;
+
+use crate::{
+    protocol,
+    protocol::{Info, PushInfo, UpgradeError},
+    PROTOCOL_NAME,
+    PUSH_PROTOCOL_NAME,
+};
 
 const STREAM_TIMEOUT: Duration = Duration::from_secs(60);
 const MAX_CONCURRENT_STREAMS_PER_CONNECTION: usize = 10;

--- a/protocols/identify/src/lib.rs
+++ b/protocols/identify/src/lib.rs
@@ -28,21 +28,24 @@
 //!
 //! # Important Discrepancies
 //!
-//! - **Using Identify with other protocols** Unlike some other libp2p implementations,
-//!   rust-libp2p does not treat Identify as a core protocol. This means that other protocols cannot
-//!   rely upon the existence of Identify, and need to be manually hooked up to Identify in order to
-//!   make use of its capabilities.
+//! - **Using Identify with other protocols** Unlike some other libp2p
+//!   implementations, rust-libp2p does not treat Identify as a core protocol.
+//!   This means that other protocols cannot rely upon the existence of
+//!   Identify, and need to be manually hooked up to Identify in order to make
+//!   use of its capabilities.
 //!
 //! # Usage
 //!
-//! The [`Behaviour`] struct implements a [`NetworkBehaviour`](libp2p_swarm::NetworkBehaviour)
-//! that negotiates and executes the protocol on every established connection, emitting
-//! [`Event`]s.
+//! The [`Behaviour`] struct implements a
+//! [`NetworkBehaviour`](libp2p_swarm::NetworkBehaviour) that negotiates and
+//! executes the protocol on every established connection, emitting [`Event`]s.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-pub use self::behaviour::{Behaviour, Config, Event};
-pub use self::protocol::{Info, UpgradeError, PROTOCOL_NAME, PUSH_PROTOCOL_NAME};
+pub use self::{
+    behaviour::{Behaviour, Config, Event},
+    protocol::{Info, UpgradeError, PROTOCOL_NAME, PUSH_PROTOCOL_NAME},
+};
 
 mod behaviour;
 mod handler;

--- a/protocols/identify/src/protocol.rs
+++ b/protocols/identify/src/protocol.rs
@@ -18,15 +18,17 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::proto;
+use std::io;
+
 use asynchronous_codec::{FramedRead, FramedWrite};
 use futures::prelude::*;
 use libp2p_core::{multiaddr, Multiaddr};
 use libp2p_identity as identity;
 use libp2p_identity::PublicKey;
 use libp2p_swarm::StreamProtocol;
-use std::io;
 use thiserror::Error;
+
+use crate::proto;
 
 const MAX_MESSAGE_SIZE_BYTES: usize = 4096;
 
@@ -77,7 +79,8 @@ impl Info {
 }
 
 /// Identify push information of a peer sent in protocol messages.
-/// Note that missing fields should be ignored, as peers may choose to send partial updates containing only the fields whose values have changed.
+/// Note that missing fields should be ignored, as peers may choose to send
+/// partial updates containing only the fields whose values have changed.
 #[derive(Debug, Clone)]
 pub struct PushInfo {
     pub public_key: Option<PublicKey>,
@@ -264,8 +267,9 @@ pub enum UpgradeError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use libp2p_identity as identity;
+
+    use super::*;
 
     #[test]
     fn skip_invalid_multiaddr() {

--- a/protocols/identify/tests/smoke.rs
+++ b/protocols/identify/tests/smoke.rs
@@ -1,10 +1,13 @@
+use std::{
+    collections::HashSet,
+    iter,
+    time::{Duration, Instant},
+};
+
 use futures::StreamExt;
 use libp2p_identify as identify;
 use libp2p_swarm::{Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt;
-use std::collections::HashSet;
-use std::iter;
-use std::time::{Duration, Instant};
 use tracing_subscriber::EnvFilter;
 
 #[async_std::test]
@@ -34,8 +37,7 @@ async fn periodic_identify() {
     let (swarm2_memory_listen, swarm2_tcp_listen_addr) = swarm2.listen().await;
     swarm2.connect(&mut swarm1).await;
 
-    use identify::Event::Received;
-    use identify::Event::Sent;
+    use identify::Event::{Received, Sent};
 
     match libp2p_swarm_test::drive(&mut swarm1, &mut swarm2).await {
         (
@@ -67,8 +69,8 @@ async fn periodic_identify() {
             assert_eq!(s2_info.agent_version, "b");
             assert!(!s2_info.protocols.is_empty());
 
-            // Cannot assert observed address of dialer because memory transport uses ephemeral, outgoing ports.
-            // assert_eq!(
+            // Cannot assert observed address of dialer because memory transport uses
+            // ephemeral, outgoing ports. assert_eq!(
             //     s2_info.observed_addr,
             //     swarm2_memory_listen.with(Protocol::P2p(swarm2_peer_id.into()))
             // );

--- a/protocols/kad/src/addresses.rs
+++ b/protocols/kad/src/addresses.rs
@@ -18,9 +18,10 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::fmt;
+
 use libp2p_core::Multiaddr;
 use smallvec::SmallVec;
-use std::fmt;
 
 /// A non-empty list of (unique) addresses of a peer in the routing table.
 /// Every address must be a fully-qualified /p2p address.
@@ -60,9 +61,9 @@ impl Addresses {
 
     /// Removes the given address from the list.
     ///
-    /// Returns `Ok(())` if the address is either not in the list or was found and
-    /// removed. Returns `Err(())` if the address is the last remaining address,
-    /// which cannot be removed.
+    /// Returns `Ok(())` if the address is either not in the list or was found
+    /// and removed. Returns `Err(())` if the address is the last remaining
+    /// address, which cannot be removed.
     ///
     /// An address should only be removed if is determined to be invalid or
     /// otherwise unreachable.
@@ -175,7 +176,8 @@ mod tests {
         );
     }
 
-    /// Helper function to easily initialize Addresses struct with multiple addresses.
+    /// Helper function to easily initialize Addresses struct with multiple
+    /// addresses.
     fn make_addresses(addresses: impl IntoIterator<Item = Multiaddr>) -> Addresses {
         Addresses {
             addrs: SmallVec::from_iter(addresses),

--- a/protocols/kad/src/behaviour/test.rs
+++ b/protocols/kad/src/behaviour/test.rs
@@ -20,17 +20,14 @@
 
 #![cfg(test)]
 
-use super::*;
-
-use crate::record::{store::MemoryStore, Key};
-use crate::{K_VALUE, PROTOCOL_NAME, SHA_256_MH};
 use futures::{executor::block_on, future::poll_fn, prelude::*};
 use futures_timer::Delay;
 use libp2p_core::{
     multiaddr::{multiaddr, Protocol},
     multihash::Multihash,
     transport::MemoryTransport,
-    upgrade, Transport,
+    upgrade,
+    Transport,
 };
 use libp2p_identity as identity;
 use libp2p_noise as noise;
@@ -38,6 +35,14 @@ use libp2p_swarm::{self as swarm, Swarm, SwarmEvent};
 use libp2p_yamux as yamux;
 use quickcheck::*;
 use rand::{random, rngs::StdRng, thread_rng, Rng, SeedableRng};
+
+use super::*;
+use crate::{
+    record::{store::MemoryStore, Key},
+    K_VALUE,
+    PROTOCOL_NAME,
+    SHA_256_MH,
+};
 
 type TestSwarm = Swarm<Behaviour<MemoryStore>>;
 
@@ -73,12 +78,14 @@ fn build_node_with_config(cfg: Config) -> (Multiaddr, TestSwarm) {
     (address, swarm)
 }
 
-/// Builds swarms, each listening on a port. Does *not* connect the nodes together.
+/// Builds swarms, each listening on a port. Does *not* connect the nodes
+/// together.
 fn build_nodes(num: usize) -> Vec<(Multiaddr, TestSwarm)> {
     build_nodes_with_config(num, Default::default())
 }
 
-/// Builds swarms, each listening on a port. Does *not* connect the nodes together.
+/// Builds swarms, each listening on a port. Does *not* connect the nodes
+/// together.
 fn build_nodes_with_config(num: usize, cfg: Config) -> Vec<(Multiaddr, TestSwarm)> {
     (0..num)
         .map(|_| build_node_with_config(cfg.clone()))
@@ -164,7 +171,8 @@ fn bootstrap() {
         let num_group = rng.gen_range(1..(num_total % K_VALUE.get()) + 2);
 
         let mut cfg = Config::new(PROTOCOL_NAME);
-        // Disabling periodic bootstrap and automatic bootstrap to prevent the bootstrap from triggering automatically.
+        // Disabling periodic bootstrap and automatic bootstrap to prevent the bootstrap
+        // from triggering automatically.
         cfg.set_periodic_bootstrap_interval(None);
         cfg.set_automatic_bootstrap_throttle(None);
         if rng.gen() {
@@ -246,7 +254,8 @@ fn query_iter() {
     fn run(rng: &mut impl Rng) {
         let num_total = rng.gen_range(2..20);
         let mut config = Config::new(PROTOCOL_NAME);
-        // Disabling periodic bootstrap and automatic bootstrap to prevent the bootstrap from triggering automatically.
+        // Disabling periodic bootstrap and automatic bootstrap to prevent the bootstrap
+        // from triggering automatically.
         config.set_periodic_bootstrap_interval(None);
         config.set_automatic_bootstrap_throttle(None);
         let mut swarms = build_connected_nodes_with_config(num_total, 1, config)
@@ -323,8 +332,8 @@ fn unresponsive_not_returned_direct() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .try_init();
-    // Build one node. It contains fake addresses to non-existing nodes. We ask it to find a
-    // random peer. We make sure that no fake address is returned.
+    // Build one node. It contains fake addresses to non-existing nodes. We ask it
+    // to find a random peer. We make sure that no fake address is returned.
 
     let mut swarms = build_nodes(1)
         .into_iter()
@@ -368,9 +377,9 @@ fn unresponsive_not_returned_direct() {
 
 #[test]
 fn unresponsive_not_returned_indirect() {
-    // Build two nodes. Node #2 knows about node #1. Node #1 contains fake addresses to
-    // non-existing nodes. We ask node #2 to find a random peer. We make sure that no fake address
-    // is returned.
+    // Build two nodes. Node #2 knows about node #1. Node #1 contains fake addresses
+    // to non-existing nodes. We ask node #2 to find a random peer. We make sure
+    // that no fake address is returned.
 
     let mut swarms = build_nodes(2);
 
@@ -468,9 +477,19 @@ fn get_closest_with_different_num_results_inner(num_results: usize, replication_
                     }))) => {
                         assert_eq!(&ok.key[..], search_target.to_bytes().as_slice());
                         if num_results > k_value {
-                            assert_eq!(ok.peers.len(), k_value, "Failed with replication_factor: {replication_factor}, num_results: {num_results}");
+                            assert_eq!(
+                                ok.peers.len(),
+                                k_value,
+                                "Failed with replication_factor: {replication_factor}, \
+                                 num_results: {num_results}"
+                            );
                         } else {
-                            assert_eq!(ok.peers.len(), num_results, "Failed with replication_factor: {replication_factor}, num_results: {num_results}");
+                            assert_eq!(
+                                ok.peers.len(),
+                                num_results,
+                                "Failed with replication_factor: {replication_factor}, \
+                                 num_results: {num_results}"
+                            );
                         }
 
                         return Poll::Ready(());
@@ -561,7 +580,8 @@ fn put_record() {
 
         let mut config = Config::new(PROTOCOL_NAME);
         config.set_replication_factor(replication_factor);
-        // Disabling periodic bootstrap and automatic bootstrap to prevent the bootstrap from triggering automatically.
+        // Disabling periodic bootstrap and automatic bootstrap to prevent the bootstrap
+        // from triggering automatically.
         config.set_periodic_bootstrap_interval(None);
         config.set_automatic_bootstrap_throttle(None);
         if rng.gen() {
@@ -933,7 +953,8 @@ fn add_provider() {
 
         let mut config = Config::new(PROTOCOL_NAME);
         config.set_replication_factor(replication_factor);
-        // Disabling periodic bootstrap and automatic bootstrap to prevent the bootstrap from triggering automatically.
+        // Disabling periodic bootstrap and automatic bootstrap to prevent the bootstrap
+        // from triggering automatically.
         config.set_periodic_bootstrap_interval(None);
         config.set_automatic_bootstrap_throttle(None);
         if rng.gen() {
@@ -1161,7 +1182,8 @@ fn disjoint_query_does_not_finish_before_all_paths_did() {
     config.disjoint_query_paths(true);
     // I.e. setting the amount disjoint paths to be explored to 2.
     config.set_parallelism(NonZeroUsize::new(2).unwrap());
-    // Disabling periodic bootstrap and automatic bootstrap to prevent the bootstrap from triggering automatically.
+    // Disabling periodic bootstrap and automatic bootstrap to prevent the bootstrap
+    // from triggering automatically.
     config.set_periodic_bootstrap_interval(None);
     config.set_automatic_bootstrap_throttle(None);
 
@@ -1218,8 +1240,8 @@ fn disjoint_query_does_not_finish_before_all_paths_did() {
                         }
                         if step.last {
                             panic!(
-                                "Expected query not to finish until all \
-                                 disjoint paths have been explored.",
+                                "Expected query not to finish until all disjoint paths have been \
+                                 explored.",
                             );
                         }
                         match result {

--- a/protocols/kad/src/jobs.rs
+++ b/protocols/kad/src/jobs.rs
@@ -25,12 +25,12 @@
 //! To ensure persistence of records in the DHT, a Kademlia node
 //! must periodically (re-)publish and (re-)replicate its records:
 //!
-//!   1. (Re-)publishing: The original publisher or provider of a record
-//!      must regularly re-publish in order to prolong the expiration.
+//!   1. (Re-)publishing: The original publisher or provider of a record must
+//!      regularly re-publish in order to prolong the expiration.
 //!
 //!   2. (Re-)replication: Every node storing a replica of a record must
-//!      regularly re-replicate it to the closest nodes to the key in
-//!      order to ensure the record is present at these nodes.
+//!      regularly re-replicate it to the closest nodes to the key in order to
+//!      ensure the record is present at these nodes.
 //!
 //! Re-publishing primarily ensures persistence of the record beyond its
 //! initial TTL, for as long as the publisher stores (or provides) the record,
@@ -41,11 +41,11 @@
 //!
 //! This module implements two periodic jobs:
 //!
-//!   * [`PutRecordJob`]: For (re-)publication and (re-)replication of
-//!     regular (value-)records.
+//!   * [`PutRecordJob`]: For (re-)publication and (re-)replication of regular
+//!     (value-)records.
 //!
-//!   * [`AddProviderJob`]: For (re-)publication of provider records.
-//!     Provider records currently have no separate replication mechanism.
+//!   * [`AddProviderJob`]: For (re-)publication of provider records. Provider
+//!     records currently have no separate replication mechanism.
 //!
 //! A periodic job is driven like a `Future` or `Stream` by `poll`ing it.
 //! Once a job starts running it emits records to send to the `k` closest
@@ -59,18 +59,23 @@
 //! > to replicate from the `RecordStore` when it starts and thus, to account
 //! > for the worst case, it temporarily requires additional memory proportional
 //! > to the size of all stored records. As a job runs, the records are moved
-//! > out of the job to the consumer, where they can be dropped after being sent.
+//! > out of the job to the consumer, where they can be dropped after being
+//! > sent.
 
-use crate::record::{self, store::RecordStore, ProviderRecord, Record};
+use std::{
+    collections::HashSet,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+    vec,
+};
+
 use futures::prelude::*;
 use futures_timer::Delay;
 use libp2p_identity::PeerId;
-use std::collections::HashSet;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::Duration;
-use std::vec;
 use web_time::Instant;
+
+use crate::record::{self, store::RecordStore, ProviderRecord, Record};
 
 /// The maximum number of queries towards which background jobs
 /// are allowed to start new queries on an invocation of
@@ -335,11 +340,12 @@ impl AddProviderJob {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::record::store::MemoryStore;
     use futures::{executor::block_on, future::poll_fn};
     use quickcheck::*;
     use rand::Rng;
+
+    use super::*;
+    use crate::record::store::MemoryStore;
 
     fn rand_put_record_job() -> PutRecordJob {
         let mut rng = rand::thread_rng();

--- a/protocols/kad/src/kbucket.rs
+++ b/protocols/kad/src/kbucket.rs
@@ -27,10 +27,11 @@
 //!
 //! When the bucket associated with the `Key` of an inserted entry is full
 //! but contains disconnected nodes, it accepts a [`PendingEntry`].
-//! Pending entries are inserted lazily when their timeout is found to be expired
-//! upon querying the `KBucketsTable`. When that happens, the `KBucketsTable` records
-//! an [`AppliedPending`] result which must be consumed by calling [`take_applied_pending`]
-//! regularly and / or after performing lookup operations like [`entry`] and [`closest`].
+//! Pending entries are inserted lazily when their timeout is found to be
+//! expired upon querying the `KBucketsTable`. When that happens, the
+//! `KBucketsTable` records an [`AppliedPending`] result which must be consumed
+//! by calling [`take_applied_pending`] regularly and / or after performing
+//! lookup operations like [`entry`] and [`closest`].
 //!
 //! [`entry`]: KBucketsTable::entry
 //! [`closest`]: KBucketsTable::closest
@@ -45,24 +46,24 @@
 // The routing table is currently implemented as a fixed-size "array" of
 // buckets, ordered by increasing distance relative to a local key
 // that identifies the local peer. This is an often-used, simplified
-// implementation that approximates the properties of the b-tree (or prefix tree)
-// implementation described in the full paper [0], whereby buckets are split on-demand.
-// This should be treated as an implementation detail, however, so that the
-// implementation may change in the future without breaking the API.
+// implementation that approximates the properties of the b-tree (or prefix
+// tree) implementation described in the full paper [0], whereby buckets are
+// split on-demand. This should be treated as an implementation detail, however,
+// so that the implementation may change in the future without breaking the API.
 //
 // 2. Replacement Cache
 //
 // In this implementation, the "replacement cache" for unresponsive peers
 // consists of a single entry per bucket. Furthermore, this implementation is
 // currently tailored to connection-oriented transports, meaning that the
-// "LRU"-based ordering of entries in a bucket is actually based on the last reported
-// connection status of the corresponding peers, from least-recently (dis)connected to
-// most-recently (dis)connected, and controlled through the `Entry` API. As a result,
-// the nodes in the buckets are not reordered as a result of RPC activity, but only as a
-// result of nodes being marked as connected or disconnected. In particular,
-// if a bucket is full and contains only entries for peers that are considered
-// connected, no pending entry is accepted. See the `bucket` submodule for
-// further details.
+// "LRU"-based ordering of entries in a bucket is actually based on the last
+// reported connection status of the corresponding peers, from least-recently
+// (dis)connected to most-recently (dis)connected, and controlled through the
+// `Entry` API. As a result, the nodes in the buckets are not reordered as a
+// result of RPC activity, but only as a result of nodes being marked as
+// connected or disconnected. In particular, if a bucket is full and contains
+// only entries for peers that are considered connected, no pending entry is
+// accepted. See the `bucket` submodule for further details.
 //
 // [0]: https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf
 
@@ -72,13 +73,11 @@ mod entry;
 #[allow(clippy::assign_op_pattern)]
 mod key;
 
-pub use bucket::NodeStatus;
-pub use entry::*;
+use std::{collections::VecDeque, num::NonZeroUsize, time::Duration};
 
 use bucket::KBucket;
-use std::collections::VecDeque;
-use std::num::NonZeroUsize;
-use std::time::Duration;
+pub use bucket::NodeStatus;
+pub use entry::*;
 use web_time::Instant;
 
 /// Maximum number of k-buckets.
@@ -132,8 +131,8 @@ pub(crate) struct KBucketsTable<TKey, TVal> {
     applied_pending: VecDeque<AppliedPending<TKey, TVal>>,
 }
 
-/// A (type-safe) index into a `KBucketsTable`, i.e. a non-negative integer in the
-/// interval `[0, NUM_BUCKETS)`.
+/// A (type-safe) index into a `KBucketsTable`, i.e. a non-negative integer in
+/// the interval `[0, NUM_BUCKETS)`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct BucketIndex(usize);
 
@@ -202,8 +201,8 @@ where
         &self.local_key
     }
 
-    /// Returns an `Entry` for the given key, representing the state of the entry
-    /// in the routing table.
+    /// Returns an `Entry` for the given key, representing the state of the
+    /// entry in the routing table.
     ///
     /// Returns `None` in case the key points to the local node.
     pub(crate) fn entry<'a>(&'a mut self, key: &'a TKey) -> Option<Entry<'a, TKey, TVal>> {
@@ -254,15 +253,17 @@ where
 
     /// Consumes the next applied pending entry, if any.
     ///
-    /// When an entry is attempted to be inserted and the respective bucket is full,
-    /// it may be recorded as pending insertion after a timeout, see [`InsertResult::Pending`].
+    /// When an entry is attempted to be inserted and the respective bucket is
+    /// full, it may be recorded as pending insertion after a timeout, see
+    /// [`InsertResult::Pending`].
     ///
-    /// If the oldest currently disconnected entry in the respective bucket does not change
-    /// its status until the timeout of pending entry expires, it is evicted and
-    /// the pending entry inserted instead. These insertions of pending entries
-    /// happens lazily, whenever the `KBucketsTable` is accessed, and the corresponding
-    /// buckets are updated accordingly. The fact that a pending entry was applied is
-    /// recorded in the `KBucketsTable` in the form of `AppliedPending` results, which must be
+    /// If the oldest currently disconnected entry in the respective bucket does
+    /// not change its status until the timeout of pending entry expires, it
+    /// is evicted and the pending entry inserted instead. These insertions
+    /// of pending entries happens lazily, whenever the `KBucketsTable` is
+    /// accessed, and the corresponding buckets are updated accordingly. The
+    /// fact that a pending entry was applied is recorded in the
+    /// `KBucketsTable` in the form of `AppliedPending` results, which must be
     /// consumed by calling this function.
     pub(crate) fn take_applied_pending(&mut self) -> Option<AppliedPending<TKey, TVal>> {
         self.applied_pending.pop_front()
@@ -292,8 +293,8 @@ where
         }
     }
 
-    /// Returns an iterator over the nodes closest to the `target` key, ordered by
-    /// increasing distance.
+    /// Returns an iterator over the nodes closest to the `target` key, ordered
+    /// by increasing distance.
     pub(crate) fn closest<'a, T>(
         &'a mut self,
         target: &'a T,
@@ -366,9 +367,10 @@ struct ClosestIter<'a, TTarget, TKey, TVal, TMap, TOut> {
     fmap: TMap,
 }
 
-/// An iterator over the bucket indices, in the order determined by the `Distance` of
-/// a target from the `local_key`, such that the entries in the buckets are incrementally
-/// further away from the target, starting with the bucket covering the target.
+/// An iterator over the bucket indices, in the order determined by the
+/// `Distance` of a target from the `local_key`, such that the entries in the
+/// buckets are incrementally further away from the target, starting with the
+/// bucket covering the target.
 struct ClosestBucketsIter {
     /// The distance to the `local_key`.
     distance: Distance,
@@ -382,10 +384,10 @@ enum ClosestBucketsIterState {
     /// then transitions to `ZoomIn`.
     Start(BucketIndex),
     /// The iterator "zooms in" to yield the next bucket containing nodes that
-    /// are incrementally closer to the local node but further from the `target`.
-    /// These buckets are identified by a `1` in the corresponding bit position
-    /// of the distance bit string. When bucket `0` is reached, the iterator
-    /// transitions to `ZoomOut`.
+    /// are incrementally closer to the local node but further from the
+    /// `target`. These buckets are identified by a `1` in the corresponding
+    /// bit position of the distance bit string. When bucket `0` is reached,
+    /// the iterator transitions to `ZoomOut`.
     ZoomIn(BucketIndex),
     /// Once bucket `0` has been reached, the iterator starts "zooming out"
     /// to buckets containing nodes that are incrementally further away from
@@ -539,10 +541,11 @@ where
 
     /// Generates a random distance that falls into this bucket.
     ///
-    /// Together with a known key `a` (e.g. the local key), a random distance `d` for
-    /// this bucket w.r.t `k` gives rise to the corresponding (random) key `b` s.t.
-    /// the XOR distance between `a` and `b` is `d`. In other words, it gives
-    /// rise to a random key falling into this bucket. See [`key::Key::for_distance`].
+    /// Together with a known key `a` (e.g. the local key), a random distance
+    /// `d` for this bucket w.r.t `k` gives rise to the corresponding
+    /// (random) key `b` s.t. the XOR distance between `a` and `b` is `d`.
+    /// In other words, it gives rise to a random key falling into this
+    /// bucket. See [`key::Key::for_distance`].
     pub fn rand_distance(&self, rng: &mut impl rand::Rng) -> Distance {
         self.index.rand_distance(rng)
     }
@@ -561,9 +564,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use libp2p_identity::PeerId;
     use quickcheck::*;
+
+    use super::*;
 
     type TestTable = KBucketsTable<KeyBytes, ()>;
 

--- a/protocols/kad/src/kbucket/bucket.rs
+++ b/protocols/kad/src/kbucket/bucket.rs
@@ -36,7 +36,8 @@ pub(crate) struct PendingNode<TKey, TVal> {
     /// The status of the pending node.
     status: NodeStatus,
 
-    /// The instant at which the pending node is eligible for insertion into a bucket.
+    /// The instant at which the pending node is eligible for insertion into a
+    /// bucket.
     replace: Instant,
 }
 
@@ -102,12 +103,12 @@ pub(crate) struct KBucket<TKey, TVal> {
 
     /// The position (index) in `nodes` that marks the first connected node.
     ///
-    /// Since the entries in `nodes` are ordered from least-recently connected to
-    /// most-recently connected, all entries above this index are also considered
-    /// connected, i.e. the range `[0, first_connected_pos)` marks the sub-list of entries
-    /// that are considered disconnected and the range
-    /// `[first_connected_pos, capacity)` marks sub-list of entries that are
-    /// considered connected.
+    /// Since the entries in `nodes` are ordered from least-recently connected
+    /// to most-recently connected, all entries above this index are also
+    /// considered connected, i.e. the range `[0, first_connected_pos)`
+    /// marks the sub-list of entries that are considered disconnected and
+    /// the range `[first_connected_pos, capacity)` marks sub-list of
+    /// entries that are considered connected.
     ///
     /// `None` indicates that there are no connected entries in the bucket, i.e.
     /// the bucket is either empty, or contains only entries for peers that are
@@ -131,14 +132,15 @@ pub(crate) struct KBucket<TKey, TVal> {
 pub(crate) enum InsertResult<TKey> {
     /// The entry has been successfully inserted.
     Inserted,
-    /// The entry is pending insertion because the relevant bucket is currently full.
-    /// The entry is inserted after a timeout elapsed, if the status of the
-    /// least-recently connected (and currently disconnected) node in the bucket
-    /// is not updated before the timeout expires.
+    /// The entry is pending insertion because the relevant bucket is currently
+    /// full. The entry is inserted after a timeout elapsed, if the status
+    /// of the least-recently connected (and currently disconnected) node in
+    /// the bucket is not updated before the timeout expires.
     Pending {
-        /// The key of the least-recently connected entry that is currently considered
-        /// disconnected and whose corresponding peer should be checked for connectivity
-        /// in order to prevent it from being evicted. If connectivity to the peer is
+        /// The key of the least-recently connected entry that is currently
+        /// considered disconnected and whose corresponding peer should
+        /// be checked for connectivity in order to prevent it from
+        /// being evicted. If connectivity to the peer is
         /// re-established, the corresponding entry should be updated with
         /// [`NodeStatus::Connected`].
         disconnected: TKey,
@@ -191,7 +193,8 @@ where
         self.pending.as_ref()
     }
 
-    /// Returns a mutable reference to the pending node of the bucket, if there is any.
+    /// Returns a mutable reference to the pending node of the bucket, if there
+    /// is any.
     pub(crate) fn pending_mut(&mut self) -> Option<&mut PendingNode<TKey, TVal>> {
         self.pending.as_mut()
     }
@@ -203,7 +206,8 @@ where
             .filter(|p| p.node.key.as_ref() == key.as_ref())
     }
 
-    /// Returns an iterator over the nodes in the bucket, together with their status.
+    /// Returns an iterator over the nodes in the bucket, together with their
+    /// status.
     pub(crate) fn iter(&self) -> impl Iterator<Item = (&Node<TKey, TVal>, NodeStatus)> {
         self.nodes
             .iter()
@@ -311,19 +315,20 @@ where
     ///
     /// The status of the node to insert determines the result as follows:
     ///
-    ///   * `NodeStatus::Connected`: If the bucket is full and either all nodes are connected
-    ///     or there is already a pending node, insertion fails with `InsertResult::Full`.
-    ///     If the bucket is full but at least one node is disconnected and there is no pending
-    ///     node, the new node is inserted as pending, yielding `InsertResult::Pending`.
-    ///     Otherwise the bucket has free slots and the new node is added to the end of the
+    ///   * `NodeStatus::Connected`: If the bucket is full and either all nodes
+    ///     are connected or there is already a pending node, insertion fails
+    ///     with `InsertResult::Full`. If the bucket is full but at least one
+    ///     node is disconnected and there is no pending node, the new node is
+    ///     inserted as pending, yielding `InsertResult::Pending`. Otherwise the
+    ///     bucket has free slots and the new node is added to the end of the
     ///     bucket as the most-recently connected node.
     ///
-    ///   * `NodeStatus::Disconnected`: If the bucket is full, insertion fails with
-    ///     `InsertResult::Full`. Otherwise the bucket has free slots and the new node
-    ///     is inserted at the position preceding the first connected node,
-    ///     i.e. as the most-recently disconnected node. If there are no connected nodes,
-    ///     the new node is added as the last element of the bucket.
-    ///
+    ///   * `NodeStatus::Disconnected`: If the bucket is full, insertion fails
+    ///     with `InsertResult::Full`. Otherwise the bucket has free slots and
+    ///     the new node is inserted at the position preceding the first
+    ///     connected node, i.e. as the most-recently disconnected node. If
+    ///     there are no connected nodes, the new node is added as the last
+    ///     element of the bucket.
     pub(crate) fn insert(
         &mut self,
         node: Node<TKey, TVal>,
@@ -416,7 +421,8 @@ where
         self.first_connected_pos.map_or(0, |i| self.nodes.len() - i)
     }
 
-    /// Gets the number of entries in the bucket that are considered disconnected.
+    /// Gets the number of entries in the bucket that are considered
+    /// disconnected.
     #[cfg(test)]
     pub(crate) fn num_disconnected(&self) -> usize {
         self.nodes.len() - self.num_connected()
@@ -443,9 +449,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use libp2p_identity::PeerId;
     use quickcheck::*;
+
+    use super::*;
 
     impl Arbitrary for KBucket<Key<PeerId>, ()> {
         fn arbitrary(g: &mut Gen) -> KBucket<Key<PeerId>, ()> {
@@ -552,7 +559,8 @@ mod tests {
             x => panic!("{x:?}"),
         }
 
-        // One-by-one fill the bucket with connected nodes, replacing the disconnected ones.
+        // One-by-one fill the bucket with connected nodes, replacing the disconnected
+        // ones.
         for i in 0..bucket.capacity {
             let (first, first_status) = bucket.iter().next().unwrap();
             let first_disconnected = first.clone();

--- a/protocols/kad/src/kbucket/entry.rs
+++ b/protocols/kad/src/kbucket/entry.rs
@@ -23,7 +23,6 @@
 
 pub(crate) use super::bucket::{AppliedPending, InsertResult, Node, K_VALUE};
 pub use super::key::*;
-
 use super::*;
 
 /// An immutable by-reference view of a bucket entry.

--- a/protocols/kad/src/kbucket/key.rs
+++ b/protocols/kad/src/kbucket/key.rs
@@ -18,14 +18,21 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::record;
+use std::{
+    borrow::Borrow,
+    hash::{Hash, Hasher},
+};
+
 use libp2p_core::multihash::Multihash;
 use libp2p_identity::PeerId;
-use sha2::digest::generic_array::{typenum::U32, GenericArray};
-use sha2::{Digest, Sha256};
-use std::borrow::Borrow;
-use std::hash::{Hash, Hasher};
+use sha2::{
+    digest::generic_array::{typenum::U32, GenericArray},
+    Digest,
+    Sha256,
+};
 use uint::*;
+
+use crate::record;
 
 construct_uint! {
     /// 256-bit unsigned integer.
@@ -37,8 +44,8 @@ construct_uint! {
 /// Keys in the DHT keyspace identify both the participating nodes, as well as
 /// the records stored in the DHT.
 ///
-/// `Key`s have an XOR metric as defined in the Kademlia paper, i.e. the bitwise XOR of
-/// the hash digests, interpreted as an integer. See [`Key::distance`].
+/// `Key`s have an XOR metric as defined in the Kademlia paper, i.e. the bitwise
+/// XOR of the hash digests, interpreted as an integer. See [`Key::distance`].
 #[derive(Clone, Copy, Debug)]
 pub struct Key<T> {
     preimage: T,
@@ -200,9 +207,10 @@ impl Distance {
 
 #[cfg(test)]
 mod tests {
+    use quickcheck::*;
+
     use super::*;
     use crate::SHA_256_MH;
-    use quickcheck::*;
 
     impl Arbitrary for Key<PeerId> {
         fn arbitrary(_: &mut Gen) -> Key<PeerId> {

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -50,44 +50,81 @@ mod proto {
     include!("generated/mod.rs");
     pub use self::dht::pb::{
         mod_Message::{ConnectionType, MessageType, Peer},
-        Message, Record,
+        Message,
+        Record,
     };
 }
 
+use std::num::NonZeroUsize;
+
 pub use addresses::Addresses;
 pub use behaviour::{
-    AddProviderContext, AddProviderError, AddProviderOk, AddProviderPhase, AddProviderResult,
-    BootstrapError, BootstrapOk, BootstrapResult, GetClosestPeersError, GetClosestPeersOk,
-    GetClosestPeersResult, GetProvidersError, GetProvidersOk, GetProvidersResult, GetRecordError,
-    GetRecordOk, GetRecordResult, InboundRequest, Mode, NoKnownPeers, PeerInfo, PeerRecord,
-    PutRecordContext, PutRecordError, PutRecordOk, PutRecordPhase, PutRecordResult, QueryInfo,
-    QueryMut, QueryRef, QueryResult, QueryStats, RoutingUpdate,
-};
-pub use behaviour::{
-    Behaviour, BucketInserts, Caching, Config, Event, ProgressStep, Quorum, StoreInserts,
+    AddProviderContext,
+    AddProviderError,
+    AddProviderOk,
+    AddProviderPhase,
+    AddProviderResult,
+    Behaviour,
+    BootstrapError,
+    BootstrapOk,
+    BootstrapResult,
+    BucketInserts,
+    Caching,
+    Config,
+    Event,
+    GetClosestPeersError,
+    GetClosestPeersOk,
+    GetClosestPeersResult,
+    GetProvidersError,
+    GetProvidersOk,
+    GetProvidersResult,
+    GetRecordError,
+    GetRecordOk,
+    GetRecordResult,
+    InboundRequest,
+    Mode,
+    NoKnownPeers,
+    PeerInfo,
+    PeerRecord,
+    ProgressStep,
+    PutRecordContext,
+    PutRecordError,
+    PutRecordOk,
+    PutRecordPhase,
+    PutRecordResult,
+    QueryInfo,
+    QueryMut,
+    QueryRef,
+    QueryResult,
+    QueryStats,
+    Quorum,
+    RoutingUpdate,
+    StoreInserts,
 };
 pub use kbucket::{
-    Distance as KBucketDistance, EntryView, KBucketRef, Key as KBucketKey, NodeStatus,
+    Distance as KBucketDistance,
+    EntryView,
+    KBucketRef,
+    Key as KBucketKey,
+    NodeStatus,
 };
+use libp2p_swarm::StreamProtocol;
 pub use protocol::{ConnectionType, KadPeer};
 pub use query::QueryId;
 pub use record::{store, Key as RecordKey, ProviderRecord, Record};
-
-use libp2p_swarm::StreamProtocol;
-use std::num::NonZeroUsize;
 
 /// The `k` parameter of the Kademlia specification.
 ///
 /// This parameter determines:
 ///
 ///   1) The (fixed) maximum number of nodes in a bucket.
-///   2) The (default) replication factor, which in turn determines:
-///       a) The number of closer peers returned in response to a request.
-///       b) The number of closest peers to a key to search for in an iterative query.
+///   2) The (default) replication factor, which in turn determines: a) The
+///      number of closer peers returned in response to a request. b) The number
+///      of closest peers to a key to search for in an iterative query.
 ///
-/// The choice of (1) is fixed to this constant. The replication factor is configurable
-/// but should generally be no greater than `K_VALUE`. All nodes in a Kademlia
-/// DHT should agree on the choices made for (1) and (2).
+/// The choice of (1) is fixed to this constant. The replication factor is
+/// configurable but should generally be no greater than `K_VALUE`. All nodes in
+/// a Kademlia DHT should agree on the choices made for (1) and (2).
 ///
 /// The current value is `20`.
 pub const K_VALUE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(20) };
@@ -104,6 +141,7 @@ pub const ALPHA_VALUE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(3) };
 
 pub const PROTOCOL_NAME: StreamProtocol = protocol::DEFAULT_PROTO_NAME;
 
-/// Constant shared across tests for the [`Multihash`](libp2p_core::multihash::Multihash) type.
+/// Constant shared across tests for the
+/// [`Multihash`](libp2p_core::multihash::Multihash) type.
 #[cfg(test)]
 const SHA_256_MH: u64 = 0x12;

--- a/protocols/kad/src/query/peers.rs
+++ b/protocols/kad/src/query/peers.rs
@@ -18,7 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! Peer selection strategies for queries in the form of iterator-like state machines.
+//! Peer selection strategies for queries in the form of iterator-like state
+//! machines.
 //!
 //! Using a peer iterator in a query involves performing the following steps
 //! repeatedly and in an alternating fashion:
@@ -28,8 +29,8 @@
 //!      waiting for responses.
 //!
 //!   2. When responses are received or requests fail, providing input to the
-//!      iterator via the `on_success` and `on_failure` callbacks,
-//!      respectively, followed by repeating step (1).
+//!      iterator via the `on_success` and `on_failure` callbacks, respectively,
+//!      followed by repeating step (1).
 //!
 //! When a call to `next` returns [`Finished`], no more peers can be obtained
 //! from the iterator and the results can be obtained from `into_result`.
@@ -40,8 +41,9 @@
 
 pub(crate) mod closest;
 pub(crate) mod fixed;
-use libp2p_identity::PeerId;
 use std::borrow::Cow;
+
+use libp2p_identity::PeerId;
 
 /// The state of a peer iterator.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -52,9 +54,9 @@ pub enum PeersIterState<'a> {
     /// from `peer`, in addition to any other peers for which it is already
     /// waiting for results.
     ///
-    /// `None` indicates that the iterator is waiting for results and there is no
-    /// new peer to contact, despite the iterator not being at capacity w.r.t.
-    /// the permitted parallelism.
+    /// `None` indicates that the iterator is waiting for results and there is
+    /// no new peer to contact, despite the iterator not being at capacity
+    /// w.r.t. the permitted parallelism.
     Waiting(Option<Cow<'a, PeerId>>),
 
     /// The iterator is waiting for results and is at capacity w.r.t. the

--- a/protocols/kad/src/query/peers/closest/disjoint.rs
+++ b/protocols/kad/src/query/peers/closest/disjoint.rs
@@ -18,12 +18,13 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use super::*;
 use std::{
     collections::HashMap,
     iter::{Cycle, Map, Peekable},
     ops::{Index, IndexMut, Range},
 };
+
+use super::*;
 
 /// Wraps around a set of [`ClosestPeersIter`], enforcing a disjoint discovery
 /// path per configured parallelism according to the S/Kademlia paper.
@@ -373,7 +374,6 @@ enum ResponseState {
 
 /// Iterator combining the result of multiple [`ClosestPeersIter`] into a single
 /// deduplicated ordered iterator.
-//
 // Note: This operates under the assumption that `I` is ordered.
 #[derive(Clone, Debug)]
 struct ResultIter<I>
@@ -433,13 +433,13 @@ impl<I: Iterator<Item = Key<PeerId>>> Iterator for ResultIter<I> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::{collections::HashSet, iter};
 
-    use crate::SHA_256_MH;
     use libp2p_core::multihash::Multihash;
     use quickcheck::*;
-    use std::collections::HashSet;
-    use std::iter;
+
+    use super::*;
+    use crate::SHA_256_MH;
 
     impl Arbitrary for ResultIter<std::vec::IntoIter<Key<PeerId>>> {
         fn arbitrary(g: &mut Gen) -> Self {
@@ -834,7 +834,8 @@ mod tests {
         }
     }
 
-    /// Ensure [`ClosestPeersIter`] and [`ClosestDisjointPeersIter`] yield same closest peers.
+    /// Ensure [`ClosestPeersIter`] and [`ClosestDisjointPeersIter`] yield same
+    /// closest peers.
     #[test]
     fn closest_and_disjoint_closest_yield_same_result() {
         fn prop(
@@ -895,21 +896,19 @@ mod tests {
 
             assert!(
                 closest.len() == num_results.0.get(),
-                "Expected `ClosestPeersIter` to find `num_results` closest \
-                 peers."
+                "Expected `ClosestPeersIter` to find `num_results` closest peers."
             );
             assert!(
                 disjoint.len() >= num_results.0.get(),
-                "Expected `ClosestDisjointPeersIter` to find at least \
-                 `num_results` closest peers."
+                "Expected `ClosestDisjointPeersIter` to find at least `num_results` closest peers."
             );
 
             if closest.len() > disjoint.len() {
                 let closest_only = closest.difference(&disjoint).collect::<Vec<_>>();
 
                 panic!(
-                    "Expected `ClosestDisjointPeersIter` to find all peers \
-                     found by `ClosestPeersIter`, but it did not find {closest_only:?}.",
+                    "Expected `ClosestDisjointPeersIter` to find all peers found by \
+                     `ClosestPeersIter`, but it did not find {closest_only:?}.",
                 );
             };
 

--- a/protocols/kad/src/query/peers/fixed.rs
+++ b/protocols/kad/src/query/peers/fixed.rs
@@ -18,10 +18,11 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use super::*;
+use std::{collections::hash_map::Entry, num::NonZeroUsize, vec};
 
 use fnv::FnvHashMap;
-use std::{collections::hash_map::Entry, num::NonZeroUsize, vec};
+
+use super::*;
 
 /// A peer iterator for a fixed set of peers.
 pub(crate) struct FixedPeersIter {
@@ -49,7 +50,8 @@ enum PeerState {
     /// The iterator is waiting for a result to be reported back for the peer.
     Waiting,
 
-    /// The iterator has been informed that the attempt to contact the peer failed.
+    /// The iterator has been informed that the attempt to contact the peer
+    /// failed.
     Failed,
 
     /// The iterator has been informed of a successful result from the peer.
@@ -189,9 +191,8 @@ mod test {
         match iter.next() {
             PeersIterState::Waiting(Some(_)) => {}
             PeersIterState::WaitingAtCapacity => panic!(
-                "Expected iterator to return another peer given that the \
-                 previous `on_failure` call should have allowed another peer \
-                 to be queried.",
+                "Expected iterator to return another peer given that the previous `on_failure` \
+                 call should have allowed another peer to be queried.",
             ),
             _ => panic!("Expected iterator to yield peer."),
         }

--- a/protocols/kad/src/record.rs
+++ b/protocols/kad/src/record.rs
@@ -22,13 +22,16 @@
 
 pub mod store;
 
+use std::{
+    borrow::Borrow,
+    hash::{Hash, Hasher},
+};
+
 use bytes::Bytes;
 use libp2p_core::{multihash::Multihash, Multiaddr};
 use libp2p_identity::PeerId;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::borrow::Borrow;
-use std::hash::{Hash, Hasher};
 use web_time::Instant;
 
 /// The (opaque) key of a record.
@@ -152,7 +155,8 @@ impl ProviderRecord {
         }
     }
 
-    /// Checks whether the provider record is expired w.r.t. the given `Instant`.
+    /// Checks whether the provider record is expired w.r.t. the given
+    /// `Instant`.
     pub fn is_expired(&self, now: Instant) -> bool {
         self.expires.map_or(false, |t| now >= t)
     }
@@ -160,10 +164,12 @@ impl ProviderRecord {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use quickcheck::*;
+
     use super::*;
     use crate::SHA_256_MH;
-    use quickcheck::*;
-    use std::time::Duration;
 
     impl Arbitrary for Key {
         fn arbitrary(g: &mut Gen) -> Key {

--- a/protocols/kad/src/record/store.rs
+++ b/protocols/kad/src/record/store.rs
@@ -20,12 +20,13 @@
 
 mod memory;
 
+use std::borrow::Cow;
+
 pub use memory::{MemoryStore, MemoryStoreConfig};
 use thiserror::Error;
 
 use super::*;
 use crate::K_VALUE;
-use std::borrow::Cow;
 
 /// The result of an operation on a `RecordStore`.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -37,7 +38,8 @@ pub enum Error {
     #[error("the store cannot contain any more records")]
     MaxRecords,
 
-    /// The store is at capacity w.r.t. the total number of stored provider records.
+    /// The store is at capacity w.r.t. the total number of stored provider
+    /// records.
     #[error("the store cannot contain any more provider records")]
     MaxProvidedKeys,
 
@@ -51,19 +53,18 @@ pub enum Error {
 /// There are two types of records managed by a `RecordStore`:
 ///
 ///   1. Regular (value-)records. These records store an arbitrary value
-///      associated with a key which is distributed to the closest nodes
-///      to the key in the Kademlia DHT as per the standard Kademlia "push-model".
-///      These records are subject to re-replication and re-publication as
-///      per the standard Kademlia protocol.
+///      associated with a key which is distributed to the closest nodes to the
+///      key in the Kademlia DHT as per the standard Kademlia "push-model".
+///      These records are subject to re-replication and re-publication as per
+///      the standard Kademlia protocol.
 ///
 ///   2. Provider records. These records associate the ID of a peer with a key
-///      who can supposedly provide the associated value. These records are
-///      mere "pointers" to the data which may be followed by contacting these
-///      providers to obtain the value. These records are specific to the
-///      libp2p Kademlia specification and realise a "pull-model" for distributed
+///      who can supposedly provide the associated value. These records are mere
+///      "pointers" to the data which may be followed by contacting these
+///      providers to obtain the value. These records are specific to the libp2p
+///      Kademlia specification and realise a "pull-model" for distributed
 ///      content. Just like a regular record, a provider record is distributed
 ///      to the closest nodes to the key.
-///
 pub trait RecordStore {
     type RecordsIter<'a>: Iterator<Item = Cow<'a, Record>>
     where

--- a/protocols/kad/src/record/store/memory.rs
+++ b/protocols/kad/src/record/store/memory.rs
@@ -18,12 +18,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use super::*;
+use std::{
+    collections::{hash_map, hash_set, HashMap, HashSet},
+    iter,
+};
 
-use crate::kbucket;
 use smallvec::SmallVec;
-use std::collections::{hash_map, hash_set, HashMap, HashSet};
-use std::iter;
+
+use super::*;
+use crate::kbucket;
 
 /// In-memory implementation of a `RecordStore`.
 pub struct MemoryStore {
@@ -208,10 +211,11 @@ impl RecordStore for MemoryStore {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::SHA_256_MH;
     use quickcheck::*;
     use rand::Rng;
+
+    use super::*;
+    use crate::SHA_256_MH;
 
     fn random_multihash() -> Multihash<64> {
         Multihash::wrap(SHA_256_MH, &rand::thread_rng().gen::<[u8; 32]>()).unwrap()

--- a/protocols/kad/tests/client_mode.rs
+++ b/protocols/kad/tests/client_mode.rs
@@ -1,7 +1,6 @@
 use libp2p_identify as identify;
 use libp2p_identity as identity;
-use libp2p_kad::store::MemoryStore;
-use libp2p_kad::{Behaviour, Config, Event, Mode};
+use libp2p_kad::{store::MemoryStore, Behaviour, Config, Event, Mode};
 use libp2p_swarm::{Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt;
 use tracing_subscriber::EnvFilter;
@@ -101,10 +100,13 @@ async fn adding_an_external_addresses_activates_server_mode_on_existing_connecti
         other => panic!("Unexpected events: {other:?}"),
     }
 
-    // Server learns its external address (this could be through AutoNAT or some other mechanism).
+    // Server learns its external address (this could be through AutoNAT or some
+    // other mechanism).
     server.add_external_address(memory_addr);
 
-    // The server reconfigured its connection to the client to be in server mode, pushes that information to client which as a result updates its routing table and triggers a mode change to Mode::Server.
+    // The server reconfigured its connection to the client to be in server mode,
+    // pushes that information to client which as a result updates its routing table
+    // and triggers a mode change to Mode::Server.
     match libp2p_swarm_test::drive(&mut client, &mut server).await {
         (
             [Identify(identify::Event::Received { .. }), Kad(RoutingUpdated { peer: peer1, .. })],

--- a/protocols/mdns/src/behaviour/iface/dns.rs
+++ b/protocols/mdns/src/behaviour/iface/dns.rs
@@ -20,12 +20,13 @@
 
 //! (M)DNS encoding and decoding on top of the `dns_parser` library.
 
-use crate::{META_QUERY_SERVICE, SERVICE_NAME};
+use std::{borrow::Cow, cmp, error, fmt, str, time::Duration};
+
 use libp2p_core::Multiaddr;
 use libp2p_identity::PeerId;
-use rand::distributions::Alphanumeric;
-use rand::{thread_rng, Rng};
-use std::{borrow::Cow, cmp, error, fmt, str, time::Duration};
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
+
+use crate::{META_QUERY_SERVICE, SERVICE_NAME};
 
 /// DNS TXT records can have up to 255 characters as a single string value.
 ///
@@ -48,7 +49,8 @@ const MAX_RECORDS_PER_PACKET: usize = (MAX_PACKET_SIZE - 100) / MAX_TXT_RECORD_S
 
 /// An encoded MDNS packet.
 pub(crate) type MdnsPacket = Vec<u8>;
-/// Decodes a `<character-string>` (as defined by RFC1035) into a `Vec` of ASCII characters.
+/// Decodes a `<character-string>` (as defined by RFC1035) into a `Vec` of ASCII
+/// characters.
 // TODO: better error type?
 pub(crate) fn decode_character_string(mut from: &[u8]) -> Result<Cow<'_, [u8]>, ()> {
     if from.is_empty() {
@@ -290,10 +292,9 @@ fn generate_peer_name() -> Vec<u8> {
 ///
 /// # Panic
 ///
-/// Panics if `name` has a zero-length component or a component that is too long.
-/// This is fine considering that this function is not public and is only called in a controlled
-/// environment.
-///
+/// Panics if `name` has a zero-length component or a component that is too
+/// long. This is fine considering that this function is not public and is only
+/// called in a controlled environment.
 fn append_qname(out: &mut Vec<u8>, name: &[u8]) {
     debug_assert!(name.is_ascii());
 
@@ -394,9 +395,10 @@ impl error::Error for MdnsResponseError {}
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use hickory_proto::op::Message;
     use libp2p_identity as identity;
+
+    use super::*;
 
     #[test]
     fn build_query_correct() {

--- a/protocols/mdns/src/behaviour/iface/query.rs
+++ b/protocols/mdns/src/behaviour/iface/query.rs
@@ -18,18 +18,23 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use super::dns;
-use crate::{META_QUERY_SERVICE_FQDN, SERVICE_NAME_FQDN};
+use std::{
+    fmt,
+    net::SocketAddr,
+    str,
+    time::{Duration, Instant},
+};
+
 use hickory_proto::{
     op::Message,
     rr::{Name, RData},
 };
 use libp2p_core::multiaddr::{Multiaddr, Protocol};
+use libp2p_identity::PeerId;
 use libp2p_swarm::_address_translation;
 
-use libp2p_identity::PeerId;
-use std::time::Instant;
-use std::{fmt, net::SocketAddr, str, time::Duration};
+use super::dns;
+use crate::{META_QUERY_SERVICE_FQDN, SERVICE_NAME_FQDN};
 
 /// A valid mDNS packet received by the service.
 #[derive(Debug)]
@@ -69,7 +74,8 @@ impl MdnsPacket {
             .iter()
             .any(|q| q.name().to_utf8() == META_QUERY_SERVICE_FQDN)
         {
-            // TODO: what if multiple questions, one with SERVICE_NAME and one with META_QUERY_SERVICE?
+            // TODO: what if multiple questions, one with SERVICE_NAME and one with
+            // META_QUERY_SERVICE?
             return Ok(Some(MdnsPacket::ServiceDiscovery(MdnsServiceDiscovery {
                 from,
                 query_id: packet.header().id(),
@@ -84,7 +90,8 @@ impl MdnsPacket {
 pub(crate) struct MdnsQuery {
     /// Sender of the address.
     from: SocketAddr,
-    /// Id of the received DNS query. We need to pass this ID back in the results.
+    /// Id of the received DNS query. We need to pass this ID back in the
+    /// results.
     query_id: u16,
 }
 
@@ -113,7 +120,8 @@ impl fmt::Debug for MdnsQuery {
 pub(crate) struct MdnsServiceDiscovery {
     /// Sender of the address.
     from: SocketAddr,
-    /// Id of the received DNS query. We need to pass this ID back in the results.
+    /// Id of the received DNS query. We need to pass this ID back in the
+    /// results.
     query_id: u16,
 }
 
@@ -202,7 +210,8 @@ impl MdnsResponse {
 
     /// Returns the list of peers that have been reported in this packet.
     ///
-    /// > **Note**: Keep in mind that this will also contain the responses we sent ourselves.
+    /// > **Note**: Keep in mind that this will also contain the responses we
+    /// > sent ourselves.
     fn discovered_peers(&self) -> impl Iterator<Item = &MdnsPeer> {
         self.peers.iter()
     }
@@ -307,8 +316,7 @@ impl fmt::Debug for MdnsPeer {
 
 #[cfg(test)]
 mod tests {
-    use super::super::dns::build_query_response;
-    use super::*;
+    use super::{super::dns::build_query_response, *};
 
     #[test]
     fn test_create_mdns_peer() {

--- a/protocols/mdns/src/behaviour/socket.rs
+++ b/protocols/mdns/src/behaviour/socket.rs
@@ -24,7 +24,8 @@ use std::{
     task::{Context, Poll},
 };
 
-/// Interface that must be implemented by the different runtimes to use the [`UdpSocket`] in async mode
+/// Interface that must be implemented by the different runtimes to use the
+/// [`UdpSocket`] in async mode
 #[allow(unreachable_pub)] // Users should not depend on this.
 pub trait AsyncSocket: Unpin + Send + 'static {
     /// Create the async socket from the [`std::net::UdpSocket`]
@@ -32,7 +33,8 @@ pub trait AsyncSocket: Unpin + Send + 'static {
     where
         Self: Sized;
 
-    /// Attempts to receive a single packet on the socket from the remote address to which it is connected.
+    /// Attempts to receive a single packet on the socket from the remote
+    /// address to which it is connected.
     fn poll_read(
         &mut self,
         _cx: &mut Context,
@@ -50,9 +52,10 @@ pub trait AsyncSocket: Unpin + Send + 'static {
 
 #[cfg(feature = "async-io")]
 pub(crate) mod asio {
-    use super::*;
     use async_io::Async;
     use futures::FutureExt;
+
+    use super::*;
 
     /// AsyncIo UdpSocket
     pub(crate) type AsyncUdpSocket = Async<UdpSocket>;
@@ -92,8 +95,9 @@ pub(crate) mod asio {
 
 #[cfg(feature = "tokio")]
 pub(crate) mod tokio {
-    use super::*;
     use ::tokio::{io::ReadBuf, net::UdpSocket as TkUdpSocket};
+
+    use super::*;
 
     /// Tokio ASync Socket`
     pub(crate) type TokioUdpSocket = TkUdpSocket;

--- a/protocols/mdns/src/behaviour/timer.rs
+++ b/protocols/mdns/src/behaviour/timer.rs
@@ -42,13 +42,15 @@ pub trait Builder: Send + Unpin + 'static {
 
 #[cfg(feature = "async-io")]
 pub(crate) mod asio {
-    use super::*;
-    use async_io::Timer as AsioTimer;
-    use futures::Stream;
     use std::{
         pin::Pin,
         task::{Context, Poll},
     };
+
+    use async_io::Timer as AsioTimer;
+    use futures::Stream;
+
+    use super::*;
 
     /// Async Timer
     pub(crate) type AsyncTimer = Timer<AsioTimer>;
@@ -83,13 +85,15 @@ pub(crate) mod asio {
 
 #[cfg(feature = "tokio")]
 pub(crate) mod tokio {
-    use super::*;
-    use ::tokio::time::{self, Instant as TokioInstant, Interval, MissedTickBehavior};
-    use futures::Stream;
     use std::{
         pin::Pin,
         task::{Context, Poll},
     };
+
+    use ::tokio::time::{self, Instant as TokioInstant, Interval, MissedTickBehavior};
+    use futures::Stream;
+
+    use super::*;
 
     /// Tokio wrapper
     pub(crate) type TokioTimer = Timer<Interval>;

--- a/protocols/mdns/src/lib.rs
+++ b/protocols/mdns/src/lib.rs
@@ -23,29 +23,28 @@
 //! mDNS is a protocol defined by [RFC 6762](https://tools.ietf.org/html/rfc6762) that allows
 //! querying nodes that correspond to a certain domain name.
 //!
-//! In the context of libp2p, the mDNS protocol is used to discover other nodes on the local
-//! network that support libp2p.
+//! In the context of libp2p, the mDNS protocol is used to discover other nodes
+//! on the local network that support libp2p.
 //!
 //! # Usage
 //!
-//! This crate provides a `Mdns` and `TokioMdns`, depending on the enabled features, which
-//! implements the `NetworkBehaviour` trait. This struct will automatically discover other
-//! libp2p nodes on the local network.
-//!
+//! This crate provides a `Mdns` and `TokioMdns`, depending on the enabled
+//! features, which implements the `NetworkBehaviour` trait. This struct will
+//! automatically discover other libp2p nodes on the local network.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use std::net::{Ipv4Addr, Ipv6Addr};
-use std::time::Duration;
+use std::{
+    net::{Ipv4Addr, Ipv6Addr},
+    time::Duration,
+};
 
 mod behaviour;
-pub use crate::behaviour::{Behaviour, Event};
-
 #[cfg(feature = "async-io")]
 pub use crate::behaviour::async_io;
-
 #[cfg(feature = "tokio")]
 pub use crate::behaviour::tokio;
+pub use crate::behaviour::{Behaviour, Event};
 
 /// The DNS service name for all libp2p peers used to query for addresses.
 const SERVICE_NAME: &[u8] = b"_p2p._udp.local";

--- a/protocols/mdns/tests/use-async-std.rs
+++ b/protocols/mdns/tests/use-async-std.rs
@@ -18,12 +18,12 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.use futures::StreamExt;
 
+use std::time::Duration;
+
 use futures::future::Either;
-use libp2p_mdns::Event;
-use libp2p_mdns::{async_io::Behaviour, Config};
+use libp2p_mdns::{async_io::Behaviour, Config, Event};
 use libp2p_swarm::{Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt as _;
-use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 
 #[async_std::test]
@@ -158,7 +158,8 @@ async fn create_swarm(config: Config) -> Swarm<Behaviour> {
     let mut swarm =
         Swarm::new_ephemeral(|key| Behaviour::new(config, key.public().to_peer_id()).unwrap());
 
-    // Manually listen on all interfaces because mDNS only works for non-loopback addresses.
+    // Manually listen on all interfaces because mDNS only works for non-loopback
+    // addresses.
     let expected_listener_id = swarm
         .listen_on("/ip4/0.0.0.0/tcp/0".parse().unwrap())
         .unwrap();

--- a/protocols/mdns/tests/use-tokio.rs
+++ b/protocols/mdns/tests/use-tokio.rs
@@ -17,11 +17,12 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.use futures::StreamExt;
+use std::time::Duration;
+
 use futures::future::Either;
 use libp2p_mdns::{tokio::Behaviour, Config, Event};
 use libp2p_swarm::{Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt as _;
-use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::test]
@@ -112,7 +113,8 @@ async fn create_swarm(config: Config) -> Swarm<Behaviour> {
     let mut swarm =
         Swarm::new_ephemeral(|key| Behaviour::new(config, key.public().to_peer_id()).unwrap());
 
-    // Manually listen on all interfaces because mDNS only works for non-loopback addresses.
+    // Manually listen on all interfaces because mDNS only works for non-loopback
+    // addresses.
     let expected_listener_id = swarm
         .listen_on("/ip4/0.0.0.0/tcp/0".parse().unwrap())
         .unwrap();

--- a/protocols/perf/src/bin/perf.rs
+++ b/protocols/perf/src/bin/perf.rs
@@ -23,12 +23,13 @@ use std::{net::SocketAddr, str::FromStr};
 use anyhow::{bail, Result};
 use clap::Parser;
 use futures::StreamExt;
-use libp2p::core::{multiaddr::Protocol, upgrade, Multiaddr};
-use libp2p::identity::PeerId;
-use libp2p::swarm::{NetworkBehaviour, Swarm, SwarmEvent};
-use libp2p::SwarmBuilder;
-use libp2p_perf::{client, server};
-use libp2p_perf::{Final, Intermediate, Run, RunParams, RunUpdate};
+use libp2p::{
+    core::{multiaddr::Protocol, upgrade, Multiaddr},
+    identity::PeerId,
+    swarm::{NetworkBehaviour, Swarm, SwarmEvent},
+    SwarmBuilder,
+};
+use libp2p_perf::{client, server, Final, Intermediate, Run, RunParams, RunUpdate};
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::EnvFilter;
 use web_time::{Duration, Instant};

--- a/protocols/perf/src/client.rs
+++ b/protocols/perf/src/client.rs
@@ -21,11 +21,13 @@
 mod behaviour;
 mod handler;
 
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::{
+    convert::Infallible,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 pub use behaviour::{Behaviour, Event};
 use libp2p_swarm::StreamUpgradeError;
-use std::convert::Infallible;
 
 static NEXT_RUN_ID: AtomicUsize = AtomicUsize::new(1);
 

--- a/protocols/perf/src/client/behaviour.rs
+++ b/protocols/perf/src/client/behaviour.rs
@@ -28,14 +28,19 @@ use std::{
 use libp2p_core::{transport::PortUse, Multiaddr};
 use libp2p_identity::PeerId;
 use libp2p_swarm::{
-    derive_prelude::ConnectionEstablished, ConnectionClosed, ConnectionId, FromSwarm,
-    NetworkBehaviour, NotifyHandler, THandlerInEvent, THandlerOutEvent, ToSwarm,
+    derive_prelude::ConnectionEstablished,
+    ConnectionClosed,
+    ConnectionId,
+    FromSwarm,
+    NetworkBehaviour,
+    NotifyHandler,
+    THandlerInEvent,
+    THandlerOutEvent,
+    ToSwarm,
 };
 
-use crate::RunParams;
-use crate::{client::handler::Handler, RunUpdate};
-
 use super::{RunError, RunId};
+use crate::{client::handler::Handler, RunParams, RunUpdate};
 
 #[derive(Debug)]
 pub struct Event {

--- a/protocols/perf/src/client/handler.rs
+++ b/protocols/perf/src/client/handler.rs
@@ -30,14 +30,23 @@ use futures::{
 use libp2p_core::upgrade::{DeniedUpgrade, ReadyUpgrade};
 use libp2p_swarm::{
     handler::{
-        ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
+        ConnectionEvent,
+        DialUpgradeError,
+        FullyNegotiatedInbound,
+        FullyNegotiatedOutbound,
         ListenUpgradeError,
     },
-    ConnectionHandler, ConnectionHandlerEvent, StreamProtocol, SubstreamProtocol,
+    ConnectionHandler,
+    ConnectionHandlerEvent,
+    StreamProtocol,
+    SubstreamProtocol,
 };
 
-use crate::client::{RunError, RunId};
-use crate::{RunParams, RunUpdate};
+use crate::{
+    client::{RunError, RunId},
+    RunParams,
+    RunUpdate,
+};
 
 #[derive(Debug)]
 pub struct Command {

--- a/protocols/perf/src/lib.rs
+++ b/protocols/perf/src/lib.rs
@@ -77,8 +77,8 @@ pub struct Final {
 
 /// Parameters for a single run, i.e. one stream, sending and receiving data.
 ///
-/// Property names are from the perspective of the actor. E.g. `to_send` is the amount of data to
-/// send, both as the client and the server.
+/// Property names are from the perspective of the actor. E.g. `to_send` is the
+/// amount of data to send, both as the client and the server.
 #[derive(Debug, Clone, Copy)]
 pub struct RunParams {
     pub to_send: usize,

--- a/protocols/perf/src/protocol.rs
+++ b/protocols/perf/src/protocol.rs
@@ -18,14 +18,21 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures_timer::Delay;
 use std::time::Duration;
-use web_time::Instant;
 
 use futures::{
     future::{select, Either},
-    AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, FutureExt, SinkExt, Stream, StreamExt,
+    AsyncRead,
+    AsyncReadExt,
+    AsyncWrite,
+    AsyncWriteExt,
+    FutureExt,
+    SinkExt,
+    Stream,
+    StreamExt,
 };
+use futures_timer::Delay;
+use web_time::Instant;
 
 use crate::{Final, Intermediate, Run, RunDuration, RunParams, RunUpdate};
 
@@ -36,8 +43,8 @@ pub(crate) fn send_receive<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
     params: RunParams,
     stream: S,
 ) -> impl Stream<Item = Result<RunUpdate, std::io::Error>> {
-    // Use a channel to simulate a generator. `send_receive_inner` can `yield` events through the
-    // channel.
+    // Use a channel to simulate a generator. `send_receive_inner` can `yield`
+    // events through the channel.
     let (sender, receiver) = futures::channel::mpsc::channel(0);
     let receiver = receiver.fuse();
     let inner = send_receive_inner(params, stream, sender).fuse();

--- a/protocols/perf/src/server/behaviour.rs
+++ b/protocols/perf/src/server/behaviour.rs
@@ -28,11 +28,15 @@ use std::{
 use libp2p_core::transport::PortUse;
 use libp2p_identity::PeerId;
 use libp2p_swarm::{
-    ConnectionId, FromSwarm, NetworkBehaviour, THandlerInEvent, THandlerOutEvent, ToSwarm,
+    ConnectionId,
+    FromSwarm,
+    NetworkBehaviour,
+    THandlerInEvent,
+    THandlerOutEvent,
+    ToSwarm,
 };
 
-use crate::server::handler::Handler;
-use crate::Run;
+use crate::{server::handler::Handler, Run};
 
 #[derive(Debug)]
 pub struct Event {

--- a/protocols/perf/src/server/handler.rs
+++ b/protocols/perf/src/server/handler.rs
@@ -18,18 +18,26 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::task::{Context, Poll};
+use std::{
+    convert::Infallible,
+    task::{Context, Poll},
+};
 
 use futures::FutureExt;
 use libp2p_core::upgrade::{DeniedUpgrade, ReadyUpgrade};
 use libp2p_swarm::{
     handler::{
-        ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
+        ConnectionEvent,
+        DialUpgradeError,
+        FullyNegotiatedInbound,
+        FullyNegotiatedOutbound,
         ListenUpgradeError,
     },
-    ConnectionHandler, ConnectionHandlerEvent, StreamProtocol, SubstreamProtocol,
+    ConnectionHandler,
+    ConnectionHandlerEvent,
+    StreamProtocol,
+    SubstreamProtocol,
 };
-use std::convert::Infallible;
 use tracing::error;
 
 use crate::Run;

--- a/protocols/perf/tests/lib.rs
+++ b/protocols/perf/tests/lib.rs
@@ -20,7 +20,8 @@
 
 use libp2p_perf::{
     client::{self},
-    server, RunParams,
+    server,
+    RunParams,
 };
 use libp2p_swarm::{Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt;

--- a/protocols/ping/src/handler.rs
+++ b/protocols/ping/src/handler.rs
@@ -18,26 +18,33 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::{protocol, PROTOCOL_NAME};
-use futures::future::{BoxFuture, Either};
-use futures::prelude::*;
-use futures_timer::Delay;
-use libp2p_core::upgrade::ReadyUpgrade;
-use libp2p_swarm::handler::{
-    ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
-};
-use libp2p_swarm::{
-    ConnectionHandler, ConnectionHandlerEvent, Stream, StreamProtocol, StreamUpgradeError,
-    SubstreamProtocol,
-};
-use std::collections::VecDeque;
-use std::convert::Infallible;
 use std::{
+    collections::VecDeque,
+    convert::Infallible,
     error::Error,
-    fmt, io,
+    fmt,
+    io,
     task::{Context, Poll},
     time::Duration,
 };
+
+use futures::{
+    future::{BoxFuture, Either},
+    prelude::*,
+};
+use futures_timer::Delay;
+use libp2p_core::upgrade::ReadyUpgrade;
+use libp2p_swarm::{
+    handler::{ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound},
+    ConnectionHandler,
+    ConnectionHandlerEvent,
+    Stream,
+    StreamProtocol,
+    StreamUpgradeError,
+    SubstreamProtocol,
+};
+
+use crate::{protocol, PROTOCOL_NAME};
 
 /// The configuration for outbound pings.
 #[derive(Debug, Clone)]
@@ -154,7 +161,8 @@ enum State {
     Inactive {
         /// Whether or not we've reported the missing support yet.
         ///
-        /// This is used to avoid repeated events being emitted for a specific connection.
+        /// This is used to avoid repeated events being emitted for a specific
+        /// connection.
         reported: bool,
     },
     /// We are actively pinging the other peer.
@@ -185,7 +193,8 @@ impl Handler {
         self.outbound = None; // Request a new substream on the next `poll`.
 
         // Timer is already polled and expired before substream request is initiated
-        // and will be polled again later on in our `poll` because we reset `self.outbound`.
+        // and will be polled again later on in our `poll` because we reset
+        // `self.outbound`.
         //
         // `futures-timer` allows an expired timer to be polled again and returns
         // immediately `Poll::Ready`. However in its WASM implementation there is

--- a/protocols/ping/src/lib.rs
+++ b/protocols/ping/src/lib.rs
@@ -27,9 +27,11 @@
 //! # Usage
 //!
 //! The [`Behaviour`] struct implements the [`NetworkBehaviour`] trait.
-//! It will respond to inbound ping requests and periodically send outbound ping requests on every established connection.
+//! It will respond to inbound ping requests and periodically send outbound ping
+//! requests on every established connection.
 //!
-//! It is up to the user to implement a health-check / connection management policy based on the ping protocol.
+//! It is up to the user to implement a health-check / connection management
+//! policy based on the ping protocol.
 //!
 //! For example:
 //!
@@ -39,8 +41,10 @@
 //!
 //! Users should inspect emitted [`Event`]s and call APIs on [`Swarm`]:
 //!
-//! - [`Swarm::close_connection`](libp2p_swarm::Swarm::close_connection) to close a specific connection
-//! - [`Swarm::disconnect_peer_id`](libp2p_swarm::Swarm::disconnect_peer_id) to close all connections to a peer
+//! - [`Swarm::close_connection`](libp2p_swarm::Swarm::close_connection) to
+//!   close a specific connection
+//! - [`Swarm::disconnect_peer_id`](libp2p_swarm::Swarm::disconnect_peer_id) to
+//!   close all connections to a peer
 //!
 //! [`Swarm`]: libp2p_swarm::Swarm
 //! [`Transport`]: libp2p_core::Transport
@@ -50,22 +54,28 @@
 mod handler;
 mod protocol;
 
-use handler::Handler;
-use libp2p_core::transport::PortUse;
-use libp2p_core::{Endpoint, Multiaddr};
-use libp2p_identity::PeerId;
-use libp2p_swarm::{
-    behaviour::FromSwarm, ConnectionDenied, ConnectionId, NetworkBehaviour, THandler,
-    THandlerInEvent, THandlerOutEvent, ToSwarm,
-};
-use std::time::Duration;
 use std::{
     collections::VecDeque,
     task::{Context, Poll},
+    time::Duration,
+};
+
+use handler::Handler;
+pub use handler::{Config, Failure};
+use libp2p_core::{transport::PortUse, Endpoint, Multiaddr};
+use libp2p_identity::PeerId;
+use libp2p_swarm::{
+    behaviour::FromSwarm,
+    ConnectionDenied,
+    ConnectionId,
+    NetworkBehaviour,
+    THandler,
+    THandlerInEvent,
+    THandlerOutEvent,
+    ToSwarm,
 };
 
 pub use self::protocol::PROTOCOL_NAME;
-pub use handler::{Config, Failure};
 
 /// A [`NetworkBehaviour`] that responds to inbound pings and
 /// periodically sends outbound pings on every established connection.

--- a/protocols/ping/src/protocol.rs
+++ b/protocols/ping/src/protocol.rs
@@ -18,10 +18,11 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::{io, time::Duration};
+
 use futures::prelude::*;
 use libp2p_swarm::StreamProtocol;
 use rand::{distributions, prelude::*};
-use std::{io, time::Duration};
 use web_time::Instant;
 
 pub const PROTOCOL_NAME: StreamProtocol = StreamProtocol::new("/ipfs/ping/1.0.0");
@@ -40,10 +41,10 @@ pub const PROTOCOL_NAME: StreamProtocol = StreamProtocol::new("/ipfs/ping/1.0.0"
 /// Successful pings report the round-trip time.
 ///
 /// > **Note**: The round-trip time of a ping may be subject to delays induced
-/// >           by the underlying transport, e.g. in the case of TCP there is
-/// >           Nagle's algorithm, delayed acks and similar configuration options
-/// >           which can affect latencies especially on otherwise low-volume
-/// >           connections.
+/// > by the underlying transport, e.g. in the case of TCP there is
+/// > Nagle's algorithm, delayed acks and similar configuration options
+/// > which can affect latencies especially on otherwise low-volume
+/// > connections.
 const PING_SIZE: usize = 32;
 
 /// Sends a ping and waits for the pong.
@@ -81,13 +82,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use futures::StreamExt;
     use libp2p_core::{
         multiaddr::multiaddr,
         transport::{memory::MemoryTransport, DialOpts, ListenerId, PortUse, Transport},
         Endpoint,
     };
+
+    use super::*;
 
     #[tokio::test]
     async fn ping_pong() {

--- a/protocols/ping/tests/ping.rs
+++ b/protocols/ping/tests/ping.rs
@@ -20,12 +20,12 @@
 
 //! Integration tests for the `Ping` network behaviour.
 
+use std::{num::NonZeroU8, time::Duration};
+
 use libp2p_ping as ping;
-use libp2p_swarm::dummy;
-use libp2p_swarm::{Swarm, SwarmEvent};
+use libp2p_swarm::{dummy, Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt;
 use quickcheck::*;
-use std::{num::NonZeroU8, time::Duration};
 
 #[tokio::test]
 async fn ping_pong() {

--- a/protocols/relay/src/behaviour.rs
+++ b/protocols/relay/src/behaviour.rs
@@ -22,26 +22,38 @@
 
 pub(crate) mod handler;
 pub(crate) mod rate_limiter;
-use crate::behaviour::handler::Handler;
-use crate::multiaddr_ext::MultiaddrExt;
-use crate::proto;
-use crate::protocol::{inbound_hop, outbound_stop};
-use either::Either;
-use libp2p_core::multiaddr::Protocol;
-use libp2p_core::transport::PortUse;
-use libp2p_core::{ConnectedPoint, Endpoint, Multiaddr};
-use libp2p_identity::PeerId;
-use libp2p_swarm::behaviour::{ConnectionClosed, FromSwarm};
-use libp2p_swarm::{
-    dummy, ConnectionDenied, ConnectionId, ExternalAddresses, NetworkBehaviour, NotifyHandler,
-    THandler, THandlerInEvent, THandlerOutEvent, ToSwarm,
+use std::{
+    collections::{hash_map, HashMap, HashSet, VecDeque},
+    num::NonZeroU32,
+    ops::Add,
+    task::{Context, Poll},
+    time::Duration,
 };
-use std::collections::{hash_map, HashMap, HashSet, VecDeque};
-use std::num::NonZeroU32;
-use std::ops::Add;
-use std::task::{Context, Poll};
-use std::time::Duration;
+
+use either::Either;
+use libp2p_core::{multiaddr::Protocol, transport::PortUse, ConnectedPoint, Endpoint, Multiaddr};
+use libp2p_identity::PeerId;
+use libp2p_swarm::{
+    behaviour::{ConnectionClosed, FromSwarm},
+    dummy,
+    ConnectionDenied,
+    ConnectionId,
+    ExternalAddresses,
+    NetworkBehaviour,
+    NotifyHandler,
+    THandler,
+    THandlerInEvent,
+    THandlerOutEvent,
+    ToSwarm,
+};
 use web_time::Instant;
+
+use crate::{
+    behaviour::handler::Handler,
+    multiaddr_ext::MultiaddrExt,
+    proto,
+    protocol::{inbound_hop, outbound_stop},
+};
 
 /// Configuration for the relay [`Behaviour`].
 ///
@@ -120,12 +132,14 @@ impl std::fmt::Debug for Config {
 impl Default for Config {
     fn default() -> Self {
         let reservation_rate_limiters = vec![
-            // For each peer ID one reservation every 2 minutes with up to 30 reservations per hour.
+            // For each peer ID one reservation every 2 minutes with up to 30 reservations per
+            // hour.
             rate_limiter::new_per_peer(rate_limiter::GenericRateLimiterConfig {
                 limit: NonZeroU32::new(30).expect("30 > 0"),
                 interval: Duration::from_secs(60 * 2),
             }),
-            // For each IP address one reservation every minute with up to 60 reservations per hour.
+            // For each IP address one reservation every minute with up to 60 reservations per
+            // hour.
             rate_limiter::new_per_ip(rate_limiter::GenericRateLimiterConfig {
                 limit: NonZeroU32::new(60).expect("60 > 0"),
                 interval: Duration::from_secs(60),
@@ -381,12 +395,13 @@ impl NetworkBehaviour for Behaviour {
 
                 assert!(
                     !endpoint.is_relayed(),
-                    "`dummy::ConnectionHandler` handles relayed connections. It \
-                     denies all inbound substreams."
+                    "`dummy::ConnectionHandler` handles relayed connections. It denies all \
+                     inbound substreams."
                 );
 
                 let action = if
-                // Deny if it is a new reservation and exceeds `max_reservations_per_peer`.
+                // Deny if it is a new reservation and exceeds
+                // `max_reservations_per_peer`.
                 (!renewed
                     && self
                         .reservations
@@ -495,9 +510,9 @@ impl NetworkBehaviour for Behaviour {
                     }
                     hash_map::Entry::Vacant(_) => {
                         unreachable!(
-                            "Expect to track timed out reservation with peer {:?} on connection {:?}",
-                            event_source,
-                            connection,
+                            "Expect to track timed out reservation with peer {:?} on connection \
+                             {:?}",
+                            event_source, connection,
                         );
                     }
                 }
@@ -515,8 +530,8 @@ impl NetworkBehaviour for Behaviour {
 
                 assert!(
                     !endpoint.is_relayed(),
-                    "`dummy::ConnectionHandler` handles relayed connections. It \
-                     denies all inbound substreams."
+                    "`dummy::ConnectionHandler` handles relayed connections. It denies all \
+                     inbound substreams."
                 );
 
                 let action = if self.circuits.num_circuits_of_peer(event_source)

--- a/protocols/relay/src/behaviour/handler.rs
+++ b/protocols/relay/src/behaviour/handler.rs
@@ -18,31 +18,44 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::behaviour::CircuitId;
-use crate::copy_future::CopyFuture;
-use crate::protocol::{inbound_hop, outbound_stop};
-use crate::{proto, HOP_PROTOCOL_NAME, STOP_PROTOCOL_NAME};
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt,
+    io,
+    task::{Context, Poll},
+    time::Duration,
+};
+
 use bytes::Bytes;
 use either::Either;
-use futures::future::{BoxFuture, FutureExt, TryFutureExt};
-use futures::io::AsyncWriteExt;
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures::{
+    future::{BoxFuture, FutureExt, TryFutureExt},
+    io::AsyncWriteExt,
+    stream::{FuturesUnordered, StreamExt},
+};
 use futures_timer::Delay;
-use libp2p_core::upgrade::ReadyUpgrade;
-use libp2p_core::{ConnectedPoint, Multiaddr};
+use libp2p_core::{upgrade::ReadyUpgrade, ConnectedPoint, Multiaddr};
 use libp2p_identity::PeerId;
-use libp2p_swarm::handler::{
-    ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
-};
 use libp2p_swarm::{
-    ConnectionHandler, ConnectionHandlerEvent, ConnectionId, Stream, StreamProtocol,
-    StreamUpgradeError, SubstreamProtocol,
+    handler::{ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound},
+    ConnectionHandler,
+    ConnectionHandlerEvent,
+    ConnectionId,
+    Stream,
+    StreamProtocol,
+    StreamUpgradeError,
+    SubstreamProtocol,
 };
-use std::collections::{HashMap, VecDeque};
-use std::task::{Context, Poll};
-use std::time::Duration;
-use std::{fmt, io};
 use web_time::Instant;
+
+use crate::{
+    behaviour::CircuitId,
+    copy_future::CopyFuture,
+    proto,
+    protocol::{inbound_hop, outbound_stop},
+    HOP_PROTOCOL_NAME,
+    STOP_PROTOCOL_NAME,
+};
 
 const MAX_CONCURRENT_STREAMS_PER_CONNECTION: usize = 10;
 const STREAM_TIMEOUT: Duration = Duration::from_secs(60);

--- a/protocols/relay/src/behaviour/rate_limiter.rs
+++ b/protocols/relay/src/behaviour/rate_limiter.rs
@@ -18,18 +18,20 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::{
+    collections::{HashMap, VecDeque},
+    hash::Hash,
+    net::IpAddr,
+    num::NonZeroU32,
+    time::Duration,
+};
+
 use libp2p_core::multiaddr::{Multiaddr, Protocol};
 use libp2p_identity::PeerId;
-use std::collections::{HashMap, VecDeque};
-use std::hash::Hash;
-use std::net::IpAddr;
-use std::num::NonZeroU32;
-use std::time::Duration;
 use web_time::Instant;
 
 /// Allows rate limiting access to some resource based on the [`PeerId`] and
 /// [`Multiaddr`] of a remote peer.
-//
 // See [`new_per_peer`] and [`new_per_ip`] for precast implementations. Use
 // [`GenericRateLimiter`] to build your own, e.g. based on the autonomous system
 // number of a peers IP address.
@@ -120,8 +122,9 @@ impl<Id: Eq + PartialEq + Hash + Clone> GenericRateLimiter<Id> {
     }
 
     fn refill(&mut self, now: Instant) {
-        // Note when used with a high number of buckets: This loop refills all the to-be-refilled
-        // buckets at once, thus potentially delaying the parent call to `try_next`.
+        // Note when used with a high number of buckets: This loop refills all the
+        // to-be-refilled buckets at once, thus potentially delaying the parent
+        // call to `try_next`.
         loop {
             match self.refill_schedule.front() {
                 // Only continue if (a) there is a bucket and (b) the bucket has not already been
@@ -170,8 +173,9 @@ impl<Id: Eq + PartialEq + Hash + Clone> GenericRateLimiter<Id> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use quickcheck::{QuickCheck, TestResult};
+
+    use super::*;
 
     #[test]
     fn first() {

--- a/protocols/relay/src/lib.rs
+++ b/protocols/relay/src/lib.rs
@@ -32,10 +32,15 @@ mod protocol;
 mod proto {
     #![allow(unreachable_pub)]
     include!("generated/mod.rs");
-    pub(crate) use self::message_v2::pb::mod_HopMessage::Type as HopMessageType;
     pub use self::message_v2::pb::mod_StopMessage::Type as StopMessageType;
     pub(crate) use self::message_v2::pb::{
-        HopMessage, Limit, Peer, Reservation, Status, StopMessage,
+        mod_HopMessage::Type as HopMessageType,
+        HopMessage,
+        Limit,
+        Peer,
+        Reservation,
+        Status,
+        StopMessage,
     };
 }
 

--- a/protocols/relay/src/multiaddr_ext.rs
+++ b/protocols/relay/src/multiaddr_ext.rs
@@ -1,5 +1,4 @@
-use libp2p_core::multiaddr::Protocol;
-use libp2p_core::Multiaddr;
+use libp2p_core::{multiaddr::Protocol, Multiaddr};
 
 pub(crate) trait MultiaddrExt {
     fn is_relayed(&self) -> bool;

--- a/protocols/relay/src/priv_client/handler.rs
+++ b/protocols/relay/src/priv_client/handler.rs
@@ -18,29 +18,41 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::client::Connection;
-use crate::priv_client::transport;
-use crate::priv_client::transport::ToListenerMsg;
-use crate::protocol::{self, inbound_stop, outbound_hop};
-use crate::{priv_client, proto, HOP_PROTOCOL_NAME, STOP_PROTOCOL_NAME};
-use futures::channel::mpsc::Sender;
-use futures::channel::{mpsc, oneshot};
-use futures::future::FutureExt;
+use std::{
+    collections::VecDeque,
+    convert::Infallible,
+    fmt,
+    io,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use futures::{
+    channel::{mpsc, mpsc::Sender, oneshot},
+    future::FutureExt,
+};
 use futures_timer::Delay;
-use libp2p_core::multiaddr::Protocol;
-use libp2p_core::upgrade::ReadyUpgrade;
-use libp2p_core::Multiaddr;
+use libp2p_core::{multiaddr::Protocol, upgrade::ReadyUpgrade, Multiaddr};
 use libp2p_identity::PeerId;
-use libp2p_swarm::handler::{ConnectionEvent, FullyNegotiatedInbound};
 use libp2p_swarm::{
-    ConnectionHandler, ConnectionHandlerEvent, Stream, StreamProtocol, StreamUpgradeError,
+    handler::{ConnectionEvent, FullyNegotiatedInbound},
+    ConnectionHandler,
+    ConnectionHandlerEvent,
+    Stream,
+    StreamProtocol,
+    StreamUpgradeError,
     SubstreamProtocol,
 };
-use std::collections::VecDeque;
-use std::convert::Infallible;
-use std::task::{Context, Poll};
-use std::time::Duration;
-use std::{fmt, io};
+
+use crate::{
+    client::Connection,
+    priv_client,
+    priv_client::{transport, transport::ToListenerMsg},
+    proto,
+    protocol::{self, inbound_stop, outbound_hop},
+    HOP_PROTOCOL_NAME,
+    STOP_PROTOCOL_NAME,
+};
 
 /// The maximum number of circuits being denied concurrently.
 ///

--- a/protocols/relay/src/protocol.rs
+++ b/protocols/relay/src/protocol.rs
@@ -18,9 +18,11 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::proto;
-use libp2p_swarm::StreamProtocol;
 use std::time::Duration;
+
+use libp2p_swarm::StreamProtocol;
+
+use crate::proto;
 
 pub(crate) mod inbound_hop;
 pub(crate) mod inbound_stop;

--- a/protocols/relay/src/protocol/inbound_hop.rs
+++ b/protocols/relay/src/protocol/inbound_hop.rs
@@ -19,21 +19,18 @@
 // DEALINGS IN THE SOFTWARE.
 
 use std::time::Duration;
-use web_time::SystemTime;
 
 use asynchronous_codec::{Framed, FramedParts};
 use bytes::Bytes;
 use either::Either;
 use futures::prelude::*;
-use thiserror::Error;
-
 use libp2p_core::Multiaddr;
 use libp2p_identity::PeerId;
 use libp2p_swarm::Stream;
+use thiserror::Error;
+use web_time::SystemTime;
 
-use crate::proto;
-use crate::proto::message_v2::pb::mod_HopMessage::Type;
-use crate::protocol::MAX_MESSAGE_SIZE;
+use crate::{proto, proto::message_v2::pb::mod_HopMessage::Type, protocol::MAX_MESSAGE_SIZE};
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/protocols/relay/src/protocol/inbound_stop.rs
+++ b/protocols/relay/src/protocol/inbound_stop.rs
@@ -18,15 +18,19 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::proto;
-use crate::protocol::{self, MAX_MESSAGE_SIZE};
+use std::io;
+
 use asynchronous_codec::{Framed, FramedParts};
 use bytes::Bytes;
 use futures::prelude::*;
 use libp2p_identity::PeerId;
 use libp2p_swarm::Stream;
-use std::io;
 use thiserror::Error;
+
+use crate::{
+    proto,
+    protocol::{self, MAX_MESSAGE_SIZE},
+};
 
 pub(crate) async fn handle_open_circuit(io: Stream) -> Result<Circuit, Error> {
     let mut substream = Framed::new(io, quick_protobuf_codec::Codec::new(MAX_MESSAGE_SIZE));

--- a/protocols/relay/src/protocol/outbound_hop.rs
+++ b/protocols/relay/src/protocol/outbound_hop.rs
@@ -18,22 +18,23 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::io;
-use std::time::Duration;
+use std::{io, time::Duration};
 
 use asynchronous_codec::{Framed, FramedParts};
 use bytes::Bytes;
 use futures::prelude::*;
 use futures_timer::Delay;
-use thiserror::Error;
-use web_time::SystemTime;
-
 use libp2p_core::Multiaddr;
 use libp2p_identity::PeerId;
 use libp2p_swarm::Stream;
+use thiserror::Error;
+use web_time::SystemTime;
 
-use crate::protocol::{Limit, MAX_MESSAGE_SIZE};
-use crate::{proto, HOP_PROTOCOL_NAME};
+use crate::{
+    proto,
+    protocol::{Limit, MAX_MESSAGE_SIZE},
+    HOP_PROTOCOL_NAME,
+};
 
 #[derive(Debug, Error)]
 pub enum ConnectError {

--- a/protocols/relay/src/protocol/outbound_stop.rs
+++ b/protocols/relay/src/protocol/outbound_stop.rs
@@ -18,19 +18,16 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::io;
-use std::time::Duration;
+use std::{io, time::Duration};
 
 use asynchronous_codec::{Framed, FramedParts};
 use bytes::Bytes;
 use futures::prelude::*;
-use thiserror::Error;
-
 use libp2p_identity::PeerId;
 use libp2p_swarm::Stream;
+use thiserror::Error;
 
-use crate::protocol::MAX_MESSAGE_SIZE;
-use crate::{proto, STOP_PROTOCOL_NAME};
+use crate::{proto, protocol::MAX_MESSAGE_SIZE, STOP_PROTOCOL_NAME};
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/protocols/relay/tests/lib.rs
+++ b/protocols/relay/tests/lib.rs
@@ -18,26 +18,28 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures::executor::LocalPool;
-use futures::future::FutureExt;
-use futures::io::{AsyncRead, AsyncWrite};
-use futures::stream::StreamExt;
-use futures::task::Spawn;
-use libp2p_core::multiaddr::{Multiaddr, Protocol};
-use libp2p_core::muxing::StreamMuxerBox;
-use libp2p_core::transport::choice::OrTransport;
-use libp2p_core::transport::{Boxed, MemoryTransport, Transport};
-use libp2p_core::upgrade;
+use std::{error::Error, time::Duration};
+
+use futures::{
+    executor::LocalPool,
+    future::FutureExt,
+    io::{AsyncRead, AsyncWrite},
+    stream::StreamExt,
+    task::Spawn,
+};
+use libp2p_core::{
+    multiaddr::{Multiaddr, Protocol},
+    muxing::StreamMuxerBox,
+    transport::{choice::OrTransport, Boxed, MemoryTransport, Transport},
+    upgrade,
+};
 use libp2p_identity as identity;
 use libp2p_identity::PeerId;
 use libp2p_ping as ping;
 use libp2p_plaintext as plaintext;
 use libp2p_relay as relay;
-use libp2p_swarm::dial_opts::DialOpts;
-use libp2p_swarm::{Config, DialError, NetworkBehaviour, Swarm, SwarmEvent};
+use libp2p_swarm::{dial_opts::DialOpts, Config, DialError, NetworkBehaviour, Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt;
-use std::error::Error;
-use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 
 #[test]
@@ -355,7 +357,8 @@ fn propagate_connect_error_to_unknown_peer_to_dialer() {
 
     let mut src = build_client();
 
-    let dst_peer_id = PeerId::random(); // We don't have a destination peer in this test, so the CONNECT request will fail.
+    let dst_peer_id = PeerId::random(); // We don't have a destination peer in this test, so the CONNECT request will
+                                        // fail.
     let dst_addr = relay_addr
         .with(Protocol::P2p(relay_peer_id))
         .with(Protocol::P2pCircuit)
@@ -414,7 +417,8 @@ fn reuse_connection() {
         .with(Protocol::P2p(relay_peer_id))
         .with(Protocol::P2pCircuit);
 
-    // To reuse the connection, we need to ensure it is not shut down due to being idle.
+    // To reuse the connection, we need to ensure it is not shut down due to being
+    // idle.
     let mut client = build_client_with_config(
         Config::with_async_std_executor().with_idle_connection_timeout(Duration::from_secs(1)),
     );

--- a/protocols/rendezvous/src/client.rs
+++ b/protocols/rendezvous/src/client.rs
@@ -18,24 +18,42 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::codec::Message::*;
-use crate::codec::{Cookie, ErrorCode, Message, Namespace, NewRegistration, Registration, Ttl};
-use futures::future::BoxFuture;
-use futures::future::FutureExt;
-use futures::stream::FuturesUnordered;
-use futures::stream::StreamExt;
-use libp2p_core::transport::PortUse;
-use libp2p_core::{Endpoint, Multiaddr, PeerRecord};
+use std::{
+    collections::HashMap,
+    iter,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use futures::{
+    future::{BoxFuture, FutureExt},
+    stream::{FuturesUnordered, StreamExt},
+};
+use libp2p_core::{transport::PortUse, Endpoint, Multiaddr, PeerRecord};
 use libp2p_identity::{Keypair, PeerId, SigningError};
 use libp2p_request_response::{OutboundRequestId, ProtocolSupport};
 use libp2p_swarm::{
-    ConnectionDenied, ConnectionId, ExternalAddresses, FromSwarm, NetworkBehaviour, THandler,
-    THandlerInEvent, THandlerOutEvent, ToSwarm,
+    ConnectionDenied,
+    ConnectionId,
+    ExternalAddresses,
+    FromSwarm,
+    NetworkBehaviour,
+    THandler,
+    THandlerInEvent,
+    THandlerOutEvent,
+    ToSwarm,
 };
-use std::collections::HashMap;
-use std::iter;
-use std::task::{Context, Poll};
-use std::time::Duration;
+
+use crate::codec::{
+    Cookie,
+    ErrorCode,
+    Message,
+    Message::*,
+    Namespace,
+    NewRegistration,
+    Registration,
+    Ttl,
+};
 
 pub struct Behaviour {
     inner: libp2p_request_response::Behaviour<crate::codec::Codec>,
@@ -47,12 +65,15 @@ pub struct Behaviour {
 
     /// Hold addresses of all peers that we have discovered so far.
     ///
-    /// Storing these internally allows us to assist the [`libp2p_swarm::Swarm`] in dialing by returning addresses from [`NetworkBehaviour::handle_pending_outbound_connection`].
+    /// Storing these internally allows us to assist the [`libp2p_swarm::Swarm`]
+    /// in dialing by returning addresses from
+    /// [`NetworkBehaviour::handle_pending_outbound_connection`].
     discovered_peers: HashMap<(PeerId, Namespace), Vec<Multiaddr>>,
 
     registered_namespaces: HashMap<(PeerId, Namespace), Ttl>,
 
-    /// Tracks the expiry of registrations that we have discovered and stored in `discovered_peers` otherwise we have a memory leak.
+    /// Tracks the expiry of registrations that we have discovered and stored in
+    /// `discovered_peers` otherwise we have a memory leak.
     expiring_registrations: FuturesUnordered<BoxFuture<'static, (PeerId, Namespace)>>,
 
     external_addresses: ExternalAddresses,
@@ -79,9 +100,11 @@ impl Behaviour {
         }
     }
 
-    /// Register our external addresses in the given namespace with the given rendezvous peer.
+    /// Register our external addresses in the given namespace with the given
+    /// rendezvous peer.
     ///
-    /// External addresses are either manually added via [`libp2p_swarm::Swarm::add_external_address`] or reported
+    /// External addresses are either manually added via
+    /// [`libp2p_swarm::Swarm::add_external_address`] or reported
     /// by other [`NetworkBehaviour`]s via [`ToSwarm::ExternalAddrConfirmed`].
     pub fn register(
         &mut self,
@@ -105,7 +128,8 @@ impl Behaviour {
         Ok(())
     }
 
-    /// Unregister ourselves from the given namespace with the given rendezvous peer.
+    /// Unregister ourselves from the given namespace with the given rendezvous
+    /// peer.
     pub fn unregister(&mut self, namespace: Namespace, rendezvous_node: PeerId) {
         self.registered_namespaces
             .retain(|(rz_node, ns), _| rz_node.ne(&rendezvous_node) && ns.ne(&namespace));
@@ -119,8 +143,8 @@ impl Behaviour {
     /// If desired, the registrations can be filtered by a namespace.
     /// If no namespace is given, peers from all namespaces will be returned.
     /// A successfully discovery returns a cookie within [`Event::Discovered`].
-    /// Such a cookie can be used to only fetch the _delta_ of registrations since
-    /// the cookie was acquired.
+    /// Such a cookie can be used to only fetch the _delta_ of registrations
+    /// since the cookie was acquired.
     pub fn discover(
         &mut self,
         namespace: Option<Namespace>,
@@ -153,7 +177,8 @@ pub enum RegisterError {
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum Event {
-    /// We successfully discovered other nodes with using the contained rendezvous node.
+    /// We successfully discovered other nodes with using the contained
+    /// rendezvous node.
     Discovered {
         rendezvous_node: PeerId,
         registrations: Vec<Registration>,

--- a/protocols/rendezvous/src/codec.rs
+++ b/protocols/rendezvous/src/codec.rs
@@ -18,16 +18,17 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::DEFAULT_TTL;
+use std::{fmt, io};
+
 use async_trait::async_trait;
-use asynchronous_codec::{BytesMut, Decoder, Encoder};
-use asynchronous_codec::{FramedRead, FramedWrite};
+use asynchronous_codec::{BytesMut, Decoder, Encoder, FramedRead, FramedWrite};
 use futures::{AsyncRead, AsyncWrite, SinkExt, StreamExt};
 use libp2p_core::{peer_record, signed_envelope, PeerRecord, SignedEnvelope};
 use libp2p_swarm::StreamProtocol;
 use quick_protobuf_codec::Codec as ProtobufCodec;
 use rand::RngCore;
-use std::{fmt, io};
+
+use crate::DEFAULT_TTL;
 
 pub type Ttl = u64;
 pub(crate) type Limit = u64;
@@ -54,7 +55,10 @@ pub struct Namespace(String);
 impl Namespace {
     /// Creates a new [`Namespace`] from a static string.
     ///
-    /// This will panic if the namespace is too long. We accepting panicking in this case because we are enforcing a `static lifetime which means this value can only be a constant in the program and hence we hope the developer checked that it is of an acceptable length.
+    /// This will panic if the namespace is too long. We accepting panicking in
+    /// this case because we are enforcing a `static lifetime which means this
+    /// value can only be a constant in the program and hence we hope the
+    /// developer checked that it is of an acceptable length.
     pub fn from_static(value: &'static str) -> Self {
         if value.len() > crate::MAX_NAMESPACE {
             panic!("Namespace '{value}' is too long!")
@@ -109,7 +113,8 @@ pub struct Cookie {
 impl Cookie {
     /// Construct a new [`Cookie`] for a given namespace.
     ///
-    /// This cookie will only be valid for subsequent DISCOVER requests targeting the same namespace.
+    /// This cookie will only be valid for subsequent DISCOVER requests
+    /// targeting the same namespace.
     pub fn for_namespace(namespace: Namespace) -> Self {
         Self {
             id: rand::thread_rng().next_u64(),
@@ -117,7 +122,8 @@ impl Cookie {
         }
     }
 
-    /// Construct a new [`Cookie`] for a DISCOVER request that inquires about all namespaces.
+    /// Construct a new [`Cookie`] for a DISCOVER request that inquires about
+    /// all namespaces.
     pub fn for_all_namespaces() -> Self {
         Self {
             id: rand::random(),

--- a/protocols/rendezvous/src/lib.rs
+++ b/protocols/rendezvous/src/lib.rs
@@ -22,8 +22,9 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-pub use self::codec::{Cookie, ErrorCode, Namespace, NamespaceTooLong, Registration, Ttl};
 use libp2p_swarm::StreamProtocol;
+
+pub use self::codec::{Cookie, ErrorCode, Namespace, NamespaceTooLong, Registration, Ttl};
 
 mod codec;
 

--- a/protocols/rendezvous/tests/rendezvous.rs
+++ b/protocols/rendezvous/tests/rendezvous.rs
@@ -18,16 +18,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures::stream::FuturesUnordered;
-use futures::StreamExt;
-use libp2p_core::multiaddr::Protocol;
-use libp2p_core::Multiaddr;
+use std::time::Duration;
+
+use futures::{stream::FuturesUnordered, StreamExt};
+use libp2p_core::{multiaddr::Protocol, Multiaddr};
 use libp2p_identity as identity;
 use libp2p_rendezvous as rendezvous;
 use libp2p_rendezvous::client::RegisterError;
 use libp2p_swarm::{DialError, Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt;
-use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::test]
@@ -471,9 +470,12 @@ async fn new_combined_node() -> Swarm<Combined> {
 }
 
 async fn new_impersonating_client() -> Swarm<rendezvous::client::Behaviour> {
-    // In reality, if Eve were to try and fake someones identity, she would obviously only know the public key.
-    // Due to the type-safe API of the `Rendezvous` behaviour and `PeerRecord`, we actually cannot construct a bad `PeerRecord` (i.e. one that is claims to be someone else).
-    // As such, the best we can do is hand eve a completely different keypair from what she is using to authenticate her connection.
+    // In reality, if Eve were to try and fake someones identity, she would
+    // obviously only know the public key. Due to the type-safe API of the
+    // `Rendezvous` behaviour and `PeerRecord`, we actually cannot construct a bad
+    // `PeerRecord` (i.e. one that is claims to be someone else). As such, the
+    // best we can do is hand eve a completely different keypair from what she is
+    // using to authenticate her connection.
     let someone_else = identity::Keypair::generate_ed25519();
     let mut eve = Swarm::new_ephemeral(move |_| rendezvous::client::Behaviour::new(someone_else));
     eve.listen().with_memory_addr_external().await;

--- a/protocols/request-response/src/cbor.rs
+++ b/protocols/request-response/src/cbor.rs
@@ -37,19 +37,23 @@
 /// }
 ///
 /// let behaviour = cbor::Behaviour::<GreetRequest, GreetResponse>::new(
-///     [(StreamProtocol::new("/my-cbor-protocol"), ProtocolSupport::Full)],
-///     request_response::Config::default()
+///     [(
+///         StreamProtocol::new("/my-cbor-protocol"),
+///         ProtocolSupport::Full,
+///     )],
+///     request_response::Config::default(),
 /// );
 /// ```
 pub type Behaviour<Req, Resp> = crate::Behaviour<codec::Codec<Req, Resp>>;
 
 mod codec {
+    use std::{collections::TryReserveError, convert::Infallible, io, marker::PhantomData};
+
     use async_trait::async_trait;
     use cbor4ii::core::error::DecodeError;
     use futures::prelude::*;
     use libp2p_swarm::StreamProtocol;
     use serde::{de::DeserializeOwned, Serialize};
-    use std::{collections::TryReserveError, convert::Infallible, io, marker::PhantomData};
 
     /// Max request size in bytes
     const REQUEST_SIZE_MAXIMUM: u64 = 1024 * 1024;
@@ -168,12 +172,12 @@ mod codec {
 
 #[cfg(test)]
 mod tests {
-    use crate::cbor::codec::Codec;
-    use crate::Codec as _;
     use futures::AsyncWriteExt;
     use futures_ringbuf::Endpoint;
     use libp2p_swarm::StreamProtocol;
     use serde::{Deserialize, Serialize};
+
+    use crate::{cbor::codec::Codec, Codec as _};
 
     #[async_std::test]
     async fn test_codec() {

--- a/protocols/request-response/src/codec.rs
+++ b/protocols/request-response/src/codec.rs
@@ -18,9 +18,10 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::io;
+
 use async_trait::async_trait;
 use futures::prelude::*;
-use std::io;
 
 /// A `Codec` defines the request and response types
 /// for a request-response [`Behaviour`](crate::Behaviour) protocol or

--- a/protocols/request-response/src/json.rs
+++ b/protocols/request-response/src/json.rs
@@ -18,7 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-/// A request-response behaviour using [`serde_json`] for serializing and deserializing the messages.
+/// A request-response behaviour using [`serde_json`] for serializing and
+/// deserializing the messages.
 ///
 /// # Example
 ///
@@ -36,18 +37,22 @@
 /// }
 ///
 /// let behaviour = json::Behaviour::<GreetRequest, GreetResponse>::new(
-///     [(StreamProtocol::new("/my-json-protocol"), ProtocolSupport::Full)],
-///     request_response::Config::default()
+///     [(
+///         StreamProtocol::new("/my-json-protocol"),
+///         ProtocolSupport::Full,
+///     )],
+///     request_response::Config::default(),
 /// );
 /// ```
 pub type Behaviour<Req, Resp> = crate::Behaviour<codec::Codec<Req, Resp>>;
 
 mod codec {
+    use std::{io, marker::PhantomData};
+
     use async_trait::async_trait;
     use futures::prelude::*;
     use libp2p_swarm::StreamProtocol;
     use serde::{de::DeserializeOwned, Serialize};
-    use std::{io, marker::PhantomData};
 
     /// Max request size in bytes
     const REQUEST_SIZE_MAXIMUM: u64 = 1024 * 1024;
@@ -140,11 +145,12 @@ mod codec {
 
 #[cfg(test)]
 mod tests {
-    use crate::Codec;
     use futures::AsyncWriteExt;
     use futures_ringbuf::Endpoint;
     use libp2p_swarm::StreamProtocol;
     use serde::{Deserialize, Serialize};
+
+    use crate::Codec;
 
     #[async_std::test]
     async fn test_codec() {

--- a/protocols/request-response/tests/error_reporting.rs
+++ b/protocols/request-response/tests/error_reporting.rs
@@ -1,3 +1,5 @@
+use std::{io, iter, pin::pin, time::Duration};
+
 use anyhow::{bail, Result};
 use async_std::task::sleep;
 use async_trait::async_trait;
@@ -8,11 +10,13 @@ use libp2p_request_response::ProtocolSupport;
 use libp2p_swarm::{StreamProtocol, Swarm};
 use libp2p_swarm_test::SwarmExt;
 use request_response::{
-    Codec, InboundFailure, InboundRequestId, OutboundFailure, OutboundRequestId, ResponseChannel,
+    Codec,
+    InboundFailure,
+    InboundRequestId,
+    OutboundFailure,
+    OutboundRequestId,
+    ResponseChannel,
 };
-use std::pin::pin;
-use std::time::Duration;
-use std::{io, iter};
 use tracing_subscriber::EnvFilter;
 
 #[async_std::test]
@@ -40,7 +44,8 @@ async fn report_outbound_failure_on_read_response() {
         assert_eq!(peer, peer2_id);
         assert_eq!(req_id_done, req_id);
 
-        // Keep the connection alive, otherwise swarm2 may receive `ConnectionClosed` instead
+        // Keep the connection alive, otherwise swarm2 may receive `ConnectionClosed`
+        // instead
         wait_no_events(&mut swarm1).await;
     };
 
@@ -84,7 +89,8 @@ async fn report_outbound_failure_on_write_request() {
     swarm2.connect(&mut swarm1).await;
 
     // Expects no events because `Event::Request` is produced after `read_request`.
-    // Keep the connection alive, otherwise swarm2 may receive `ConnectionClosed` instead.
+    // Keep the connection alive, otherwise swarm2 may receive `ConnectionClosed`
+    // instead.
     let server_task = wait_no_events(&mut swarm1);
 
     // Expects OutboundFailure::Io failure with `FailOnWriteRequest` error.
@@ -140,7 +146,8 @@ async fn report_outbound_timeout_on_read_response() {
         assert_eq!(peer, peer2_id);
         assert_eq!(req_id_done, req_id);
 
-        // Keep the connection alive, otherwise swarm2 may receive `ConnectionClosed` instead
+        // Keep the connection alive, otherwise swarm2 may receive `ConnectionClosed`
+        // instead
         wait_no_events(&mut swarm1).await;
     };
 
@@ -183,7 +190,8 @@ async fn report_outbound_failure_on_max_streams() {
             .behaviour_mut()
             .send_request(&peer2_id, Action::FailOnMaxStreams);
 
-        // Keep the connection alive, otherwise swarm2 may receive `ConnectionClosed` instead.
+        // Keep the connection alive, otherwise swarm2 may receive `ConnectionClosed`
+        // instead.
         wait_no_events(&mut swarm1).await;
     };
 
@@ -226,7 +234,8 @@ async fn report_inbound_failure_on_read_request() {
     swarm2.connect(&mut swarm1).await;
 
     // Expects no events because `Event::Request` is produced after `read_request`.
-    // Keep the connection alive, otherwise swarm2 may receive `ConnectionClosed` instead.
+    // Keep the connection alive, otherwise swarm2 may receive `ConnectionClosed`
+    // instead.
     let server_task = wait_no_events(&mut swarm1);
 
     // Expects io::ErrorKind::UnexpectedEof
@@ -300,8 +309,8 @@ async fn report_inbound_failure_on_write_response() {
 
         match error {
             OutboundFailure::ConnectionClosed => {
-                // ConnectionClosed is allowed here because we mainly test the behavior
-                // of `server_task`.
+                // ConnectionClosed is allowed here because we mainly test the
+                // behavior of `server_task`.
             }
             OutboundFailure::Io(e) if e.kind() == io::ErrorKind::UnexpectedEof => {}
             e => panic!("Unexpected error: {e:?}"),
@@ -357,8 +366,8 @@ async fn report_inbound_timeout_on_write_response() {
 
         match error {
             OutboundFailure::ConnectionClosed => {
-                // ConnectionClosed is allowed here because we mainly test the behavior
-                // of `server_task`.
+                // ConnectionClosed is allowed here because we mainly test the
+                // behavior of `server_task`.
             }
             OutboundFailure::Io(e) if e.kind() == io::ErrorKind::UnexpectedEof => {}
             e => panic!("Unexpected error: {e:?}"),

--- a/protocols/request-response/tests/peer_address.rs
+++ b/protocols/request-response/tests/peer_address.rs
@@ -1,10 +1,11 @@
+use std::iter;
+
 use libp2p_core::ConnectedPoint;
 use libp2p_request_response as request_response;
 use libp2p_request_response::ProtocolSupport;
 use libp2p_swarm::{StreamProtocol, Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt;
 use serde::{Deserialize, Serialize};
-use std::iter;
 use tracing_subscriber::EnvFilter;
 
 #[async_std::test]

--- a/protocols/request-response/tests/ping.rs
+++ b/protocols/request-response/tests/ping.rs
@@ -20,6 +20,8 @@
 
 //! Integration tests for the `Behaviour`.
 
+use std::{io, iter};
+
 use futures::prelude::*;
 use libp2p_identity::PeerId;
 use libp2p_request_response as request_response;
@@ -28,7 +30,6 @@ use libp2p_swarm::{StreamProtocol, Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use std::{io, iter};
 use tracing_subscriber::EnvFilter;
 
 #[async_std::test]
@@ -236,11 +237,12 @@ async fn emits_inbound_connection_closed_failure() {
     }
 }
 
-/// We expect the substream to be properly closed when response channel is dropped.
-/// Since the ping protocol used here expects a response, the sender considers this
-/// early close as a protocol violation which results in the connection being closed.
-/// If the substream were not properly closed when dropped, the sender would instead
-/// run into a timeout waiting for the response.
+/// We expect the substream to be properly closed when response channel is
+/// dropped. Since the ping protocol used here expects a response, the sender
+/// considers this early close as a protocol violation which results in the
+/// connection being closed. If the substream were not properly closed when
+/// dropped, the sender would instead run into a timeout waiting for the
+/// response.
 #[async_std::test]
 #[cfg(feature = "cbor")]
 async fn emits_inbound_connection_closed_if_channel_is_dropped() {

--- a/protocols/stream/src/behaviour.rs
+++ b/protocols/stream/src/behaviour.rs
@@ -8,11 +8,22 @@ use futures::{channel::mpsc, StreamExt};
 use libp2p_core::{transport::PortUse, Endpoint, Multiaddr};
 use libp2p_identity::PeerId;
 use libp2p_swarm::{
-    self as swarm, dial_opts::DialOpts, ConnectionDenied, ConnectionId, FromSwarm,
-    NetworkBehaviour, THandler, THandlerInEvent, THandlerOutEvent, ToSwarm,
+    self as swarm,
+    dial_opts::DialOpts,
+    ConnectionDenied,
+    ConnectionId,
+    FromSwarm,
+    NetworkBehaviour,
+    THandler,
+    THandlerInEvent,
+    THandlerOutEvent,
+    ToSwarm,
 };
 use swarm::{
-    behaviour::ConnectionEstablished, dial_opts::PeerCondition, ConnectionClosed, DialError,
+    behaviour::ConnectionEstablished,
+    dial_opts::PeerCondition,
+    ConnectionClosed,
+    DialError,
     DialFailure,
 };
 

--- a/protocols/stream/src/control.rs
+++ b/protocols/stream/src/control.rs
@@ -6,17 +6,18 @@ use std::{
     task::{Context, Poll},
 };
 
-use crate::AlreadyRegistered;
-use crate::{handler::NewStream, shared::Shared};
-
 use futures::{
     channel::{mpsc, oneshot},
-    SinkExt as _, StreamExt as _,
+    SinkExt as _,
+    StreamExt as _,
 };
 use libp2p_identity::PeerId;
 use libp2p_swarm::{Stream, StreamProtocol};
 
-/// A (remote) control for opening new streams and registration of inbound protocols.
+use crate::{handler::NewStream, shared::Shared, AlreadyRegistered};
+
+/// A (remote) control for opening new streams and registration of inbound
+/// protocols.
 ///
 /// A [`Control`] can be cloned and thus allows for concurrent access.
 #[derive(Clone)]
@@ -31,15 +32,18 @@ impl Control {
 
     /// Attempt to open a new stream for the given protocol and peer.
     ///
-    /// In case we are currently not connected to the peer, we will attempt to make a new connection.
+    /// In case we are currently not connected to the peer, we will attempt to
+    /// make a new connection.
     ///
     /// ## Backpressure
     ///
     /// [`Control`]s support backpressure similarly to bounded channels:
     /// Each [`Control`] has a guaranteed slot for internal messages.
-    /// A single control will always open one stream at a time which is enforced by requiring `&mut self`.
+    /// A single control will always open one stream at a time which is enforced
+    /// by requiring `&mut self`.
     ///
-    /// This backpressure mechanism breaks if you clone [`Control`]s excessively.
+    /// This backpressure mechanism breaks if you clone [`Control`]s
+    /// excessively.
     pub async fn open_stream(
         &mut self,
         peer: PeerId,
@@ -65,7 +69,8 @@ impl Control {
 
     /// Accept inbound streams for the provided protocol.
     ///
-    /// To stop accepting streams, simply drop the returned [`IncomingStreams`] handle.
+    /// To stop accepting streams, simply drop the returned [`IncomingStreams`]
+    /// handle.
     pub fn accept(
         &mut self,
         protocol: StreamProtocol,

--- a/protocols/stream/src/handler.rs
+++ b/protocols/stream/src/handler.rs
@@ -13,7 +13,9 @@ use libp2p_identity::PeerId;
 use libp2p_swarm::{
     self as swarm,
     handler::{ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound},
-    ConnectionHandler, Stream, StreamProtocol,
+    ConnectionHandler,
+    Stream,
+    StreamProtocol,
 };
 
 use crate::{shared::Shared, upgrade::Upgrade, OpenStreamError};
@@ -162,7 +164,8 @@ impl ConnectionHandler for Handler {
     }
 }
 
-/// Message from a [`Control`](crate::Control) to a [`ConnectionHandler`] to negotiate a new outbound stream.
+/// Message from a [`Control`](crate::Control) to a [`ConnectionHandler`] to
+/// negotiate a new outbound stream.
 #[derive(Debug)]
 pub(crate) struct NewStream {
     pub(crate) protocol: StreamProtocol,

--- a/protocols/stream/src/shared.rs
+++ b/protocols/stream/src/shared.rs
@@ -12,9 +12,11 @@ use rand::seq::IteratorRandom as _;
 use crate::{handler::NewStream, AlreadyRegistered, IncomingStreams};
 
 pub(crate) struct Shared {
-    /// Tracks the supported inbound protocols created via [`Control::accept`](crate::Control::accept).
+    /// Tracks the supported inbound protocols created via
+    /// [`Control::accept`](crate::Control::accept).
     ///
-    /// For each [`StreamProtocol`], we hold the [`mpsc::Sender`] corresponding to the [`mpsc::Receiver`] in [`IncomingStreams`].
+    /// For each [`StreamProtocol`], we hold the [`mpsc::Sender`] corresponding
+    /// to the [`mpsc::Receiver`] in [`IncomingStreams`].
     supported_inbound_protocols: HashMap<StreamProtocol, mpsc::Sender<(PeerId, Stream)>>,
 
     connections: HashMap<ConnectionId, PeerId>,
@@ -25,7 +27,8 @@ pub(crate) struct Shared {
 
     /// Sender for peers we want to dial.
     ///
-    /// We manage this through a channel to avoid locks as part of [`NetworkBehaviour::poll`](libp2p_swarm::NetworkBehaviour::poll).
+    /// We manage this through a channel to avoid locks as part of
+    /// [`NetworkBehaviour::poll`](libp2p_swarm::NetworkBehaviour::poll).
     dial_sender: mpsc::Sender<PeerId>,
 }
 
@@ -61,7 +64,8 @@ impl Shared {
         Ok(IncomingStreams::new(receiver))
     }
 
-    /// Lists the protocols for which we have an active [`IncomingStreams`] instance.
+    /// Lists the protocols for which we have an active [`IncomingStreams`]
+    /// instance.
     pub(crate) fn supported_inbound_protocols(&mut self) -> Vec<StreamProtocol> {
         self.supported_inbound_protocols
             .retain(|_, sender| !sender.is_closed());

--- a/protocols/upnp/src/lib.rs
+++ b/protocols/upnp/src/lib.rs
@@ -24,7 +24,6 @@
 //! implements the [`libp2p_swarm::NetworkBehaviour`] trait.
 //! This struct will automatically try to map the ports externally to internal
 //! addresses on the gateway.
-//!
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 

--- a/protocols/upnp/src/tokio.rs
+++ b/protocols/upnp/src/tokio.rs
@@ -20,16 +20,17 @@
 
 use std::{error::Error, net::IpAddr};
 
-use crate::behaviour::{GatewayEvent, GatewayRequest};
 use futures::{
     channel::{mpsc, oneshot},
-    SinkExt, StreamExt,
+    SinkExt,
+    StreamExt,
 };
 use igd_next::SearchOptions;
 
 pub use crate::behaviour::Behaviour;
+use crate::behaviour::{GatewayEvent, GatewayRequest};
 
-//TODO: remove when `IpAddr::is_global` stabilizes.
+// TODO: remove when `IpAddr::is_global` stabilizes.
 pub(crate) fn is_addr_global(addr: IpAddr) -> bool {
     match addr {
         IpAddr::V4(ip) => {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,11 @@
+# Imports
+reorder_imports  = true
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+imports_layout = "HorizontalVertical"
+
+# Docs
+wrap_comments = true
+format_strings = true
+normalize_comments = true
+format_code_in_doc_comments = true

--- a/swarm-derive/src/lib.rs
+++ b/swarm-derive/src/lib.rs
@@ -23,15 +23,15 @@
 
 mod syn_ext;
 
-use crate::syn_ext::RequireStrLit;
 use heck::ToUpperCamelCase;
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::punctuated::Punctuated;
-use syn::{parse_macro_input, Data, DataStruct, DeriveInput, Meta, Token};
+use syn::{parse_macro_input, punctuated::Punctuated, Data, DataStruct, DeriveInput, Meta, Token};
 
-/// Generates a delegating `NetworkBehaviour` implementation for the struct this is used for. See
-/// the trait documentation for better description.
+use crate::syn_ext::RequireStrLit;
+
+/// Generates a delegating `NetworkBehaviour` implementation for the struct this
+/// is used for. See the trait documentation for better description.
 #[proc_macro_derive(NetworkBehaviour, attributes(behaviour))]
 pub fn hello_macro_derive(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
@@ -225,10 +225,12 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> syn::Result<Toke
             })
     };
 
-    // Build the list of variants to put in the body of `on_connection_handler_event()`.
+    // Build the list of variants to put in the body of
+    // `on_connection_handler_event()`.
     //
-    // The event type is a construction of nested `#either_ident`s of the events of the children.
-    // We call `on_connection_handler_event` on the corresponding child.
+    // The event type is a construction of nested `#either_ident`s of the events of
+    // the children. We call `on_connection_handler_event` on the corresponding
+    // child.
     let on_node_event_stmts =
         data_struct
             .fields
@@ -496,7 +498,8 @@ struct BehaviourAttributes {
     user_specified_out_event: Option<syn::Type>,
 }
 
-/// Parses the `value` of a key=value pair in the `#[behaviour]` attribute into the requested type.
+/// Parses the `value` of a key=value pair in the `#[behaviour]` attribute into
+/// the requested type.
 fn parse_attributes(ast: &DeriveInput) -> syn::Result<BehaviourAttributes> {
     let mut attributes = BehaviourAttributes {
         prelude_path: syn::parse_quote! { ::libp2p::swarm::derive_prelude },

--- a/swarm-test/src/lib.rs
+++ b/swarm-test/src/lib.rs
@@ -18,58 +18,75 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::{fmt::Debug, future::IntoFuture, time::Duration};
+
 use async_trait::async_trait;
-use futures::future::{BoxFuture, Either};
-use futures::{FutureExt, StreamExt};
+use futures::{
+    future::{BoxFuture, Either},
+    FutureExt,
+    StreamExt,
+};
 use libp2p_core::{multiaddr::Protocol, Multiaddr};
 use libp2p_identity::PeerId;
-use libp2p_swarm::dial_opts::PeerCondition;
-use libp2p_swarm::{dial_opts::DialOpts, NetworkBehaviour, Swarm, SwarmEvent};
-use std::fmt::Debug;
-use std::future::IntoFuture;
-use std::time::Duration;
+use libp2p_swarm::{
+    dial_opts::{DialOpts, PeerCondition},
+    NetworkBehaviour,
+    Swarm,
+    SwarmEvent,
+};
 
-/// An extension trait for [`Swarm`] that makes it easier to set up a network of [`Swarm`]s for tests.
+/// An extension trait for [`Swarm`] that makes it easier to set up a network of
+/// [`Swarm`]s for tests.
 #[async_trait]
 pub trait SwarmExt {
     type NB: NetworkBehaviour;
 
-    /// Create a new [`Swarm`] with an ephemeral identity and the `async-std` runtime.
+    /// Create a new [`Swarm`] with an ephemeral identity and the `async-std`
+    /// runtime.
     ///
-    /// The swarm will use a [`libp2p_core::transport::MemoryTransport`] together with a [`libp2p_plaintext::Config`] authentication layer and
-    /// [`libp2p_yamux::Config`] as the multiplexer. However, these details should not be relied upon by the test
-    /// and may change at any time.
+    /// The swarm will use a [`libp2p_core::transport::MemoryTransport`]
+    /// together with a [`libp2p_plaintext::Config`] authentication layer and
+    /// [`libp2p_yamux::Config`] as the multiplexer. However, these details
+    /// should not be relied upon by the test and may change at any time.
     #[cfg(feature = "async-std")]
     fn new_ephemeral(behaviour_fn: impl FnOnce(libp2p_identity::Keypair) -> Self::NB) -> Self
     where
         Self: Sized;
 
-    /// Create a new [`Swarm`] with an ephemeral identity and the `tokio` runtime.
+    /// Create a new [`Swarm`] with an ephemeral identity and the `tokio`
+    /// runtime.
     ///
-    /// The swarm will use a [`libp2p_core::transport::MemoryTransport`] together with a [`libp2p_plaintext::Config`] authentication layer and
-    /// [`libp2p_yamux::Config`] as the multiplexer. However, these details should not be relied upon by the test
-    /// and may change at any time.
+    /// The swarm will use a [`libp2p_core::transport::MemoryTransport`]
+    /// together with a [`libp2p_plaintext::Config`] authentication layer and
+    /// [`libp2p_yamux::Config`] as the multiplexer. However, these details
+    /// should not be relied upon by the test and may change at any time.
     #[cfg(feature = "tokio")]
     fn new_ephemeral_tokio(behaviour_fn: impl FnOnce(libp2p_identity::Keypair) -> Self::NB) -> Self
     where
         Self: Sized;
 
-    /// Establishes a connection to the given [`Swarm`], polling both of them until the connection is established.
+    /// Establishes a connection to the given [`Swarm`], polling both of them
+    /// until the connection is established.
     ///
-    /// This will take addresses from the `other` [`Swarm`] via [`Swarm::external_addresses`].
-    /// By default, this iterator will not yield any addresses.
-    /// To add listen addresses as external addresses, use [`ListenFuture::with_memory_addr_external`] or [`ListenFuture::with_tcp_addr_external`].
+    /// This will take addresses from the `other` [`Swarm`] via
+    /// [`Swarm::external_addresses`]. By default, this iterator will not
+    /// yield any addresses. To add listen addresses as external addresses,
+    /// use [`ListenFuture::with_memory_addr_external`] or
+    /// [`ListenFuture::with_tcp_addr_external`].
     async fn connect<T>(&mut self, other: &mut Swarm<T>)
     where
         T: NetworkBehaviour + Send,
         <T as NetworkBehaviour>::ToSwarm: Debug;
 
-    /// Dial the provided address and wait until a connection has been established.
+    /// Dial the provided address and wait until a connection has been
+    /// established.
     ///
-    /// In a normal test scenario, you should prefer [`SwarmExt::connect`] but that is not always possible.
-    /// This function only abstracts away the "dial and wait for `ConnectionEstablished` event" part.
+    /// In a normal test scenario, you should prefer [`SwarmExt::connect`] but
+    /// that is not always possible. This function only abstracts away the
+    /// "dial and wait for `ConnectionEstablished` event" part.
     ///
-    /// Because we don't have access to the other [`Swarm`], we can't guarantee that it makes progress.
+    /// Because we don't have access to the other [`Swarm`], we can't guarantee
+    /// that it makes progress.
     async fn dial_and_wait(&mut self, addr: Multiaddr) -> PeerId;
 
     /// Wait for specified condition to return `Some`.
@@ -78,19 +95,23 @@ pub trait SwarmExt {
         P: Fn(SwarmEvent<<Self::NB as NetworkBehaviour>::ToSwarm>) -> Option<E>,
         P: Send;
 
-    /// Listens for incoming connections, polling the [`Swarm`] until the transport is ready to accept connections.
+    /// Listens for incoming connections, polling the [`Swarm`] until the
+    /// transport is ready to accept connections.
     ///
-    /// The first address is for the memory transport, the second one for the TCP transport.
+    /// The first address is for the memory transport, the second one for the
+    /// TCP transport.
     fn listen(&mut self) -> ListenFuture<&mut Self>;
 
     /// Returns the next [`SwarmEvent`] or times out after 10 seconds.
     ///
-    /// If the 10s timeout does not fit your usecase, please fall back to `StreamExt::next`.
+    /// If the 10s timeout does not fit your usecase, please fall back to
+    /// `StreamExt::next`.
     async fn next_swarm_event(&mut self) -> SwarmEvent<<Self::NB as NetworkBehaviour>::ToSwarm>;
 
     /// Returns the next behaviour event or times out after 10 seconds.
     ///
-    /// If the 10s timeout does not fit your usecase, please fall back to `StreamExt::next`.
+    /// If the 10s timeout does not fit your usecase, please fall back to
+    /// `StreamExt::next`.
     async fn next_behaviour_event(&mut self) -> <Self::NB as NetworkBehaviour>::ToSwarm;
 
     async fn loop_on_next(self);
@@ -102,31 +123,41 @@ pub trait SwarmExt {
 ///
 /// ## Number of events
 ///
-/// The number of events is configured via const generics based on the array size of the return type.
-/// This allows the compiler to infer how many events you are expecting based on how you use this function.
-/// For example, if you expect the first [`Swarm`] to emit 2 events, you should assign the first variable of the returned tuple value to an array of size 2.
-/// This works especially well if you directly pattern-match on the return value.
+/// The number of events is configured via const generics based on the array
+/// size of the return type. This allows the compiler to infer how many events
+/// you are expecting based on how you use this function. For example, if you
+/// expect the first [`Swarm`] to emit 2 events, you should assign the first
+/// variable of the returned tuple value to an array of size 2. This works
+/// especially well if you directly pattern-match on the return value.
 ///
 /// ## Type of event
 ///
 /// This function utilizes the [`TryIntoOutput`] trait.
-/// Similar as to the number of expected events, the type of event is inferred based on your usage.
-/// If you match against a [`SwarmEvent`], the first [`SwarmEvent`] will be returned.
-/// If you match against your [`NetworkBehaviour::ToSwarm`] type, [`SwarmEvent`]s which are not [`SwarmEvent::Behaviour`] will be skipped until the [`Swarm`] returns a behaviour event.
+/// Similar as to the number of expected events, the type of event is inferred
+/// based on your usage. If you match against a [`SwarmEvent`], the first
+/// [`SwarmEvent`] will be returned. If you match against your
+/// [`NetworkBehaviour::ToSwarm`] type, [`SwarmEvent`]s which are not
+/// [`SwarmEvent::Behaviour`] will be skipped until the [`Swarm`] returns a
+/// behaviour event.
 ///
-/// You can implement the [`TryIntoOutput`] for any other type to further customize this behaviour.
+/// You can implement the [`TryIntoOutput`] for any other type to further
+/// customize this behaviour.
 ///
 /// # Difference to [`futures::future::join`]
 ///
-/// This function is similar to joining two futures with two crucial differences:
+/// This function is similar to joining two futures with two crucial
+/// differences:
 /// 1. As described above, it allows you to obtain more than a single event.
-/// 2. More importantly, it will continue to poll the [`Swarm`]s **even if they already has emitted all expected events**.
+/// 2. More importantly, it will continue to poll the [`Swarm`]s **even if they
+///    already has emitted all expected events**.
 ///
 /// Especially (2) is crucial for our usage of this function.
 /// If a [`Swarm`] is not polled, nothing within it makes progress.
-/// This can "starve" the other swarm which for example may wait for another message to be sent on a connection.
+/// This can "starve" the other swarm which for example may wait for another
+/// message to be sent on a connection.
 ///
-/// Using [`drive`] instead of [`futures::future::join`] ensures that a [`Swarm`] continues to be polled, even after it emitted its events.
+/// Using [`drive`] instead of [`futures::future::join`] ensures that a
+/// [`Swarm`] continues to be polled, even after it emitted its events.
 pub async fn drive<
     TBehaviour1,
     const NUM_EVENTS_SWARM_1: usize,
@@ -231,7 +262,11 @@ where
             behaviour_fn(identity),
             peer_id,
             libp2p_swarm::Config::with_async_std_executor()
-                .with_idle_connection_timeout(Duration::from_secs(5)), // Some tests need connections to be kept alive beyond what the individual behaviour configures.,
+                .with_idle_connection_timeout(Duration::from_secs(5)), /* Some tests need
+                                                                        * connections to be kept
+                                                                        * alive beyond what the
+                                                                        * individual behaviour
+                                                                        * configures., */
         )
     }
 
@@ -259,7 +294,11 @@ where
             behaviour_fn(identity),
             peer_id,
             libp2p_swarm::Config::with_tokio_executor()
-                .with_idle_connection_timeout(Duration::from_secs(5)), // Some tests need connections to be kept alive beyond what the individual behaviour configures.,
+                .with_idle_connection_timeout(Duration::from_secs(5)), /* Some tests need
+                                                                        * connections to be kept
+                                                                        * alive beyond what the
+                                                                        * individual behaviour
+                                                                        * configures., */
         )
     }
 
@@ -385,20 +424,26 @@ pub struct ListenFuture<S> {
 }
 
 impl<S> ListenFuture<S> {
-    /// Adds the memory address we are starting to listen on as an external address using [`Swarm::add_external_address`].
+    /// Adds the memory address we are starting to listen on as an external
+    /// address using [`Swarm::add_external_address`].
     ///
-    /// This is typically "safe" for tests because within a process, memory addresses are "globally" reachable.
-    /// However, some tests depend on which addresses are external and need this to be configurable so it is not a good default.
+    /// This is typically "safe" for tests because within a process, memory
+    /// addresses are "globally" reachable. However, some tests depend on
+    /// which addresses are external and need this to be configurable so it is
+    /// not a good default.
     pub fn with_memory_addr_external(mut self) -> Self {
         self.add_memory_external = true;
 
         self
     }
 
-    /// Adds the TCP address we are starting to listen on as an external address using [`Swarm::add_external_address`].
+    /// Adds the TCP address we are starting to listen on as an external address
+    /// using [`Swarm::add_external_address`].
     ///
-    /// This is typically "safe" for tests because on the same machine, 127.0.0.1 is reachable for other [`Swarm`]s.
-    /// However, some tests depend on which addresses are external and need this to be configurable so it is not a good default.
+    /// This is typically "safe" for tests because on the same machine,
+    /// 127.0.0.1 is reachable for other [`Swarm`]s. However, some tests
+    /// depend on which addresses are external and need this to be configurable
+    /// so it is not a good default.
     pub fn with_tcp_addr_external(mut self) -> Self {
         self.add_tcp_external = true;
 

--- a/swarm/benches/connection_handler.rs
+++ b/swarm/benches/connection_handler.rs
@@ -1,11 +1,17 @@
+use std::{convert::Infallible, sync::atomic::AtomicUsize};
+
 use async_std::stream::StreamExt;
 use criterion::{criterion_group, criterion_main, Criterion};
 use libp2p_core::{
-    transport::MemoryTransport, InboundUpgrade, Multiaddr, OutboundUpgrade, Transport, UpgradeInfo,
+    transport::MemoryTransport,
+    InboundUpgrade,
+    Multiaddr,
+    OutboundUpgrade,
+    Transport,
+    UpgradeInfo,
 };
 use libp2p_identity::PeerId;
 use libp2p_swarm::{ConnectionHandler, NetworkBehaviour, StreamProtocol};
-use std::{convert::Infallible, sync::atomic::AtomicUsize};
 use web_time::Duration;
 
 macro_rules! gen_behaviour {
@@ -82,7 +88,7 @@ benchmarks! {
         SpinningBehaviour20::bench().name(m).poll_count(500).protocols_per_behaviour(100),
     ];
 }
-//fn main() {}
+// fn main() {}
 
 trait BigBehaviour: Sized {
     fn behaviours(&mut self) -> &mut [SpinningBehaviour];

--- a/swarm/src/behaviour/either.rs
+++ b/swarm/src/behaviour/either.rs
@@ -18,16 +18,23 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::behaviour::{self, NetworkBehaviour, ToSwarm};
-use crate::connection::ConnectionId;
-use crate::{ConnectionDenied, THandler, THandlerInEvent, THandlerOutEvent};
-use either::Either;
-use libp2p_core::transport::PortUse;
-use libp2p_core::{Endpoint, Multiaddr};
-use libp2p_identity::PeerId;
-use std::{task::Context, task::Poll};
+use std::task::{Context, Poll};
 
-/// Implementation of [`NetworkBehaviour`] that can be either of two implementations.
+use either::Either;
+use libp2p_core::{transport::PortUse, Endpoint, Multiaddr};
+use libp2p_identity::PeerId;
+
+use crate::{
+    behaviour::{self, NetworkBehaviour, ToSwarm},
+    connection::ConnectionId,
+    ConnectionDenied,
+    THandler,
+    THandlerInEvent,
+    THandlerOutEvent,
+};
+
+/// Implementation of [`NetworkBehaviour`] that can be either of two
+/// implementations.
 impl<L, R> NetworkBehaviour for Either<L, R>
 where
     L: NetworkBehaviour,

--- a/swarm/src/behaviour/external_addresses.rs
+++ b/swarm/src/behaviour/external_addresses.rs
@@ -1,12 +1,14 @@
-use crate::behaviour::{ExternalAddrConfirmed, ExternalAddrExpired, FromSwarm};
 use libp2p_core::Multiaddr;
+
+use crate::behaviour::{ExternalAddrConfirmed, ExternalAddrExpired, FromSwarm};
 
 /// The maximum number of local external addresses. When reached any
 /// further externally reported addresses are ignored. The behaviour always
 /// tracks all its listen addresses.
 const MAX_LOCAL_EXTERNAL_ADDRS: usize = 20;
 
-/// Utility struct for tracking the external addresses of a [`Swarm`](crate::Swarm).
+/// Utility struct for tracking the external addresses of a
+/// [`Swarm`](crate::Swarm).
 #[derive(Debug, Clone, Default)]
 pub struct ExternalAddresses {
     addresses: Vec<Multiaddr>,
@@ -78,16 +80,19 @@ impl ExternalAddresses {
     }
 
     fn push_front(&mut self, addr: &Multiaddr) {
-        self.addresses.insert(0, addr.clone()); // We have at most `MAX_LOCAL_EXTERNAL_ADDRS` so this isn't very expensive.
+        self.addresses.insert(0, addr.clone()); // We have at most
+                                                // `MAX_LOCAL_EXTERNAL_ADDRS` so
+                                                // this isn't very expensive.
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use libp2p_core::multiaddr::Protocol;
     use once_cell::sync::Lazy;
     use rand::Rng;
+
+    use super::*;
 
     #[test]
     fn new_external_addr_returns_correct_changed_value() {

--- a/swarm/src/behaviour/listen_addresses.rs
+++ b/swarm/src/behaviour/listen_addresses.rs
@@ -1,8 +1,11 @@
-use crate::behaviour::{ExpiredListenAddr, FromSwarm, NewListenAddr};
-use libp2p_core::Multiaddr;
 use std::collections::HashSet;
 
-/// Utility struct for tracking the addresses a [`Swarm`](crate::Swarm) is listening on.
+use libp2p_core::Multiaddr;
+
+use crate::behaviour::{ExpiredListenAddr, FromSwarm, NewListenAddr};
+
+/// Utility struct for tracking the addresses a [`Swarm`](crate::Swarm) is
+/// listening on.
 #[derive(Debug, Default, Clone)]
 pub struct ListenAddresses {
     addresses: HashSet<Multiaddr>,
@@ -32,9 +35,10 @@ impl ListenAddresses {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use libp2p_core::{multiaddr::Protocol, transport::ListenerId};
     use once_cell::sync::Lazy;
+
+    use super::*;
 
     #[test]
     fn new_listen_addr_returns_correct_changed_value() {

--- a/swarm/src/behaviour/peer_addresses.rs
+++ b/swarm/src/behaviour/peer_addresses.rs
@@ -1,19 +1,19 @@
-use crate::behaviour::FromSwarm;
-use crate::{DialError, DialFailure, NewExternalAddrOfPeer};
+use std::num::NonZeroUsize;
 
 use libp2p_core::Multiaddr;
 use libp2p_identity::PeerId;
-
 use lru::LruCache;
 
-use std::num::NonZeroUsize;
+use crate::{behaviour::FromSwarm, DialError, DialFailure, NewExternalAddrOfPeer};
 
-/// Struct for tracking peers' external addresses of the [`Swarm`](crate::Swarm).
+/// Struct for tracking peers' external addresses of the
+/// [`Swarm`](crate::Swarm).
 #[derive(Debug)]
 pub struct PeerAddresses(LruCache<PeerId, LruCache<Multiaddr, ()>>);
 
 impl PeerAddresses {
-    /// Creates a [`PeerAddresses`] cache with capacity for the given number of peers.
+    /// Creates a [`PeerAddresses`] cache with capacity for the given number of
+    /// peers.
     ///
     /// For each peer, we will at most store 10 addresses.
     pub fn new(number_of_peers: NonZeroUsize) -> Self {
@@ -46,7 +46,6 @@ impl PeerAddresses {
     /// Appends address to the existing set if peer addresses already exist.
     /// Creates a new cache entry for peer_id if no addresses are present.
     /// Returns true if the newly added address was not previously in the cache.
-    ///
     pub fn add(&mut self, peer: PeerId, address: Multiaddr) -> bool {
         match prepare_addr(&peer, &address) {
             Ok(address) => {
@@ -98,16 +97,16 @@ impl Default for PeerAddresses {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::io;
 
-    use crate::ConnectionId;
     use libp2p_core::{
         multiaddr::Protocol,
         transport::{memory::MemoryTransportError, TransportError},
     };
-
     use once_cell::sync::Lazy;
+
+    use super::*;
+    use crate::ConnectionId;
 
     #[test]
     fn new_peer_addr_returns_correct_changed_value() {

--- a/swarm/src/behaviour/toggle.rs
+++ b/swarm/src/behaviour/toggle.rs
@@ -18,24 +18,38 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::behaviour::FromSwarm;
-use crate::connection::ConnectionId;
-use crate::handler::{
-    AddressChange, ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, DialUpgradeError,
-    FullyNegotiatedInbound, FullyNegotiatedOutbound, ListenUpgradeError, SubstreamProtocol,
-};
-use crate::upgrade::SendWrapper;
-use crate::{
-    ConnectionDenied, NetworkBehaviour, THandler, THandlerInEvent, THandlerOutEvent, ToSwarm,
-};
+use std::task::{Context, Poll};
+
 use either::Either;
 use futures::future;
-use libp2p_core::transport::PortUse;
-use libp2p_core::{upgrade::DeniedUpgrade, Endpoint, Multiaddr};
+use libp2p_core::{transport::PortUse, upgrade::DeniedUpgrade, Endpoint, Multiaddr};
 use libp2p_identity::PeerId;
-use std::{task::Context, task::Poll};
 
-/// Implementation of `NetworkBehaviour` that can be either in the disabled or enabled state.
+use crate::{
+    behaviour::FromSwarm,
+    connection::ConnectionId,
+    handler::{
+        AddressChange,
+        ConnectionEvent,
+        ConnectionHandler,
+        ConnectionHandlerEvent,
+        DialUpgradeError,
+        FullyNegotiatedInbound,
+        FullyNegotiatedOutbound,
+        ListenUpgradeError,
+        SubstreamProtocol,
+    },
+    upgrade::SendWrapper,
+    ConnectionDenied,
+    NetworkBehaviour,
+    THandler,
+    THandlerInEvent,
+    THandlerOutEvent,
+    ToSwarm,
+};
+
+/// Implementation of `NetworkBehaviour` that can be either in the disabled or
+/// enabled state.
 ///
 /// The state can only be chosen at initialization.
 pub struct Toggle<TBehaviour> {
@@ -242,12 +256,12 @@ where
             // Ignore listen upgrade errors in disabled state.
             (None, Either::Right(())) => return,
             (Some(_), Either::Right(())) => panic!(
-                "Unexpected `Either::Right` inbound info through \
-                 `on_listen_upgrade_error` in enabled state.",
+                "Unexpected `Either::Right` inbound info through `on_listen_upgrade_error` in \
+                 enabled state.",
             ),
             (None, Either::Left(_)) => panic!(
-                "Unexpected `Either::Left` inbound info through \
-                 `on_listen_upgrade_error` in disabled state.",
+                "Unexpected `Either::Left` inbound info through `on_listen_upgrade_error` in \
+                 disabled state.",
             ),
         };
 

--- a/swarm/src/connection/error.rs
+++ b/swarm/src/connection/error.rs
@@ -18,10 +18,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::transport::TransportError;
-use crate::Multiaddr;
-use crate::{ConnectedPoint, PeerId};
 use std::{fmt, io};
+
+use crate::{transport::TransportError, ConnectedPoint, Multiaddr, PeerId};
 
 /// Errors that can occur in the context of an established `Connection`.
 #[derive(Debug)]
@@ -62,9 +61,9 @@ impl From<io::Error> for ConnectionError {
 
 /// Errors that can occur in the context of a pending outgoing `Connection`.
 ///
-/// Note: Addresses for an outbound connection are dialed in parallel. Thus, compared to
-/// [`PendingInboundConnectionError`], one or more [`TransportError`]s can occur for a single
-/// connection.
+/// Note: Addresses for an outbound connection are dialed in parallel. Thus,
+/// compared to [`PendingInboundConnectionError`], one or more
+/// [`TransportError`]s can occur for a single connection.
 pub(crate) type PendingOutboundConnectionError =
     PendingConnectionError<Vec<(Multiaddr, TransportError<io::Error>)>>;
 
@@ -74,7 +73,8 @@ pub(crate) type PendingInboundConnectionError = PendingConnectionError<Transport
 /// Errors that can occur in the context of a pending `Connection`.
 #[derive(Debug)]
 pub enum PendingConnectionError<TTransErr> {
-    /// An error occurred while negotiating the transport protocol(s) on a connection.
+    /// An error occurred while negotiating the transport protocol(s) on a
+    /// connection.
     Transport(TTransErr),
 
     /// Pending connection attempt has been aborted.

--- a/swarm/src/connection/pool/concurrent_dial.rs
+++ b/swarm/src/connection/pool/concurrent_dial.rs
@@ -18,7 +18,12 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::{transport::TransportError, Multiaddr};
+use std::{
+    num::NonZeroU8,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
 use futures::{
     future::{BoxFuture, Future},
     ready,
@@ -26,11 +31,8 @@ use futures::{
 };
 use libp2p_core::muxing::StreamMuxerBox;
 use libp2p_identity::PeerId;
-use std::{
-    num::NonZeroU8,
-    pin::Pin,
-    task::{Context, Poll},
-};
+
+use crate::{transport::TransportError, Multiaddr};
 
 type Dial = BoxFuture<
     'static,

--- a/swarm/src/connection/pool/task.rs
+++ b/swarm/src/connection/pool/task.rs
@@ -19,25 +19,33 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! Async functions driving pending and established connections in the form of a task.
+//! Async functions driving pending and established connections in the form of a
+//! task.
+
+use std::{convert::Infallible, pin::Pin};
+
+use futures::{
+    channel::{mpsc, oneshot},
+    future::{poll_fn, Either, Future},
+    SinkExt,
+    StreamExt,
+};
+use libp2p_core::muxing::StreamMuxerBox;
 
 use super::concurrent_dial::ConcurrentDial;
 use crate::{
     connection::{
-        self, ConnectionError, ConnectionId, PendingInboundConnectionError,
+        self,
+        ConnectionError,
+        ConnectionId,
+        PendingInboundConnectionError,
         PendingOutboundConnectionError,
     },
     transport::TransportError,
-    ConnectionHandler, Multiaddr, PeerId,
+    ConnectionHandler,
+    Multiaddr,
+    PeerId,
 };
-use futures::{
-    channel::{mpsc, oneshot},
-    future::{poll_fn, Either, Future},
-    SinkExt, StreamExt,
-};
-use libp2p_core::muxing::StreamMuxerBox;
-use std::convert::Infallible;
-use std::pin::Pin;
 
 /// Commands that can be sent to a task driving an established connection.
 #[derive(Debug)]

--- a/swarm/src/connection/supported_protocols.rs
+++ b/swarm/src/connection/supported_protocols.rs
@@ -1,6 +1,6 @@
-use crate::handler::ProtocolsChange;
-use crate::StreamProtocol;
 use std::collections::HashSet;
+
+use crate::{handler::ProtocolsChange, StreamProtocol};
 
 #[derive(Default, Clone, Debug)]
 pub struct SupportedProtocols {

--- a/swarm/src/dial_opts.rs
+++ b/swarm/src/dial_opts.rs
@@ -19,13 +19,12 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::ConnectionId;
-use libp2p_core::connection::Endpoint;
-use libp2p_core::multiaddr::Protocol;
-use libp2p_core::transport::PortUse;
-use libp2p_core::Multiaddr;
-use libp2p_identity::PeerId;
 use std::num::NonZeroU8;
+
+use libp2p_core::{connection::Endpoint, multiaddr::Protocol, transport::PortUse, Multiaddr};
+use libp2p_identity::PeerId;
+
+use crate::ConnectionId;
 
 macro_rules! fn_override_role {
     () => {
@@ -45,8 +44,8 @@ macro_rules! fn_override_role {
 macro_rules! fn_allocate_new_port {
     () => {
         /// Enforce the allocation of a new port.
-        /// Default behaviour is best effort reuse of existing ports. If there is no existing
-        /// fitting listener, a new port is allocated.
+        /// Default behaviour is best effort reuse of existing ports. If there is no
+        /// existing fitting listener, a new port is allocated.
         pub fn allocate_new_port(mut self) -> Self {
             self.port_use = PortUse::New;
             self
@@ -110,8 +109,9 @@ impl DialOpts {
         WithoutPeerId {}
     }
 
-    /// Retrieves the [`PeerId`] from the [`DialOpts`] if specified or otherwise tries to extract it
-    /// from the multihash in the `/p2p` part of the address, if present.
+    /// Retrieves the [`PeerId`] from the [`DialOpts`] if specified or otherwise
+    /// tries to extract it from the multihash in the `/p2p` part of the
+    /// address, if present.
     pub fn get_peer_id(&self) -> Option<PeerId> {
         if let Some(peer_id) = self.peer_id {
             return Some(peer_id);
@@ -130,7 +130,8 @@ impl DialOpts {
     /// Get the [`ConnectionId`] of this dial attempt.
     ///
     /// All future events of this dial will be associated with this ID.
-    /// See [`DialFailure`](crate::DialFailure) and [`ConnectionEstablished`](crate::behaviour::ConnectionEstablished).
+    /// See [`DialFailure`](crate::DialFailure) and
+    /// [`ConnectionEstablished`](crate::behaviour::ConnectionEstablished).
     pub fn connection_id(&self) -> ConnectionId {
         self.connection_id
     }
@@ -189,7 +190,8 @@ impl WithPeerId {
     }
 
     /// Override
-    /// Number of addresses concurrently dialed for a single outbound connection attempt.
+    /// Number of addresses concurrently dialed for a single outbound connection
+    /// attempt.
     pub fn override_dial_concurrency_factor(mut self, factor: NonZeroU8) -> Self {
         self.dial_concurrency_factor_override = Some(factor);
         self
@@ -255,7 +257,8 @@ impl WithPeerIdWithAddresses {
     fn_allocate_new_port!();
 
     /// Override
-    /// Number of addresses concurrently dialed for a single outbound connection attempt.
+    /// Number of addresses concurrently dialed for a single outbound connection
+    /// attempt.
     pub fn override_dial_concurrency_factor(mut self, factor: NonZeroU8) -> Self {
         self.dial_concurrency_factor_override = Some(factor);
         self
@@ -324,8 +327,8 @@ impl WithoutPeerIdWithAddress {
 /// # use libp2p_identity::PeerId;
 /// #
 /// DialOpts::peer_id(PeerId::random())
-///    .condition(PeerCondition::Disconnected)
-///    .build();
+///     .condition(PeerCondition::Disconnected)
+///     .build();
 /// ```
 #[derive(Debug, Copy, Clone, Default)]
 pub enum PeerCondition {

--- a/swarm/src/dummy.rs
+++ b/swarm/src/dummy.rs
@@ -1,19 +1,23 @@
-use crate::behaviour::{FromSwarm, NetworkBehaviour, ToSwarm};
-use crate::connection::ConnectionId;
-use crate::handler::{
-    ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
+use std::{
+    convert::Infallible,
+    task::{Context, Poll},
 };
-use crate::{
-    ConnectionDenied, ConnectionHandlerEvent, StreamUpgradeError, SubstreamProtocol, THandler,
-    THandlerInEvent, THandlerOutEvent,
-};
-use libp2p_core::transport::PortUse;
-use libp2p_core::upgrade::DeniedUpgrade;
-use libp2p_core::Endpoint;
-use libp2p_core::Multiaddr;
+
+use libp2p_core::{transport::PortUse, upgrade::DeniedUpgrade, Endpoint, Multiaddr};
 use libp2p_identity::PeerId;
-use std::convert::Infallible;
-use std::task::{Context, Poll};
+
+use crate::{
+    behaviour::{FromSwarm, NetworkBehaviour, ToSwarm},
+    connection::ConnectionId,
+    handler::{ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound},
+    ConnectionDenied,
+    ConnectionHandlerEvent,
+    StreamUpgradeError,
+    SubstreamProtocol,
+    THandler,
+    THandlerInEvent,
+    THandlerOutEvent,
+};
 
 /// Implementation of [`NetworkBehaviour`] that doesn't do anything.
 pub struct Behaviour;
@@ -61,7 +65,8 @@ impl NetworkBehaviour for Behaviour {
     fn on_swarm_event(&mut self, _event: FromSwarm) {}
 }
 
-/// An implementation of [`ConnectionHandler`] that neither handles any protocols nor does it keep the connection alive.
+/// An implementation of [`ConnectionHandler`] that neither handles any
+/// protocols nor does it keep the connection alive.
 #[derive(Clone)]
 pub struct ConnectionHandler;
 

--- a/swarm/src/executor.rs
+++ b/swarm/src/executor.rs
@@ -1,14 +1,19 @@
 //! Provides executors for spawning background tasks.
-use futures::executor::ThreadPool;
 use std::{future::Future, pin::Pin};
+
+use futures::executor::ThreadPool;
 
 /// Implemented on objects that can run a `Future` in the background.
 ///
-/// > **Note**: While it may be tempting to implement this trait on types such as
-/// >           [`futures::stream::FuturesUnordered`], please note that passing an `Executor` is
-/// >           optional, and that `FuturesUnordered` (or a similar struct) will automatically
-/// >           be used as fallback by libp2p. The `Executor` trait should therefore only be
-/// >           about running `Future`s on a separate task.
+/// > **Note**: While it may be tempting to implement this trait on types such
+/// > as
+/// > [`futures::stream::FuturesUnordered`], please note that passing an
+/// > `Executor` is
+/// > optional, and that `FuturesUnordered` (or a similar struct) will
+/// > automatically
+/// > be used as fallback by libp2p. The `Executor` trait should therefore only
+/// > be
+/// > about running `Future`s on a separate task.
 pub trait Executor {
     /// Run the given future in the background until it ends.
     #[track_caller]

--- a/swarm/src/handler/either.rs
+++ b/swarm/src/handler/either.rs
@@ -18,14 +18,23 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::handler::{
-    ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, FullyNegotiatedInbound,
-    InboundUpgradeSend, ListenUpgradeError, SubstreamProtocol,
-};
-use crate::upgrade::SendWrapper;
+use std::task::{Context, Poll};
+
 use either::Either;
 use futures::future;
-use std::task::{Context, Poll};
+
+use crate::{
+    handler::{
+        ConnectionEvent,
+        ConnectionHandler,
+        ConnectionHandlerEvent,
+        FullyNegotiatedInbound,
+        InboundUpgradeSend,
+        ListenUpgradeError,
+        SubstreamProtocol,
+    },
+    upgrade::SendWrapper,
+};
 
 impl<LIP, RIP, LIOI, RIOI>
     FullyNegotiatedInbound<Either<SendWrapper<LIP>, SendWrapper<RIP>>, Either<LIOI, RIOI>>
@@ -71,8 +80,8 @@ where
     }
 }
 
-/// Implementation of a [`ConnectionHandler`] that represents either of two [`ConnectionHandler`]
-/// implementations.
+/// Implementation of a [`ConnectionHandler`] that represents either of two
+/// [`ConnectionHandler`] implementations.
 impl<L, R> ConnectionHandler for Either<L, R>
 where
     L: ConnectionHandler,

--- a/swarm/src/handler/map_in.rs
+++ b/swarm/src/handler/map_in.rs
@@ -18,12 +18,21 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::handler::{
-    ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, SubstreamProtocol,
+use std::{
+    fmt::Debug,
+    marker::PhantomData,
+    task::{Context, Poll},
 };
-use std::{fmt::Debug, marker::PhantomData, task::Context, task::Poll};
 
-/// Wrapper around a protocol handler that turns the input event into something else.
+use crate::handler::{
+    ConnectionEvent,
+    ConnectionHandler,
+    ConnectionHandlerEvent,
+    SubstreamProtocol,
+};
+
+/// Wrapper around a protocol handler that turns the input event into something
+/// else.
 #[derive(Debug)]
 pub struct MapInEvent<TConnectionHandler, TNewIn, TMap> {
     inner: TConnectionHandler,

--- a/swarm/src/handler/map_out.rs
+++ b/swarm/src/handler/map_out.rs
@@ -18,14 +18,22 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::handler::{
-    ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, SubstreamProtocol,
+use std::{
+    fmt::Debug,
+    task::{Context, Poll},
 };
-use futures::ready;
-use std::fmt::Debug;
-use std::task::{Context, Poll};
 
-/// Wrapper around a protocol handler that turns the output event into something else.
+use futures::ready;
+
+use crate::handler::{
+    ConnectionEvent,
+    ConnectionHandler,
+    ConnectionHandlerEvent,
+    SubstreamProtocol,
+};
+
+/// Wrapper around a protocol handler that turns the output event into something
+/// else.
 #[derive(Debug)]
 pub struct MapOutEvent<TConnectionHandler, TMap> {
     inner: TConnectionHandler,

--- a/swarm/src/handler/multi.rs
+++ b/swarm/src/handler/multi.rs
@@ -18,17 +18,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! A [`ConnectionHandler`] implementation that combines multiple other [`ConnectionHandler`]s
-//! indexed by some key.
+//! A [`ConnectionHandler`] implementation that combines multiple other
+//! [`ConnectionHandler`]s indexed by some key.
 
-use crate::handler::{
-    AddressChange, ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, DialUpgradeError,
-    FullyNegotiatedInbound, FullyNegotiatedOutbound, ListenUpgradeError, SubstreamProtocol,
-};
-use crate::upgrade::{InboundUpgradeSend, OutboundUpgradeSend, UpgradeInfoSend};
-use crate::Stream;
-use futures::{future::BoxFuture, prelude::*, ready};
-use rand::Rng;
 use std::{
     cmp,
     collections::{HashMap, HashSet},
@@ -40,7 +32,27 @@ use std::{
     time::Duration,
 };
 
-/// A [`ConnectionHandler`] for multiple [`ConnectionHandler`]s of the same type.
+use futures::{future::BoxFuture, prelude::*, ready};
+use rand::Rng;
+
+use crate::{
+    handler::{
+        AddressChange,
+        ConnectionEvent,
+        ConnectionHandler,
+        ConnectionHandlerEvent,
+        DialUpgradeError,
+        FullyNegotiatedInbound,
+        FullyNegotiatedOutbound,
+        ListenUpgradeError,
+        SubstreamProtocol,
+    },
+    upgrade::{InboundUpgradeSend, OutboundUpgradeSend, UpgradeInfoSend},
+    Stream,
+};
+
+/// A [`ConnectionHandler`] for multiple [`ConnectionHandler`]s of the same
+/// type.
 #[derive(Clone)]
 pub struct MultiHandler<K, H> {
     handlers: HashMap<K, H>,
@@ -65,7 +77,8 @@ where
 {
     /// Create and populate a `MultiHandler` from the given handler iterator.
     ///
-    /// It is an error for any two protocols handlers to share the same protocol name.
+    /// It is an error for any two protocols handlers to share the same protocol
+    /// name.
     pub fn try_from_iter<I>(iter: I) -> Result<Self, DuplicateProtonameError>
     where
         I: IntoIterator<Item = (K, H)>,
@@ -242,13 +255,14 @@ where
     ) -> Poll<
         ConnectionHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Self::ToBehaviour>,
     > {
-        // Calling `gen_range(0, 0)` (see below) would panic, so we have return early to avoid
-        // that situation.
+        // Calling `gen_range(0, 0)` (see below) would panic, so we have return early to
+        // avoid that situation.
         if self.handlers.is_empty() {
             return Poll::Pending;
         }
 
-        // Not always polling handlers in the same order should give anyone the chance to make progress.
+        // Not always polling handlers in the same order should give anyone the chance
+        // to make progress.
         let pos = rand::thread_rng().gen_range(0..self.handlers.len());
 
         for (k, h) in self.handlers.iter_mut().skip(pos) {

--- a/swarm/src/handler/one_shot.rs
+++ b/swarm/src/handler/one_shot.rs
@@ -18,14 +18,28 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::handler::{
-    ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, DialUpgradeError,
-    FullyNegotiatedInbound, FullyNegotiatedOutbound, SubstreamProtocol,
+use std::{
+    error,
+    fmt::Debug,
+    task::{Context, Poll},
+    time::Duration,
 };
-use crate::upgrade::{InboundUpgradeSend, OutboundUpgradeSend};
-use crate::StreamUpgradeError;
+
 use smallvec::SmallVec;
-use std::{error, fmt::Debug, task::Context, task::Poll, time::Duration};
+
+use crate::{
+    handler::{
+        ConnectionEvent,
+        ConnectionHandler,
+        ConnectionHandlerEvent,
+        DialUpgradeError,
+        FullyNegotiatedInbound,
+        FullyNegotiatedOutbound,
+        SubstreamProtocol,
+    },
+    upgrade::{InboundUpgradeSend, OutboundUpgradeSend},
+    StreamUpgradeError,
+};
 
 /// A [`ConnectionHandler`] that opens a new substream for each request.
 // TODO: Debug
@@ -70,16 +84,18 @@ where
 
     /// Returns a reference to the listen protocol configuration.
     ///
-    /// > **Note**: If you modify the protocol, modifications will only applies to future inbound
-    /// >           substreams, not the ones already being negotiated.
+    /// > **Note**: If you modify the protocol, modifications will only applies
+    /// > to future inbound
+    /// > substreams, not the ones already being negotiated.
     pub fn listen_protocol_ref(&self) -> &SubstreamProtocol<TInbound, ()> {
         &self.listen_protocol
     }
 
     /// Returns a mutable reference to the listen protocol configuration.
     ///
-    /// > **Note**: If you modify the protocol, modifications will only applies to future inbound
-    /// >           substreams, not the ones already being negotiated.
+    /// > **Note**: If you modify the protocol, modifications will only applies
+    /// > to future inbound
+    /// > substreams, not the ones already being negotiated.
     pub fn listen_protocol_mut(&mut self) -> &mut SubstreamProtocol<TInbound, ()> {
         &mut self.listen_protocol
     }
@@ -212,12 +228,12 @@ impl Default for OneShotHandlerConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    use futures::executor::block_on;
-    use futures::future::poll_fn;
-    use libp2p_core::upgrade::DeniedUpgrade;
     use std::convert::Infallible;
+
+    use futures::{executor::block_on, future::poll_fn};
+    use libp2p_core::upgrade::DeniedUpgrade;
+
+    use super::*;
 
     #[test]
     fn do_not_keep_idle_connection_alive() {

--- a/swarm/src/handler/pending.rs
+++ b/swarm/src/handler/pending.rs
@@ -19,13 +19,21 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::handler::{
-    ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, FullyNegotiatedInbound,
-    FullyNegotiatedOutbound, SubstreamProtocol,
+use std::{
+    convert::Infallible,
+    task::{Context, Poll},
 };
+
 use libp2p_core::upgrade::PendingUpgrade;
-use std::convert::Infallible;
-use std::task::{Context, Poll};
+
+use crate::handler::{
+    ConnectionEvent,
+    ConnectionHandler,
+    ConnectionHandlerEvent,
+    FullyNegotiatedInbound,
+    FullyNegotiatedOutbound,
+    SubstreamProtocol,
+};
 
 /// Implementation of [`ConnectionHandler`] that returns a pending upgrade.
 #[derive(Clone, Debug)]

--- a/swarm/src/handler/select.rs
+++ b/swarm/src/handler/select.rs
@@ -18,18 +18,35 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::handler::{
-    AddressChange, ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, DialUpgradeError,
-    FullyNegotiatedInbound, FullyNegotiatedOutbound, InboundUpgradeSend, ListenUpgradeError,
-    OutboundUpgradeSend, StreamUpgradeError, SubstreamProtocol,
+use std::{
+    cmp,
+    task::{Context, Poll},
 };
-use crate::upgrade::SendWrapper;
+
 use either::Either;
 use futures::{future, ready};
 use libp2p_core::upgrade::SelectUpgrade;
-use std::{cmp, task::Context, task::Poll};
 
-/// Implementation of [`ConnectionHandler`] that combines two protocols into one.
+use crate::{
+    handler::{
+        AddressChange,
+        ConnectionEvent,
+        ConnectionHandler,
+        ConnectionHandlerEvent,
+        DialUpgradeError,
+        FullyNegotiatedInbound,
+        FullyNegotiatedOutbound,
+        InboundUpgradeSend,
+        ListenUpgradeError,
+        OutboundUpgradeSend,
+        StreamUpgradeError,
+        SubstreamProtocol,
+    },
+    upgrade::SendWrapper,
+};
+
+/// Implementation of [`ConnectionHandler`] that combines two protocols into
+/// one.
 #[derive(Debug, Clone)]
 pub struct ConnectionHandlerSelect<TProto1, TProto2> {
     /// The first protocol.

--- a/swarm/src/listen_opts.rs
+++ b/swarm/src/listen_opts.rs
@@ -1,5 +1,6 @@
-use crate::ListenerId;
 use libp2p_core::Multiaddr;
+
+use crate::ListenerId;
 
 #[derive(Debug)]
 pub struct ListenOpts {

--- a/swarm/src/stream.rs
+++ b/swarm/src/stream.rs
@@ -1,12 +1,12 @@
-use futures::{AsyncRead, AsyncWrite};
-use libp2p_core::muxing::SubstreamBox;
-use libp2p_core::Negotiated;
 use std::{
     io::{IoSlice, IoSliceMut},
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
 };
+
+use futures::{AsyncRead, AsyncWrite};
+use libp2p_core::{muxing::SubstreamBox, Negotiated};
 
 /// Counter for the number of active streams on a connection.
 #[derive(Debug, Clone)]
@@ -40,14 +40,16 @@ impl Stream {
         }
     }
 
-    /// Ignore this stream in the [Swarm](crate::Swarm)'s connection-keep-alive algorithm.
+    /// Ignore this stream in the [Swarm](crate::Swarm)'s connection-keep-alive
+    /// algorithm.
     ///
-    /// By default, any active stream keeps a connection alive. For most protocols,
-    /// this is a good default as it ensures that the protocol is completed before
-    /// a connection is shut down.
+    /// By default, any active stream keeps a connection alive. For most
+    /// protocols, this is a good default as it ensures that the protocol is
+    /// completed before a connection is shut down.
     /// Some protocols like libp2p's [ping](https://github.com/libp2p/specs/blob/master/ping/ping.md)
     /// for example never complete and are of an auxiliary nature.
-    /// These protocols should opt-out of the keep alive algorithm using this method.
+    /// These protocols should opt-out of the keep alive algorithm using this
+    /// method.
     pub fn ignore_for_keep_alive(&mut self) {
         self.counter.take();
     }

--- a/swarm/src/stream_protocol.rs
+++ b/swarm/src/stream_protocol.rs
@@ -1,12 +1,16 @@
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
+
 use either::Either;
-use std::fmt;
-use std::hash::{Hash, Hasher};
-use std::sync::Arc;
 
 /// Identifies a protocol for a stream.
 ///
-/// libp2p nodes use stream protocols to negotiate what to do with a newly opened stream.
-/// Stream protocols are string-based and must start with a forward slash: `/`.
+/// libp2p nodes use stream protocols to negotiate what to do with a newly
+/// opened stream. Stream protocols are string-based and must start with a
+/// forward slash: `/`.
 #[derive(Clone, Eq)]
 pub struct StreamProtocol {
     inner: Either<&'static str, Arc<str>>,
@@ -17,7 +21,8 @@ impl StreamProtocol {
     ///
     /// # Panics
     ///
-    /// This function panics if the protocol does not start with a forward slash: `/`.
+    /// This function panics if the protocol does not start with a forward
+    /// slash: `/`.
     pub const fn new(s: &'static str) -> Self {
         match s.as_bytes() {
             [b'/', ..] => {}
@@ -31,15 +36,17 @@ impl StreamProtocol {
 
     /// Attempt to construct a protocol from an owned string.
     ///
-    /// This function will fail if the protocol does not start with a forward slash: `/`.
-    /// Where possible, you should use [`StreamProtocol::new`] instead to avoid allocations.
+    /// This function will fail if the protocol does not start with a forward
+    /// slash: `/`. Where possible, you should use [`StreamProtocol::new`]
+    /// instead to avoid allocations.
     pub fn try_from_owned(protocol: String) -> Result<Self, InvalidProtocol> {
         if !protocol.starts_with('/') {
             return Err(InvalidProtocol::missing_forward_slash());
         }
 
         Ok(StreamProtocol {
-            inner: Either::Right(Arc::from(protocol)), // FIXME: Can we somehow reuse the allocation from the owned string?
+            inner: Either::Right(Arc::from(protocol)), /* FIXME: Can we somehow reuse the
+                                                        * allocation from the owned string? */
         })
     }
 }

--- a/swarm/src/test.rs
+++ b/swarm/src/test.rs
@@ -18,19 +18,42 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::behaviour::{
-    ConnectionClosed, ConnectionEstablished, DialFailure, ExpiredListenAddr, ExternalAddrExpired,
-    FromSwarm, ListenerClosed, ListenerError, NewExternalAddrCandidate, NewListenAddr, NewListener,
+use std::{
+    collections::HashMap,
+    task::{Context, Poll},
 };
-use crate::{
-    ConnectionDenied, ConnectionHandler, ConnectionId, NetworkBehaviour, THandler, THandlerInEvent,
-    THandlerOutEvent, ToSwarm,
+
+use libp2p_core::{
+    multiaddr::Multiaddr,
+    transport::{ListenerId, PortUse},
+    ConnectedPoint,
+    Endpoint,
 };
-use libp2p_core::transport::PortUse;
-use libp2p_core::{multiaddr::Multiaddr, transport::ListenerId, ConnectedPoint, Endpoint};
 use libp2p_identity::PeerId;
-use std::collections::HashMap;
-use std::task::{Context, Poll};
+
+use crate::{
+    behaviour::{
+        ConnectionClosed,
+        ConnectionEstablished,
+        DialFailure,
+        ExpiredListenAddr,
+        ExternalAddrExpired,
+        FromSwarm,
+        ListenerClosed,
+        ListenerError,
+        NewExternalAddrCandidate,
+        NewListenAddr,
+        NewListener,
+    },
+    ConnectionDenied,
+    ConnectionHandler,
+    ConnectionId,
+    NetworkBehaviour,
+    THandler,
+    THandlerInEvent,
+    THandlerOutEvent,
+    ToSwarm,
+};
 
 /// A `MockBehaviour` is a `NetworkBehaviour` that allows for
 /// the instrumentation of return values, without keeping
@@ -42,9 +65,12 @@ where
     TOutEvent: Send + 'static,
 {
     /// The prototype protocols handler that is cloned for every
-    /// invocation of [`NetworkBehaviour::handle_established_inbound_connection`] and [`NetworkBehaviour::handle_established_outbound_connection`]
+    /// invocation of
+    /// [`NetworkBehaviour::handle_established_inbound_connection`] and
+    /// [`NetworkBehaviour::handle_established_outbound_connection`]
     pub(crate) handler_proto: THandler,
-    /// The addresses to return from [`NetworkBehaviour::handle_established_outbound_connection`].
+    /// The addresses to return from
+    /// [`NetworkBehaviour::handle_established_outbound_connection`].
     pub(crate) addresses: HashMap<PeerId, Vec<Multiaddr>>,
     /// The next action to return from `poll`.
     ///
@@ -218,8 +244,9 @@ where
                 .count()
     }
 
-    /// Checks that when the expected number of established connection notifications are received,
-    /// a given number of expected connections have been received as well.
+    /// Checks that when the expected number of established connection
+    /// notifications are received, a given number of expected connections
+    /// have been received as well.
     ///
     /// Returns if the first condition is met.
     pub(crate) fn assert_connected(
@@ -266,8 +293,9 @@ where
             })
             .take(other_established);
 
-        // We are informed that there are `other_established` additional connections. Ensure that the
-        // number of previous connections is consistent with this
+        // We are informed that there are `other_established` additional connections.
+        // Ensure that the number of previous connections is consistent with
+        // this
         if let Some(&prev) = other_peer_connections.next() {
             if prev < other_established {
                 assert_eq!(
@@ -319,8 +347,9 @@ where
             })
             .take(remaining_established);
 
-        // We are informed that there are `other_established` additional connections. Ensure that the
-        // number of previous connections is consistent with this
+        // We are informed that there are `other_established` additional connections.
+        // Ensure that the number of previous connections is consistent with
+        // this
         if let Some(&prev) = other_closed_connections.next() {
             if prev < remaining_established {
                 assert_eq!(
@@ -338,8 +367,8 @@ where
                 .iter()
                 .any(|(peer, conn_id, endpoint, _)| (peer, conn_id, endpoint)
                     == (&peer_id, &connection_id, endpoint)),
-            "`on_swarm_event` with `FromSwarm::ConnectionClosed is called only for connections for\
-             which `on_swarm_event` with `FromSwarm::ConnectionEstablished` was called first."
+            "`on_swarm_event` with `FromSwarm::ConnectionClosed is called only for connections \
+             forwhich `on_swarm_event` with `FromSwarm::ConnectionEstablished` was called first."
         );
         self.on_connection_closed.push((
             peer_id,

--- a/swarm/src/translation.rs
+++ b/swarm/src/translation.rs
@@ -22,17 +22,18 @@ use libp2p_core::{multiaddr::Protocol, Multiaddr};
 
 /// Perform IP address translation.
 ///
-/// Given an `original` [`Multiaddr`] and some `observed` [`Multiaddr`], replace the first protocol
-/// of the `original` with the first protocol of the `observed` [`Multiaddr`] and return this
-/// translated [`Multiaddr`].
+/// Given an `original` [`Multiaddr`] and some `observed` [`Multiaddr`], replace
+/// the first protocol of the `original` with the first protocol of the
+/// `observed` [`Multiaddr`] and return this translated [`Multiaddr`].
 ///
-/// This function can for example be useful when handling tcp connections. Tcp does not listen and
-/// dial on the same port by default. Thus when receiving an observed address on a connection that
-/// we initiated, it will contain our dialing port, not our listening port. We need to take the ip
-/// address or dns address from the observed address and the port from the original address.
+/// This function can for example be useful when handling tcp connections. Tcp
+/// does not listen and dial on the same port by default. Thus when receiving an
+/// observed address on a connection that we initiated, it will contain our
+/// dialing port, not our listening port. We need to take the ip address or dns
+/// address from the observed address and the port from the original address.
 ///
-/// This is a mixed-mode translation, i.e. an IPv4 / DNS4 address may be replaced by an IPv6 / DNS6
-/// address and vice versa.
+/// This is a mixed-mode translation, i.e. an IPv4 / DNS4 address may be
+/// replaced by an IPv6 / DNS6 address and vice versa.
 ///
 /// If the first [`Protocol`]s are not IP addresses, `None` is returned instead.
 #[doc(hidden)]

--- a/swarm/src/upgrade.rs
+++ b/swarm/src/upgrade.rs
@@ -18,13 +18,13 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::Stream;
-
 use futures::prelude::*;
 use libp2p_core::upgrade;
 
-/// Implemented automatically on all types that implement [`UpgradeInfo`](upgrade::UpgradeInfo)
-/// and `Send + 'static`.
+use crate::Stream;
+
+/// Implemented automatically on all types that implement
+/// [`UpgradeInfo`](upgrade::UpgradeInfo) and `Send + 'static`.
 ///
 /// Do not implement this trait yourself. Instead, please implement
 /// [`UpgradeInfo`](upgrade::UpgradeInfo).
@@ -34,7 +34,8 @@ pub trait UpgradeInfoSend: Send + 'static {
     /// Equivalent to [`UpgradeInfo::InfoIter`](upgrade::UpgradeInfo::InfoIter).
     type InfoIter: Iterator<Item = Self::Info> + Send + 'static;
 
-    /// Equivalent to [`UpgradeInfo::protocol_info`](upgrade::UpgradeInfo::protocol_info).
+    /// Equivalent to
+    /// [`UpgradeInfo::protocol_info`](upgrade::UpgradeInfo::protocol_info).
     fn protocol_info(&self) -> Self::InfoIter;
 }
 
@@ -58,14 +59,18 @@ where
 /// Do not implement this trait yourself. Instead, please implement
 /// [`OutboundUpgrade`](upgrade::OutboundUpgrade).
 pub trait OutboundUpgradeSend: UpgradeInfoSend {
-    /// Equivalent to [`OutboundUpgrade::Output`](upgrade::OutboundUpgrade::Output).
+    /// Equivalent to
+    /// [`OutboundUpgrade::Output`](upgrade::OutboundUpgrade::Output).
     type Output: Send + 'static;
-    /// Equivalent to [`OutboundUpgrade::Error`](upgrade::OutboundUpgrade::Error).
+    /// Equivalent to
+    /// [`OutboundUpgrade::Error`](upgrade::OutboundUpgrade::Error).
     type Error: Send + 'static;
-    /// Equivalent to [`OutboundUpgrade::Future`](upgrade::OutboundUpgrade::Future).
+    /// Equivalent to
+    /// [`OutboundUpgrade::Future`](upgrade::OutboundUpgrade::Future).
     type Future: Future<Output = Result<Self::Output, Self::Error>> + Send + 'static;
 
-    /// Equivalent to [`OutboundUpgrade::upgrade_outbound`](upgrade::OutboundUpgrade::upgrade_outbound).
+    /// Equivalent to
+    /// [`OutboundUpgrade::upgrade_outbound`](upgrade::OutboundUpgrade::upgrade_outbound).
     fn upgrade_outbound(self, socket: Stream, info: Self::Info) -> Self::Future;
 }
 
@@ -92,14 +97,17 @@ where
 /// Do not implement this trait yourself. Instead, please implement
 /// [`InboundUpgrade`](upgrade::InboundUpgrade).
 pub trait InboundUpgradeSend: UpgradeInfoSend {
-    /// Equivalent to [`InboundUpgrade::Output`](upgrade::InboundUpgrade::Output).
+    /// Equivalent to
+    /// [`InboundUpgrade::Output`](upgrade::InboundUpgrade::Output).
     type Output: Send + 'static;
     /// Equivalent to [`InboundUpgrade::Error`](upgrade::InboundUpgrade::Error).
     type Error: Send + 'static;
-    /// Equivalent to [`InboundUpgrade::Future`](upgrade::InboundUpgrade::Future).
+    /// Equivalent to
+    /// [`InboundUpgrade::Future`](upgrade::InboundUpgrade::Future).
     type Future: Future<Output = Result<Self::Output, Self::Error>> + Send + 'static;
 
-    /// Equivalent to [`InboundUpgrade::upgrade_inbound`](upgrade::InboundUpgrade::upgrade_inbound).
+    /// Equivalent to
+    /// [`InboundUpgrade::upgrade_inbound`](upgrade::InboundUpgrade::upgrade_inbound).
     fn upgrade_inbound(self, socket: Stream, info: Self::Info) -> Self::Future;
 }
 
@@ -120,13 +128,15 @@ where
     }
 }
 
-/// Wraps around a type that implements [`OutboundUpgradeSend`], [`InboundUpgradeSend`], or
+/// Wraps around a type that implements [`OutboundUpgradeSend`],
+/// [`InboundUpgradeSend`], or
 ///
 /// both, and implements [`OutboundUpgrade`](upgrade::OutboundUpgrade) and/or
 /// [`InboundUpgrade`](upgrade::InboundUpgrade).
 ///
-/// > **Note**: This struct is mostly an implementation detail of the library and normally
-/// >           doesn't need to be used directly.
+/// > **Note**: This struct is mostly an implementation detail of the library
+/// > and normally
+/// > doesn't need to be used directly.
 pub struct SendWrapper<T>(pub T);
 
 impl<T: UpgradeInfoSend> upgrade::UpgradeInfo for SendWrapper<T> {

--- a/swarm/tests/connection_close.rs
+++ b/swarm/tests/connection_close.rs
@@ -1,16 +1,27 @@
-use libp2p_core::transport::PortUse;
-use libp2p_core::upgrade::DeniedUpgrade;
-use libp2p_core::{Endpoint, Multiaddr};
+use std::{
+    convert::Infallible,
+    task::{Context, Poll},
+};
+
+use libp2p_core::{transport::PortUse, upgrade::DeniedUpgrade, Endpoint, Multiaddr};
 use libp2p_identity::PeerId;
-use libp2p_swarm::handler::ConnectionEvent;
 use libp2p_swarm::{
-    ConnectionDenied, ConnectionHandler, ConnectionHandlerEvent, ConnectionId, FromSwarm,
-    NetworkBehaviour, SubstreamProtocol, Swarm, SwarmEvent, THandler, THandlerInEvent,
-    THandlerOutEvent, ToSwarm,
+    handler::ConnectionEvent,
+    ConnectionDenied,
+    ConnectionHandler,
+    ConnectionHandlerEvent,
+    ConnectionId,
+    FromSwarm,
+    NetworkBehaviour,
+    SubstreamProtocol,
+    Swarm,
+    SwarmEvent,
+    THandler,
+    THandlerInEvent,
+    THandlerOutEvent,
+    ToSwarm,
 };
 use libp2p_swarm_test::SwarmExt;
-use std::convert::Infallible;
-use std::task::{Context, Poll};
 
 #[async_std::test]
 async fn sends_remaining_events_to_behaviour_on_connection_close() {

--- a/swarm/tests/listener.rs
+++ b/swarm/tests/listener.rs
@@ -7,15 +7,28 @@ use std::{
 use libp2p_core::{
     multiaddr::Protocol,
     transport::{ListenerId, PortUse},
-    Endpoint, Multiaddr,
+    Endpoint,
+    Multiaddr,
 };
 use libp2p_identity::PeerId;
 use libp2p_swarm::{
-    derive_prelude::NewListener, dummy, ConnectionDenied, ConnectionId, FromSwarm, ListenOpts,
-    ListenerClosed, ListenerError, NetworkBehaviour, NewListenAddr, Swarm, SwarmEvent, THandler,
-    THandlerInEvent, THandlerOutEvent, ToSwarm,
+    derive_prelude::NewListener,
+    dummy,
+    ConnectionDenied,
+    ConnectionId,
+    FromSwarm,
+    ListenOpts,
+    ListenerClosed,
+    ListenerError,
+    NetworkBehaviour,
+    NewListenAddr,
+    Swarm,
+    SwarmEvent,
+    THandler,
+    THandlerInEvent,
+    THandlerOutEvent,
+    ToSwarm,
 };
-
 use libp2p_swarm_test::SwarmExt;
 
 #[async_std::test]

--- a/swarm/tests/swarm_derive.rs
+++ b/swarm/tests/swarm_derive.rs
@@ -18,27 +18,34 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::fmt::Debug;
+
 use futures::StreamExt;
 use libp2p_core::{transport::PortUse, Endpoint, Multiaddr};
 use libp2p_identify as identify;
 use libp2p_ping as ping;
 use libp2p_swarm::{
-    behaviour::FromSwarm, dummy, ConnectionDenied, NetworkBehaviour, SwarmEvent, THandler,
-    THandlerInEvent, THandlerOutEvent,
+    behaviour::FromSwarm,
+    dummy,
+    ConnectionDenied,
+    NetworkBehaviour,
+    SwarmEvent,
+    THandler,
+    THandlerInEvent,
+    THandlerOutEvent,
 };
-use std::fmt::Debug;
 
 /// Small utility to check that a type implements `NetworkBehaviour`.
 #[allow(dead_code)]
 fn require_net_behaviour<T: libp2p_swarm::NetworkBehaviour>() {}
 
 // TODO: doesn't compile
-/*#[test]
-fn empty() {
-    #[allow(dead_code)]
-    #[derive(NetworkBehaviour)]
-    struct Foo {}
-}*/
+// #[test]
+// fn empty() {
+// #[allow(dead_code)]
+// #[derive(NetworkBehaviour)]
+// struct Foo {}
+// }
 
 #[test]
 fn one_field() {
@@ -378,7 +385,8 @@ fn with_generics_constrained() {
     struct Marked;
     impl Mark for Marked {}
 
-    /// A struct with a generic constraint, for which we manually implement `NetworkBehaviour`.
+    /// A struct with a generic constraint, for which we manually implement
+    /// `NetworkBehaviour`.
     #[allow(dead_code)]
     struct Bar<A: Mark> {
         a: A,
@@ -537,10 +545,10 @@ fn multiple_behaviour_attributes() {
 
 #[test]
 fn custom_out_event_no_type_parameters() {
+    use std::task::{Context, Poll};
+
     use libp2p_identity::PeerId;
     use libp2p_swarm::{ConnectionId, ToSwarm};
-    use std::task::Context;
-    use std::task::Poll;
 
     pub(crate) struct TemplatedBehaviour<T: 'static> {
         _data: T,

--- a/transports/noise/src/io.rs
+++ b/transports/noise/src/io.rs
@@ -22,17 +22,18 @@
 
 mod framed;
 pub(crate) mod handshake;
-use asynchronous_codec::Framed;
-use bytes::Bytes;
-use framed::{Codec, MAX_FRAME_LEN};
-use futures::prelude::*;
-use futures::ready;
 use std::{
     cmp::min,
-    fmt, io,
+    fmt,
+    io,
     pin::Pin,
     task::{Context, Poll},
 };
+
+use asynchronous_codec::Framed;
+use bytes::Bytes;
+use framed::{Codec, MAX_FRAME_LEN};
+use futures::{prelude::*, ready};
 
 /// A noise session to a remote.
 ///

--- a/transports/noise/src/protocol.rs
+++ b/transports/noise/src/protocol.rs
@@ -20,13 +20,14 @@
 
 //! Components of a Noise protocol.
 
-use crate::Error;
 use libp2p_identity as identity;
 use once_cell::sync::Lazy;
 use rand::{Rng as _, SeedableRng};
 use snow::params::NoiseParams;
 use x25519_dalek::{x25519, X25519_BASEPOINT_BYTES};
 use zeroize::Zeroize;
+
+use crate::Error;
 
 /// Prefix of static key signatures for domain separation.
 pub(crate) const STATIC_KEY_DOMAIN: &str = "noise-libp2p-static-key:";
@@ -84,7 +85,8 @@ impl Keypair {
     }
 
     /// Turn this DH keypair into a [`AuthenticKeypair`], i.e. a DH keypair that
-    /// is authentic w.r.t. the given identity keypair, by signing the DH public key.
+    /// is authentic w.r.t. the given identity keypair, by signing the DH public
+    /// key.
     pub(crate) fn into_authentic(
         self,
         id_keys: &identity::Keypair,

--- a/transports/noise/tests/smoke.rs
+++ b/transports/noise/tests/smoke.rs
@@ -18,14 +18,17 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::io;
+
 use futures::prelude::*;
-use libp2p_core::transport::{MemoryTransport, Transport};
-use libp2p_core::upgrade;
-use libp2p_core::upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade};
+use libp2p_core::{
+    transport::{MemoryTransport, Transport},
+    upgrade,
+    upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade},
+};
 use libp2p_identity as identity;
 use libp2p_noise as noise;
 use quickcheck::*;
-use std::io;
 use tracing_subscriber::EnvFilter;
 
 #[allow(dead_code)]

--- a/transports/noise/tests/webtransport_certhashes.rs
+++ b/transports/noise/tests/webtransport_certhashes.rs
@@ -1,8 +1,9 @@
+use std::collections::HashSet;
+
 use libp2p_core::upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade};
 use libp2p_identity as identity;
 use libp2p_noise as noise;
 use multihash::Multihash;
-use std::collections::HashSet;
 
 const SHA_256_MH: u64 = 0x12;
 

--- a/transports/plaintext/src/error.rs
+++ b/transports/plaintext/src/error.rs
@@ -18,9 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use std::error;
-use std::fmt;
-use std::io::Error as IoError;
+use std::{error, fmt, io::Error as IoError};
 
 #[derive(Debug)]
 pub enum Error {
@@ -33,7 +31,8 @@ pub enum Error {
     /// Failed to parse public key from bytes in protobuf message.
     InvalidPublicKey(libp2p_identity::DecodingError),
 
-    /// Failed to parse the [`PeerId`](libp2p_identity::PeerId) from bytes in the protobuf message.
+    /// Failed to parse the [`PeerId`](libp2p_identity::PeerId) from bytes in
+    /// the protobuf message.
     InvalidPeerId(libp2p_identity::ParseError),
 
     /// The peer id of the exchange isn't consistent with the remote public key.

--- a/transports/plaintext/src/handshake.rs
+++ b/transports/plaintext/src/handshake.rs
@@ -18,20 +18,25 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::error::{DecodeError, Error};
-use crate::proto::Exchange;
-use crate::Config;
+use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+
 use asynchronous_codec::{Framed, FramedParts};
 use bytes::Bytes;
 use futures::prelude::*;
 use libp2p_identity::{PeerId, PublicKey};
-use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+
+use crate::{
+    error::{DecodeError, Error},
+    proto::Exchange,
+    Config,
+};
 
 pub(crate) async fn handshake<S>(socket: S, config: Config) -> Result<(S, PublicKey, Bytes), Error>
 where
     S: AsyncRead + AsyncWrite + Send + Unpin,
 {
-    // The handshake messages all start with a variable-length integer indicating the size.
+    // The handshake messages all start with a variable-length integer indicating
+    // the size.
     let mut framed_socket = Framed::new(socket, quick_protobuf_codec::Codec::<Exchange>::new(100));
 
     tracing::trace!("sending exchange to remote");

--- a/transports/plaintext/src/lib.rs
+++ b/transports/plaintext/src/lib.rs
@@ -22,21 +22,23 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use crate::error::Error;
-
-use bytes::Bytes;
-use futures::future::BoxFuture;
-use futures::prelude::*;
-use libp2p_core::upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade};
-use libp2p_core::UpgradeInfo;
-use libp2p_identity as identity;
-use libp2p_identity::PeerId;
-use libp2p_identity::PublicKey;
 use std::{
-    io, iter,
+    io,
+    iter,
     pin::Pin,
     task::{Context, Poll},
 };
+
+use bytes::Bytes;
+use futures::{future::BoxFuture, prelude::*};
+use libp2p_core::{
+    upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade},
+    UpgradeInfo,
+};
+use libp2p_identity as identity;
+use libp2p_identity::{PeerId, PublicKey};
+
+use crate::error::Error;
 
 mod error;
 mod handshake;

--- a/transports/pnet/src/lib.rs
+++ b/transports/pnet/src/lib.rs
@@ -19,23 +19,13 @@
 // DEALINGS IN THE SOFTWARE.
 
 //! Implementation of the [pnet](https://github.com/libp2p/specs/blob/master/pnet/Private-Networks-PSK-V1.md) protocol.
-//!
 //| The `pnet` protocol implements *Pre-shared Key Based Private Networks in libp2p*.
-//! Libp2p nodes configured with a pre-shared key can only communicate with other nodes with
-//! the same key.
+//! Libp2p nodes configured with a pre-shared key can only communicate with
+//! other nodes with the same key.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 mod crypt_writer;
-use crypt_writer::CryptWriter;
-use futures::prelude::*;
-use pin_project::pin_project;
-use rand::RngCore;
-use salsa20::{
-    cipher::{KeyIvInit, StreamCipher},
-    Salsa20, XSalsa20,
-};
-use sha3::{digest::ExtendableOutput, Shake128};
 use std::{
     error,
     fmt::{self, Write},
@@ -46,6 +36,17 @@ use std::{
     str::FromStr,
     task::{Context, Poll},
 };
+
+use crypt_writer::CryptWriter;
+use futures::prelude::*;
+use pin_project::pin_project;
+use rand::RngCore;
+use salsa20::{
+    cipher::{KeyIvInit, StreamCipher},
+    Salsa20,
+    XSalsa20,
+};
+use sha3::{digest::ExtendableOutput, Shake128};
 
 const KEY_SIZE: usize = 32;
 const NONCE_SIZE: usize = 24;
@@ -168,7 +169,8 @@ pub enum KeyParseError {
     InvalidKeyEncoding,
     /// Key is of the wrong length
     InvalidKeyLength,
-    /// key string contains a char that is not consistent with the specified encoding
+    /// key string contains a char that is not consistent with the specified
+    /// encoding
     InvalidKeyChar(ParseIntError),
 }
 
@@ -200,8 +202,8 @@ impl PnetConfig {
 
     /// upgrade a connection to use pre shared key encryption.
     ///
-    /// the upgrade works by both sides exchanging 24 byte nonces and then encrypting
-    /// subsequent traffic with XSalsa20
+    /// the upgrade works by both sides exchanging 24 byte nonces and then
+    /// encrypting subsequent traffic with XSalsa20
     pub async fn handshake<TSocket>(
         self,
         mut socket: TSocket,
@@ -229,8 +231,8 @@ impl PnetConfig {
     }
 }
 
-/// The result of a handshake. This implements AsyncRead and AsyncWrite and can therefore
-/// be used as base for additional upgrades.
+/// The result of a handshake. This implements AsyncRead and AsyncWrite and can
+/// therefore be used as base for additional upgrades.
 #[pin_project]
 pub struct PnetOutput<S> {
     #[pin]
@@ -319,8 +321,9 @@ impl fmt::Display for PnetError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use quickcheck::*;
+
+    use super::*;
 
     impl Arbitrary for PreSharedKey {
         fn arbitrary(g: &mut Gen) -> PreSharedKey {
@@ -367,7 +370,10 @@ mod tests {
     #[test]
     fn fingerprint() {
         // checked against go-ipfs output
-        let key = "/key/swarm/psk/1.0.0/\n/base16/\n6189c5cf0b87fb800c1a9feeda73c6ab5e998db48fb9e6a978575c770ceef683".parse::<PreSharedKey>().unwrap();
+        let key = "/key/swarm/psk/1.0.0/\n/base16/\\
+                   n6189c5cf0b87fb800c1a9feeda73c6ab5e998db48fb9e6a978575c770ceef683"
+            .parse::<PreSharedKey>()
+            .unwrap();
         let expected = "45fc986bbc9388a11d939df26f730f0c";
         let actual = key.fingerprint().to_string();
         assert_eq!(expected, actual);

--- a/transports/pnet/tests/smoke.rs
+++ b/transports/pnet/tests/smoke.rs
@@ -1,10 +1,13 @@
 use std::time::Duration;
 
 use futures::{future, AsyncRead, AsyncWrite, StreamExt};
-use libp2p_core::transport::MemoryTransport;
-use libp2p_core::upgrade::Version;
-use libp2p_core::Transport;
-use libp2p_core::{multiaddr::Protocol, Multiaddr};
+use libp2p_core::{
+    multiaddr::Protocol,
+    transport::MemoryTransport,
+    upgrade::Version,
+    Multiaddr,
+    Transport,
+};
 use libp2p_pnet::{PnetConfig, PreSharedKey};
 use libp2p_swarm::{dummy, Config, NetworkBehaviour, Swarm, SwarmEvent};
 

--- a/transports/quic/src/config.rs
+++ b/transports/quic/src/config.rs
@@ -18,19 +18,23 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+use std::{sync::Arc, time::Duration};
+
 use quinn::{
     crypto::rustls::{QuicClientConfig, QuicServerConfig},
-    MtuDiscoveryConfig, VarInt,
+    MtuDiscoveryConfig,
+    VarInt,
 };
-use std::{sync::Arc, time::Duration};
 
 /// Config for the transport.
 #[derive(Clone)]
 pub struct Config {
     /// Timeout for the initial handshake when establishing a connection.
-    /// The actual timeout is the minimum of this and the [`Config::max_idle_timeout`].
+    /// The actual timeout is the minimum of this and the
+    /// [`Config::max_idle_timeout`].
     pub handshake_timeout: Duration,
-    /// Maximum duration of inactivity in ms to accept before timing out the connection.
+    /// Maximum duration of inactivity in ms to accept before timing out the
+    /// connection.
     pub max_idle_timeout: u32,
     /// Period of inactivity before sending a keep-alive packet.
     /// Must be set lower than the idle_timeout of both
@@ -46,17 +50,17 @@ pub struct Config {
     /// Max unacknowledged data in bytes that may be sent on a single stream.
     pub max_stream_data: u32,
 
-    /// Max unacknowledged data in bytes that may be sent in total on all streams
-    /// of a connection.
+    /// Max unacknowledged data in bytes that may be sent in total on all
+    /// streams of a connection.
     pub max_connection_data: u32,
 
     /// Support QUIC version draft-29 for dialing and listening.
     ///
-    /// Per default only QUIC Version 1 / [`libp2p_core::multiaddr::Protocol::QuicV1`]
-    /// is supported.
+    /// Per default only QUIC Version 1 /
+    /// [`libp2p_core::multiaddr::Protocol::QuicV1`] is supported.
     ///
-    /// If support for draft-29 is enabled servers support draft-29 and version 1 on all
-    /// QUIC listening addresses.
+    /// If support for draft-29 is enabled servers support draft-29 and version
+    /// 1 on all QUIC listening addresses.
     /// As client the version is chosen based on the remote's address.
     pub support_draft_29: bool,
 
@@ -67,7 +71,8 @@ pub struct Config {
     /// Libp2p identity of the node.
     keypair: libp2p_identity::Keypair,
 
-    /// Parameters governing MTU discovery. See [`MtuDiscoveryConfig`] for details.
+    /// Parameters governing MTU discovery. See [`MtuDiscoveryConfig`] for
+    /// details.
     mtu_discovery_config: Option<MtuDiscoveryConfig>,
 }
 
@@ -98,7 +103,8 @@ impl Config {
         }
     }
 
-    /// Set the upper bound to the max UDP payload size that MTU discovery will search for.
+    /// Set the upper bound to the max UDP payload size that MTU discovery will
+    /// search for.
     pub fn mtu_upper_bound(mut self, value: u16) -> Self {
         self.mtu_discovery_config
             .get_or_insert_with(Default::default)
@@ -153,8 +159,8 @@ impl From<Config> for QuinnConfig {
         let mut server_config = quinn::ServerConfig::with_crypto(server_tls_config);
         server_config.transport = Arc::clone(&transport);
         // Disables connection migration.
-        // Long-term this should be enabled, however we then need to handle address change
-        // on connections in the `Connection`.
+        // Long-term this should be enabled, however we then need to handle address
+        // change on connections in the `Connection`.
         server_config.migration(false);
 
         let mut client_config = quinn::ClientConfig::new(client_tls_config);

--- a/transports/quic/src/connection.rs
+++ b/transports/quic/src/connection.rs
@@ -21,17 +21,17 @@
 mod connecting;
 mod stream;
 
-pub use connecting::Connecting;
-pub use stream::Stream;
-
-use crate::{ConnectionError, Error};
-
-use futures::{future::BoxFuture, FutureExt};
-use libp2p_core::muxing::{StreamMuxer, StreamMuxerEvent};
 use std::{
     pin::Pin,
     task::{Context, Poll},
 };
+
+pub use connecting::Connecting;
+use futures::{future::BoxFuture, FutureExt};
+use libp2p_core::muxing::{StreamMuxer, StreamMuxerEvent};
+pub use stream::Stream;
+
+use crate::{ConnectionError, Error};
 
 /// State for a single opened QUIC connection.
 pub struct Connection {
@@ -52,8 +52,9 @@ pub struct Connection {
 impl Connection {
     /// Build a [`Connection`] from raw components.
     ///
-    /// This function assumes that the [`quinn::Connection`] is completely fresh and none of
-    /// its methods has ever been called. Failure to comply might lead to logic errors and panics.
+    /// This function assumes that the [`quinn::Connection`] is completely fresh
+    /// and none of its methods has ever been called. Failure to comply
+    /// might lead to logic errors and panics.
     fn new(connection: quinn::Connection) -> Self {
         Self {
             connection,

--- a/transports/quic/src/connection/connecting.rs
+++ b/transports/quic/src/connection/connecting.rs
@@ -18,9 +18,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! Future that drives a QUIC connection until is has performed its TLS handshake.
+//! Future that drives a QUIC connection until is has performed its TLS
+//! handshake.
 
-use crate::{Connection, ConnectionError, Error};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
 
 use futures::{
     future::{select, Either, FutureExt, Select},
@@ -29,11 +34,8 @@ use futures::{
 use futures_timer::Delay;
 use libp2p_identity::PeerId;
 use quinn::rustls::pki_types::CertificateDer;
-use std::{
-    pin::Pin,
-    task::{Context, Poll},
-    time::Duration,
-};
+
+use crate::{Connection, ConnectionError, Error};
 
 /// A QUIC connection currently being negotiated.
 #[derive(Debug)]

--- a/transports/quic/src/hole_punching.rs
+++ b/transports/quic/src/hole_punching.rs
@@ -1,14 +1,13 @@
-use crate::{provider::Provider, Error};
-
-use futures::future::Either;
-
-use rand::{distributions, Rng};
-
-use std::convert::Infallible;
 use std::{
+    convert::Infallible,
     net::{SocketAddr, UdpSocket},
     time::Duration,
 };
+
+use futures::future::Either;
+use rand::{distributions, Rng};
+
+use crate::{provider::Provider, Error};
 
 pub(crate) async fn hole_puncher<P: Provider>(
     socket: UdpSocket,

--- a/transports/quic/src/lib.rs
+++ b/transports/quic/src/lib.rs
@@ -31,29 +31,33 @@
 //! # #[cfg(feature = "async-std")]
 //! # fn main() -> std::io::Result<()> {
 //! #
+//! use libp2p_core::{transport::ListenerId, Multiaddr, Transport};
 //! use libp2p_quic as quic;
-//! use libp2p_core::{Multiaddr, Transport, transport::ListenerId};
 //!
 //! let keypair = libp2p_identity::Keypair::generate_ed25519();
 //! let quic_config = quic::Config::new(&keypair);
 //!
 //! let mut quic_transport = quic::async_std::Transport::new(quic_config);
 //!
-//! let addr = "/ip4/127.0.0.1/udp/12345/quic-v1".parse().expect("address should be valid");
-//! quic_transport.listen_on(ListenerId::next(), addr).expect("listen error.");
+//! let addr = "/ip4/127.0.0.1/udp/12345/quic-v1"
+//!     .parse()
+//!     .expect("address should be valid");
+//! quic_transport
+//!     .listen_on(ListenerId::next(), addr)
+//!     .expect("listen error.");
 //! #
 //! # Ok(())
 //! # }
 //! ```
 //!
-//! The [`GenTransport`] struct implements the [`libp2p_core::Transport`]. See the
-//! documentation of [`libp2p_core`] and of libp2p in general to learn how to use the
-//! [`Transport`][libp2p_core::Transport] trait.
+//! The [`GenTransport`] struct implements the [`libp2p_core::Transport`]. See
+//! the documentation of [`libp2p_core`] and of libp2p in general to learn how
+//! to use the [`Transport`][libp2p_core::Transport] trait.
 //!
-//! Note that QUIC provides transport, security, and multiplexing in a single protocol.  Therefore,
-//! QUIC connections do not need to be upgraded. You will get a compile-time error if you try.
-//! Instead, you must pass all needed configuration into the constructor.
-//!
+//! Note that QUIC provides transport, security, and multiplexing in a single
+//! protocol.  Therefore, QUIC connections do not need to be upgraded. You will
+//! get a compile-time error if you try. Instead, you must pass all needed
+//! configuration into the constructor.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
@@ -67,7 +71,6 @@ use std::net::SocketAddr;
 
 pub use config::Config;
 pub use connection::{Connecting, Connection, Stream};
-
 #[cfg(feature = "async-std")]
 pub use provider::async_std;
 #[cfg(feature = "tokio")]
@@ -94,7 +97,8 @@ pub enum Error {
     #[error("Handshake with the remote timed out.")]
     HandshakeTimedOut,
 
-    /// Error when `Transport::dial_as_listener` is called without an active listener.
+    /// Error when `Transport::dial_as_listener` is called without an active
+    /// listener.
     #[error("Tried to dial as listener without an active listener.")]
     NoActiveListenerForDialAsListener,
 

--- a/transports/quic/src/provider.rs
+++ b/transports/quic/src/provider.rs
@@ -18,14 +18,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures::future::BoxFuture;
-use if_watch::IfEvent;
 use std::{
     io,
     net::{SocketAddr, UdpSocket},
     task::{Context, Poll},
     time::Duration,
 };
+
+use futures::future::BoxFuture;
+use if_watch::IfEvent;
 
 #[cfg(feature = "async-std")]
 pub mod async_std;
@@ -47,7 +48,8 @@ pub trait Provider: Unpin + Send + Sized + 'static {
     /// Run the corresponding runtime
     fn runtime() -> Runtime;
 
-    /// Create a new [`if_watch`] watcher that reports [`IfEvent`]s for network interface changes.
+    /// Create a new [`if_watch`] watcher that reports [`IfEvent`]s for network
+    /// interface changes.
     fn new_if_watcher() -> io::Result<Self::IfWatcher>;
 
     /// Poll for an address change event.
@@ -59,7 +61,8 @@ pub trait Provider: Unpin + Send + Sized + 'static {
     /// Sleep for specified amount of time.
     fn sleep(duration: Duration) -> BoxFuture<'static, ()>;
 
-    /// Sends data on the socket to the given address. On success, returns the number of bytes written.
+    /// Sends data on the socket to the given address. On success, returns the
+    /// number of bytes written.
     fn send_to<'a>(
         udp_socket: &'a UdpSocket,
         buf: &'a [u8],

--- a/transports/quic/src/provider/async_std.rs
+++ b/transports/quic/src/provider/async_std.rs
@@ -18,13 +18,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures::{future::BoxFuture, FutureExt};
 use std::{
     io,
     net::UdpSocket,
     task::{Context, Poll},
     time::Duration,
 };
+
+use futures::{future::BoxFuture, FutureExt};
 
 use crate::GenTransport;
 

--- a/transports/quic/src/provider/tokio.rs
+++ b/transports/quic/src/provider/tokio.rs
@@ -18,13 +18,14 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures::{future::BoxFuture, FutureExt};
 use std::{
     io,
     net::{SocketAddr, UdpSocket},
     task::{Context, Poll},
     time::Duration,
 };
+
+use futures::{future::BoxFuture, FutureExt};
 
 use crate::GenTransport;
 

--- a/transports/quic/tests/stream_compliance.rs
+++ b/transports/quic/tests/stream_compliance.rs
@@ -1,9 +1,12 @@
-use futures::channel::oneshot;
-use futures::StreamExt;
-use libp2p_core::transport::{DialOpts, ListenerId, PortUse};
-use libp2p_core::{Endpoint, Transport};
-use libp2p_quic as quic;
 use std::time::Duration;
+
+use futures::{channel::oneshot, StreamExt};
+use libp2p_core::{
+    transport::{DialOpts, ListenerId, PortUse},
+    Endpoint,
+    Transport,
+};
+use libp2p_quic as quic;
 
 #[async_std::test]
 async fn close_implies_flush() {

--- a/transports/tcp/src/provider.rs
+++ b/transports/tcp/src/provider.rs
@@ -26,13 +26,19 @@ pub mod async_io;
 #[cfg(feature = "tokio")]
 pub mod tokio;
 
-use futures::future::BoxFuture;
-use futures::io::{AsyncRead, AsyncWrite};
-use futures::Stream;
+use std::{
+    fmt,
+    io,
+    net::{SocketAddr, TcpListener, TcpStream},
+    task::{Context, Poll},
+};
+
+use futures::{
+    future::BoxFuture,
+    io::{AsyncRead, AsyncWrite},
+    Stream,
+};
 use if_watch::{IfEvent, IpNet};
-use std::net::{SocketAddr, TcpListener, TcpStream};
-use std::task::{Context, Poll};
-use std::{fmt, io};
 
 /// An incoming connection returned from [`Provider::poll_accept()`].
 pub struct Incoming<S> {
@@ -67,8 +73,8 @@ pub trait Provider: Clone + Send + 'static {
     /// setup to complete, i.e. for the stream to be writable.
     fn new_stream(_: TcpStream) -> BoxFuture<'static, io::Result<Self::Stream>>;
 
-    /// Polls a [`Self::Listener`] for an incoming connection, ensuring a task wakeup,
-    /// if necessary.
+    /// Polls a [`Self::Listener`] for an incoming connection, ensuring a task
+    /// wakeup, if necessary.
     fn poll_accept(
         _: &mut Self::Listener,
         _: &mut Context<'_>,

--- a/transports/tcp/src/provider/async_io.rs
+++ b/transports/tcp/src/provider/async_io.rs
@@ -18,15 +18,19 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use super::{Incoming, Provider};
+use std::{
+    io,
+    net,
+    task::{Context, Poll},
+};
 
 use async_io::Async;
 use futures::future::{BoxFuture, FutureExt};
-use std::io;
-use std::net;
-use std::task::{Context, Poll};
 
-/// A TCP [`Transport`](libp2p_core::Transport) that works with the `async-std` ecosystem.
+use super::{Incoming, Provider};
+
+/// A TCP [`Transport`](libp2p_core::Transport) that works with the `async-std`
+/// ecosystem.
 ///
 /// # Example
 ///
@@ -40,9 +44,14 @@ use std::task::{Context, Poll};
 /// # async fn main() {
 /// let mut transport = tcp::async_io::Transport::new(tcp::Config::default());
 /// let id = ListenerId::next();
-/// transport.listen_on(id, "/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
+/// transport
+///     .listen_on(id, "/ip4/127.0.0.1/tcp/0".parse().unwrap())
+///     .unwrap();
 ///
-/// let addr = future::poll_fn(|cx| Pin::new(&mut transport).poll(cx)).await.into_new_address().unwrap();
+/// let addr = future::poll_fn(|cx| Pin::new(&mut transport).poll(cx))
+///     .await
+///     .into_new_address()
+///     .unwrap();
 ///
 /// println!("Listening on {addr}");
 /// # }
@@ -100,8 +109,9 @@ impl Provider for Tcp {
                     Some(Err(e)) => return Poll::Ready(Err(e)),
                     Some(Ok(res)) => break res,
                     None => {
-                        // Since it doesn't do any harm, account for false positives of
-                        // `poll_readable` just in case, i.e. try again.
+                        // Since it doesn't do any harm, account for false
+                        // positives of `poll_readable`
+                        // just in case, i.e. try again.
                     }
                 },
             }

--- a/transports/tcp/src/provider/tokio.rs
+++ b/transports/tcp/src/provider/tokio.rs
@@ -18,18 +18,22 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use super::{Incoming, Provider};
+use std::{
+    io,
+    net,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use futures::{
     future::{BoxFuture, FutureExt},
     prelude::*,
 };
-use std::io;
-use std::net;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 
-/// A TCP [`Transport`](libp2p_core::Transport) that works with the `tokio` ecosystem.
+use super::{Incoming, Provider};
+
+/// A TCP [`Transport`](libp2p_core::Transport) that works with the `tokio`
+/// ecosystem.
 ///
 /// # Example
 ///
@@ -42,9 +46,14 @@ use std::task::{Context, Poll};
 /// # #[tokio::main]
 /// # async fn main() {
 /// let mut transport = tcp::tokio::Transport::new(tcp::Config::default());
-/// let id = transport.listen_on(ListenerId::next(), "/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
+/// let id = transport
+///     .listen_on(ListenerId::next(), "/ip4/127.0.0.1/tcp/0".parse().unwrap())
+///     .unwrap();
 ///
-/// let addr = future::poll_fn(|cx| Pin::new(&mut transport).poll(cx)).await.into_new_address().unwrap();
+/// let addr = future::poll_fn(|cx| Pin::new(&mut transport).poll(cx))
+///     .await
+///     .into_new_address()
+///     .unwrap();
 ///
 /// println!("Listening on {addr}");
 /// # }
@@ -116,7 +125,8 @@ impl Provider for Tcp {
     }
 }
 
-/// A [`tokio::net::TcpStream`] that implements [`AsyncRead`] and [`AsyncWrite`].
+/// A [`tokio::net::TcpStream`] that implements [`AsyncRead`] and
+/// [`AsyncWrite`].
 #[derive(Debug)]
 pub struct TcpStream(pub tokio::net::TcpStream);
 

--- a/transports/tls/src/certificate.rs
+++ b/transports/tls/src/certificate.rs
@@ -22,11 +22,11 @@
 //!
 //! This module handles generation, signing, and verification of certificates.
 
+use std::sync::Arc;
+
 use libp2p_identity as identity;
 use libp2p_identity::PeerId;
 use x509_parser::{prelude::*, signature_algorithm::SignatureAlgorithm};
-
-use std::sync::Arc;
 
 /// The libp2p Public Key Extension is a X.509 extension
 /// with the Object Identifier 1.3.6.1.4.1.53594.1.1,
@@ -37,11 +37,13 @@ const P2P_EXT_OID: [u64; 9] = [1, 3, 6, 1, 4, 1, 53594, 1, 1];
 /// and the public key that it used to generate the certificate carrying
 /// the libp2p Public Key Extension, using its private host key.
 /// This signature provides cryptographic proof that the peer was
-/// in possession of the private host key at the time the certificate was signed.
+/// in possession of the private host key at the time the certificate was
+/// signed.
 const P2P_SIGNING_PREFIX: [u8; 21] = *b"libp2p-tls-handshake:";
 
 // Certificates MUST use the NamedCurve encoding for elliptic curve parameters.
-// Similarly, hash functions with an output length less than 256 bits MUST NOT be used.
+// Similarly, hash functions with an output length less than 256 bits MUST NOT
+// be used.
 static P2P_SIGNATURE_ALGORITHM: &rcgen::SignatureAlgorithm = &rcgen::PKCS_ECDSA_P256_SHA256;
 
 #[derive(Debug)]
@@ -123,8 +125,8 @@ pub fn generate(
 
 /// Attempts to parse the provided bytes as a [`P2pCertificate`].
 ///
-/// For this to succeed, the certificate must contain the specified extension and the signature must
-/// match the embedded public key.
+/// For this to succeed, the certificate must contain the specified extension
+/// and the signature must match the embedded public key.
 pub fn parse<'a>(
     certificate: &'a rustls::pki_types::CertificateDer<'a>,
 ) -> Result<P2pCertificate<'a>, ParseError> {
@@ -146,13 +148,14 @@ pub struct P2pCertificate<'a> {
     extension: P2pExtension,
 }
 
-/// The contents of the specific libp2p extension, containing the public host key
-/// and a signature performed using the private host key.
+/// The contents of the specific libp2p extension, containing the public host
+/// key and a signature performed using the private host key.
 #[derive(Debug)]
 pub struct P2pExtension {
     public_key: identity::PublicKey,
     /// This signature provides cryptographic proof that the peer was
-    /// in possession of the private host key at the time the certificate was signed.
+    /// in possession of the private host key at the time the certificate was
+    /// signed.
     signature: Vec<u8>,
 }
 
@@ -226,7 +229,8 @@ fn parse_unverified(der_input: &[u8]) -> Result<P2pCertificate, webpki::Error> {
             return Err(webpki::Error::UnsupportedCriticalExtension);
         }
 
-        // Implementations MUST ignore non-critical extensions with unknown OIDs.
+        // Implementations MUST ignore non-critical extensions with unknown
+        // OIDs.
     }
 
     // The certificate MUST contain the libp2p Public Key Extension.
@@ -283,8 +287,8 @@ impl P2pCertificate<'_> {
         self.extension.public_key.to_peer_id()
     }
 
-    /// Verify the `signature` of the `message` signed by the private key corresponding to the public key stored
-    /// in the certificate.
+    /// Verify the `signature` of the `message` signed by the private key
+    /// corresponding to the public key stored in the certificate.
     pub fn verify_signature(
         &self,
         signature_scheme: rustls::SignatureScheme,
@@ -298,9 +302,10 @@ impl P2pCertificate<'_> {
         Ok(())
     }
 
-    /// Get a [`ring::signature::UnparsedPublicKey`] for this `signature_scheme`.
-    /// Return `Error` if the `signature_scheme` does not match the public key signature
-    /// and hashing algorithm or if the `signature_scheme` is not supported.
+    /// Get a [`ring::signature::UnparsedPublicKey`] for this
+    /// `signature_scheme`. Return `Error` if the `signature_scheme` does
+    /// not match the public key signature and hashing algorithm or if the
+    /// `signature_scheme` is not supported.
     fn public_key(
         &self,
         signature_scheme: rustls::SignatureScheme,
@@ -492,8 +497,9 @@ impl P2pCertificate<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use hex_literal::hex;
+
+    use super::*;
 
     #[test]
     fn sanity_check() {

--- a/transports/tls/src/lib.rs
+++ b/transports/tls/src/lib.rs
@@ -29,14 +29,12 @@ pub mod certificate;
 mod upgrade;
 mod verifier;
 
-use certificate::AlwaysResolvesCert;
-use libp2p_identity::Keypair;
-use libp2p_identity::PeerId;
 use std::sync::Arc;
 
+use certificate::AlwaysResolvesCert;
 pub use futures_rustls::TlsStream;
-pub use upgrade::Config;
-pub use upgrade::UpgradeError;
+use libp2p_identity::{Keypair, PeerId};
+pub use upgrade::{Config, UpgradeError};
 
 const P2P_ALPN: [u8; 6] = *b"libp2p";
 

--- a/transports/tls/src/upgrade.rs
+++ b/transports/tls/src/upgrade.rs
@@ -18,20 +18,22 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::certificate;
-use crate::certificate::P2pCertificate;
-use futures::future::BoxFuture;
-use futures::AsyncWrite;
-use futures::{AsyncRead, FutureExt};
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    sync::Arc,
+};
+
+use futures::{future::BoxFuture, AsyncRead, AsyncWrite, FutureExt};
 use futures_rustls::TlsStream;
-use libp2p_core::upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade};
-use libp2p_core::UpgradeInfo;
+use libp2p_core::{
+    upgrade::{InboundConnectionUpgrade, OutboundConnectionUpgrade},
+    UpgradeInfo,
+};
 use libp2p_identity as identity;
 use libp2p_identity::PeerId;
 use rustls::{pki_types::ServerName, CommonState};
 
-use std::net::{IpAddr, Ipv4Addr};
-use std::sync::Arc;
+use crate::{certificate, certificate::P2pCertificate};
 
 #[derive(thiserror::Error, Debug)]
 pub enum UpgradeError {
@@ -102,8 +104,11 @@ where
 
     fn upgrade_outbound(self, socket: C, _: Self::Info) -> Self::Future {
         async move {
-            // Spec: In order to keep this flexibility for future versions, clients that only support the version of the handshake defined in this document MUST NOT send any value in the Server Name Indication.
-            // Setting `ServerName` to unspecified will disable the use of the SNI extension.
+            // Spec: In order to keep this flexibility for future versions, clients that
+            // only support the version of the handshake defined in this document MUST NOT
+            // send any value in the Server Name Indication.
+            // Setting `ServerName` to unspecified will disable the use of the SNI
+            // extension.
             let name = ServerName::IpAddress(rustls::pki_types::IpAddr::from(IpAddr::V4(
                 Ipv4Addr::UNSPECIFIED,
             )));

--- a/transports/tls/src/verifier.rs
+++ b/transports/tls/src/verifier.rs
@@ -23,19 +23,28 @@
 //! This module handles a verification of a client/server certificate chain
 //! and signatures allegedly by the given certificates.
 
-use crate::certificate;
+use std::sync::Arc;
+
 use libp2p_identity::PeerId;
 use rustls::{
     client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
     crypto::ring::cipher_suite::{
-        TLS13_AES_128_GCM_SHA256, TLS13_AES_256_GCM_SHA384, TLS13_CHACHA20_POLY1305_SHA256,
+        TLS13_AES_128_GCM_SHA256,
+        TLS13_AES_256_GCM_SHA384,
+        TLS13_CHACHA20_POLY1305_SHA256,
     },
     pki_types::CertificateDer,
     server::danger::{ClientCertVerified, ClientCertVerifier},
-    CertificateError, DigitallySignedStruct, DistinguishedName, OtherError, SignatureScheme,
-    SupportedCipherSuite, SupportedProtocolVersion,
+    CertificateError,
+    DigitallySignedStruct,
+    DistinguishedName,
+    OtherError,
+    SignatureScheme,
+    SupportedCipherSuite,
+    SupportedProtocolVersion,
 };
-use std::sync::Arc;
+
+use crate::certificate;
 
 /// The protocol versions supported by this verifier.
 ///
@@ -56,7 +65,8 @@ pub(crate) static CIPHERSUITES: &[SupportedCipherSuite] = &[
 
 /// Implementation of the `rustls` certificate verification traits for libp2p.
 ///
-/// Only TLS 1.3 is supported. TLS 1.2 should be disabled in the configuration of `rustls`.
+/// Only TLS 1.3 is supported. TLS 1.2 should be disabled in the configuration
+/// of `rustls`.
 #[derive(Debug)]
 pub(crate) struct Libp2pCertificateVerifier {
     /// The peer ID we intend to connect to
@@ -205,8 +215,8 @@ impl ClientCertVerifier for Libp2pCertificateVerifier {
 /// MUST check these conditions and abort the connection attempt if
 /// (a) the presented certificate is not yet valid, OR
 /// (b) if it is expired.
-/// Endpoints MUST abort the connection attempt if more than one certificate is received,
-/// or if the certificate’s self-signature is not valid.
+/// Endpoints MUST abort the connection attempt if more than one certificate is
+/// received, or if the certificate’s self-signature is not valid.
 fn verify_presented_certs(
     end_entity: &CertificateDer,
     intermediates: &[CertificateDer],

--- a/transports/tls/tests/smoke.rs
+++ b/transports/tls/tests/smoke.rs
@@ -1,10 +1,8 @@
-use futures::{future, StreamExt};
-use libp2p_core::multiaddr::Protocol;
-use libp2p_core::transport::MemoryTransport;
-use libp2p_core::upgrade::Version;
-use libp2p_core::Transport;
-use libp2p_swarm::{dummy, Config, Swarm, SwarmEvent};
 use std::time::Duration;
+
+use futures::{future, StreamExt};
+use libp2p_core::{multiaddr::Protocol, transport::MemoryTransport, upgrade::Version, Transport};
+use libp2p_swarm::{dummy, Config, Swarm, SwarmEvent};
 
 #[tokio::test]
 async fn can_establish_connection() {

--- a/transports/uds/src/lib.rs
+++ b/transports/uds/src/lib.rs
@@ -26,10 +26,12 @@
 //!
 //! # Usage
 //!
-//! The `UdsConfig` transport supports multiaddresses of the form `/unix//tmp/foo`.
+//! The `UdsConfig` transport supports multiaddresses of the form
+//! `/unix//tmp/foo`.
 //!
-//! The `UdsConfig` structs implements the `Transport` trait of the `core` library. See the
-//! documentation of `core` and of libp2p in general to learn how to use the `Transport` trait.
+//! The `UdsConfig` structs implements the `Transport` trait of the `core`
+//! library. See the documentation of `core` and of libp2p in general to learn
+//! how to use the `Transport` trait.
 
 #![cfg(all(
     unix,
@@ -38,21 +40,24 @@
 ))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use futures::stream::BoxStream;
+use std::{
+    collections::VecDeque,
+    io,
+    path::PathBuf,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
 use futures::{
     future::{BoxFuture, Ready},
     prelude::*,
+    stream::BoxStream,
 };
-use libp2p_core::transport::ListenerId;
 use libp2p_core::{
     multiaddr::{Multiaddr, Protocol},
-    transport::{DialOpts, TransportError, TransportEvent},
+    transport::{DialOpts, ListenerId, TransportError, TransportEvent},
     Transport,
 };
-use std::collections::VecDeque;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::{io, path::PathBuf};
 
 pub type Listener<T> = BoxStream<
     'static,
@@ -219,8 +224,8 @@ codegen!(
 
 /// Turns a `Multiaddr` containing a single `Unix` component into a path.
 ///
-/// Also returns an error if the path is not absolute, as we don't want to dial/listen on relative
-/// paths.
+/// Also returns an error if the path is not absolute, as we don't want to
+/// dial/listen on relative paths.
 // This type of logic should probably be moved into the multiaddr package
 fn multiaddr_to_path(addr: &Multiaddr) -> Result<PathBuf, ()> {
     let mut protocols = addr.iter();
@@ -241,14 +246,17 @@ fn multiaddr_to_path(addr: &Multiaddr) -> Result<PathBuf, ()> {
 
 #[cfg(all(test, feature = "async-std"))]
 mod tests {
-    use super::{multiaddr_to_path, UdsConfig};
+    use std::{borrow::Cow, path::Path};
+
     use futures::{channel::oneshot, prelude::*};
     use libp2p_core::{
         multiaddr::{Multiaddr, Protocol},
         transport::{DialOpts, ListenerId, PortUse},
-        Endpoint, Transport,
+        Endpoint,
+        Transport,
     };
-    use std::{borrow::Cow, path::Path};
+
+    use super::{multiaddr_to_path, UdsConfig};
 
     #[test]
     fn multiaddr_to_path_conversion() {

--- a/transports/webrtc-websys/src/lib.rs
+++ b/transports/webrtc-websys/src/lib.rs
@@ -7,7 +7,9 @@ mod stream;
 mod transport;
 mod upgrade;
 
-pub use self::connection::Connection;
-pub use self::error::Error;
-pub use self::stream::Stream;
-pub use self::transport::{Config, Transport};
+pub use self::{
+    connection::Connection,
+    error::Error,
+    stream::Stream,
+    transport::{Config, Transport},
+};

--- a/transports/webrtc-websys/src/sdp.rs
+++ b/transports/webrtc-websys/src/sdp.rs
@@ -1,5 +1,6 @@
-use libp2p_webrtc_utils::Fingerprint;
 use std::net::SocketAddr;
+
+use libp2p_webrtc_utils::Fingerprint;
 use web_sys::{RtcSdpType, RtcSessionDescriptionInit};
 
 /// Creates the SDP answer used by the client.
@@ -19,7 +20,8 @@ pub(crate) fn answer(
 
 /// Creates the munged SDP offer from the Browser's given SDP offer
 ///
-/// Certificate verification is disabled which is why we hardcode a dummy fingerprint here.
+/// Certificate verification is disabled which is why we hardcode a dummy
+/// fingerprint here.
 pub(crate) fn offer(offer: String, client_ufrag: &str) -> RtcSessionDescriptionInit {
     // find line and replace a=ice-ufrag: with "\r\na=ice-ufrag:{client_ufrag}\r\n"
     // find line and replace a=ice-pwd: with "\r\na=ice-ufrag:{client_ufrag}\r\n"

--- a/transports/webrtc-websys/src/stream.rs
+++ b/transports/webrtc-websys/src/stream.rs
@@ -1,10 +1,14 @@
 //! The WebRTC [Stream] over the Connection
-use self::poll_data_channel::PollDataChannel;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
 use futures::{AsyncRead, AsyncWrite};
 use send_wrapper::SendWrapper;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 use web_sys::RtcDataChannel;
+
+use self::poll_data_channel::PollDataChannel;
 
 mod poll_data_channel;
 

--- a/transports/webrtc-websys/src/stream/poll_data_channel.rs
+++ b/transports/webrtc-websys/src/stream/poll_data_channel.rs
@@ -1,19 +1,23 @@
-use std::cmp::min;
-use std::io;
-use std::pin::Pin;
-use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Mutex;
-use std::task::{Context, Poll};
+use std::{
+    cmp::min,
+    io,
+    pin::Pin,
+    rc::Rc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Mutex,
+    },
+    task::{Context, Poll},
+};
 
 use bytes::BytesMut;
-use futures::task::AtomicWaker;
-use futures::{AsyncRead, AsyncWrite};
+use futures::{task::AtomicWaker, AsyncRead, AsyncWrite};
 use libp2p_webrtc_utils::MAX_MSG_LEN;
 use wasm_bindgen::prelude::*;
 use web_sys::{Event, MessageEvent, RtcDataChannel, RtcDataChannelEvent, RtcDataChannelState};
 
-/// [`PollDataChannel`] is a wrapper around [`RtcDataChannel`] which implements [`AsyncRead`] and [`AsyncWrite`].
+/// [`PollDataChannel`] is a wrapper around [`RtcDataChannel`] which implements
+/// [`AsyncRead`] and [`AsyncWrite`].
 #[derive(Debug, Clone)]
 pub(crate) struct PollDataChannel {
     /// The [`RtcDataChannel`] being wrapped.
@@ -25,7 +29,8 @@ pub(crate) struct PollDataChannel {
     /// Waker for when we are waiting for the DC to be opened.
     open_waker: Rc<AtomicWaker>,
 
-    /// Waker for when we are waiting to write (again) to the DC because we previously exceeded the [`MAX_MSG_LEN`] threshold.
+    /// Waker for when we are waiting to write (again) to the DC because we
+    /// previously exceeded the [`MAX_MSG_LEN`] threshold.
     write_waker: Rc<AtomicWaker>,
 
     /// Waker for when we are waiting for the DC to be closed.
@@ -33,9 +38,12 @@ pub(crate) struct PollDataChannel {
 
     /// Whether we've been overloaded with data by the remote.
     ///
-    /// This is set to `true` in case `read_buffer` overflows, i.e. the remote is sending us messages faster than we can read them.
-    /// In that case, we return an [`std::io::Error`] from [`AsyncRead`] or [`AsyncWrite`], depending which one gets called earlier.
-    /// Failing these will (very likely), cause the application developer to drop the stream which resets it.
+    /// This is set to `true` in case `read_buffer` overflows, i.e. the remote
+    /// is sending us messages faster than we can read them. In that case,
+    /// we return an [`std::io::Error`] from [`AsyncRead`] or [`AsyncWrite`],
+    /// depending which one gets called earlier. Failing these will (very
+    /// likely), cause the application developer to drop the stream which resets
+    /// it.
     overloaded: Rc<AtomicBool>,
 
     // Store the closures for proper garbage collection.
@@ -83,7 +91,8 @@ impl PollDataChannel {
         inner.set_onclose(Some(on_close_closure.as_ref().unchecked_ref()));
 
         let new_data_waker = Rc::new(AtomicWaker::new());
-        let read_buffer = Rc::new(Mutex::new(BytesMut::new())); // We purposely don't use `with_capacity` so we don't eagerly allocate `MAX_READ_BUFFER` per stream.
+        let read_buffer = Rc::new(Mutex::new(BytesMut::new())); // We purposely don't use `with_capacity` so we don't eagerly allocate
+                                                                // `MAX_READ_BUFFER` per stream.
         let overloaded = Rc::new(AtomicBool::new(false));
 
         let on_message_closure = Closure::<dyn FnMut(_)>::new({

--- a/transports/webrtc-websys/src/transport.rs
+++ b/transports/webrtc-websys/src/transport.rs
@@ -1,15 +1,18 @@
-use super::upgrade;
-use super::Connection;
-use super::Error;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
 use futures::future::FutureExt;
-use libp2p_core::multiaddr::Multiaddr;
-use libp2p_core::muxing::StreamMuxerBox;
-use libp2p_core::transport::DialOpts;
-use libp2p_core::transport::{Boxed, ListenerId, Transport as _, TransportError, TransportEvent};
+use libp2p_core::{
+    multiaddr::Multiaddr,
+    muxing::StreamMuxerBox,
+    transport::{Boxed, DialOpts, ListenerId, Transport as _, TransportError, TransportEvent},
+};
 use libp2p_identity::{Keypair, PeerId};
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+
+use super::{upgrade, Connection, Error};
 
 /// Config for the [`Transport`].
 #[derive(Clone)]
@@ -17,7 +20,8 @@ pub struct Config {
     keypair: Keypair,
 }
 
-/// A WebTransport [`Transport`](libp2p_core::Transport) that works with `web-sys`.
+/// A WebTransport [`Transport`](libp2p_core::Transport) that works with
+/// `web-sys`.
 pub struct Transport {
     config: Config,
 }

--- a/transports/webrtc-websys/src/upgrade.rs
+++ b/transports/webrtc-websys/src/upgrade.rs
@@ -1,13 +1,11 @@
-use super::Error;
-use crate::connection::RtcPeerConnection;
-use crate::error::AuthenticationError;
-use crate::sdp;
-use crate::Connection;
-use libp2p_identity::{Keypair, PeerId};
-use libp2p_webrtc_utils::noise;
-use libp2p_webrtc_utils::Fingerprint;
-use send_wrapper::SendWrapper;
 use std::net::SocketAddr;
+
+use libp2p_identity::{Keypair, PeerId};
+use libp2p_webrtc_utils::{noise, Fingerprint};
+use send_wrapper::SendWrapper;
+
+use super::Error;
+use crate::{connection::RtcPeerConnection, error::AuthenticationError, sdp, Connection};
 
 /// Upgrades an outbound WebRTC connection by creating the data channel
 /// and conducting a Noise handshake
@@ -29,7 +27,8 @@ async fn outbound_inner(
     let rtc_peer_connection = RtcPeerConnection::new(remote_fingerprint.algorithm()).await?;
 
     // Create stream for Noise handshake
-    // Must create data channel before Offer is created for it to be included in the SDP
+    // Must create data channel before Offer is created for it to be included in the
+    // SDP
     let (channel, listener) = rtc_peer_connection.new_handshake_stream();
     drop(listener);
 

--- a/transports/webrtc/src/lib.rs
+++ b/transports/webrtc/src/lib.rs
@@ -18,67 +18,71 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-//! Implementation of the [`libp2p_core::Transport`] trait for WebRTC protocol without a signaling
-//! server.
+//! Implementation of the [`libp2p_core::Transport`] trait for WebRTC protocol
+//! without a signaling server.
 //!
 //! # Overview
 //!
-//! ## ICE
+//!  ## ICE
 //!
 //! RFCs: 8839, 8445 See also:
 //! <https://tools.ietf.org/id/draft-ietf-rtcweb-sdp-08.html#rfc.section.5.2.3>
 //!
 //! The WebRTC protocol uses ICE in order to establish a connection.
 //!
-//! In a typical ICE setup, there are two endpoints, called agents, that want to communicate. One
-//! of these two agents can be the local browser, while the other agent is the target of the
-//! connection.
+//! In a typical ICE setup, there are two endpoints, called agents, that want to
+//! communicate. One of these two agents can be the local browser, while the
+//! other agent is the target of the connection.
 //!
-//! Even though in this specific context all we want is a simple client-server communication, it is
-//! helpful to keep in mind that ICE was designed to solve the problem of NAT traversal.
+//! Even though in this specific context all we want is a simple client-server
+//! communication, it is helpful to keep in mind that ICE was designed to solve
+//! the problem of NAT traversal.
 //!
 //! The ICE workflow works as follows:
 //!
-//! - An "offerer" determines ways in which it could be accessible (either an
-//!   IP address or through a relay using a TURN server), which are called "candidates". It then
-//!   generates a small text payload in a format called SDP, that describes the request for a
-//!   connection.
-//! - The offerer sends this SDP-encoded message to the answerer. The medium through which this
-//!   exchange is done is out of scope of the ICE protocol.
-//! - The answerer then finds its own candidates, and generates an answer, again in the SDP format.
-//!   This answer is sent back to the offerer.
+//! - An "offerer" determines ways in which it could be accessible (either an IP
+//!   address or through a relay using a TURN server), which are called
+//!   "candidates". It then generates a small text payload in a format called
+//!   SDP, that describes the request for a connection.
+//! - The offerer sends this SDP-encoded message to the answerer. The medium
+//!   through which this exchange is done is out of scope of the ICE protocol.
+//! - The answerer then finds its own candidates, and generates an answer, again
+//!   in the SDP format. This answer is sent back to the offerer.
 //! - Each agent then tries to connect to the remote's candidates.
 //!
-//! We pretend to send the offer to the remote agent (the target of the connection), then pretend
-//! that it has found a valid IP address for itself (i.e. a candidate), then pretend that the SDP
-//! answer containing this candidate has been sent back. This will cause the offerer to execute
-//! step 4: try to connect to the remote's candidate.
+//! We pretend to send the offer to the remote agent (the target of the
+//! connection), then pretend that it has found a valid IP address for itself
+//! (i.e. a candidate), then pretend that the SDP answer containing this
+//! candidate has been sent back. This will cause the offerer to execute step 4:
+//! try to connect to the remote's candidate.
 //!
 //! ## TCP or UDP
 //!
-//! WebRTC by itself doesn't hardcode any specific protocol for media streams. Instead, it is the
-//! SDP message of the offerer that specifies which protocol to use. In our use case (one or more
-//! data channels), we know that the offerer will always request either TCP+DTLS+SCTP, or
-//! UDP+DTLS+SCTP.
+//! WebRTC by itself doesn't hardcode any specific protocol for media streams.
+//! Instead, it is the SDP message of the offerer that specifies which protocol
+//! to use. In our use case (one or more data channels), we know that the
+//! offerer will always request either TCP+DTLS+SCTP, or UDP+DTLS+SCTP.
 //!
-//! The implementation only supports UDP at the moment, so if the offerer requests TCP+DTLS+SCTP, it
-//! will not respond. Support for TCP may be added in the future (see
-//! <https://github.com/webrtc-rs/webrtc/issues/132>).
+//! The implementation only supports UDP at the moment, so if the offerer
+//! requests TCP+DTLS+SCTP, it will not respond. Support for TCP may be added in
+//! the future (see <https://github.com/webrtc-rs/webrtc/issues/132>).
 //!
 //! ## DTLS+SCTP
 //!
 //! RFCs: 8841, 8832
 //!
-//! In both cases (TCP or UDP), the next layer is DTLS. DTLS is similar to the well-known TLS
-//! protocol, except that it doesn't guarantee ordering of delivery (as this is instead provided by
-//! the SCTP layer on top of DTLS). In other words, once the TCP or UDP connection is established,
-//! the browser will try to perform a DTLS handshake.
+//! In both cases (TCP or UDP), the next layer is DTLS. DTLS is similar to the
+//! well-known TLS protocol, except that it doesn't guarantee ordering of
+//! delivery (as this is instead provided by the SCTP layer on top of DTLS). In
+//! other words, once the TCP or UDP connection is established, the browser will
+//! try to perform a DTLS handshake.
 //!
-//! During the ICE negotiation, each agent must include in its SDP packet a hash of the self-signed
-//! certificate that it will use during the DTLS handshake. In our use-case, where we try to
-//! hand-crate the SDP answer generated by the remote, this is problematic. A way to solve this
-//! is to make the hash a part of the remote's multiaddr. On the server side, we turn
-//! certificate verification off.
+//! During the ICE negotiation, each agent must include in its SDP packet a hash
+//! of the self-signed certificate that it will use during the DTLS handshake.
+//! In our use-case, where we try to hand-crate the SDP answer generated by the
+//! remote, this is problematic. A way to solve this is to make the hash a part
+//! of the remote's multiaddr. On the server side, we turn certificate
+//! verification off.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 

--- a/transports/webrtc/src/tokio/certificate.rs
+++ b/transports/webrtc/src/tokio/certificate.rs
@@ -50,8 +50,8 @@ impl Certificate {
     ///
     /// # Panics
     ///
-    /// This function will panic if there's no fingerprint with the SHA-256 algorithm (see
-    /// [`RTCCertificate::get_fingerprints`]).
+    /// This function will panic if there's no fingerprint with the SHA-256
+    /// algorithm (see [`RTCCertificate::get_fingerprints`]).
     pub fn fingerprint(&self) -> Fingerprint {
         let fingerprints = self.inner.get_fingerprints();
         let sha256_fingerprint = fingerprints
@@ -72,7 +72,8 @@ impl Certificate {
         })
     }
 
-    /// Serializes the certificate (including the private key) in PKCS#8 format in PEM.
+    /// Serializes the certificate (including the private key) in PKCS#8 format
+    /// in PEM.
     ///
     /// See [`RTCCertificate::serialize_pem`]
     #[cfg(feature = "pem")]
@@ -82,7 +83,8 @@ impl Certificate {
 
     /// Extract the [`RTCCertificate`] from this wrapper.
     ///
-    /// This function is `pub(crate)` to avoid leaking the `webrtc` dependency to our users.
+    /// This function is `pub(crate)` to avoid leaking the `webrtc` dependency
+    /// to our users.
     pub(crate) fn to_rtc_certificate(&self) -> RTCCertificate {
         self.inner.clone()
     }
@@ -100,8 +102,9 @@ enum Kind {
 
 #[cfg(all(test, feature = "pem"))]
 mod test {
-    use super::*;
     use rand::thread_rng;
+
+    use super::*;
 
     #[test]
     fn test_certificate_serialize_pem_and_from_pem() {

--- a/transports/webrtc/src/tokio/fingerprint.rs
+++ b/transports/webrtc/src/tokio/fingerprint.rs
@@ -24,7 +24,8 @@ const SHA256: &str = "sha-256";
 
 type Multihash = multihash::Multihash<64>;
 
-/// A certificate fingerprint that is assumed to be created using the SHA256 hash algorithm.
+/// A certificate fingerprint that is assumed to be created using the SHA256
+/// hash algorithm.
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct Fingerprint(libp2p_webrtc_utils::Fingerprint);
 

--- a/transports/webrtc/src/tokio/req_res_chan.rs
+++ b/transports/webrtc/src/tokio/req_res_chan.rs
@@ -18,14 +18,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures::{
-    channel::{mpsc, oneshot},
-    SinkExt, StreamExt,
-};
-
 use std::{
     io,
     task::{Context, Poll},
+};
+
+use futures::{
+    channel::{mpsc, oneshot},
+    SinkExt,
+    StreamExt,
 };
 
 pub(crate) fn new<Req, Res>(capacity: usize) -> (Sender<Req, Res>, Receiver<Req, Res>) {

--- a/transports/webrtc/src/tokio/sdp.rs
+++ b/transports/webrtc/src/tokio/sdp.rs
@@ -18,10 +18,10 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-pub(crate) use libp2p_webrtc_utils::sdp::random_ufrag;
-use libp2p_webrtc_utils::sdp::render_description;
-use libp2p_webrtc_utils::Fingerprint;
 use std::net::SocketAddr;
+
+pub(crate) use libp2p_webrtc_utils::sdp::random_ufrag;
+use libp2p_webrtc_utils::{sdp::render_description, Fingerprint};
 use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
 
 /// Creates the SDP answer used by the client.
@@ -40,7 +40,8 @@ pub(crate) fn answer(
 
 /// Creates the SDP offer used by the server.
 ///
-/// Certificate verification is disabled which is why we hardcode a dummy fingerprint here.
+/// Certificate verification is disabled which is why we hardcode a dummy
+/// fingerprint here.
 pub(crate) fn offer(addr: SocketAddr, client_ufrag: &str) -> RTCSessionDescription {
     let offer = render_description(
         CLIENT_SESSION_DESCRIPTION,
@@ -67,9 +68,9 @@ pub(crate) fn offer(addr: SocketAddr, client_ufrag: &str) -> RTCSessionDescripti
 // v=<protocol-version> -> always 0
 // o=<username> <sess-id> <sess-version> <nettype> <addrtype> <unicast-address>
 //
-//     <username> identifies the creator of the SDP document. We are allowed to use dummy values
-//     (`-` and `0.0.0.0` as <addrtype>) to remain anonymous, which we do. Note that "IN" means
-//     "Internet".
+//     <username> identifies the creator of the SDP document. We are allowed to
+// use dummy values     (`-` and `0.0.0.0` as <addrtype>) to remain anonymous,
+// which we do. Note that "IN" means     "Internet".
 //
 // s=<session name>
 //
@@ -82,15 +83,16 @@ pub(crate) fn offer(addr: SocketAddr, client_ufrag: &str) -> RTCSessionDescripti
 //
 // t=<start-time> <stop-time>
 //
-//     Start and end of the validity of the session. `0 0` means that the session never expires.
+//     Start and end of the validity of the session. `0 0` means that the
+// session never expires.
 //
 // m=<media> <port> <proto> <fmt> ...
 //
-//     A `m=` line describes a request to establish a certain protocol. The protocol in this line
-//     (i.e. `TCP/DTLS/SCTP` or `UDP/DTLS/SCTP`) must always be the same as the one in the offer.
-//     We know that this is true because we tweak the offer to match the protocol. The `<fmt>`
-//     component must always be `webrtc-datachannel` for WebRTC.
-//     RFCs: 8839, 8866, 8841
+//     A `m=` line describes a request to establish a certain protocol. The
+// protocol in this line     (i.e. `TCP/DTLS/SCTP` or `UDP/DTLS/SCTP`) must
+// always be the same as the one in the offer.     We know that this is true
+// because we tweak the offer to match the protocol. The `<fmt>`     component
+// must always be `webrtc-datachannel` for WebRTC.     RFCs: 8839, 8866, 8841
 //
 // a=mid:<MID>
 //
@@ -98,7 +100,8 @@ pub(crate) fn offer(addr: SocketAddr, client_ufrag: &str) -> RTCSessionDescripti
 //
 // a=ice-options:ice2
 //
-//     Indicates that we are complying with RFC8839 (as opposed to the legacy RFC5245).
+//     Indicates that we are complying with RFC8839 (as opposed to the legacy
+// RFC5245).
 //
 // a=ice-ufrag:<ICE user>
 // a=ice-pwd:<ICE password>
@@ -114,14 +117,15 @@ pub(crate) fn offer(addr: SocketAddr, client_ufrag: &str) -> RTCSessionDescripti
 //
 // a=setup:actpass
 //
-//     The endpoint that is the offerer MUST use the setup attribute value of setup:actpass and be
-//     prepared to receive a client_hello before it receives the answer.
+//     The endpoint that is the offerer MUST use the setup attribute value of
+// setup:actpass and be     prepared to receive a client_hello before it
+// receives the answer.
 //
 // a=sctp-port:<value>
 //
 //     The SCTP port (RFC8841)
-//     Note it's different from the "m=" line port value, which indicates the port of the
-//     underlying transport-layer protocol (UDP or TCP).
+//     Note it's different from the "m=" line port value, which indicates the
+// port of the     underlying transport-layer protocol (UDP or TCP).
 //
 // a=max-message-size:<value>
 //

--- a/transports/webrtc/src/tokio/stream.rs
+++ b/transports/webrtc/src/tokio/stream.rs
@@ -31,8 +31,9 @@ use webrtc::data::data_channel::{DataChannel, PollDataChannel};
 
 /// A substream on top of a WebRTC data channel.
 ///
-/// To be a proper libp2p substream, we need to implement [`AsyncRead`] and [`AsyncWrite`] as well
-/// as support a half-closed state which we do by framing messages in a protobuf envelope.
+/// To be a proper libp2p substream, we need to implement [`AsyncRead`] and
+/// [`AsyncWrite`] as well as support a half-closed state which we do by framing
+/// messages in a protobuf envelope.
 pub struct Stream {
     inner: libp2p_webrtc_utils::Stream<Compat<PollDataChannel>>,
 }
@@ -40,8 +41,8 @@ pub struct Stream {
 pub(crate) type DropListener = libp2p_webrtc_utils::DropListener<Compat<PollDataChannel>>;
 
 impl Stream {
-    /// Returns a new `Substream` and a listener, which will notify the receiver when/if the substream
-    /// is dropped.
+    /// Returns a new `Substream` and a listener, which will notify the receiver
+    /// when/if the substream is dropped.
     pub(crate) fn new(data_channel: Arc<DataChannel>) -> (Self, DropListener) {
         let mut data_channel = PollDataChannel::new(data_channel).compat();
         data_channel.get_mut().set_read_buf_capacity(MAX_MSG_LEN);

--- a/transports/webrtc/tests/smoke.rs
+++ b/transports/webrtc/tests/smoke.rs
@@ -18,21 +18,35 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures::channel::mpsc;
-use futures::future::{BoxFuture, Either};
-use futures::stream::StreamExt;
-use futures::{future, ready, AsyncReadExt, AsyncWriteExt, FutureExt, SinkExt};
-use libp2p_core::muxing::{StreamMuxerBox, StreamMuxerExt};
-use libp2p_core::transport::{Boxed, DialOpts, ListenerId, PortUse, TransportEvent};
-use libp2p_core::{Endpoint, Multiaddr, Transport};
+use std::{
+    future::Future,
+    num::NonZeroU8,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use futures::{
+    channel::mpsc,
+    future,
+    future::{BoxFuture, Either},
+    ready,
+    stream::StreamExt,
+    AsyncReadExt,
+    AsyncWriteExt,
+    FutureExt,
+    SinkExt,
+};
+use libp2p_core::{
+    muxing::{StreamMuxerBox, StreamMuxerExt},
+    transport::{Boxed, DialOpts, ListenerId, PortUse, TransportEvent},
+    Endpoint,
+    Multiaddr,
+    Transport,
+};
 use libp2p_identity::PeerId;
 use libp2p_webrtc as webrtc;
 use rand::{thread_rng, RngCore};
-use std::future::Future;
-use std::num::NonZeroU8;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::test]

--- a/transports/websocket-websys/src/lib.rs
+++ b/transports/websocket-websys/src/lib.rs
@@ -7,8 +7,8 @@
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
 //
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -22,21 +22,25 @@
 
 mod web_context;
 
+use std::{
+    cmp::min,
+    pin::Pin,
+    rc::Rc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Mutex,
+    },
+    task::{Context, Poll},
+};
+
 use bytes::BytesMut;
-use futures::task::AtomicWaker;
-use futures::{future::Ready, io, prelude::*};
+use futures::{future::Ready, io, prelude::*, task::AtomicWaker};
 use js_sys::Array;
-use libp2p_core::transport::DialOpts;
 use libp2p_core::{
     multiaddr::{Multiaddr, Protocol},
-    transport::{ListenerId, TransportError, TransportEvent},
+    transport::{DialOpts, ListenerId, TransportError, TransportEvent},
 };
 use send_wrapper::SendWrapper;
-use std::cmp::min;
-use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Mutex;
-use std::{pin::Pin, task::Context, task::Poll};
 use wasm_bindgen::prelude::*;
 use web_sys::{CloseEvent, Event, MessageEvent, WebSocket};
 
@@ -60,13 +64,13 @@ use crate::web_context::WebContext;
 ///     .multiplex(yamux::Config::default())
 ///     .boxed();
 /// ```
-///
 #[derive(Default)]
 pub struct Transport {
     _private: (),
 }
 
-/// Arbitrary, maximum amount we are willing to buffer before we throttle our user.
+/// Arbitrary, maximum amount we are willing to buffer before we throttle our
+/// user.
 const MAX_BUFFER: usize = 1024 * 1024;
 
 impl libp2p_core::Transport for Transport {
@@ -174,7 +178,8 @@ struct Inner {
     /// Waker for when we are waiting for the WebSocket to be opened.
     open_waker: Rc<AtomicWaker>,
 
-    /// Waker for when we are waiting to write (again) to the WebSocket because we previously exceeded the [`MAX_BUFFER`] threshold.
+    /// Waker for when we are waiting to write (again) to the WebSocket because
+    /// we previously exceeded the [`MAX_BUFFER`] threshold.
     write_waker: Rc<AtomicWaker>,
 
     /// Waker for when we are waiting for the WebSocket to be closed.
@@ -306,7 +311,8 @@ impl Connection {
             .expect("to have a window or worker context")
             .set_interval_with_callback_and_timeout_and_arguments(
                 on_buffered_amount_low_closure.as_ref().unchecked_ref(),
-                100, // Chosen arbitrarily and likely worth tuning. Due to low impact of the /ws transport, no further effort was invested at the time.
+                100, /* Chosen arbitrarily and likely worth tuning. Due to low impact of the /ws
+                      * transport, no further effort was invested at the time. */
                 &Array::new(),
             )
             .expect("to be able to set an interval");
@@ -432,7 +438,8 @@ impl AsyncWrite for Connection {
 
 impl Drop for Connection {
     fn drop(&mut self) {
-        // Unset event listeners, as otherwise they will be called by JS after the handlers have already been dropped.
+        // Unset event listeners, as otherwise they will be called by JS after the
+        // handlers have already been dropped.
         self.inner.socket.set_onclose(None);
         self.inner.socket.set_onerror(None);
         self.inner.socket.set_onopen(None);
@@ -456,8 +463,9 @@ impl Drop for Connection {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use libp2p_identity::PeerId;
+
+    use super::*;
 
     #[test]
     fn extract_url() {

--- a/transports/websocket/src/error.rs
+++ b/transports/websocket/src/error.rs
@@ -18,9 +18,11 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::tls;
-use libp2p_core::Multiaddr;
 use std::{error, fmt};
+
+use libp2p_core::Multiaddr;
+
+use crate::tls;
 
 /// Error in WebSockets.
 #[derive(Debug)]

--- a/transports/websocket/src/framed.rs
+++ b/transports/websocket/src/framed.rs
@@ -18,11 +18,22 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::{error::Error, quicksink, tls};
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    fmt,
+    io,
+    mem,
+    net::IpAddr,
+    ops::DerefMut,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
 use either::Either;
 use futures::{future::BoxFuture, prelude::*, ready, stream::BoxStream};
-use futures_rustls::rustls::pki_types::ServerName;
-use futures_rustls::{client, server};
+use futures_rustls::{client, rustls::pki_types::ServerName, server};
 use libp2p_core::{
     multiaddr::{Multiaddr, Protocol},
     transport::{DialOpts, ListenerId, TransportError, TransportEvent},
@@ -33,11 +44,9 @@ use soketto::{
     connection::{self, CloseReason},
     handshake,
 };
-use std::borrow::Cow;
-use std::net::IpAddr;
-use std::{collections::HashMap, ops::DerefMut, sync::Arc};
-use std::{fmt, io, mem, pin::Pin, task::Context, task::Poll};
 use url::Url;
+
+use crate::{error::Error, quicksink, tls};
 
 /// Max. number of payload bytes of a single frame.
 const MAX_DATA_SIZE: usize = 256 * 1024 * 1024;
@@ -809,9 +818,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use libp2p_identity::PeerId;
     use std::io;
+
+    use libp2p_identity::PeerId;
+
+    use super::*;
 
     #[test]
     fn listen_addr() {

--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -27,6 +27,12 @@ pub mod framed;
 mod quicksink;
 pub mod tls;
 
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
 use error::Error;
 use framed::{Connection, Incoming};
 use futures::{future::BoxFuture, prelude::*, ready};
@@ -37,25 +43,23 @@ use libp2p_core::{
     Transport,
 };
 use rw_stream_sink::RwStreamSink;
-use std::{
-    io,
-    pin::Pin,
-    task::{Context, Poll},
-};
 
 /// A Websocket transport.
 ///
-/// DO NOT wrap this transport with a DNS transport if you want Secure Websockets to work.
+/// DO NOT wrap this transport with a DNS transport if you want Secure
+/// Websockets to work.
 ///
-/// A Secure Websocket transport needs to wrap DNS transport to resolve domain names after
-/// they are checked against the remote certificates. Use a combination of DNS and TCP transports
-/// to build a Secure Websocket transport.
+/// A Secure Websocket transport needs to wrap DNS transport to resolve domain
+/// names after they are checked against the remote certificates. Use a
+/// combination of DNS and TCP transports to build a Secure Websocket transport.
 ///
-/// If you don't need Secure Websocket's support, use a plain TCP transport as an inner transport.
+/// If you don't need Secure Websocket's support, use a plain TCP transport as
+/// an inner transport.
 ///
 /// # Dependencies
 ///
-/// This transport requires the `zlib` shared library to be installed on the system.
+/// This transport requires the `zlib` shared library to be installed on the
+/// system.
 ///
 /// Future releases might lift this requirement, see <https://github.com/paritytech/soketto/issues/72>.
 ///
@@ -75,18 +79,28 @@ use std::{
 /// # #[async_std::main]
 /// # async fn main() {
 ///
-/// let mut transport = websocket::WsConfig::new(dns::async_std::Transport::system(
-///     tcp::async_io::Transport::new(tcp::Config::default()),
-/// ).await.unwrap());
+/// let mut transport = websocket::WsConfig::new(
+///     dns::async_std::Transport::system(tcp::async_io::Transport::new(tcp::Config::default()))
+///         .await
+///         .unwrap(),
+/// );
 ///
 /// let rcgen_cert = generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
 /// let priv_key = websocket::tls::PrivateKey::new(rcgen_cert.serialize_private_key_der());
 /// let cert = websocket::tls::Certificate::new(rcgen_cert.serialize_der().unwrap());
 /// transport.set_tls_config(websocket::tls::Config::new(priv_key, vec![cert]).unwrap());
 ///
-/// let id = transport.listen_on(ListenerId::next(), "/ip4/127.0.0.1/tcp/0/tls/ws".parse().unwrap()).unwrap();
+/// let id = transport
+///     .listen_on(
+///         ListenerId::next(),
+///         "/ip4/127.0.0.1/tcp/0/tls/ws".parse().unwrap(),
+///     )
+///     .unwrap();
 ///
-/// let addr = future::poll_fn(|cx| Pin::new(&mut transport).poll(cx)).await.into_new_address().unwrap();
+/// let addr = future::poll_fn(|cx| Pin::new(&mut transport).poll(cx))
+///     .await
+///     .into_new_address()
+///     .unwrap();
 /// println!("Listening on {addr}");
 ///
 /// # }
@@ -105,13 +119,20 @@ use std::{
 /// # #[async_std::main]
 /// # async fn main() {
 ///
-/// let mut transport = websocket::WsConfig::new(
-///     tcp::async_io::Transport::new(tcp::Config::default()),
-/// );
+/// let mut transport =
+///     websocket::WsConfig::new(tcp::async_io::Transport::new(tcp::Config::default()));
 ///
-/// let id = transport.listen_on(ListenerId::next(), "/ip4/127.0.0.1/tcp/0/ws".parse().unwrap()).unwrap();
+/// let id = transport
+///     .listen_on(
+///         ListenerId::next(),
+///         "/ip4/127.0.0.1/tcp/0/ws".parse().unwrap(),
+///     )
+///     .unwrap();
 ///
-/// let addr = future::poll_fn(|cx| Pin::new(&mut transport).poll(cx)).await.into_new_address().unwrap();
+/// let addr = future::poll_fn(|cx| Pin::new(&mut transport).poll(cx))
+///     .await
+///     .into_new_address()
+///     .unwrap();
 /// println!("Listening on {addr}");
 ///
 /// # }
@@ -218,7 +239,8 @@ where
     }
 }
 
-/// Type alias corresponding to `framed::WsConfig::Dial` and `framed::WsConfig::ListenerUpgrade`.
+/// Type alias corresponding to `framed::WsConfig::Dial` and
+/// `framed::WsConfig::ListenerUpgrade`.
 pub type InnerFuture<T, E> = BoxFuture<'static, Result<Connection<T>, Error<E>>>;
 
 /// Function type that wraps a websocket connection (see. `wrap_connection`).
@@ -279,19 +301,23 @@ where
     }
 }
 
-// Tests //////////////////////////////////////////////////////////////////////////////////////////
+// Tests ///////////////////////////////////////////////////////////////////////
+// ///////////////////
 
 #[cfg(test)]
 mod tests {
-    use super::WsConfig;
     use futures::prelude::*;
     use libp2p_core::{
         multiaddr::Protocol,
         transport::{DialOpts, ListenerId, PortUse},
-        Endpoint, Multiaddr, Transport,
+        Endpoint,
+        Multiaddr,
+        Transport,
     };
     use libp2p_identity::PeerId;
     use libp2p_tcp as tcp;
+
+    use super::WsConfig;
 
     #[test]
     fn dialer_connects_to_listener_ipv4() {

--- a/transports/websocket/src/quicksink.rs
+++ b/transports/websocket/src/quicksink.rs
@@ -19,25 +19,27 @@
 // ```no_run
 // use async_std::io;
 // use futures::prelude::*;
+//
 // use crate::quicksink::Action;
 //
 // crate::quicksink::make_sink(io::stdout(), |mut stdout, action| async move {
 //     match action {
 //         Action::Send(x) => stdout.write_all(x).await?,
 //         Action::Flush => stdout.flush().await?,
-//         Action::Close => stdout.close().await?
+//         Action::Close => stdout.close().await?,
 //     }
 //     Ok::<_, io::Error>(stdout)
 // });
 // ```
 
-use futures::{ready, sink::Sink};
-use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
+
+use futures::{ready, sink::Sink};
+use pin_project_lite::pin_project;
 
 /// Returns a `Sink` impl based on the initial value and the given closure.
 ///
@@ -291,9 +293,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::quicksink::{make_sink, Action};
     use async_std::{io, task};
     use futures::{channel::mpsc, prelude::*};
+
+    use crate::quicksink::{make_sink, Action};
 
     #[test]
     fn smoke_test() {

--- a/transports/websocket/src/tls.rs
+++ b/transports/websocket/src/tls.rs
@@ -18,8 +18,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures_rustls::{rustls, TlsAcceptor, TlsConnector};
 use std::{fmt, io, sync::Arc};
+
+use futures_rustls::{rustls, TlsAcceptor, TlsConnector};
 
 /// TLS configuration.
 #[derive(Clone)]
@@ -38,7 +39,8 @@ impl fmt::Debug for Config {
 pub struct PrivateKey(rustls::pki_types::PrivateKeyDer<'static>);
 
 impl PrivateKey {
-    /// Assert the given bytes are DER-encoded ASN.1 in either PKCS#8 or PKCS#1 format.
+    /// Assert the given bytes are DER-encoded ASN.1 in either PKCS#8 or PKCS#1
+    /// format.
     pub fn new(bytes: Vec<u8>) -> Self {
         PrivateKey(
             rustls::pki_types::PrivateKeyDer::try_from(bytes)
@@ -65,7 +67,8 @@ impl Certificate {
 }
 
 impl Config {
-    /// Create a new TLS configuration with the given server key and certificate chain.
+    /// Create a new TLS configuration with the given server key and certificate
+    /// chain.
     pub fn new<I>(key: PrivateKey, certs: I) -> Result<Self, Error>
     where
         I: IntoIterator<Item = Certificate>,
@@ -164,7 +167,8 @@ pub(crate) fn dns_name_ref(name: &str) -> Result<rustls::pki_types::ServerName<'
         .map_err(|_| Error::InvalidDnsName(name.into()))
 }
 
-// Error //////////////////////////////////////////////////////////////////////////////////////////
+// Error ///////////////////////////////////////////////////////////////////////
+// ///////////////////
 
 /// TLS related errors.
 #[derive(Debug)]

--- a/transports/webtransport-websys/src/connection.rs
+++ b/transports/webtransport-websys/src/connection.rs
@@ -1,22 +1,30 @@
+use std::{
+    collections::HashSet,
+    future::poll_fn,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+
 use futures::FutureExt;
-use libp2p_core::muxing::{StreamMuxer, StreamMuxerEvent};
-use libp2p_core::upgrade::OutboundConnectionUpgrade;
-use libp2p_core::UpgradeInfo;
+use libp2p_core::{
+    muxing::{StreamMuxer, StreamMuxerEvent},
+    upgrade::OutboundConnectionUpgrade,
+    UpgradeInfo,
+};
 use libp2p_identity::{Keypair, PeerId};
 use multihash::Multihash;
 use send_wrapper::SendWrapper;
-use std::collections::HashSet;
-use std::future::poll_fn;
-use std::pin::Pin;
-use std::task::{ready, Context, Poll};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::ReadableStreamDefaultReader;
 
-use crate::bindings::{WebTransport, WebTransportBidirectionalStream};
-use crate::endpoint::Endpoint;
-use crate::fused_js_promise::FusedJsPromise;
-use crate::utils::{detach_promise, parse_reader_response, to_js_type};
-use crate::{Error, Stream};
+use crate::{
+    bindings::{WebTransport, WebTransportBidirectionalStream},
+    endpoint::Endpoint,
+    fused_js_promise::FusedJsPromise,
+    utils::{detach_promise, parse_reader_response, to_js_type},
+    Error,
+    Stream,
+};
 
 /// An opened WebTransport connection.
 #[derive(Debug)]

--- a/transports/webtransport-websys/src/endpoint.rs
+++ b/transports/webtransport-websys/src/endpoint.rs
@@ -1,11 +1,14 @@
+use std::collections::HashSet;
+
 use js_sys::{Array, Uint8Array};
 use libp2p_identity::PeerId;
 use multiaddr::{Multiaddr, Protocol};
 use multihash::Multihash;
-use std::collections::HashSet;
 
-use crate::bindings::{WebTransportHash, WebTransportOptions};
-use crate::Error;
+use crate::{
+    bindings::{WebTransportHash, WebTransportOptions},
+    Error,
+};
 
 pub(crate) struct Endpoint {
     pub(crate) host: String,
@@ -149,8 +152,9 @@ impl Endpoint {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::str::FromStr;
+
+    use super::*;
 
     fn multihash_from_str(s: &str) -> Multihash<64> {
         let (_base, bytes) = multibase::decode(s).unwrap();
@@ -159,7 +163,13 @@ mod tests {
 
     #[test]
     fn valid_webtransport_multiaddr() {
-        let addr = Multiaddr::from_str("/ip4/127.0.0.1/udp/44874/quic-v1/webtransport/certhash/uEiCaDd1Ca1A8IVJ3hsIxIyi11cwxaDKqzVrBkGJbKZU5ng/certhash/uEiDv-VGW8oXxui_G_Kqp-87YjvET-Hr2qYAMYPePJDcsjQ/p2p/12D3KooWR7EfNv5SLtgjMRjUwR8AvNu3hP4fLrtSa9fmHHXKYWNG").unwrap();
+        let addr = Multiaddr::from_str(
+            "/ip4/127.0.0.1/udp/44874/quic-v1/webtransport/certhash/\
+             uEiCaDd1Ca1A8IVJ3hsIxIyi11cwxaDKqzVrBkGJbKZU5ng/certhash/\
+             uEiDv-VGW8oXxui_G_Kqp-87YjvET-Hr2qYAMYPePJDcsjQ/p2p/\
+             12D3KooWR7EfNv5SLtgjMRjUwR8AvNu3hP4fLrtSa9fmHHXKYWNG",
+        )
+        .unwrap();
         let endpoint = Endpoint::from_multiaddr(&addr).unwrap();
 
         assert_eq!(endpoint.host, "127.0.0.1");
@@ -187,7 +197,11 @@ mod tests {
 
     #[test]
     fn valid_webtransport_multiaddr_without_certhashes() {
-        let addr = Multiaddr::from_str("/ip4/127.0.0.1/udp/44874/quic-v1/webtransport/p2p/12D3KooWR7EfNv5SLtgjMRjUwR8AvNu3hP4fLrtSa9fmHHXKYWNG").unwrap();
+        let addr = Multiaddr::from_str(
+            "/ip4/127.0.0.1/udp/44874/quic-v1/webtransport/p2p/\
+             12D3KooWR7EfNv5SLtgjMRjUwR8AvNu3hP4fLrtSa9fmHHXKYWNG",
+        )
+        .unwrap();
         let endpoint = Endpoint::from_multiaddr(&addr).unwrap();
 
         assert_eq!(endpoint.host, "127.0.0.1");
@@ -201,7 +215,13 @@ mod tests {
 
     #[test]
     fn ipv6_webtransport() {
-        let addr = Multiaddr::from_str("/ip6/::1/udp/44874/quic-v1/webtransport/certhash/uEiCaDd1Ca1A8IVJ3hsIxIyi11cwxaDKqzVrBkGJbKZU5ng/certhash/uEiDv-VGW8oXxui_G_Kqp-87YjvET-Hr2qYAMYPePJDcsjQ/p2p/12D3KooWR7EfNv5SLtgjMRjUwR8AvNu3hP4fLrtSa9fmHHXKYWNG").unwrap();
+        let addr = Multiaddr::from_str(
+            "/ip6/::1/udp/44874/quic-v1/webtransport/certhash/\
+             uEiCaDd1Ca1A8IVJ3hsIxIyi11cwxaDKqzVrBkGJbKZU5ng/certhash/\
+             uEiDv-VGW8oXxui_G_Kqp-87YjvET-Hr2qYAMYPePJDcsjQ/p2p/\
+             12D3KooWR7EfNv5SLtgjMRjUwR8AvNu3hP4fLrtSa9fmHHXKYWNG",
+        )
+        .unwrap();
         let endpoint = Endpoint::from_multiaddr(&addr).unwrap();
 
         assert_eq!(endpoint.host, "::1");
@@ -214,7 +234,13 @@ mod tests {
 
     #[test]
     fn dns_webtransport() {
-        let addr = Multiaddr::from_str("/dns/libp2p.io/udp/44874/quic-v1/webtransport/certhash/uEiCaDd1Ca1A8IVJ3hsIxIyi11cwxaDKqzVrBkGJbKZU5ng/certhash/uEiDv-VGW8oXxui_G_Kqp-87YjvET-Hr2qYAMYPePJDcsjQ/p2p/12D3KooWR7EfNv5SLtgjMRjUwR8AvNu3hP4fLrtSa9fmHHXKYWNG").unwrap();
+        let addr = Multiaddr::from_str(
+            "/dns/libp2p.io/udp/44874/quic-v1/webtransport/certhash/\
+             uEiCaDd1Ca1A8IVJ3hsIxIyi11cwxaDKqzVrBkGJbKZU5ng/certhash/\
+             uEiDv-VGW8oXxui_G_Kqp-87YjvET-Hr2qYAMYPePJDcsjQ/p2p/\
+             12D3KooWR7EfNv5SLtgjMRjUwR8AvNu3hP4fLrtSa9fmHHXKYWNG",
+        )
+        .unwrap();
         let endpoint = Endpoint::from_multiaddr(&addr).unwrap();
 
         assert_eq!(endpoint.host, "libp2p.io");

--- a/transports/webtransport-websys/src/fused_js_promise.rs
+++ b/transports/webtransport-websys/src/fused_js_promise.rs
@@ -1,8 +1,11 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+
 use futures::FutureExt;
 use js_sys::Promise;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{ready, Context, Poll};
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::JsFuture;
 

--- a/transports/webtransport-websys/src/lib.rs
+++ b/transports/webtransport-websys/src/lib.rs
@@ -9,7 +9,9 @@ mod stream;
 mod transport;
 mod utils;
 
-pub use self::connection::Connection;
-pub use self::error::Error;
-pub use self::stream::Stream;
-pub use self::transport::{Config, Transport};
+pub use self::{
+    connection::Connection,
+    error::Error,
+    stream::Stream,
+    transport::{Config, Transport},
+};

--- a/transports/webtransport-websys/src/stream.rs
+++ b/transports/webtransport-websys/src/stream.rs
@@ -1,16 +1,20 @@
+use std::{
+    io,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+
 use futures::{AsyncRead, AsyncWrite, FutureExt};
 use js_sys::Uint8Array;
 use send_wrapper::SendWrapper;
-use std::io;
-use std::pin::Pin;
-use std::task::ready;
-use std::task::{Context, Poll};
 use web_sys::{ReadableStreamDefaultReader, WritableStreamDefaultWriter};
 
-use crate::bindings::WebTransportBidirectionalStream;
-use crate::fused_js_promise::FusedJsPromise;
-use crate::utils::{detach_promise, parse_reader_response, to_io_error, to_js_type};
-use crate::Error;
+use crate::{
+    bindings::WebTransportBidirectionalStream,
+    fused_js_promise::FusedJsPromise,
+    utils::{detach_promise, parse_reader_response, to_io_error, to_js_type},
+    Error,
+};
 
 /// A stream on a connection.
 #[derive(Debug)]

--- a/transports/webtransport-websys/src/transport.rs
+++ b/transports/webtransport-websys/src/transport.rs
@@ -1,24 +1,26 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
 use futures::future::FutureExt;
-use libp2p_core::muxing::StreamMuxerBox;
-use libp2p_core::transport::{
-    Boxed, DialOpts, ListenerId, Transport as _, TransportError, TransportEvent,
+use libp2p_core::{
+    muxing::StreamMuxerBox,
+    transport::{Boxed, DialOpts, ListenerId, Transport as _, TransportError, TransportEvent},
 };
 use libp2p_identity::{Keypair, PeerId};
 use multiaddr::Multiaddr;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 
-use crate::endpoint::Endpoint;
-use crate::Connection;
-use crate::Error;
+use crate::{endpoint::Endpoint, Connection, Error};
 
 /// Config for the [`Transport`].
 pub struct Config {
     keypair: Keypair,
 }
 
-/// A WebTransport [`Transport`](libp2p_core::Transport) that works with `web-sys`.
+/// A WebTransport [`Transport`](libp2p_core::Transport) that works with
+/// `web-sys`.
 pub struct Transport {
     config: Config,
 }

--- a/transports/webtransport-websys/src/utils.rs
+++ b/transports/webtransport-websys/src/utils.rs
@@ -1,7 +1,8 @@
+use std::io;
+
 use js_sys::{Promise, Reflect};
 use once_cell::sync::Lazy;
 use send_wrapper::SendWrapper;
-use std::io;
 use wasm_bindgen::{JsCast, JsValue};
 
 use crate::Error;
@@ -17,7 +18,6 @@ static DO_NOTHING: Lazy<SendWrapper<Closure>> = Lazy::new(|| {
 /// A promise always runs in the background, however if you don't await it,
 /// or specify a `catch` handler before you drop it, it might cause some side
 /// effects. This function avoids any side effects.
-//
 // Ref: https://github.com/typescript-eslint/typescript-eslint/blob/391a6702c0a9b5b3874a7a27047f2a721f090fb6/packages/eslint-plugin/docs/rules/no-floating-promises.md
 pub(crate) fn detach_promise(promise: Promise) {
     // Avoid having "floating" promise and ignore any errors.
@@ -50,7 +50,6 @@ where
 }
 
 /// Parse response from `ReadableStreamDefaultReader::read`.
-//
 // Ref: https://streams.spec.whatwg.org/#default-reader-prototype
 pub(crate) fn parse_reader_response(resp: &JsValue) -> Result<Option<JsValue>, JsValue> {
     let value = Reflect::get(resp, &JsValue::from_str("value"))?;

--- a/wasm-tests/webtransport-tests/src/lib.rs
+++ b/wasm-tests/webtransport-tests/src/lib.rs
@@ -1,15 +1,18 @@
-use futures::channel::oneshot;
-use futures::{AsyncReadExt, AsyncWriteExt};
+use std::{future::poll_fn, pin::Pin};
+
+use futures::{channel::oneshot, AsyncReadExt, AsyncWriteExt};
 use getrandom::getrandom;
-use libp2p_core::transport::{DialOpts, PortUse};
-use libp2p_core::{Endpoint, StreamMuxer, Transport as _};
+use libp2p_core::{
+    transport::{DialOpts, PortUse},
+    Endpoint,
+    StreamMuxer,
+    Transport as _,
+};
 use libp2p_identity::{Keypair, PeerId};
 use libp2p_noise as noise;
 use libp2p_webtransport_websys::{Config, Connection, Error, Stream, Transport};
 use multiaddr::{Multiaddr, Protocol};
 use multihash::Multihash;
-use std::future::poll_fn;
-use std::pin::Pin;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::{spawn_local, JsFuture};
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};


### PR DESCRIPTION
## Description

closes #5684 

Uses `cargo +nightly fmt` for 
- reordering and formatting imports for better formatting and readability
- formatting code in the `///` doc comments