### PR TITLE
chore(kad): revert version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.47.1"
+version = "0.47.0"
 dependencies = [
  "async-std",
  "asynchronous-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ libp2p-floodsub = { version = "0.45.0", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.48.0", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.46.1", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.10" }
-libp2p-kad = { version = "0.47.1", path = "protocols/kad" }
+libp2p-kad = { version = "0.47.0", path = "protocols/kad" }
 libp2p-mdns = { version = "0.46.1", path = "protocols/mdns" }
 libp2p-memory-connection-limits = { version = "0.3.1", path = "misc/memory-connection-limits" }
 libp2p-metrics = { version = "0.15.0", path = "misc/metrics" }

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,10 +1,3 @@
-## 0.47.1
-
-- Expose Distance private field U256 to public.
-  See [PR 5705](https://github.com/libp2p/rust-libp2p/pull/5705).
-- Fix systematic memory allocation when iterating over `KBuckets`.
-  See [PR 5715](https://github.com/libp2p/rust-libp2p/pull/5715).
-
 ## 0.47.0
 
 - Expose a kad query facility allowing specify num_results dynamicaly.
@@ -15,6 +8,10 @@
   See [PR 5645](https://github.com/libp2p/rust-libp2p/pull/5645).
 - Fix `cargo clippy` warnings in `rustc 1.84.0-beta.1`.
   See [PR 5700](https://github.com/libp2p/rust-libp2p/pull/5700).
+- Expose Distance private field U256 to public.
+  See [PR 5705](https://github.com/libp2p/rust-libp2p/pull/5705).
+- Fix systematic memory allocation when iterating over `KBuckets`.
+  See [PR 5715](https://github.com/libp2p/rust-libp2p/pull/5715).
 
 ## 0.46.2
 

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-kad"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Kademlia protocol for libp2p"
-version = "0.47.1"
+version = "0.47.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
## Description

Revert version bump, because `libp2p-kad-0.47.0` isn't released yet.

## Notes & open questions

Came up in #5774.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~A changelog entry has been made in the appropriate crates~~
