### PR TITLE
chore(ci): update mergify script

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -61,9 +61,8 @@ pull_request_rules:
       queue:
 
 queue_rules:
-  - name: default merge queue
+  - name: default
     queue_conditions:
-      - label=send-it
       - base=master
     merge_conditions: []
     merge_method: squash

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -19,6 +19,8 @@ pull_request_rules:
       - label=send-it
       - author!=@libp2p/rust-libp2p-maintainers
       - author!=dependabot[bot]
+      # Do not remove approvals if last commit was a merge of master into the branch, required for the PR to be merged.
+      - commits[-1].author!=@libp2p/rust-libp2p-maintainers
     actions:
       dismiss_reviews:
         message: Approvals have been dismissed because the PR was updated after the


### PR DESCRIPTION
## Description

missed this, with this dependabot is not able to merge PR's by itself as it needs the `send-it` label.
also add a clause for the dismiss of stale approvals to not do so when the last commit was done by one of the `rust-libp2p` maintainers, so that we don't dismiss approvals if the last commit was a merge of master into the PR that is necessary before merging the PR.
Latest example of this happening [here](https://github.com/libp2p/rust-libp2p/pull/5758#issuecomment-2585904938)
 