### PR TITLE
fix(libp2p): expose builder phase error

### DIFF
--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.54.2
 
 - Deprecate `void` crate.
-  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).  
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
 
 - Expose swarm builder phase errors.
   See [PR 5726](https://github.com/libp2p/rust-libp2p/pull/5726).

--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -1,12 +1,10 @@
-## unreleased
-
-- Expose swarm builder phase errors.
-  See [PR 5726](https://github.com/libp2p/rust-libp2p/pull/5726)
-
 ## 0.54.2
 
 - Deprecate `void` crate.
-  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).  
+
+- Expose swarm builder phase errors.
+  See [PR 5726](https://github.com/libp2p/rust-libp2p/pull/5726).
 
 ## 0.54.1
 

--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased
+
+- Expose swarm builder phase errors.
+  See [PR 5726](https://github.com/libp2p/rust-libp2p/pull/5726)
+
 ## 0.54.2
 
 - Deprecate `void` crate.

--- a/libp2p/src/builder.rs
+++ b/libp2p/src/builder.rs
@@ -4,6 +4,8 @@ mod phase;
 mod select_muxer;
 mod select_security;
 
+pub use phase::{BehaviourError, TransportError, WebsocketError};
+
 /// Build a [`Swarm`](libp2p_swarm::Swarm) by combining an identity, a set of
 /// [`Transport`](libp2p_core::Transport)s and a
 /// [`NetworkBehaviour`](libp2p_swarm::NetworkBehaviour).

--- a/libp2p/src/builder.rs
+++ b/libp2p/src/builder.rs
@@ -4,7 +4,9 @@ mod phase;
 mod select_muxer;
 mod select_security;
 
-pub use phase::{BehaviourError, TransportError, WebsocketError};
+#[cfg(all(not(target_arch = "wasm32"), feature = "websocket"))]
+pub use phase::WebsocketError;
+pub use phase::{BehaviourError, TransportError};
 
 /// Build a [`Swarm`](libp2p_swarm::Swarm) by combining an identity, a set of
 /// [`Transport`](libp2p_core::Transport)s and a

--- a/libp2p/src/builder/phase.rs
+++ b/libp2p/src/builder/phase.rs
@@ -16,22 +16,23 @@ mod websocket;
 
 use bandwidth_logging::*;
 use bandwidth_metrics::*;
-pub use behaviour::BehaviourError;
 use behaviour::*;
 use build::*;
 use dns::*;
 use libp2p_core::{muxing::StreamMuxerBox, Transport};
 use libp2p_identity::Keypair;
-pub use other_transport::TransportError;
 use other_transport::*;
 use provider::*;
 use quic::*;
 use relay::*;
 use swarm::*;
 use tcp::*;
+use websocket::*;
+
+pub use behaviour::BehaviourError;
+pub use other_transport::TransportError;
 #[cfg(all(not(target_arch = "wasm32"), feature = "websocket"))]
 pub use websocket::WebsocketError;
-use websocket::*;
 
 use super::{
     select_muxer::SelectMuxerUpgrade, select_security::SelectSecurityUpgrade, SwarmBuilder,

--- a/libp2p/src/builder/phase.rs
+++ b/libp2p/src/builder/phase.rs
@@ -29,6 +29,7 @@ use quic::*;
 use relay::*;
 use swarm::*;
 use tcp::*;
+#[cfg(all(not(target_arch = "wasm32"), feature = "websocket"))]
 pub use websocket::WebsocketError;
 use websocket::*;
 

--- a/libp2p/src/builder/phase.rs
+++ b/libp2p/src/builder/phase.rs
@@ -16,17 +16,20 @@ mod websocket;
 
 use bandwidth_logging::*;
 use bandwidth_metrics::*;
+pub use behaviour::BehaviourError;
 use behaviour::*;
 use build::*;
 use dns::*;
 use libp2p_core::{muxing::StreamMuxerBox, Transport};
 use libp2p_identity::Keypair;
+pub use other_transport::TransportError;
 use other_transport::*;
 use provider::*;
 use quic::*;
 use relay::*;
 use swarm::*;
 use tcp::*;
+pub use websocket::WebsocketError;
 use websocket::*;
 
 use super::{

--- a/libp2p/src/lib.rs
+++ b/libp2p/src/lib.rs
@@ -148,6 +148,8 @@ pub mod bandwidth;
 #[cfg(doc)]
 pub mod tutorials;
 
+#[cfg(all(not(target_arch = "wasm32"), feature = "websocket"))]
+pub use builder::WebsocketError as WebsocketBuilderError;
 pub use libp2p_identity as identity;
 pub use libp2p_identity::PeerId;
 pub use libp2p_swarm::{Stream, StreamProtocol};
@@ -155,7 +157,7 @@ pub use libp2p_swarm::{Stream, StreamProtocol};
 pub use self::{
     builder::{
         BehaviourError as BehaviourBuilderError, SwarmBuilder,
-        TransportError as TransportBuilderError, WebsocketError as WebsocketBuilderError,
+        TransportError as TransportBuilderError,
     },
     core::{
         transport::TransportError,

--- a/libp2p/src/lib.rs
+++ b/libp2p/src/lib.rs
@@ -153,7 +153,10 @@ pub use libp2p_identity::PeerId;
 pub use libp2p_swarm::{Stream, StreamProtocol};
 
 pub use self::{
-    builder::SwarmBuilder,
+    builder::{
+        BehaviourError as BehaviourBuilderError, SwarmBuilder,
+        TransportError as TransportBuilderError, WebsocketError as WebsocketBuilderError,
+    },
     core::{
         transport::TransportError,
         upgrade::{InboundUpgrade, OutboundUpgrade},


### PR DESCRIPTION
## Description
May close #4829 and #4824.  
Export three error types `BehaviourError`, `TransportError`, `WebsocketError` with rename. Feature gated `WebsocketError`.  
Exported at crate root as [suggested](https://github.com/libp2p/rust-libp2p/issues/4824#issuecomment-1803013514).
<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues in here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
