### PR TITLE
chore(core): avoid unused props matching on connection.rs

### DIFF
--- a/core/src/connection.rs
+++ b/core/src/connection.rs
@@ -138,11 +138,7 @@ impl ConnectedPoint {
     /// Returns true if the connection is relayed.
     pub fn is_relayed(&self) -> bool {
         match self {
-            ConnectedPoint::Dialer {
-                address,
-                role_override: _,
-                port_use: _,
-            } => address,
+            ConnectedPoint::Dialer { address, .. } => address,
             ConnectedPoint::Listener { local_addr, .. } => local_addr,
         }
         .iter()


### PR DESCRIPTION
Avoid explicitly matching properties that are not actually used.