### PR TITLE
chore: add Unicode V3 license to deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -43,6 +43,7 @@ allow = [
     "MIT",
     "MPL-2.0",
     "Unlicense",
+    "Unicode-3.0",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the


### PR DESCRIPTION
## Description
Add `Unicode` `v3` License to our `cargo.deny` file.
This is required because of the [`icu_collections`](https://crates.io/crates/icu_collections) dependency which is authored by The Unicode Consortium.
in my ignorance, seems to be safe as the Open Source Initiative [approves it](https://opensource.org/license/unicode-license-v3), and the main `deny.toml` has also [added it](https://github.com/EmbarkStudios/cargo-deny/pull/713/files#diff-1040309c64844eb1b6b63d8fd67938adbf9461f1b3c61f12cf738f064a02d3deR50).