### PR TITLE
chore(ci): fix workspace version enforcing job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
       - uses: taiki-e/cache-cargo-install-action@v2
         with:
-          tool: tomlq
+          tool: tomlq@0.1.6
 
       - name: Extract version from manifest
         run: |


### PR DESCRIPTION
## Description
Cue due to an [update](https://crates.io/crates/tomlq/0.2.0) to the `tomlq` tool, there's now a mismatch between the `$CRATE_VERSION` and the  `$SPECIFIED_VERSION` variables: 
```bash
Package version: 0.43.0
Specified version: "0.43.0"
```
This PR attempts to fix the "Enforce version in `workspace.dependencies` matches the latest version" job by locking to the previous version until (and if) the situation is solved. 
Also see https://github.com/cryptaliagy/tomlq/issues/22