### PR TITLE
chore(docs): fix typos in documentation

### DIFF
--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -236,7 +236,7 @@ Concurrency adds complexity. Concurrency adds overhead due to synchronization.
 Thus unless proven to be a bottleneck, don't make things concurrent. As an example
 the hierarchical `NetworkBehaviour` state machine runs sequentially. It is easy
 to debug as it runs sequentially. Thus far there has been no proof that
-shows a speed up when running it concurrently.
+shows a speed-up when running it concurrently.
 
 ## Use `async/await` for sequential execution only
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -246,7 +246,7 @@
 
 - Move from `open-metrics-client` to `prometheus-client` (see [PR 2442]).
 
-- Emit gossip of all non empty topics (see [PR 2481]).
+- Emit gossip of all non-empty topics (see [PR 2481]).
 
 - Merge NetworkBehaviour's inject_\* paired methods (see [PR 2445]).
 


### PR DESCRIPTION
This PR fixes minor typos in the documentation and changelog:  

1. Updated "speed up" to "speed-up" in `docs/coding-guidelines.md` to correctly hyphenate the term when used as a noun.  
2. Updated "non empty" to "non-empty" in `protocols/gossipsub/CHANGELOG.md` for consistency and adherence to standard grammar rules.  

These changes improve readability and maintain accuracy in the project's documentation.  

### Notes & Open Questions  
- No functional changes are introduced in this PR.  
- These updates are purely grammatical corrections and do not require additional tests.  

### Change Checklist  
- [x] I have performed a self-review of my own code.  
- [x] I have made corresponding changes to the documentation.  
- [x] A changelog entry has been made in the appropriate crates.  
