### PR TITLE
Fix typographical errors in Documentation and Comments

### DIFF
--- a/identity/src/rsa.rs
+++ b/identity/src/rsa.rs
@@ -105,7 +105,7 @@ impl PublicKey {
         self.0.clone()
     }
 
-    /// Encode the RSA public key in DER as a X.509 SubjectPublicKeyInfo structure,
+    /// Encode the RSA public key in DER as an X.509 SubjectPublicKeyInfo structure,
     /// as defined in [RFC5280].
     ///
     /// [RFC5280]: https://tools.ietf.org/html/rfc5280#section-4.1

--- a/misc/keygen/src/main.rs
+++ b/misc/keygen/src/main.rs
@@ -42,7 +42,7 @@ enum Command {
     },
 }
 
-// Due to the fact that a peer id uses a SHA-256 multihash, it always starts with the
+// Due to the fact that a peer id uses an SHA-256 multihash, it always starts with the
 // bytes 0x1220, meaning that only some characters are valid.
 const ALLOWED_FIRST_BYTE: &[u8] = b"NPQRSTUVWXYZ";
 

--- a/misc/multistream-select/src/protocol.rs
+++ b/misc/multistream-select/src/protocol.rs
@@ -120,7 +120,7 @@ impl fmt::Display for Protocol {
 /// A multistream-select protocol message.
 ///
 /// Multistream-select protocol messages are exchanged with the goal
-/// of agreeing on a application-layer protocol to use on an I/O stream.
+/// of agreeing on an application-layer protocol to use on an I/O stream.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Message {
     /// A header message identifies the multistream-select protocol


### PR DESCRIPTION
This pull request addresses minor typographical errors in documentation and comments across three files. These changes improve readability and ensure consistency with proper grammar. The updates include:

1. **`rsa.rs`**:
   - Corrected "a X.509" to "an X.509" in the comment for RSA public key encoding.

2. **`main.rs`**:
   - Updated "a SHA-256" to "an SHA-256" in the explanation of peer ID usage.

3. **`protocol.rs`**:
   - Fixed "a application-layer" to "an application-layer" in the comment about multistream-select protocol messages.

#### Notes & Open Questions:
- These changes do not affect functionality or introduce any breaking changes.
- Focused solely on improving comment clarity.

#### Change Checklist:
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable here).
- [x] A changelog entry has been made in the appropriate crates (if needed).
