### PR TITLE
fix(gossipsub): Improve `max_messages_per_rpc` consistency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "async-channel 2.3.1",
  "asynchronous-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ libp2p-core = { version = "0.43.0", path = "core" }
 libp2p-dcutr = { version = "0.13.0", path = "protocols/dcutr" }
 libp2p-dns = { version = "0.43.0", path = "transports/dns" }
 libp2p-floodsub = { version = "0.46.0", path = "protocols/floodsub" }
-libp2p-gossipsub = { version = "0.48.0", path = "protocols/gossipsub" }
+libp2p-gossipsub = { version = "0.48.1", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.46.0", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.10" }
 libp2p-kad = { version = "0.47.0", path = "protocols/kad" }

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.48.1
 - Improve `max_messages_per_rpc` consistency by ensuring RPC control messages also adhere to the existing limits.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX)
+  See [PR 5826](https://github.com/libp2p/rust-libp2p/pull/5826)
 
 ## 0.48.0
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.48.1
+- Improve `max_messages_per_rpc` consistency by ensuring RPC control messages also adhere to the existing limits.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX)
+
 ## 0.48.0
 
 - Allow broadcasting `IDONTWANT` messages when publishing to avoid downloading data that is already available.

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-gossipsub"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Gossipsub protocol for libp2p"
-version = "0.48.0"
+version = "0.48.1"
 authors = ["Age Manning <Age@AgeManning.com>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -3260,7 +3260,15 @@ where
                 let mut ihave_msgs = vec![];
                 let mut graft_msgs = vec![];
                 let mut prune_msgs = vec![];
-                for control_msg in rpc.control_msgs {
+                for (count, control_msg) in rpc.control_msgs.into_iter().enumerate() {
+                    // Only process the amount of messages the configuration allows.
+                    if self.config.max_messages_per_rpc().is_some()
+                        && Some(count) >= self.config.max_messages_per_rpc()
+                    {
+                        tracing::warn!("Received more control messages than permitted. Ignoring further messages. Processed: {}", count);
+                        break;
+                    }
+
                     match control_msg {
                         ControlAction::IHave(IHave {
                             topic_hash,

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -3245,8 +3245,10 @@ where
                 // Handle messages
                 for (count, raw_message) in rpc.messages.into_iter().enumerate() {
                     // Only process the amount of messages the configuration allows.
-                    if self.config.max_messages_per_rpc().is_some()
-                        && Some(count) >= self.config.max_messages_per_rpc()
+                    if self
+                        .config
+                        .max_messages_per_rpc()
+                        .is_some_and(|max_msg| count >= max_msg)
                     {
                         tracing::warn!("Received more messages than permitted. Ignoring further messages. Processed: {}", count);
                         break;
@@ -3262,8 +3264,10 @@ where
                 let mut prune_msgs = vec![];
                 for (count, control_msg) in rpc.control_msgs.into_iter().enumerate() {
                     // Only process the amount of messages the configuration allows.
-                    if self.config.max_messages_per_rpc().is_some()
-                        && Some(count) >= self.config.max_messages_per_rpc()
+                    if self
+                        .config
+                        .max_messages_per_rpc()
+                        .is_some_and(|max_msg| count >= max_msg)
                     {
                         tracing::warn!("Received more control messages than permitted. Ignoring further messages. Processed: {}", count);
                         break;


### PR DESCRIPTION
## Description

Currently, when a gossipsub [Rpc](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md#protobuf) is received, only the publish messages are being checked for `max_messages_per_rpc`.
This PR improves the config flag consistency by applying the check to the Control Messages as well.