### PR TITLE
chore(ci): update Rust stable version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
       fail-fast: false
       matrix:
         rust-version: [
-          1.80.0, # current stable
+          1.83.0, # current stable
           beta,
         ]
     steps:


### PR DESCRIPTION
## Description

Update Rust stable version in our CI to the latest stable version 1.83.0.
