### PR TITLE
fix: public cbor/json codec module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ libp2p-pnet = { version = "0.26.0", path = "transports/pnet" }
 libp2p-quic = { version = "0.12.0", path = "transports/quic" }
 libp2p-relay = { version = "0.19.0", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.16.0", path = "protocols/rendezvous" }
-libp2p-request-response = { version = "0.28.0", path = "protocols/request-response" }
+libp2p-request-response = { version = "0.28.1", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.6", path = "misc/server" }
 libp2p-stream = { version = "0.3.0-alpha", path = "protocols/stream" }
 libp2p-swarm = { version = "0.46.0", path = "swarm" }

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Allow configurable request and response sizes for `json` and `cbor` codec.
   See [PR 5792](https://github.com/libp2p/rust-libp2p/pull/5792).
 
+- fix: public cbor/json codec module
+  See [PR 5830](https://github.com/libp2p/rust-libp2p/pull/5830).
+
 <!-- Update to libp2p-core v0.43.0 -->
 
 ## 0.27.0

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.28.1
+
+- fix: public cbor/json codec module
+  See [PR 5830](https://github.com/libp2p/rust-libp2p/pull/5830).
+
 ## 0.28.0
 
 - Deprecate `void` crate.
@@ -8,9 +13,6 @@
 
 - Allow configurable request and response sizes for `json` and `cbor` codec.
   See [PR 5792](https://github.com/libp2p/rust-libp2p/pull/5792).
-
-- fix: public cbor/json codec module
-  See [PR 5830](https://github.com/libp2p/rust-libp2p/pull/5830).
 
 <!-- Update to libp2p-core v0.43.0 -->
 

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-request-response"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Generic Request/Response Protocols"
-version = "0.28.0"
+version = "0.28.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/request-response/src/cbor.rs
+++ b/protocols/request-response/src/cbor.rs
@@ -46,7 +46,7 @@
 /// ```
 pub type Behaviour<Req, Resp> = crate::Behaviour<codec::Codec<Req, Resp>>;
 
-mod codec {
+pub mod codec {
     use std::{collections::TryReserveError, convert::Infallible, io, marker::PhantomData};
 
     use async_trait::async_trait;

--- a/protocols/request-response/src/json.rs
+++ b/protocols/request-response/src/json.rs
@@ -46,7 +46,7 @@
 /// ```
 pub type Behaviour<Req, Resp> = crate::Behaviour<codec::Codec<Req, Resp>>;
 
-mod codec {
+pub mod codec {
     use std::{io, marker::PhantomData};
 
     use async_trait::async_trait;


### PR DESCRIPTION
## Description

follow-up to #5792

configuring a request_response behavior with generic codec does not allow for setting request/response size limits.

e.g. the following fails to compile since `request_response::cbor::codec` is private:
```rust
let non_default_codec = request_response::cbor::codec::Codec::<CustomRequest, CustomLargeResponse>::default()
    .set_response_size_maximum(large_response_size_max);
let request_response = request_response::Behaviour::with_codec(
    non_default_codec,
    std::iter::once((
        StreamProtocol::new("/request-response/1"),
        request_response::ProtocolSupport::Full,
    )),
    request_response::Config::default(),
);
```

## Notes & open questions

- is there an alternative to making the codec module public?

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [X] I have performed a self-review of my own code
- [X] ~~I have made corresponding changes to the documentation~~
- [X] ~~I have added tests that prove my fix is effective or that my feature works~~
- [X] A changelog entry has been made in the appropriate crates
