### PR TITLE
chore(kad): remove default constructor for ProtocolConfig

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -12,6 +12,8 @@
   See [PR 5705](https://github.com/libp2p/rust-libp2p/pull/5705).
 - Fix systematic memory allocation when iterating over `KBuckets`.
   See [PR 5715](https://github.com/libp2p/rust-libp2p/pull/5715).
+- Remove deprecated default constructor for `ProtocolConfig`.
+  See [PR 5774](https://github.com/libp2p/rust-libp2p/pull/5774).
 
 ## 0.46.2
 

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -238,29 +238,6 @@ impl Config {
         }
     }
 
-    /// Returns the default configuration.
-    #[deprecated(note = "Use `Config::new` instead")]
-    #[allow(clippy::should_implement_trait)]
-    pub fn default() -> Self {
-        Default::default()
-    }
-
-    /// Sets custom protocol names.
-    ///
-    /// Kademlia nodes only communicate with other nodes using the same protocol
-    /// name. Using custom name(s) therefore allows to segregate the DHT from
-    /// others, if that is desired.
-    ///
-    /// More than one protocol name can be supplied. In this case the node will
-    /// be able to talk to other nodes supporting any of the provided names.
-    /// Multiple names must be used with caution to avoid network partitioning.
-    #[deprecated(note = "Use `Config::new` instead")]
-    #[allow(deprecated)]
-    pub fn set_protocol_names(&mut self, names: Vec<StreamProtocol>) -> &mut Self {
-        self.protocol_config.set_protocol_names(names);
-        self
-    }
-
     /// Sets the timeout for a single query.
     ///
     /// > **Note**: A single query usually comprises at least as many requests

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -26,7 +26,7 @@
 //! to poll the underlying transport for incoming messages, and the `Sink` component
 //! is used to send messages to remote peers.
 
-use std::{io, iter, marker::PhantomData, time::Duration};
+use std::{io, marker::PhantomData, time::Duration};
 
 use asynchronous_codec::{Decoder, Encoder, Framed};
 use bytes::BytesMut;
@@ -164,18 +164,6 @@ impl ProtocolConfig {
     /// Modifies the maximum allowed size of a single Kademlia packet.
     pub fn set_max_packet_size(&mut self, size: usize) {
         self.max_packet_size = size;
-    }
-}
-
-impl Default for ProtocolConfig {
-    /// Returns the default configuration.
-    ///
-    /// Deprecated: use `ProtocolConfig::new` instead.
-    fn default() -> Self {
-        ProtocolConfig {
-            protocol_names: iter::once(DEFAULT_PROTO_NAME).collect(),
-            max_packet_size: DEFAULT_MAX_PACKET_SIZE,
-        }
     }
 }
 

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -156,23 +156,9 @@ impl ProtocolConfig {
         }
     }
 
-    /// Returns the default configuration.
-    #[deprecated(note = "Use `ProtocolConfig::new` instead")]
-    #[allow(clippy::should_implement_trait)]
-    pub fn default() -> Self {
-        Default::default()
-    }
-
     /// Returns the configured protocol name.
     pub fn protocol_names(&self) -> &[StreamProtocol] {
         &self.protocol_names
-    }
-
-    /// Modifies the protocol names used on the wire. Can be used to create incompatibilities
-    /// between networks on purpose.
-    #[deprecated(note = "Use `ProtocolConfig::new` instead")]
-    pub fn set_protocol_names(&mut self, names: Vec<StreamProtocol>) {
-        self.protocol_names = names;
     }
 
     /// Modifies the maximum allowed size of a single Kademlia packet.


### PR DESCRIPTION
## Description
Remove items that were deprecated in #5122.
<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

~~`0.47.0` for `libp2p-kad` doesn't seem to be released on crates.io(latest `0.46.2`)  but changelog entry has reached `0.47.1`.~~

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] A changelog entry has been made in the appropriate crates
