### PR TITLE
chore: remove @guillaumemichel from maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 
 (In alphabetical order.)
 
-- Guillaume Michel ([@guillaumemichel](https://github.com/guillaumemichel))
 - João Oliveira ([@jxs](https://github.com/jxs))
 
 ## Notable users


### PR DESCRIPTION
## Description

Removing myself from the maintainers list, since I have less time to invest to the project. I will spend more time working on IPFS in Go, so I won't be far away :)

Feel free to continue tagging me for `kad` reviews.
