### PR TITLE
misc: implement RwStreamSink in memory transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,7 +2781,6 @@ dependencies = [
  "quick-protobuf",
  "quickcheck-ext",
  "rand 0.8.5",
- "rw-stream-sink",
  "serde",
  "smallvec",
  "thiserror 2.0.3",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,7 +25,6 @@ parking_lot = "0.12.3"
 pin-project = "1.1.5"
 quick-protobuf = "0.8"
 rand = "0.8"
-rw-stream-sink = { workspace = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 smallvec = "1.13.2"
 thiserror = { workspace = true }

--- a/core/src/transport/memory.rs
+++ b/core/src/transport/memory.rs
@@ -21,21 +21,17 @@
 use std::{
     collections::{hash_map::Entry, VecDeque},
     error, fmt, io,
+    io::Read,
     num::NonZeroU64,
     pin::Pin,
+    task::{Context, Poll},
 };
 
 use fnv::FnvHashMap;
-use futures::{
-    channel::mpsc,
-    future::Ready,
-    prelude::*,
-    task::{Context, Poll},
-};
+use futures::{channel::mpsc, future::Ready, prelude::*, ready};
 use multiaddr::{Multiaddr, Protocol};
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
-use rw_stream_sink::RwStreamSink;
 
 use crate::transport::{DialOpts, ListenerId, Transport, TransportError, TransportEvent};
 
@@ -326,6 +322,80 @@ fn parse_memory_addr(a: &Multiaddr) -> Result<u64, ()> {
             _ => Err(()),
         },
         _ => Err(()),
+    }
+}
+
+#[pin_project::pin_project]
+pub struct RwStreamSink<S: TryStream> {
+    #[pin]
+    inner: S,
+    current_item: Option<std::io::Cursor<<S as TryStream>::Ok>>,
+}
+
+impl<S: TryStream> RwStreamSink<S> {
+    /// Wraps around `inner`.
+    pub fn new(inner: S) -> Self {
+        RwStreamSink {
+            inner,
+            current_item: None,
+        }
+    }
+}
+
+impl<S> AsyncRead for RwStreamSink<S>
+where
+    S: TryStream<Error = io::Error>,
+    <S as TryStream>::Ok: AsRef<[u8]>,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        let mut this = self.project();
+
+        // Grab the item to copy from.
+        let item_to_copy = loop {
+            if let Some(ref mut i) = this.current_item {
+                if i.position() < i.get_ref().as_ref().len() as u64 {
+                    break i;
+                }
+            }
+            *this.current_item = Some(match ready!(this.inner.as_mut().try_poll_next(cx)) {
+                Some(Ok(i)) => std::io::Cursor::new(i),
+                Some(Err(e)) => return Poll::Ready(Err(e)),
+                None => return Poll::Ready(Ok(0)), // EOF
+            });
+        };
+
+        // Copy it!
+        Poll::Ready(Ok(item_to_copy.read(buf)?))
+    }
+}
+
+impl<S> AsyncWrite for RwStreamSink<S>
+where
+    S: TryStream + Sink<<S as TryStream>::Ok, Error = io::Error>,
+    <S as TryStream>::Ok: for<'r> From<&'r [u8]>,
+{
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<io::Result<usize>> {
+        let mut this = self.project();
+        ready!(this.inner.as_mut().poll_ready(cx)?);
+        let n = buf.len();
+        if let Err(e) = this.inner.start_send(buf.into()) {
+            return Poll::Ready(Err(e));
+        }
+        Poll::Ready(Ok(n))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        let this = self.project();
+        this.inner.poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        let this = self.project();
+        this.inner.poll_close(cx)
     }
 }
 


### PR DESCRIPTION
## Description
Implement RwStreamSink inlined into the memory-transport implementation

- https://github.com/libp2p/rust-libp2p/issues/4345

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
