### PR TITLE
chore(quic): migrate tests from async-std to tokio

### DIFF
--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/libp2p/rust-libp2p"
 license = "MIT"
 
 [dependencies]
+async-std = { version = "1.12.0", optional = true }
 futures = { workspace = true }
 futures-timer = "3.0.3"
 if-watch = { workspace = true }
@@ -26,6 +27,7 @@ ring = { workspace = true }
 
 [features]
 tokio = ["dep:tokio", "if-watch/tokio", "quinn/runtime-tokio"]
+async-std = ["dep:async-std", "if-watch/smol", "quinn/runtime-async-std"]
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -38,7 +38,7 @@ all-features = true
 libp2p-identity = { workspace = true, features = ["rand"] }
 libp2p-muxer-test-harness = { path = "../../muxers/test-harness" }
 libp2p-noise = { workspace = true }
-libp2p-tcp = { workspace = true, features = ["async-io"] }
+libp2p-tcp = { workspace = true, features = ["tokio"] }
 libp2p-yamux = { workspace = true }
 quickcheck = "1"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -47,7 +47,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [[test]]
 name = "stream_compliance"
-required-features = ["async-std"]
+required-features = ["tokio"]
 
 [lints]
 workspace = true

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/libp2p/rust-libp2p"
 license = "MIT"
 
 [dependencies]
-async-std = { version = "1.12.0", optional = true }
 futures = { workspace = true }
 futures-timer = "3.0.3"
 if-watch = { workspace = true }
@@ -27,7 +26,6 @@ ring = { workspace = true }
 
 [features]
 tokio = ["dep:tokio", "if-watch/tokio", "quinn/runtime-tokio"]
-async-std = ["dep:async-std", "if-watch/smol", "quinn/runtime-async-std"]
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling
@@ -35,7 +33,6 @@ async-std = ["dep:async-std", "if-watch/smol", "quinn/runtime-async-std"]
 all-features = true
 
 [dev-dependencies]
-async-std = { version = "1.12.0", features = ["attributes"] }
 libp2p-identity = { workspace = true, features = ["rand"] }
 libp2p-muxer-test-harness = { path = "../../muxers/test-harness" }
 libp2p-noise = { workspace = true }

--- a/transports/quic/src/transport.rs
+++ b/transports/quic/src/transport.rs
@@ -845,12 +845,12 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "async-std")]
-    #[async_std::test]
+    #[cfg(feature = "tokio")]
+    #[tokio::test]
     async fn test_close_listener() {
         let keypair = libp2p_identity::Keypair::generate_ed25519();
         let config = Config::new(&keypair);
-        let mut transport = crate::async_std::Transport::new(config);
+        let mut transport = crate::tokio::Transport::new(config);
         assert!(poll_fn(|cx| Pin::new(&mut transport).as_mut().poll(cx))
             .now_or_never()
             .is_none());

--- a/transports/quic/tests/stream_compliance.rs
+++ b/transports/quic/tests/stream_compliance.rs
@@ -7,14 +7,16 @@ use libp2p_core::{
 };
 use libp2p_quic as quic;
 
-#[async_std::test]
+#[cfg(feature = "tokio")]
+#[tokio::test]
 async fn close_implies_flush() {
     let (alice, bob) = connected_peers().await;
 
     libp2p_muxer_test_harness::close_implies_flush(alice, bob).await;
 }
 
-#[async_std::test]
+#[cfg(feature = "tokio")]
+#[tokio::test]
 async fn read_after_close() {
     let (alice, bob) = connected_peers().await;
 
@@ -36,10 +38,10 @@ async fn connected_peers() -> (quic::Connection, quic::Connection) {
     let (dialer_conn_sender, dialer_conn_receiver) = oneshot::channel();
     let (listener_conn_sender, listener_conn_receiver) = oneshot::channel();
 
-    async_std::task::spawn(async move {
+    tokio::spawn(async move {
         let (upgrade, _) = listener.next().await.unwrap().into_incoming().unwrap();
 
-        async_std::task::spawn(async move {
+        tokio::spawn(async move {
             let (_, connection) = upgrade.await.unwrap();
 
             let _ = listener_conn_sender.send(connection);
@@ -58,13 +60,13 @@ async fn connected_peers() -> (quic::Connection, quic::Connection) {
             },
         )
         .unwrap();
-    async_std::task::spawn(async move {
+    tokio::spawn(async move {
         let connection = dial_fut.await.unwrap().1;
 
         let _ = dialer_conn_sender.send(connection);
     });
 
-    async_std::task::spawn(async move {
+    tokio::spawn(async move {
         loop {
             dialer.next().await;
         }
@@ -75,10 +77,10 @@ async fn connected_peers() -> (quic::Connection, quic::Connection) {
         .unwrap()
 }
 
-fn new_transport() -> quic::async_std::Transport {
+fn new_transport() -> quic::tokio::Transport {
     let keypair = libp2p_identity::Keypair::generate_ed25519();
     let mut config = quic::Config::new(&keypair);
     config.handshake_timeout = Duration::from_secs(1);
 
-    quic::async_std::Transport::new(config)
+    quic::tokio::Transport::new(config)
 }

--- a/transports/quic/tests/stream_compliance.rs
+++ b/transports/quic/tests/stream_compliance.rs
@@ -7,7 +7,6 @@ use libp2p_core::{
 };
 use libp2p_quic as quic;
 
-#[cfg(feature = "tokio")]
 #[tokio::test]
 async fn close_implies_flush() {
     let (alice, bob) = connected_peers().await;
@@ -15,7 +14,6 @@ async fn close_implies_flush() {
     libp2p_muxer_test_harness::close_implies_flush(alice, bob).await;
 }
 
-#[cfg(feature = "tokio")]
 #[tokio::test]
 async fn read_after_close() {
     let (alice, bob) = connected_peers().await;


### PR DESCRIPTION
## Description

Migrate tests from async-std to tokio in transports/quic as per #4449 

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
