### PR TITLE
feat(gossipsub): Allow setting a size threshold for IDONTWANT messages

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 0.48.0
+- Add configurable `idontwant_message_size_threshold` parameter.
+  See [PR 5770](https://github.com/libp2p/rust-libp2p/pull/5770)
 
 - Introduce Gossipsub v1.2 [spec](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.2.md).
   See [PR 5697](https://github.com/libp2p/rust-libp2p/pull/5697)

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1739,9 +1739,6 @@ where
         // Calculate the message id on the transformed data.
         let msg_id = self.config.message_id(&message);
 
-        // Broadcast IDONTWANT messages.
-        self.send_idontwant(&raw_message, &msg_id, propagation_source);
-
         // Check the validity of the message
         // Peers get penalized if this message is invalid. We don't add it to the duplicate cache
         // and instead continually penalize peers that repeatedly send this message.
@@ -1757,6 +1754,12 @@ where
             self.mcache.observe_duplicate(&msg_id, propagation_source);
             return;
         }
+
+        // Broadcast IDONTWANT messages
+        if raw_message.raw_protobuf_len() > self.config.idontwant_message_size_threshold() {
+            self.send_idontwant(&raw_message, &msg_id, propagation_source);
+        }
+
         tracing::debug!(
             message=%msg_id,
             "Put message in duplicate_cache and resolve promises"

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1739,16 +1739,16 @@ where
         // Calculate the message id on the transformed data.
         let msg_id = self.config.message_id(&message);
 
+        // Broadcast IDONTWANT messages
+        if raw_message.raw_protobuf_len() > self.config.idontwant_message_size_threshold() {
+            self.send_idontwant(&raw_message, &msg_id, propagation_source);
+        }
+
         // Check the validity of the message
         // Peers get penalized if this message is invalid. We don't add it to the duplicate cache
         // and instead continually penalize peers that repeatedly send this message.
         if !self.message_is_valid(&msg_id, &mut raw_message, propagation_source) {
             return;
-        }
-
-        // Broadcast IDONTWANT messages
-        if raw_message.raw_protobuf_len() > self.config.idontwant_message_size_threshold() {
-            self.send_idontwant(&raw_message, &msg_id, propagation_source);
         }
 
         if !self.duplicate_cache.insert(msg_id.clone()) {

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1746,6 +1746,11 @@ where
             return;
         }
 
+        // Broadcast IDONTWANT messages
+        if raw_message.raw_protobuf_len() > self.config.idontwant_message_size_threshold() {
+            self.send_idontwant(&raw_message, &msg_id, propagation_source);
+        }
+
         if !self.duplicate_cache.insert(msg_id.clone()) {
             tracing::debug!(message=%msg_id, "Message already received, ignoring");
             if let Some((peer_score, ..)) = &mut self.peer_score {
@@ -1753,11 +1758,6 @@ where
             }
             self.mcache.observe_duplicate(&msg_id, propagation_source);
             return;
-        }
-
-        // Broadcast IDONTWANT messages
-        if raw_message.raw_protobuf_len() > self.config.idontwant_message_size_threshold() {
-            self.send_idontwant(&raw_message, &msg_id, propagation_source);
         }
 
         tracing::debug!(

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -5288,7 +5288,7 @@ fn sends_idontwant() {
 
     let message = RawMessage {
         source: Some(peers[1]),
-        data: vec![12u8;1024],
+        data: vec![12u8; 1024],
         sequence_number: Some(0),
         topic: topic_hashes[0].clone(),
         signature: None,

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -1637,7 +1637,7 @@ fn do_forward_messages_to_explicit_peers() {
 
     let message = RawMessage {
         source: Some(peers[1]),
-        data: vec![12u8,1024],
+        data: vec![12],
         sequence_number: Some(0),
         topic: topic_hashes[0].clone(),
         signature: None,
@@ -5288,7 +5288,7 @@ fn sends_idontwant() {
 
     let message = RawMessage {
         source: Some(peers[1]),
-        data: vec![12],
+        data: vec![12u8;1024],
         sequence_number: Some(0),
         topic: topic_hashes[0].clone(),
         signature: None,
@@ -5342,7 +5342,7 @@ fn doesnt_sends_idontwant_for_lower_message_size() {
         receivers
             .into_iter()
             .fold(0, |mut idontwants, (peer_id, c)| {
-                let non_priority = c.non_priority.into_inner();
+                let non_priority = c.non_priority.get_ref();
                 while !non_priority.is_empty() {
                     if let Ok(RpcOut::IDontWant(_)) = non_priority.try_recv() {
                         assert_ne!(peer_id, peers[1]);
@@ -5374,49 +5374,6 @@ fn doesnt_send_idontwant() {
     let message = RawMessage {
         source: Some(peers[1]),
         data: vec![12],
-
-
-    #[test]
-        fn doesnt_sends_idontwant_for_lower_message_size() {
-            let (mut gs, peers, receivers, topic_hashes) = inject_nodes1()
-                    .peer_no(5)
-                    .topics(vec![String::from("topic1")])
-                    .to_subscribe(true)
-                    .gs_config(Config::default())
-                    .explicit(1)
-                    .peer_kind(PeerKind::Gossipsubv1_2)
-                    .create_network();
-
-        let local_id = PeerId::random();
-
-        let message = RawMessage {
-                source: Some(peers[1]),
-                data: vec![12],
-                sequence_number: Some(0),
-                topic: topic_hashes[0].clone(),
-                signature: None,
-                key: None,
-                validated: true,
-            };
-
-        gs.handle_received_message(message.clone(), &local_id);
-        assert_eq!(
-                    receivers
-                            .into_iter()
-                            .fold(0, |mut idontwants, (peer_id, c)| {
-                    let non_priority = c.non_priority.into_inner();
-                    while !non_priority.is_empty() {
-                            if let Ok(RpcOut::IDontWant(_)) = non_priority.try_recv() {
-                                assert_ne!(peer_id, peers[1]);
-                                idontwants += 1;
-                            }
-                            }
-                        idontwants
-                }),
-                    0,
-                    "IDONTWANT was sent"
-                    );
-}
         sequence_number: Some(0),
         topic: topic_hashes[0].clone(),
         signature: None,

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -98,6 +98,7 @@ pub struct Config {
     connection_handler_queue_len: usize,
     connection_handler_publish_duration: Duration,
     connection_handler_forward_duration: Duration,
+    idontwant_message_size_threshold: usize,
 }
 
 impl Config {
@@ -124,6 +125,7 @@ impl Config {
     /// Minimum number of peers in mesh network before adding more (D_lo in the spec, default is 5).
     pub fn mesh_n_low(&self) -> usize {
         self.mesh_n_low
+        idontwant_message_size_threshold: usize,
     }
 
     /// Maximum number of peers in mesh network before removing some (D_high in the spec, default
@@ -371,6 +373,16 @@ impl Config {
     pub fn forward_queue_duration(&self) -> Duration {
         self.connection_handler_forward_duration
     }
+
+    // The message size threshold for which IDONTWANT messages are sent.
+    // Sending IDONTWANT messages for small messages can have a negative effect to the overall
+    // traffic and CPU load. This acts as a lower bound cutoff for the message size to which
+    // IDONTWANT won't be sent to peers. Only works if the peers support Gossipsub1.2
+    // (see https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.2.md#idontwant-message)
+    // default is 1kB
+    pub fn idontwant_message_size_threshold(&self) -> usize {
+        self.idontwant_message_size_threshold
+    }
 }
 
 impl Default for Config {
@@ -443,6 +455,7 @@ impl Default for ConfigBuilder {
                 connection_handler_queue_len: 5000,
                 connection_handler_publish_duration: Duration::from_secs(5),
                 connection_handler_forward_duration: Duration::from_secs(1),
+                idontwant_message_size_threshold: 1000,
             },
             invalid_protocol: false,
         }
@@ -898,6 +911,10 @@ impl std::fmt::Debug for Config {
         let _ = builder.field(
             "published_message_ids_cache_time",
             &self.published_message_ids_cache_time,
+        );
+        let _ = builder.field(
+            "idontwant_message_size_threhold",
+            &self.idontwant_message_size_threshold,
         );
         builder.finish()
     }

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -841,6 +841,17 @@ impl ConfigBuilder {
         self
     }
 
+    // The message size threshold for which IDONTWANT messages are sent.
+    // Sending IDONTWANT messages for small messages can have a negative effect to the overall
+    // traffic and CPU load. This acts as a lower bound cutoff for the message size to which
+    // IDONTWANT won't be sent to peers. Only works if the peers support Gossipsub1.2
+    // (see https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.2.md#idontwant-message)
+    // default is 1kB
+    pub fn idontwant_message_size_threshold(&mut self, size: usize) -> &mut Self {
+        self.config.idontwant_message_size_threshold = size;
+        self
+    }
+
     /// Constructs a [`Config`] from the given configuration and validates the settings.
     pub fn build(&self) -> Result<Config, ConfigBuilderError> {
         // check all constraints on config

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -125,7 +125,6 @@ impl Config {
     /// Minimum number of peers in mesh network before adding more (D_lo in the spec, default is 5).
     pub fn mesh_n_low(&self) -> usize {
         self.mesh_n_low
-        idontwant_message_size_threshold: usize,
     }
 
     /// Maximum number of peers in mesh network before removing some (D_high in the spec, default


### PR DESCRIPTION
## Description

This PR adds configurable parameter that sets minimum message size for which `IDONTWANT` messages would be send. This is an optimisation trick, discussion regarding the same can be found [here](https://github.com/sigp/lighthouse/issues/6437)
## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
