### PR TITLE
fix(tcp): make `TCP_NODELAY` actually the default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "async-io",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ libp2p-stream = { version = "0.2.0-alpha.1", path = "protocols/stream" }
 libp2p-swarm = { version = "0.45.2", path = "swarm" }
 libp2p-swarm-derive = { version = "=0.35.0", path = "swarm-derive" } # `libp2p-swarm-derive` may not be compatible with different `libp2p-swarm` non-breaking releases. E.g. `libp2p-swarm` might introduce a new enum variant `FromSwarm` (which is `#[non-exhaustive]`) in a non-breaking release. Older versions of `libp2p-swarm-derive` would not forward this enum variant within the `NetworkBehaviour` hierarchy. Thus the version pinning is required.
 libp2p-swarm-test = { version = "0.5.0", path = "swarm-test" }
-libp2p-tcp = { version = "0.42.0", path = "transports/tcp" }
+libp2p-tcp = { version = "0.42.1", path = "transports/tcp" }
 libp2p-tls = { version = "0.5.0", path = "transports/tls" }
 libp2p-uds = { version = "0.41.0", path = "transports/uds" }
 libp2p-upnp = { version = "0.3.1", path = "protocols/upnp" }

--- a/transports/tcp/CHANGELOG.md
+++ b/transports/tcp/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.42.1
+
+- Fix the disabling of Nagle's algorithm, which requires setting `TCP_NODELAY` to _true_.
+  See [PR 5764](https://github.com/libp2p/rust-libp2p/pull/5764)
+
 ## 0.42.0
 
 - Implement refactored `Transport`.

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-tcp"
 edition = "2021"
 rust-version = { workspace = true }
 description = "TCP/IP transport protocol for libp2p"
-version = "0.42.0"
+version = "0.42.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/transports/tcp/src/lib.rs
+++ b/transports/tcp/src/lib.rs
@@ -130,7 +130,7 @@ impl PortReuse {
 impl Config {
     /// Creates a new configuration for a TCP/IP transport:
     ///
-    ///   * Nagle's algorithm, i.e. `TCP_NODELAY`, is _enabled_. See [`Config::nodelay`].
+    ///   * Nagle's algorithm is _disabled_, i.e. `TCP_NODELAY` _enabled_. See [`Config::nodelay`].
     ///   * Reuse of listening ports is _disabled_. See [`Config::port_reuse`].
     ///   * No custom `IP_TTL` is set. The default of the OS TCP stack applies. See [`Config::ttl`].
     ///   * The size of the listen backlog for new listening sockets is `1024`. See
@@ -138,7 +138,7 @@ impl Config {
     pub fn new() -> Self {
         Self {
             ttl: None,
-            nodelay: false, // Disable Nagle's algorithm by default
+            nodelay: true, // Disable Nagle's algorithm by default.
             backlog: 1024,
         }
     }

--- a/transports/tcp/src/lib.rs
+++ b/transports/tcp/src/lib.rs
@@ -59,8 +59,8 @@ use socket2::{Domain, Socket, Type};
 pub struct Config {
     /// TTL to set for opened sockets, or `None` to keep default.
     ttl: Option<u32>,
-    /// `TCP_NODELAY` to set for opened sockets, or `None` to keep default.
-    nodelay: Option<bool>,
+    /// `TCP_NODELAY` to set for opened sockets.
+    nodelay: bool,
     /// Size of the listen backlog for listen sockets.
     backlog: u32,
 }
@@ -138,7 +138,7 @@ impl Config {
     pub fn new() -> Self {
         Self {
             ttl: None,
-            nodelay: Some(false), // Disable Nagle's algorithm by default
+            nodelay: false, // Disable Nagle's algorithm by default
             backlog: 1024,
         }
     }
@@ -151,7 +151,7 @@ impl Config {
 
     /// Configures the `TCP_NODELAY` option for new sockets.
     pub fn nodelay(mut self, value: bool) -> Self {
-        self.nodelay = Some(value);
+        self.nodelay = value;
         self
     }
 
@@ -198,9 +198,7 @@ impl Config {
         if let Some(ttl) = self.ttl {
             socket.set_ttl(ttl)?;
         }
-        if let Some(nodelay) = self.nodelay {
-            socket.set_nodelay(nodelay)?;
-        }
+        socket.set_nodelay(self.nodelay)?;
         socket.set_reuse_address(true)?;
         #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
         if port_use == PortUse::Reuse {


### PR DESCRIPTION
## Description

Nagle's algorithm is actually disabled by setting `TCP_NODELAY` to _true_. In the current master, it is set to _false_, i.e. Nagle's algorithm is enabled. 
This PR sets `TCP_NODELAY` per default to `true` and fixes the description of `tcp::Config::new`.

Fixes #4890.

## Notes & open questions

Brought up by users in https://github.com/libp2p/rust-libp2p/pull/5469#discussion_r1750303584 and https://github.com/libp2p/rust-libp2p/pull/4916#issuecomment-2560081916

I also removed the `Option` around `Config.nodelay` because even it in the current master it can never be `None`. However, that means user's can never opt to just use the OS defaults.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] A changelog entry has been made in the appropriate crates
