### PR TITLE
chore(core): use `matches!` in connection.rs

### DIFF
--- a/core/src/connection.rs
+++ b/core/src/connection.rs
@@ -121,18 +121,12 @@ impl ConnectedPoint {
 
     /// Returns true if we are `Dialer`.
     pub fn is_dialer(&self) -> bool {
-        match self {
-            ConnectedPoint::Dialer { .. } => true,
-            ConnectedPoint::Listener { .. } => false,
-        }
+        matches!(self, ConnectedPoint::Dialer { .. })
     }
 
     /// Returns true if we are `Listener`.
     pub fn is_listener(&self) -> bool {
-        match self {
-            ConnectedPoint::Dialer { .. } => false,
-            ConnectedPoint::Listener { .. } => true,
-        }
+        matches!(self, ConnectedPoint::Listener { .. })
     }
 
     /// Returns true if the connection is relayed.


### PR DESCRIPTION
Use `matches!` in cases when pattern matching is resolved to a boolean.