### PR TITLE
chore(server): revert version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-server"
-version = "0.12.8"
+version = "0.12.6"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ libp2p-quic = { version = "0.11.2", path = "transports/quic" }
 libp2p-relay = { version = "0.18.1", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.15.1", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.28.0", path = "protocols/request-response" }
-libp2p-server = { version = "0.12.8", path = "misc/server" }
+libp2p-server = { version = "0.12.6", path = "misc/server" }
 libp2p-stream = { version = "0.2.0-alpha.1", path = "protocols/stream" }
 libp2p-swarm = { version = "0.45.2", path = "swarm" }
 libp2p-swarm-derive = { version = "=0.35.0", path = "swarm-derive" } # `libp2p-swarm-derive` may not be compatible with different `libp2p-swarm` non-breaking releases. E.g. `libp2p-swarm` might introduce a new enum variant `FromSwarm` (which is `#[non-exhaustive]`) in a non-breaking release. Older versions of `libp2p-swarm-derive` would not forward this enum variant within the `NetworkBehaviour` hierarchy. Thus the version pinning is required.

--- a/misc/server/CHANGELOG.md
+++ b/misc/server/CHANGELOG.md
@@ -1,25 +1,15 @@
-## 0.12.8
-
-### Changed
-
-- Remove deprecated [`libp2p-lookup`](https://github.com/mxinden/libp2p-lookup) from Dockerfile.
-  See [PR 5610](https://github.com/libp2p/rust-libp2p/pull/5610).
-
-## 0.12.7
-
-### Changed
-
-- Use periodic and automatic bootstrap of Kademlia.
-  See [PR 4838](https://github.com/libp2p/rust-libp2p/pull/4838).
-- Update to [`libp2p-identify` `v0.45.0`](protocols/identify/CHANGELOG.md#0450).
-  See [PR 4981](https://github.com/libp2p/rust-libp2p/pull/4981).
-
 ## 0.12.6
 
 ### Changed
 
 - Stop using kad default protocol.
   See [PR 5122](https://github.com/libp2p/rust-libp2p/pull/5122)
+- Use periodic and automatic bootstrap of Kademlia.
+  See [PR 4838](https://github.com/libp2p/rust-libp2p/pull/4838).
+- Update to [`libp2p-identify` `v0.45.0`](protocols/identify/CHANGELOG.md#0450).
+  See [PR 4981](https://github.com/libp2p/rust-libp2p/pull/4981).
+- Remove deprecated [`libp2p-lookup`](https://github.com/mxinden/libp2p-lookup) from Dockerfile.
+  See [PR 5610](https://github.com/libp2p/rust-libp2p/pull/5610).
 
 ## 0.12.5
 

--- a/misc/server/Cargo.toml
+++ b/misc/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-server"
-version = "0.12.8"
+version = "0.12.6"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2021"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
## Description

Revert version bump, `libp2p-server-v0.12.6` isn't released yet.

## Notes & open questions

https://crates.io/crates/libp2p-server

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~A changelog entry has been made in the appropriate crates~~
