### PR TITLE
fix(swarm-derive): use full path for std result in derive macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "heck",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ libp2p-request-response = { version = "0.28.1", path = "protocols/request-respon
 libp2p-server = { version = "0.12.6", path = "misc/server" }
 libp2p-stream = { version = "0.3.0-alpha", path = "protocols/stream" }
 libp2p-swarm = { version = "0.46.0", path = "swarm" }
-libp2p-swarm-derive = { version = "=0.35.0", path = "swarm-derive" } # `libp2p-swarm-derive` may not be compatible with different `libp2p-swarm` non-breaking releases. E.g. `libp2p-swarm` might introduce a new enum variant `FromSwarm` (which is `#[non-exhaustive]`) in a non-breaking release. Older versions of `libp2p-swarm-derive` would not forward this enum variant within the `NetworkBehaviour` hierarchy. Thus the version pinning is required.
+libp2p-swarm-derive = { version = "=0.35.1", path = "swarm-derive" } # `libp2p-swarm-derive` may not be compatible with different `libp2p-swarm` non-breaking releases. E.g. `libp2p-swarm` might introduce a new enum variant `FromSwarm` (which is `#[non-exhaustive]`) in a non-breaking release. Older versions of `libp2p-swarm-derive` would not forward this enum variant within the `NetworkBehaviour` hierarchy. Thus the version pinning is required.
 libp2p-swarm-test = { version = "0.5.0", path = "swarm-test" }
 libp2p-tcp = { version = "0.43.0", path = "transports/tcp" }
 libp2p-tls = { version = "0.6.0", path = "transports/tls" }

--- a/swarm-derive/CHANGELOG.md
+++ b/swarm-derive/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.35.1
+
+- Fix `NetworkBehaviour` derive macro: replace the `Result` with `std::result::Result`.
+  See [PR 4568](https://github.com/libp2p/rust-libp2p/pull/5839)
+
 ## 0.35.0
 
 - Implement refactored `Transport`.

--- a/swarm-derive/Cargo.toml
+++ b/swarm-derive/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-swarm-derive"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Procedural macros of libp2p-swarm"
-version = "0.35.0"
+version = "0.35.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/swarm-derive/src/lib.rs
+++ b/swarm-derive/src/lib.rs
@@ -170,7 +170,7 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> syn::Result<Toke
                         }
 
                         impl #impl_generics ::core::fmt::Debug for #enum_name #ty_generics #where_clause_debug {
-                            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+                            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
                                 match &self {
                                     #(#enum_name::#match_variants(event) => {
                                         write!(f, "{}: {:?}", #enum_name_str, event)
@@ -426,7 +426,7 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> syn::Result<Toke
                 connection_id: #connection_id,
                 local_addr: &#multiaddr,
                 remote_addr: &#multiaddr,
-            ) -> Result<(), #connection_denied> {
+            ) -> std::result::Result<(), #connection_denied> {
                 #(#handle_pending_inbound_connection_stmts)*
 
                 Ok(())
@@ -439,7 +439,7 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> syn::Result<Toke
                 peer: #peer_id,
                 local_addr: &#multiaddr,
                 remote_addr: &#multiaddr,
-            ) -> Result<#t_handler<Self>, #connection_denied> {
+            ) -> std::result::Result<#t_handler<Self>, #connection_denied> {
                 Ok(#handle_established_inbound_connection)
             }
 
@@ -450,7 +450,7 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> syn::Result<Toke
                 maybe_peer: Option<#peer_id>,
                 addresses: &[#multiaddr],
                 effective_role: #endpoint,
-            ) -> Result<::std::vec::Vec<#multiaddr>, #connection_denied> {
+            ) -> std::result::Result<::std::vec::Vec<#multiaddr>, #connection_denied> {
                 #handle_pending_outbound_connection
             }
 
@@ -462,7 +462,7 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> syn::Result<Toke
                 addr: &#multiaddr,
                 role_override: #endpoint,
                 port_use: #port_use,
-            ) -> Result<#t_handler<Self>, #connection_denied> {
+            ) -> std::result::Result<#t_handler<Self>, #connection_denied> {
                 Ok(#handle_established_outbound_connection)
             }
 


### PR DESCRIPTION
## Description
Replace the `Result` in the `./swarm-derive/src/lib.rs` file with `std::result::Result`.
Fixes https://github.com/libp2p/rust-libp2p/issues/5833
superseeds #5839 as it was created before the git tag existed for `lib2p-swarm-derive-v0.35.0`