### PR TITLE
chore(mdns): revert version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2955,7 +2955,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.46.2"
+version = "0.46.1"
 dependencies = [
  "async-io",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ libp2p-gossipsub = { version = "0.48.0", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.46.1", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.10" }
 libp2p-kad = { version = "0.47.1", path = "protocols/kad" }
-libp2p-mdns = { version = "0.46.2", path = "protocols/mdns" }
+libp2p-mdns = { version = "0.46.1", path = "protocols/mdns" }
 libp2p-memory-connection-limits = { version = "0.3.1", path = "misc/memory-connection-limits" }
 libp2p-metrics = { version = "0.15.0", path = "misc/metrics" }
 libp2p-mplex = { version = "0.42.0", path = "muxers/mplex" }

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,10 +1,7 @@
-## 0.46.2
+## 0.46.1
 
 - Emit `ToSwarm::NewExternalAddrOfPeer` on discovery.
   See [PR 5753](https://github.com/libp2p/rust-libp2p/pull/5753)
-
-## 0.46.1
-
 - Upgrade `hickory-proto`.
   See [PR 5727](https://github.com/libp2p/rust-libp2p/pull/5727)
 

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libp2p-mdns"
 edition = "2021"
 rust-version = { workspace = true }
-version = "0.46.2"
+version = "0.46.1"
 description = "Implementation of the libp2p mDNS discovery method"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"


### PR DESCRIPTION
## Description

Revert version bump of #5753, because libp2p-mdns-0.46.1 isn't released yet.

## Notes & open questions

See https://github.com/libp2p/rust-libp2p/pull/5753#issuecomment-2561050159.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~A changelog entry has been made in the appropriate crates~~
