### PR TITLE
chore: Remove async-trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2813,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "async-std",
  "async-std-resolver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2718,7 +2718,6 @@ dependencies = [
 name = "libp2p-autonat"
 version = "0.13.1"
 dependencies = [
- "async-trait",
  "asynchronous-codec",
  "either",
  "futures",
@@ -2818,7 +2817,6 @@ version = "0.42.1"
 dependencies = [
  "async-std",
  "async-std-resolver",
- "async-trait",
  "futures",
  "hickory-resolver",
  "libp2p-core",
@@ -3221,7 +3219,6 @@ dependencies = [
 name = "libp2p-rendezvous"
 version = "0.15.1"
 dependencies = [
- "async-trait",
  "asynchronous-codec",
  "bimap",
  "futures",
@@ -3247,7 +3244,6 @@ version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-std",
- "async-trait",
  "cbor4ii",
  "futures",
  "futures-bounded",
@@ -3344,7 +3340,6 @@ dependencies = [
 name = "libp2p-swarm-test"
 version = "0.5.0"
 dependencies = [
- "async-trait",
  "futures",
  "futures-timer",
  "libp2p-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ libp2p-autonat = { version = "0.13.1", path = "protocols/autonat" }
 libp2p-connection-limits = { version = "0.4.1", path = "misc/connection-limits" }
 libp2p-core = { version = "0.42.1", path = "core" }
 libp2p-dcutr = { version = "0.12.1", path = "protocols/dcutr" }
-libp2p-dns = { version = "0.42.1", path = "transports/dns" }
+libp2p-dns = { version = "0.43.0", path = "transports/dns" }
 libp2p-floodsub = { version = "0.45.0", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.48.0", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.46.0", path = "protocols/identify" }

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -16,7 +16,6 @@ categories = ["network-programming", "asynchronous"]
 
 
 [dependencies]
-async-trait = { version = "0.1", optional = true }
 asynchronous-codec = { workspace = true }
 either = { version = "1.9.0", optional = true }
 futures = { workspace = true }
@@ -43,7 +42,7 @@ libp2p-swarm = { workspace = true, features = ["macros"] }
 
 [features]
 default = ["v1", "v2"]
-v1 = ["dep:libp2p-request-response", "dep:web-time", "dep:async-trait"]
+v1 = ["dep:libp2p-request-response", "dep:web-time"]
 v2 = ["dep:either", "dep:futures-bounded", "dep:thiserror", "dep:rand_core"]
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.

--- a/protocols/rendezvous/Cargo.toml
+++ b/protocols/rendezvous/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 asynchronous-codec = { workspace = true }
-async-trait = "0.1"
 bimap = "0.6.3"
 futures = { workspace = true, features = ["std"] }
 futures-timer = "3.0.3"

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Allow configurable request and response sizes for `json` and `cbor` codec.
   See [PR 5792](https://github.com/libp2p/rust-libp2p/pull/5792).
 
+- Remove async-trait for RPIT. See [PR 5812](https:/github.com/libp2p/rust-libp2p/pull/5812).
+
 ## 0.27.1
 
 - Deprecate `void` crate.

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-trait = "0.1"
 cbor4ii = { version = "0.3.2", features = ["serde1", "use_std"], optional = true }
 futures = { workspace = true }
 libp2p-core = { workspace = true }

--- a/protocols/request-response/src/codec.rs
+++ b/protocols/request-response/src/codec.rs
@@ -20,13 +20,11 @@
 
 use std::io;
 
-use async_trait::async_trait;
 use futures::prelude::*;
 
 /// A `Codec` defines the request and response types
 /// for a request-response [`Behaviour`](crate::Behaviour) protocol or
 /// protocol family and how they are encoded / decoded on an I/O stream.
-#[async_trait]
 pub trait Codec {
     /// The type of protocol(s) or protocol versions being negotiated.
     type Protocol: AsRef<str> + Send + Clone;
@@ -37,43 +35,43 @@ pub trait Codec {
 
     /// Reads a request from the given I/O stream according to the
     /// negotiated protocol.
-    async fn read_request<T>(
+    fn read_request<T>(
         &mut self,
         protocol: &Self::Protocol,
         io: &mut T,
-    ) -> io::Result<Self::Request>
+    ) -> impl Send + Future<Output = io::Result<Self::Request>>
     where
         T: AsyncRead + Unpin + Send;
 
     /// Reads a response from the given I/O stream according to the
     /// negotiated protocol.
-    async fn read_response<T>(
+    fn read_response<T>(
         &mut self,
         protocol: &Self::Protocol,
         io: &mut T,
-    ) -> io::Result<Self::Response>
+    ) -> impl Send + Future<Output = io::Result<Self::Response>>
     where
         T: AsyncRead + Unpin + Send;
 
     /// Writes a request to the given I/O stream according to the
     /// negotiated protocol.
-    async fn write_request<T>(
+    fn write_request<T>(
         &mut self,
         protocol: &Self::Protocol,
         io: &mut T,
         req: Self::Request,
-    ) -> io::Result<()>
+    ) -> impl Send + Future<Output = io::Result<()>>
     where
         T: AsyncWrite + Unpin + Send;
 
     /// Writes a response to the given I/O stream according to the
     /// negotiated protocol.
-    async fn write_response<T>(
+    fn write_response<T>(
         &mut self,
         protocol: &Self::Protocol,
         io: &mut T,
         res: Self::Response,
-    ) -> io::Result<()>
+    ) -> impl Send + Future<Output = io::Result<()>>
     where
         T: AsyncWrite + Unpin + Send;
 }

--- a/swarm-test/CHANGELOG.md
+++ b/swarm-test/CHANGELOG.md
@@ -3,7 +3,8 @@
 - Add `tokio` runtime support and make `tokio` and `async-std` runtimes optional behind features.
   See [PR 5551].
   - Update default for idle-connection-timeout to 10s on `SwarmExt::new_ephemeral` methods.
-  See [PR 4967](https://github.com/libp2p/rust-libp2p/pull/4967).
+  See [PR 4967](https://github.com/libp2p/rust-libp2p/pull/4967).  
+- Remove async-trait for RPIT. See [PR 5812](https:/github.com/libp2p/rust-libp2p/pull/5812).
 
 [PR 5551]: https://github.com/libp2p/rust-libp2p/pull/5551
 

--- a/swarm-test/Cargo.toml
+++ b/swarm-test/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["network-programming", "asynchronous"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1.80"
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true, features = ["rand"] }
 libp2p-plaintext = { workspace = true }

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.43.0
+
+- Remove async-trait for RPIT. See [PR 5812](https:/github.com/libp2p/rust-libp2p/pull/5812).
+
 ## 0.42.1
 
 - Upgrade `async-std-resolver` and `hickory-resolver`.

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-dns"
 edition = "2021"
 rust-version = { workspace = true }
 description = "DNS transport implementation for libp2p"
-version = "0.42.1"
+version = "0.43.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 async-std-resolver = { workspace = true, features = ["system-config"], optional = true }
-async-trait = "0.1.80"
 futures = { workspace = true }
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true }

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -156,7 +156,6 @@ use std::{
     task::{Context, Poll},
 };
 
-use async_trait::async_trait;
 use futures::{future::BoxFuture, prelude::*};
 pub use hickory_resolver::{
     config::{ResolverConfig, ResolverOpts},
@@ -583,34 +582,56 @@ fn invalid_data(e: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> io::E
     io::Error::new(io::ErrorKind::InvalidData, e)
 }
 
-#[async_trait::async_trait]
 #[doc(hidden)]
 pub trait Resolver {
-    async fn lookup_ip(&self, name: String) -> Result<LookupIp, ResolveError>;
-    async fn ipv4_lookup(&self, name: String) -> Result<Ipv4Lookup, ResolveError>;
-    async fn ipv6_lookup(&self, name: String) -> Result<Ipv6Lookup, ResolveError>;
-    async fn txt_lookup(&self, name: String) -> Result<TxtLookup, ResolveError>;
+    fn lookup_ip(
+        &self,
+        name: String,
+    ) -> impl Send + Future<Output = Result<LookupIp, ResolveError>>;
+    fn ipv4_lookup(
+        &self,
+        name: String,
+    ) -> impl Send + Future<Output = Result<Ipv4Lookup, ResolveError>>;
+    fn ipv6_lookup(
+        &self,
+        name: String,
+    ) -> impl Send + Future<Output = Result<Ipv6Lookup, ResolveError>>;
+    fn txt_lookup(
+        &self,
+        name: String,
+    ) -> impl Send + Future<Output = Result<TxtLookup, ResolveError>>;
 }
 
-#[async_trait]
 impl<C> Resolver for hickory_resolver::Resolver<C>
 where
     C: ConnectionProvider,
 {
-    async fn lookup_ip(&self, name: String) -> Result<LookupIp, ResolveError> {
-        self.lookup_ip(name).await
+    fn lookup_ip(
+        &self,
+        name: String,
+    ) -> impl Send + Future<Output = Result<LookupIp, ResolveError>> {
+        self.lookup_ip(name)
     }
 
-    async fn ipv4_lookup(&self, name: String) -> Result<Ipv4Lookup, ResolveError> {
-        self.ipv4_lookup(name).await
+    fn ipv4_lookup(
+        &self,
+        name: String,
+    ) -> impl Send + Future<Output = Result<Ipv4Lookup, ResolveError>> {
+        self.ipv4_lookup(name)
     }
 
-    async fn ipv6_lookup(&self, name: String) -> Result<Ipv6Lookup, ResolveError> {
-        self.ipv6_lookup(name).await
+    fn ipv6_lookup(
+        &self,
+        name: String,
+    ) -> impl Send + Future<Output = Result<Ipv6Lookup, ResolveError>> {
+        self.ipv6_lookup(name)
     }
 
-    async fn txt_lookup(&self, name: String) -> Result<TxtLookup, ResolveError> {
-        self.txt_lookup(name).await
+    fn txt_lookup(
+        &self,
+        name: String,
+    ) -> impl Send + Future<Output = Result<TxtLookup, ResolveError>> {
+        self.txt_lookup(name)
     }
 }
 


### PR DESCRIPTION
## Description

Removes async-trait for usage of RPIT.

## Notes & open questions

libp2p's MSRV has included RPIT for a while now, making this possible. The `Send` bounds follow the behavior from async-trait. async-trait's generation of `Pin<Box<dyn Future>>` also provided `Unpin` which has *not* been a preserved bound EXCEPT in the test code which required it in in-tree call sites. Moving forward, callers expecting `Unpin` should wrap their futures themselves with `Box::pin`.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
