### PR TITLE
feat(kad): make Distance private field public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2844,7 +2844,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "arrayvec",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ libp2p-floodsub = { version = "0.45.0", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.48.0", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.46.0", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.10" }
-libp2p-kad = { version = "0.47.0", path = "protocols/kad" }
+libp2p-kad = { version = "0.47.1", path = "protocols/kad" }
 libp2p-mdns = { version = "0.46.0", path = "protocols/mdns" }
 libp2p-memory-connection-limits = { version = "0.3.1", path = "misc/memory-connection-limits" }
 libp2p-metrics = { version = "0.15.0", path = "misc/metrics" }

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.47.1
+
+- Expose Distance private field U256 to public.
+  See [PR 5705](https://github.com/libp2p/rust-libp2p/pull/5705).
+
 ## 0.47.0
 
 - Expose a kad query facility allowing specify num_results dynamicaly.

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-kad"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Kademlia protocol for libp2p"
-version = "0.47.0"
+version = "0.47.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/kad/src/kbucket/key.rs
+++ b/protocols/kad/src/kbucket/key.rs
@@ -35,7 +35,7 @@ use crate::record;
 
 construct_uint! {
     /// 256-bit unsigned integer.
-    pub(super) struct U256(4);
+    pub struct U256(4);
 }
 
 /// A `Key` in the DHT keyspace with preserved preimage.
@@ -193,7 +193,7 @@ impl AsRef<KeyBytes> for KeyBytes {
 
 /// A distance between two keys in the DHT keyspace.
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Debug)]
-pub struct Distance(pub(super) U256);
+pub struct Distance(pub U256);
 
 impl Distance {
     /// Returns the integer part of the base 2 logarithm of the [`Distance`].

--- a/protocols/kad/src/lib.rs
+++ b/protocols/kad/src/lib.rs
@@ -67,7 +67,7 @@ pub use behaviour::{
     QueryResult, QueryStats, Quorum, RoutingUpdate, StoreInserts,
 };
 pub use kbucket::{
-    Distance as KBucketDistance, EntryView, KBucketRef, Key as KBucketKey, NodeStatus,
+    Distance as KBucketDistance, EntryView, KBucketRef, Key as KBucketKey, NodeStatus, U256,
 };
 use libp2p_swarm::StreamProtocol;
 pub use protocol::{ConnectionType, KadPeer};


### PR DESCRIPTION
## Description

make Distance private field (U256) public

So that some `network density` in Distance can be calculated as below:

```rust
let density = U256::MAX / U256::from(estimated_network_size);
let density_distance = Distance(estimated_distance);
```

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
