### PR TITLE
fix: minor version bump packages affected by #5676

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-std",
  "libp2p-core",
@@ -2716,7 +2716,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-autonat"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-std",
  "libp2p-core",
@@ -2759,7 +2759,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "async-std",
  "either",
@@ -2989,7 +2989,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-memory-connection-limits"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "libp2p-core",
  "libp2p-identify",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.45.1"
+version = "0.46.0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.11.2"
+version = "0.11.1"
 dependencies = [
  "async-std",
  "futures",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-stream"
-version = "0.2.0-alpha.1"
+version = "0.3.0-alpha"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -3299,7 +3299,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.45.2"
+version = "0.46.0"
 dependencies = [
  "async-std",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,10 +73,10 @@ rust-version = "1.83.0"
 
 [workspace.dependencies]
 libp2p = { version = "0.55.0", path = "libp2p" }
-libp2p-allow-block-list = { version = "0.4.1", path = "misc/allow-block-list" }
-libp2p-autonat = { version = "0.13.1", path = "protocols/autonat" }
-libp2p-connection-limits = { version = "0.4.1", path = "misc/connection-limits" }
-libp2p-core = { version = "0.42.1", path = "core" }
+libp2p-allow-block-list = { version = "0.5.0", path = "misc/allow-block-list" }
+libp2p-autonat = { version = "0.14.0", path = "protocols/autonat" }
+libp2p-connection-limits = { version = "0.5.0", path = "misc/connection-limits" }
+libp2p-core = { version = "0.43.0", path = "core" }
 libp2p-dcutr = { version = "0.12.1", path = "protocols/dcutr" }
 libp2p-dns = { version = "0.42.1", path = "transports/dns" }
 libp2p-floodsub = { version = "0.45.0", path = "protocols/floodsub" }
@@ -85,21 +85,21 @@ libp2p-identify = { version = "0.46.0", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.10" }
 libp2p-kad = { version = "0.47.0", path = "protocols/kad" }
 libp2p-mdns = { version = "0.46.1", path = "protocols/mdns" }
-libp2p-memory-connection-limits = { version = "0.3.1", path = "misc/memory-connection-limits" }
+libp2p-memory-connection-limits = { version = "0.4.0", path = "misc/memory-connection-limits" }
 libp2p-metrics = { version = "0.15.0", path = "misc/metrics" }
 libp2p-mplex = { version = "0.42.0", path = "muxers/mplex" }
 libp2p-noise = { version = "0.45.1", path = "transports/noise" }
 libp2p-perf = { version = "0.4.0", path = "protocols/perf" }
-libp2p-ping = { version = "0.45.1", path = "protocols/ping" }
+libp2p-ping = { version = "0.46.0", path = "protocols/ping" }
 libp2p-plaintext = { version = "0.42.0", path = "transports/plaintext" }
 libp2p-pnet = { version = "0.25.0", path = "transports/pnet" }
-libp2p-quic = { version = "0.11.2", path = "transports/quic" }
+libp2p-quic = { version = "0.11.1", path = "transports/quic" }
 libp2p-relay = { version = "0.18.1", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.15.1", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.28.0", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.6", path = "misc/server" }
-libp2p-stream = { version = "0.2.0-alpha.1", path = "protocols/stream" }
-libp2p-swarm = { version = "0.45.2", path = "swarm" }
+libp2p-stream = { version = "0.3.0-alpha", path = "protocols/stream" }
+libp2p-swarm = { version = "0.46.0", path = "swarm" }
 libp2p-swarm-derive = { version = "=0.35.0", path = "swarm-derive" } # `libp2p-swarm-derive` may not be compatible with different `libp2p-swarm` non-breaking releases. E.g. `libp2p-swarm` might introduce a new enum variant `FromSwarm` (which is `#[non-exhaustive]`) in a non-breaking release. Older versions of `libp2p-swarm-derive` would not forward this enum variant within the `NetworkBehaviour` hierarchy. Thus the version pinning is required.
 libp2p-swarm-test = { version = "0.5.0", path = "swarm-test" }
 libp2p-tcp = { version = "0.42.1", path = "transports/tcp" }

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.42.1
+## 0.43.0
 
 - Added `libp2p::core::util::unreachable` that is a drop-in replacement of `void::unreachable`.
   See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-core"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Core traits and structs of libp2p"
-version = "0.42.1"
+version = "0.43.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/examples/stream/Cargo.toml
+++ b/examples/stream/Cargo.toml
@@ -12,7 +12,7 @@ release = false
 anyhow = "1"
 futures = { workspace = true }
 libp2p = { path = "../../libp2p", features = [ "tokio", "quic"] }
-libp2p-stream = { path = "../../protocols/stream", version = "0.2.0-alpha" }
+libp2p-stream = { path = "../../protocols/stream", version = "0.3.0-alpha" }
 rand = "0.8"
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }

--- a/misc/allow-block-list/CHANGELOG.md
+++ b/misc/allow-block-list/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.1
+## 0.5.0
 
 - Add getters & setters for the allowed/blocked peers.
   Return a `bool` for every "insert/remove" function, informing if a change was performed.

--- a/misc/allow-block-list/Cargo.toml
+++ b/misc/allow-block-list/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-allow-block-list"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Allow/block list connection management for libp2p."
-version = "0.4.1"
+version = "0.5.0"
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
 keywords = ["peer-to-peer", "libp2p", "networking"]

--- a/misc/connection-limits/CHANGELOG.md
+++ b/misc/connection-limits/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.1
+## 0.5.0
 
 - Deprecate `void` crate.
   See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).

--- a/misc/connection-limits/Cargo.toml
+++ b/misc/connection-limits/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-connection-limits"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Connection limits for libp2p."
-version = "0.4.1"
+version = "0.5.0"
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
 keywords = ["peer-to-peer", "libp2p", "networking"]

--- a/misc/memory-connection-limits/CHANGELOG.md
+++ b/misc/memory-connection-limits/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.1
+## 0.4.0
 
 - Deprecate `void` crate.
   See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).

--- a/misc/memory-connection-limits/Cargo.toml
+++ b/misc/memory-connection-limits/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-memory-connection-limits"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Memory usage based connection limits for libp2p."
-version = "0.3.1"
+version = "0.4.0"
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
 keywords = ["peer-to-peer", "libp2p", "networking"]

--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.13.1
+## 0.14.0
 
 - Verify that an incoming AutoNAT dial comes from a connected peer. See [PR 5597](https://github.com/libp2p/rust-libp2p/pull/5597).
 - Deprecate `void` crate.

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-autonat"
 edition = "2021"
 rust-version = { workspace = true }
 description = "NAT and firewall detection for libp2p"
-version = "0.13.1"
+version = "0.14.0"
 authors = [
     "David Craven <david@craven.ch>",
     "Elena Frank <elena.frank@protonmail.com>",

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.45.1
+## 0.46.0
 
 - Deprecate `void` crate.
   See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).

--- a/protocols/ping/Cargo.toml
+++ b/protocols/ping/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-ping"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Ping protocol for libp2p"
-version = "0.45.1"
+version = "0.46.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,15 +1,13 @@
 ## 0.28.0
 
+- Deprecate `void` crate.
+  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
+
 - Add connection id to the events emitted by a request-response `Behaviour`.
   See [PR 5719](https://github.com/libp2p/rust-libp2p/pull/5719).
 
 - Allow configurable request and response sizes for `json` and `cbor` codec.
   See [PR 5792](https://github.com/libp2p/rust-libp2p/pull/5792).
-
-## 0.27.1
-
-- Deprecate `void` crate.
-  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
 
 ## 0.27.0
 

--- a/protocols/stream/CHANGELOG.md
+++ b/protocols/stream/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.0-alpha.1
+## 0.3.0-alpha
 
 - Deprecate `void` crate.
   See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).

--- a/protocols/stream/Cargo.toml
+++ b/protocols/stream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-stream"
-version = "0.2.0-alpha.1"
+version = "0.3.0-alpha"
 edition = "2021"
 rust-version.workspace = true
 description = "Generic stream protocols for libp2p"

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.45.2
+## 0.46.0
 
 - Don't report `NewExternalAddrCandidate` for confirmed external addresses.
   See [PR 5582](https://github.com/libp2p/rust-libp2p/pull/5582).

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-swarm"
 edition = "2021"
 rust-version = { workspace = true }
 description = "The libp2p swarm"
-version = "0.45.2"
+version = "0.46.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/transports/quic/CHANGELOG.md
+++ b/transports/quic/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 0.11.2
-
-- Deprecate `void` crate.
-  See [PR 5676](https://github.com/libp2p/rust-libp2p/pull/5676).
-
 ## 0.11.1
 
 - Update `libp2p-tls` to version `0.5.0`, see [PR 5547]

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-quic"
-version = "0.11.2"
+version = "0.11.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 rust-version = { workspace = true }


### PR DESCRIPTION
## Description

By switching from `void::Void` to `std::convert::Infallible`, #5676 changed the output types of some `NetworkBehavior` implementations in different protocols.
This can cause a type mismatch for the user and therefore is a breaking change.

#5678 (follow-up PR that version-bumped the crates affected by #5676) only bumped the patch version of the affected crates.
The current PR now changes it to a minor version bump for all crates where types in a `NetworkBehavior` implementation were affected.

It also reverts the version bump and CHANGELOG entry in `libp2p-quic` that was added with #5678, because that crate was never touched by the original PR.

## Notes & open questions


## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] A changelog entry has been made in the appropriate crates
