### PR TITLE
Typos fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 
 (open a pull request if you want your project to be added here)
 
-- [COMIT](https://github.com/comit-network/xmr-btc-swap) - Bitcoin–Monero Cross-chain Atomic Swap.
+- [COMMIT](https://github.com/comit-network/xmr-btc-swap) - Bitcoin–Monero Cross-chain Atomic Swap.
 - [Forest](https://github.com/ChainSafe/forest) - An implementation of Filecoin written in Rust.
 - [fuel-core](https://github.com/FuelLabs/fuel-core) - A Rust implementation of the Fuel protocol.
 - [HotShot](https://github.com/EspressoSystems/HotShot) - Decentralized sequencer in Rust developed by [Espresso Systems](https://www.espressosys.com/).

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -445,7 +445,7 @@ See [PR 4568].
 - New configurable connection limits for established connections and
   dedicated connection counters. Removed the connection limit dedicated
   to outgoing pending connection _per peer_. Connection limits are now
-  represented by `u32` intead of `usize` types.
+  represented by `u32` instead of `usize` types.
   [PR 1848](https://github.com/libp2p/rust-libp2p/pull/1848/).
 
 - Update `multihash`.

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -191,7 +191,7 @@
 
 - Update to `libp2p-swarm` `v0.36.0`.
 
-- Expose explicits errors via `UpgradeError` instead of generic `io::Error`. See [PR 2630].
+- Expose explicit errors via `UpgradeError` instead of generic `io::Error`. See [PR 2630].
 
 [PR 2630]: https://github.com/libp2p/rust-libp2p/pull/2630
 ## 0.35.0

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -158,7 +158,7 @@
 - Update dependencies.
 
 - Don't close connection if ping protocol is unsupported by remote.
-  Previously, a failed protocol negotation for ping caused a force close of the connection.
+  Previously, a failed protocol negotiation for ping caused a force close of the connection.
   As a result, all nodes in a network had to support ping.
   To allow networks where some nodes don't support ping, we now emit
   `PingFailure::Unsupported` once for every connection on which ping is not supported.


### PR DESCRIPTION
### Changes

1. **File:** `/README.md`
    - Fixed `COMIT` to `COMMIT` (Line 87)
1. **File:** `/core/CHANGELOG.md`
    - Fixed `intead` to `instead` (Line 448)
1. **File:** `/protocols/identify/CHANGELOG.md`
    - Fixed `explicits` to `explicit` (Line 194)
1. **File:** `/protocols/ping/CHANGELOG.md`
    - Fixed `negotation` to `negotiation` (Line 161)

### Purpose

- Improved documentation accuracy by fixing typographical errors.
- Ensured better readability and consistency.