### PR TITLE
chore(identify): revert version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,7 +2886,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.46.1"
+version = "0.46.0"
 dependencies = [
  "async-std",
  "asynchronous-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ libp2p-dcutr = { version = "0.12.1", path = "protocols/dcutr" }
 libp2p-dns = { version = "0.42.1", path = "transports/dns" }
 libp2p-floodsub = { version = "0.45.0", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.48.0", path = "protocols/gossipsub" }
-libp2p-identify = { version = "0.46.1", path = "protocols/identify" }
+libp2p-identify = { version = "0.46.0", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.10" }
 libp2p-kad = { version = "0.47.1", path = "protocols/kad" }
 libp2p-mdns = { version = "0.46.1", path = "protocols/mdns" }

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,11 +1,9 @@
-## 0.46.1
-- Discard `Info`s received from remote peers that contain a public key that doesn't match their peer ID.
-  See [PR 5707](https://github.com/libp2p/rust-libp2p/pull/5707).
-
 ## 0.46.0
 
 - Make `identify::Config` fields private and add getter functions.
   See [PR 5663](https://github.com/libp2p/rust-libp2p/pull/5663).
+- Discard `Info`s received from remote peers that contain a public key that doesn't match their peer ID.
+  See [PR 5707](https://github.com/libp2p/rust-libp2p/pull/5707).
 
 ## 0.45.1
 

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-identify"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Nodes identification protocol for libp2p"
-version = "0.46.1"
+version = "0.46.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
## Description

Revert version bump, `libp2p-identify-v0.46.0` isn't released yet.

## Notes & open questions

https://crates.io/crates/libp2p-identify

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~A changelog entry has been made in the appropriate crates~~
