### PR TITLE
chore: fix format with nightly

### DIFF
--- a/libp2p/src/builder/phase.rs
+++ b/libp2p/src/builder/phase.rs
@@ -16,23 +16,22 @@ mod websocket;
 
 use bandwidth_logging::*;
 use bandwidth_metrics::*;
+pub use behaviour::BehaviourError;
 use behaviour::*;
 use build::*;
 use dns::*;
 use libp2p_core::{muxing::StreamMuxerBox, Transport};
 use libp2p_identity::Keypair;
+pub use other_transport::TransportError;
 use other_transport::*;
 use provider::*;
 use quic::*;
 use relay::*;
 use swarm::*;
 use tcp::*;
-use websocket::*;
-
-pub use behaviour::BehaviourError;
-pub use other_transport::TransportError;
 #[cfg(all(not(target_arch = "wasm32"), feature = "websocket"))]
 pub use websocket::WebsocketError;
+use websocket::*;
 
 use super::{
     select_muxer::SelectMuxerUpgrade, select_security::SelectSecurityUpgrade, SwarmBuilder,

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -1497,14 +1497,17 @@ impl Config {
     ///
     /// Defaults to 10s.
     ///
-    /// Typically, you shouldn't _need_ to modify this default as connections will be kept alive whilst they are "in use" (see below).
-    /// Depending on the application's usecase, it may be desirable to keep connections alive despite them not being in use.
+    /// Typically, you shouldn't _need_ to modify this default as connections will be kept alive
+    /// whilst they are "in use" (see below). Depending on the application's usecase, it may be
+    /// desirable to keep connections alive despite them not being in use.
     ///
     /// A connection is considered idle if:
     /// - There are no active inbound streams.
     /// - There are no active outbounds streams.
-    /// - There are no pending outbound streams (i.e. all streams requested via [`ConnectionHandlerEvent::OutboundSubstreamRequest`] have completed).
-    /// - Every [`ConnectionHandler`] returns `false` from [`ConnectionHandler::connection_keep_alive`].
+    /// - There are no pending outbound streams (i.e. all streams requested via
+    ///   [`ConnectionHandlerEvent::OutboundSubstreamRequest`] have completed).
+    /// - Every [`ConnectionHandler`] returns `false` from
+    ///   [`ConnectionHandler::connection_keep_alive`].
     ///
     /// Once all these conditions are true, the idle connection timeout starts ticking.
     pub fn with_idle_connection_timeout(mut self, timeout: Duration) -> Self {

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -160,7 +160,7 @@ use async_trait::async_trait;
 use futures::{future::BoxFuture, prelude::*};
 pub use hickory_resolver::{
     config::{ResolverConfig, ResolverOpts},
-    {ResolveError, ResolveErrorKind},
+    ResolveError, ResolveErrorKind,
 };
 use hickory_resolver::{
     lookup::{Ipv4Lookup, Ipv6Lookup, TxtLookup},


### PR DESCRIPTION
## Description

Fix formatting with nightly. 

Without nightly, some of our `rustfmt.toml` rules aren't applied because they are not stable yet (e.g. our `group_imports` rule).
Our CI didn't catch it yet because it doesn't check fmt on nightly. Will fix that in a follow-up PR.

## Notes & open questions

Came up in https://github.com/libp2p/rust-libp2p/pull/5725#discussion_r1885004515.

cc @drHuangMHT you were actually correct in https://github.com/libp2p/rust-libp2p/pull/5726#discussion_r1877544943, the items are reordered across blocks because of our rule `group_imports = "StdExternalCrate"`)

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~A changelog entry has been made in the appropriate crates~~
