### PR TITLE
chore(ci): check rustfmt with nightly toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
 


### PR DESCRIPTION
## Description

Some of our rustfmt rules aren't stable yet. Thus our rustfmt CI check should run on nightly.  

## Notes & open questions

Depends on #5742.

I am not super familiar with CI workflows. Can/ should this be solved differently?

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~A changelog entry has been made in the appropriate crates~~
