### PR TITLE
Fix typo Update CHANGELOG.md

### DIFF
--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -68,7 +68,7 @@
   See [PR 4755](https://github.com/libp2p/rust-libp2p/pull/4755).
 - Add `PeerCondition::DisconnectedAndNotDialing` variant, combining pre-existing conditions.
   This is the new default.
-  A new dialing attempt is iniated _only if_ the peer is both considered disconnected and there is currently no ongoing dialing attempt.
+  A new dialing attempt is initiated _only if_ the peer is both considered disconnected and there is currently no ongoing dialing attempt.
   See [PR 4225](https://github.com/libp2p/rust-libp2p/pull/4225).
 - Remove deprecated `keep_alive_timeout` in `OneShotHandlerConfig`.
   See [PR 4677](https://github.com/libp2p/rust-libp2p/pull/4677).


### PR DESCRIPTION
# Pull Request Title: Fix Typo in CHANGELOG.md (iniated to initiated)

## Description:
This pull request addresses a typographical error in the `CHANGELOG.md` file. The word "iniated" has been corrected to "initiated" for improved accuracy and professionalism in the documentation.

## Changes:
- Fixed typo "iniated" to "initiated" in `swarm/CHANGELOG.md`.

## File(s) Modified:
- `swarm/CHANGELOG.md`

## Reasoning:
Accurate documentation ensures better understanding and a polished experience for contributors and users. Correcting typographical errors is part of maintaining high-quality project standards.

## Checklist:
- [x] Documentation updated.
- [x] Changes adhere to the project's contribution guidelines.
- [x] No impact on functionality or operations.

## Related Issues:
N/A

## Additional Notes:
This change affects only the documentation and has no impact on the code or its behavior.
