### PR TITLE
fix: typos in documentation files

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 - Update `Transport::dial` function signature with a `DialOpts` param and remove `Transport::dial_as_listener`:
   - `DialOpts` struct contains `PortUse` and `Endpoint`, 
-  - `PortUse` allows controling port allocation of new connections (defaults to `PortUse::Reuse`)   - 
+  - `PortUse` allows controlling port allocation of new connections (defaults to `PortUse::Reuse`)   - 
   - Add `port_use` field to `ConnectedPoint`
   - Set `endpoint` field in `DialOpts` to `Endpoint::Listener` to dial as a listener
 - Remove `Transport::address_translation` and relocate functionality to `libp2p_swarm`

--- a/identity/CHANGELOG.md
+++ b/identity/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## 0.2.8
 
-- Bump `ring` to `0.17.5.
+- Bump `ring` to `0.17.5`.
   See [PR 4779](https://github.com/libp2p/rust-libp2p/pull/4779).
 
 ## 0.2.7


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "controling" to "controlling"
Also, in the sentence "Bump `ring` to `0.17.5" is missing a closing quotation mark at the end, which has been fixed.

Please review the changes and let me know if any additional changes are needed.

