### PR TITLE
chore(ci): add Zlib to deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -44,6 +44,7 @@ allow = [
     "MPL-2.0",
     "Unlicense",
     "Unicode-3.0",
+    "Zlib",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the


### PR DESCRIPTION
## Description
Similar to https://github.com/libp2p/rust-libp2p/pull/5738,  [`foldhash`](https://crates.io/crates/foldhash) is the dependency that requires it. It was introduced by `hashbrown` which is dependency of a lot of crates [here](https://github.com/rust-lang/hashbrown/pull/563).
`hashbrown` is MIT, and Zlib is also an Open Source Initiative [approved license](https://opensource.org/license/zlib). 

If you prefer we can also do as the upstream `cargo-deny` do and just add `foldhash` [to the exceptions](https://github.com/EmbarkStudios/cargo-deny/pull/618/files#diff-1040309c64844eb1b6b63d8fd67938adbf9461f1b3c61f12cf738f064a02d3deR56) but I can't see any advantage to it.
Cc @hanabi1224  