### PR TITLE
feat(ci): ensure exactly one version bump

### DIFF
--- a/scripts/ensure-version-bump-and-changelog.sh
+++ b/scripts/ensure-version-bump-and-changelog.sh
@@ -10,7 +10,7 @@ MERGE_BASE=$(git merge-base "$HEAD_SHA" "$PR_BASE") # Find the merge base. This 
 SRC_DIFF_TO_BASE=$(git diff "$HEAD_SHA".."$MERGE_BASE" --name-status -- "$DIR_TO_CRATE/src" "$DIR_TO_CRATE/Cargo.toml")
 CHANGELOG_DIFF=$(git diff "$HEAD_SHA".."$MERGE_BASE" --name-only -- "$DIR_TO_CRATE/CHANGELOG.md")
 
-RELEASED_VERSION=$(git tag | grep "^$CRATE-v" | tail -n1 | grep -Po "\d+\.\d+\.\d+")
+RELEASED_VERSION=$(git tag --sort=version:refname | grep "^$CRATE-v" | tail -n1 | grep -Po "\d+\.\d+\.\d+")
 
 
 # If the source files of this crate weren't touched in this PR, exit early.

--- a/scripts/ensure-version-bump-and-changelog.sh
+++ b/scripts/ensure-version-bump-and-changelog.sh
@@ -10,7 +10,7 @@ MERGE_BASE=$(git merge-base "$HEAD_SHA" "$PR_BASE") # Find the merge base. This 
 SRC_DIFF_TO_BASE=$(git diff "$HEAD_SHA".."$MERGE_BASE" --name-status -- "$DIR_TO_CRATE/src" "$DIR_TO_CRATE/Cargo.toml")
 CHANGELOG_DIFF=$(git diff "$HEAD_SHA".."$MERGE_BASE" --name-only -- "$DIR_TO_CRATE/CHANGELOG.md")
 
-RELEASED_VERSION=$(cargo search $CRATE | grep -Po "(?<=^$CRATE = \")\d+\.\d+\.\d+")
+RELEASED_VERSION=$(git tag | grep "^$CRATE-v" | tail -n1 | grep -Po "\d+\.\d+\.\d+")
 
 version_bump() {
   released=$(echo $RELEASED_VERSION | cut -d '.' -f $1)


### PR DESCRIPTION
## Description

Check in CI that the version of a crate has been bumped exactly once since the last release.

Based on discussion in #5781.

## Notes & open questions

Current solution feels a bit hacky. Does anyone know a better way to solve this?

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
