### PR TITLE
Fix typo Update CHANGELOG.md

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -445,7 +445,7 @@ See [PR 4568].
 - New configurable connection limits for established connections and
   dedicated connection counters. Removed the connection limit dedicated
   to outgoing pending connection _per peer_. Connection limits are now
-  represented by `u32` intead of `usize` types.
+  represented by `u32` instead of `usize` types.
   [PR 1848](https://github.com/libp2p/rust-libp2p/pull/1848/).
 
 - Update `multihash`.


### PR DESCRIPTION
# Pull Request: Fix Typo in `CHANGELOG.md`

## Summary
- **Fix**: Corrected the typo in the `CHANGELOG.md` file by fixing the spelling of "intead" to "instead".

## Changes Made
- Corrected the typo in the changelog entry related to the update of connection limits and types.

## Motivation
- This small fix improves the clarity and accuracy of the changelog.

## Checklist
- [ ] I have tested my changes.
- [ ] I have updated the documentation where necessary.
- [ ] I have followed the contributing guidelines of the repository.

## Related Issues
- None

## Additional Information
- A simple typo correction in the changelog.
