### PR TITLE
Fix typo Update CHANGELOG.md

### DIFF
--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -77,7 +77,7 @@ AutoNAT where port reuse is disabled. This information is now passed by the beha
 
 - Update to `libp2p-request-response` `v0.23.0`.
 
-- Replace `Behaviour`'s `NetworkBehaviour` implemention `inject_*` methods with the new `on_*` methods.
+- Replace `Behaviour`'s `NetworkBehaviour` implementation `inject_*` methods with the new `on_*` methods.
   See [PR 3011].
 
 - Update `rust-version` to reflect the actual MSRV: 1.62.0. See [PR 3090].


### PR DESCRIPTION
# Pull Request Title: Fix Typo in CHANGELOG.md

## Description
This pull request fixes a typo in the `CHANGELOG.md` file. Specifically, the word "implemention" has been corrected to "implementation."

### Changes
- Fixed the typo in line 77 of `protocols/autonat/CHANGELOG.md` from "implemention" to "implementation."

## Related Issue
- No related issue.
