### PR TITLE
feat(request-response): Add support for custom dial options when making request to disconnected peer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.27.1"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ libp2p-pnet = { version = "0.25.0", path = "transports/pnet" }
 libp2p-quic = { version = "0.11.2", path = "transports/quic" }
 libp2p-relay = { version = "0.18.1", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.15.0", path = "protocols/rendezvous" }
-libp2p-request-response = { version = "0.27.1", path = "protocols/request-response" }
+libp2p-request-response = { version = "0.28.0", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.8", path = "misc/server" }
 libp2p-stream = { version = "0.2.0-alpha.1", path = "protocols/stream" }
 libp2p-swarm = { version = "0.45.2", path = "swarm" }

--- a/protocols/autonat/src/v1/behaviour/as_client.rs
+++ b/protocols/autonat/src/v1/behaviour/as_client.rs
@@ -154,11 +154,20 @@ impl HandleInnerEvent for AsClient<'_> {
                 error,
                 request_id,
             } => {
-                tracing::debug!(
-                    %peer,
-                    "Outbound Failure {} when on dial-back request to peer.",
-                    error,
-                );
+                if let Some(peer) = peer {
+                    tracing::debug!(
+                        %peer,
+                        %request_id,
+                        "Outbound Failure {} when on dial-back request to peer.",
+                        error,
+                    );
+                } else {
+                    tracing::debug!(
+                        %request_id,
+                        "Outbound Failure {} when on dial-back request to peer.",
+                        error,
+                    );
+                }
                 let probe_id = self
                     .ongoing_outbound
                     .remove(&request_id)
@@ -169,7 +178,7 @@ impl HandleInnerEvent for AsClient<'_> {
                 VecDeque::from([ToSwarm::GenerateEvent(Event::OutboundProbe(
                     OutboundProbeEvent::Error {
                         probe_id,
-                        peer: Some(peer),
+                        peer,
                         error: OutboundProbeError::OutboundRequest(error),
                     },
                 ))])

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.28.0
+
+- `send_request` Add support for custom dial options when making request to disconnected peer.
+  See [PR 5692](https://github.com/libp2p/rust-libp2p/pull/5692).
+
 ## 0.27.1
 
 - Deprecate `void` crate.

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-request-response"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Generic Request/Response Protocols"
-version = "0.27.1"
+version = "0.28.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -19,7 +19,7 @@ libp2p-core = { workspace = true }
 libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true }
 rand = "0.8"
-serde = { version = "1.0", optional = true}
+serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0.117", optional = true }
 smallvec = "1.13.2"
 tracing = { workspace = true }

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -708,18 +708,11 @@ where
         }
     }
 
-    fn on_dial_failure(
-        &mut self,
-        DialFailure {
-            peer_id,
-            connection_id,
-            ..
-        }: DialFailure,
-    ) {
-        let key = if let Some(peer_id) = peer_id {
+    fn on_dial_failure(&mut self, failure: DialFailure) {
+        let key = if let Some(peer_id) = failure.peer_id {
             peer_id.into()
         } else {
-            connection_id.into()
+            failure.connection_id.into()
         };
 
         // If there are pending outgoing requests when a dial failure occurs,
@@ -732,7 +725,7 @@ where
             for request in pending {
                 self.pending_events
                     .push_back(ToSwarm::GenerateEvent(Event::OutboundFailure {
-                        peer: peer_id,
+                        peer: failure.peer_id,
                         request_id: request.request_id,
                         error: OutboundFailure::DialFailure,
                     }));

--- a/protocols/request-response/tests/error_reporting.rs
+++ b/protocols/request-response/tests/error_reporting.rs
@@ -51,7 +51,7 @@ async fn report_outbound_failure_on_read_response() {
             .send_request(&peer1_id, Action::FailOnReadResponse);
 
         let (peer, req_id_done, error) = wait_outbound_failure(&mut swarm2).await.unwrap();
-        assert_eq!(peer, peer1_id);
+        assert_eq!(peer, Some(peer1_id));
         assert_eq!(req_id_done, req_id);
 
         let error = match error {
@@ -94,7 +94,7 @@ async fn report_outbound_failure_on_write_request() {
             .send_request(&peer1_id, Action::FailOnWriteRequest);
 
         let (peer, req_id_done, error) = wait_outbound_failure(&mut swarm2).await.unwrap();
-        assert_eq!(peer, peer1_id);
+        assert_eq!(peer, Some(peer1_id));
         assert_eq!(req_id_done, req_id);
 
         let error = match error {
@@ -151,7 +151,7 @@ async fn report_outbound_timeout_on_read_response() {
             .send_request(&peer1_id, Action::TimeoutOnReadResponse);
 
         let (peer, req_id_done, error) = wait_outbound_failure(&mut swarm2).await.unwrap();
-        assert_eq!(peer, peer1_id);
+        assert_eq!(peer, Some(peer1_id));
         assert_eq!(req_id_done, req_id);
         assert!(matches!(error, OutboundFailure::Timeout));
     };
@@ -203,7 +203,7 @@ async fn report_outbound_failure_on_max_streams() {
             .send_request(&peer1_id, Action::FailOnMaxStreams);
 
         let (peer, req_id_done, error) = wait_outbound_failure(&mut swarm2).await.unwrap();
-        assert_eq!(peer, peer1_id);
+        assert_eq!(peer, Some(peer1_id));
         assert_eq!(req_id_done, outbound_req_id);
         assert!(matches!(error, OutboundFailure::Io(_)));
     };
@@ -236,7 +236,7 @@ async fn report_inbound_failure_on_read_request() {
             .send_request(&peer1_id, Action::FailOnReadRequest);
 
         let (peer, req_id_done, error) = wait_outbound_failure(&mut swarm2).await.unwrap();
-        assert_eq!(peer, peer1_id);
+        assert_eq!(peer, Some(peer1_id));
         assert_eq!(req_id_done, req_id);
 
         match error {
@@ -295,7 +295,7 @@ async fn report_inbound_failure_on_write_response() {
             .send_request(&peer1_id, Action::FailOnWriteResponse);
 
         let (peer, req_id_done, error) = wait_outbound_failure(&mut swarm2).await.unwrap();
-        assert_eq!(peer, peer1_id);
+        assert_eq!(peer, Some(peer1_id));
         assert_eq!(req_id_done, req_id);
 
         match error {
@@ -352,7 +352,7 @@ async fn report_inbound_timeout_on_write_response() {
             .send_request(&peer1_id, Action::TimeoutOnWriteResponse);
 
         let (peer, req_id_done, error) = wait_outbound_failure(&mut swarm2).await.unwrap();
-        assert_eq!(peer, peer1_id);
+        assert_eq!(peer, Some(peer1_id));
         assert_eq!(req_id_done, req_id);
 
         match error {
@@ -612,7 +612,7 @@ async fn wait_inbound_failure(
 
 async fn wait_outbound_failure(
     swarm: &mut Swarm<request_response::Behaviour<TestCodec>>,
-) -> Result<(PeerId, OutboundRequestId, OutboundFailure)> {
+) -> Result<(Option<PeerId>, OutboundRequestId, OutboundFailure)> {
     loop {
         match swarm.select_next_some().await.try_into_behaviour_event() {
             Ok(request_response::Event::OutboundFailure {

--- a/protocols/request-response/tests/ping.rs
+++ b/protocols/request-response/tests/ping.rs
@@ -24,6 +24,7 @@ use futures::prelude::*;
 use libp2p_identity::PeerId;
 use libp2p_request_response as request_response;
 use libp2p_request_response::ProtocolSupport;
+use libp2p_swarm::dial_opts::DialOpts;
 use libp2p_swarm::{StreamProtocol, Swarm, SwarmEvent};
 use libp2p_swarm_test::SwarmExt;
 use rand::Rng;
@@ -42,10 +43,7 @@ async fn is_response_outbound() {
 
     let mut swarm1 = Swarm::new_ephemeral(|_| {
         request_response::cbor::Behaviour::<Ping, Pong>::new(
-            [(
-                StreamProtocol::new("/ping/1"),
-                request_response::ProtocolSupport::Full,
-            )],
+            [(StreamProtocol::new("/ping/1"), ProtocolSupport::Full)],
             request_response::Config::default(),
         )
     });
@@ -65,7 +63,7 @@ async fn is_response_outbound() {
             request_id: req_id,
             error: _error,
         } => {
-            assert_eq!(&offline_peer, &peer);
+            assert_eq!(&Some(offline_peer), &peer);
             assert_eq!(req_id, request_id1);
         }
         e => panic!("Peer: Unexpected event: {e:?}"),
@@ -169,6 +167,125 @@ async fn ping_protocol() {
                 }
                 e => panic!("Peer2: Unexpected event: {e:?}"),
             }
+        }
+    };
+
+    async_std::task::spawn(Box::pin(peer1));
+    peer2.await;
+}
+
+/// Exercises a simple ping protocol where peers are not connected prior to request sending.
+#[async_std::test]
+#[cfg(feature = "cbor")]
+async fn ping_protocol_explicit_address() {
+    let ping = Ping("ping".to_string().into_bytes());
+    let pong = Pong("pong".to_string().into_bytes());
+
+    let protocols = iter::once((StreamProtocol::new("/ping/1"), ProtocolSupport::Full));
+    let cfg = request_response::Config::default();
+
+    let mut swarm1 = Swarm::new_ephemeral(|_| {
+        request_response::cbor::Behaviour::<Ping, Pong>::new(protocols.clone(), cfg.clone())
+    });
+    let peer1_id = *swarm1.local_peer_id();
+    let mut swarm2 = Swarm::new_ephemeral(|_| {
+        request_response::cbor::Behaviour::<Ping, Pong>::new(protocols, cfg)
+    });
+    let peer2_id = *swarm2.local_peer_id();
+
+    let (peer1_listen_addr, _) = swarm1.listen().with_memory_addr_external().await;
+
+    let expected_ping = ping.clone();
+    let expected_pong = pong.clone();
+
+    let peer1 = async move {
+        loop {
+            match swarm1.next_swarm_event().await.try_into_behaviour_event() {
+                Ok(request_response::Event::Message {
+                    peer,
+                    message:
+                        request_response::Message::Request {
+                            request, channel, ..
+                        },
+                }) => {
+                    assert_eq!(&request, &expected_ping);
+                    assert_eq!(&peer, &peer2_id);
+                    swarm1
+                        .behaviour_mut()
+                        .send_response(channel, pong.clone())
+                        .unwrap();
+                }
+                Ok(request_response::Event::ResponseSent { peer, .. }) => {
+                    assert_eq!(&peer, &peer2_id);
+                }
+                Ok(e) => {
+                    panic!("Peer1: Unexpected event: {e:?}")
+                }
+                Err(..) => {}
+            }
+        }
+    };
+
+    let peer2 = async {
+        let req_id = swarm2.behaviour_mut().send_request(&peer1_id, ping.clone());
+        assert!(swarm2.behaviour().is_pending_outbound(&peer1_id, &req_id));
+
+        // Can't dial to unknown peer
+        match swarm2
+            .next_swarm_event()
+            .await
+            .try_into_behaviour_event()
+            .unwrap()
+        {
+            request_response::Event::OutboundFailure {
+                peer, request_id, ..
+            } => {
+                assert_eq!(&peer, &Some(peer1_id));
+                assert_eq!(req_id, request_id);
+            }
+            e => panic!("Peer2: Unexpected event: {e:?}"),
+        }
+
+        let req_id = swarm2.behaviour_mut().send_request(
+            DialOpts::peer_id(peer1_id)
+                .addresses(vec![peer1_listen_addr])
+                .build(),
+            ping.clone(),
+        );
+        assert!(swarm2.behaviour().is_pending_outbound(&peer1_id, &req_id));
+
+        // Dial to peer with explicit address succeeds
+        match swarm2.select_next_some().await {
+            SwarmEvent::Dialing { peer_id, .. } => {
+                assert_eq!(&peer_id, &Some(peer1_id));
+            }
+            e => panic!("Peer2: Unexpected event: {e:?}"),
+        }
+        match swarm2.select_next_some().await {
+            SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                assert_eq!(&peer_id, &peer1_id);
+            }
+            e => panic!("Peer2: Unexpected event: {e:?}"),
+        }
+        match swarm2
+            .next_swarm_event()
+            .await
+            .try_into_behaviour_event()
+            .unwrap()
+        {
+            request_response::Event::Message {
+                peer,
+                message:
+                    request_response::Message::Response {
+                        request_id,
+                        response,
+                    },
+            } => {
+                assert_eq!(&response, &expected_pong);
+                assert_eq!(&peer, &peer1_id);
+                assert_eq!(req_id, request_id);
+            }
+            e => panic!("Peer2: Unexpected event: {e:?}"),
         }
     };
 

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Deprecate `void` crate.
   See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
 
+- Add `impl From<&PeerId> for DialOpts`.
+  See [PR 5692](https://github.com/libp2p/rust-libp2p/pull/5692).
+
 ## 0.45.1
 
 - Update `libp2p-swarm-derive` to version `0.35.0`, see [PR 5545]

--- a/swarm/src/dial_opts.rs
+++ b/swarm/src/dial_opts.rs
@@ -172,6 +172,12 @@ impl From<PeerId> for DialOpts {
     }
 }
 
+impl From<&PeerId> for DialOpts {
+    fn from(peer_id: &PeerId) -> Self {
+        DialOpts::peer_id(*peer_id).build()
+    }
+}
+
 #[derive(Debug)]
 pub struct WithPeerId {
     peer_id: PeerId,


### PR DESCRIPTION
## Description

We discussed https://github.com/libp2p/rust-libp2p/issues/5634 at one of the community calls and the ways to approach it, one of the challenges we discussed was around the argument type and how to handle the case where `PeerId` is not specified in `DialOpts`.

I went with a relatively straightforward route: use `PeerId` when it is specified (same behavior as before this PR) and use `ConnectionId` otherwise, wrapping both into an enum to use as a key in internal `HashMap`.

Implementation ended up being fairly simple with the only breaking change being `peer` field in `request_response::Event::OutboundFailure` changing from `PeerId` to `Option<PeerId>`.

Resolves https://github.com/libp2p/rust-libp2p/issues/5634

## Notes & open questions

One thing I do not like too much and only did for backwards compatibility purposes is additional `impl From<&PeerId> for DialOpts` such that existing calls continue to work. If changing `&peer_id` to `peer_id` is an acceptable breaking change then that impl can be removed.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
