### PR TITLE
chore(autonat): revert version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,7 +2716,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-autonat"
-version = "0.13.2"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "asynchronous-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ rust-version = "1.75.0"
 [workspace.dependencies]
 libp2p = { version = "0.54.2", path = "libp2p" }
 libp2p-allow-block-list = { version = "0.4.2", path = "misc/allow-block-list" }
-libp2p-autonat = { version = "0.13.2", path = "protocols/autonat" }
+libp2p-autonat = { version = "0.13.1", path = "protocols/autonat" }
 libp2p-connection-limits = { version = "0.4.1", path = "misc/connection-limits" }
 libp2p-core = { version = "0.42.1", path = "core" }
 libp2p-dcutr = { version = "0.12.1", path = "protocols/dcutr" }

--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -1,13 +1,9 @@
-## 0.13.2
-
-- Update to `libp2p-request-response` `v0.28.0`.
-
 ## 0.13.1
 
 - Verify that an incoming AutoNAT dial comes from a connected peer. See [PR 5597](https://github.com/libp2p/rust-libp2p/pull/5597).
-
 - Deprecate `void` crate.
   See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+- Update to `libp2p-request-response` `v0.28.0`.
 
 ## 0.13.0
 

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-autonat"
 edition = "2021"
 rust-version = { workspace = true }
 description = "NAT and firewall detection for libp2p"
-version = "0.13.2"
+version = "0.13.1"
 authors = [
     "David Craven <david@craven.ch>",
     "Elena Frank <elena.frank@protonmail.com>",


### PR DESCRIPTION
## Description

Revert version bump, `libp2p-autonat-v0.13.1` isn't released yet.

## Notes & open questions

https://crates.io/crates/libp2p-autonat

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~A changelog entry has been made in the appropriate crates~~
