### PR TITLE
chore(identify): fix changelog entry

### DIFF
--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,14 +1,11 @@
 ## 0.46.0
 
+- Add `hide_listen_addrs` option to prevent leaking (local) listen addresses.
+  See [PR 5507](https://github.com/libp2p/rust-libp2p/pull/5507).
 - Make `identify::Config` fields private and add getter functions.
   See [PR 5663](https://github.com/libp2p/rust-libp2p/pull/5663).
 - Discard `Info`s received from remote peers that contain a public key that doesn't match their peer ID.
   See [PR 5707](https://github.com/libp2p/rust-libp2p/pull/5707).
-
-## 0.45.1
-
-- Add `hide_listen_addrs` option to prevent leaking (local) listen addresses.
-  See [PR 5507](https://github.com/libp2p/rust-libp2p/pull/5507).
 
 ## 0.45.0
 


### PR DESCRIPTION
## Description

Amendment to #5778.

Merged CHANGELOG entries of `0.45.1` and `0.46.0`. Version `0.45.1` has been superseded by `0.46.0` before it was released.

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
