### PR TITLE
chore(allow-block-list): revert version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.4.2"
+version = "0.4.1"
 dependencies = [
  "async-std",
  "libp2p-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ rust-version = "1.75.0"
 
 [workspace.dependencies]
 libp2p = { version = "0.54.2", path = "libp2p" }
-libp2p-allow-block-list = { version = "0.4.2", path = "misc/allow-block-list" }
+libp2p-allow-block-list = { version = "0.4.1", path = "misc/allow-block-list" }
 libp2p-autonat = { version = "0.13.2", path = "protocols/autonat" }
 libp2p-connection-limits = { version = "0.4.1", path = "misc/connection-limits" }
 libp2p-core = { version = "0.42.1", path = "core" }

--- a/misc/allow-block-list/CHANGELOG.md
+++ b/misc/allow-block-list/CHANGELOG.md
@@ -1,13 +1,10 @@
-## 0.4.2
-
-- Deprecate `void` crate.
-  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
-
 ## 0.4.1
 
 - Add getters & setters for the allowed/blocked peers.
   Return a `bool` for every "insert/remove" function, informing if a change was performed.
   See [PR 5572](https://github.com/libp2p/rust-libp2p/pull/5572).
+- Deprecate `void` crate.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
 
 ## 0.4.0
 

--- a/misc/allow-block-list/Cargo.toml
+++ b/misc/allow-block-list/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-allow-block-list"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Allow/block list connection management for libp2p."
-version = "0.4.2"
+version = "0.4.1"
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
 keywords = ["peer-to-peer", "libp2p", "networking"]


### PR DESCRIPTION
## Description

Revert version bump, `libp2p-allow-block-list-v0.4.1` isn't released yet.

## Notes & open questions

https://crates.io/crates/libp2p-allow-block-list

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~A changelog entry has been made in the appropriate crates~~
