### PR TITLE
chore: add Swarm NL to list of notable users

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,5 +101,6 @@ Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 - [Subspace](https://github.com/subspace/subspace) - Subspace Network reference implementation
 - [Substrate](https://github.com/paritytech/substrate) - Framework for blockchain innovation,
 used by [Polkadot](https://www.parity.io/technologies/polkadot/).
+- [Swarm NL](https://github.com/algorealmInc/SwarmNL) - A library that makes it easy to configure the networking requirements for any distributed application.
 - [Taple](https://github.com/opencanarias/taple-core) - Sustainable DLT for asset and process traceability by [OpenCanarias](https://www.opencanarias.com/en/).
 - [Ceylon](https://github.com/ceylonai/ceylon) - A Multi-Agent System (MAS) Development Framework.


### PR DESCRIPTION
We recently published the Swarm NL crate to [crates.io](https://crates.io/crates/swarm-nl). Thought we'd add it to the list here, hopefully it can help developers get started with using the magic of libp2p =)