### PR TITLE
chore(kad): migrate tests from async-std to tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,7 +2938,6 @@ dependencies = [
 name = "libp2p-kad"
 version = "0.47.0"
 dependencies = [
- "async-std",
  "asynchronous-codec",
  "bytes",
  "either",
@@ -2961,6 +2960,7 @@ dependencies = [
  "sha2 0.10.8",
  "smallvec",
  "thiserror 2.0.9",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "uint",

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-async-std = { version = "1.12.0", features = ["attributes"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 futures-timer = "3.0"
 libp2p-identify = { path = "../identify" }
 libp2p-noise = { workspace = true }

--- a/protocols/kad/src/bootstrap.rs
+++ b/protocols/kad/src/bootstrap.rs
@@ -198,7 +198,7 @@ mod tests {
         do_bootstrap(status);
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn immediate_automatic_bootstrap_is_triggered_immediately() {
         let mut status = Status::new(Some(Duration::from_secs(1)), Some(Duration::ZERO));
 
@@ -216,14 +216,14 @@ mod tests {
         );
 
         assert!(
-            async_std::future::timeout(Duration::from_millis(500), status.next())
+            tokio::time::timeout(Duration::from_millis(500), status.next())
                 .await
                 .is_ok(),
             "bootstrap to be triggered in less then the configured delay because we connected to a new peer"
         );
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn delayed_automatic_bootstrap_is_triggered_before_periodic_bootstrap() {
         let mut status = Status::new(Some(Duration::from_secs(1)), Some(MS_5));
 
@@ -241,7 +241,7 @@ mod tests {
         );
 
         assert!(
-            async_std::future::timeout(MS_5 * 2, status.next())
+            tokio::time::timeout(MS_5 * 2, status.next())
                 .await
                 .is_ok(),
             "bootstrap to be triggered in less then the configured periodic delay because we connected to a new peer"
@@ -263,7 +263,7 @@ mod tests {
         )
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn given_periodic_bootstrap_when_routing_table_updated_then_wont_bootstrap_until_next_interval(
     ) {
         let mut status = Status::new(Some(MS_100), Some(MS_5));
@@ -283,7 +283,7 @@ mod tests {
         assert!(elapsed > MS_100);
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn given_no_periodic_bootstrap_and_automatic_bootstrap_when_new_entry_then_will_bootstrap(
     ) {
         let mut status = Status::new(None, Some(Duration::ZERO));
@@ -293,7 +293,7 @@ mod tests {
         status.next().await;
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn given_periodic_bootstrap_and_no_automatic_bootstrap_triggers_periodically() {
         let mut status = Status::new(Some(MS_100), None);
 
@@ -308,7 +308,7 @@ mod tests {
         }
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn given_no_periodic_bootstrap_and_automatic_bootstrap_reset_throttle_when_multiple_peers(
     ) {
         let mut status = Status::new(None, Some(MS_100));
@@ -327,14 +327,14 @@ mod tests {
         Delay::new(MS_100 - MS_5).await;
 
         assert!(
-            async_std::future::timeout(MS_5*2, status.next())
+            tokio::time::timeout(MS_5*2, status.next())
                 .await
                 .is_ok(),
             "bootstrap to be triggered in the configured throttle delay because we connected to a new peer"
         );
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn given_periodic_bootstrap_and_no_automatic_bootstrap_manually_triggering_prevent_periodic(
     ) {
         let mut status = Status::new(Some(MS_100), None);
@@ -347,7 +347,7 @@ mod tests {
         status.on_finish();
 
         assert!(
-            async_std::future::timeout(10 * MS_100, status.next())
+            tokio::time::timeout(10 * MS_100, status.next())
                 .await
                 .is_err(),
             "periodic bootstrap to never be triggered because one is still being run"

--- a/protocols/kad/tests/client_mode.rs
+++ b/protocols/kad/tests/client_mode.rs
@@ -7,7 +7,7 @@ use tracing_subscriber::EnvFilter;
 use Event::*;
 use MyBehaviourEvent::*;
 
-#[async_std::test]
+#[tokio::test]
 async fn server_gets_added_to_routing_table_by_client() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
@@ -20,7 +20,7 @@ async fn server_gets_added_to_routing_table_by_client() {
     client.connect(&mut server).await;
 
     let server_peer_id = *server.local_peer_id();
-    async_std::task::spawn(server.loop_on_next());
+    tokio::spawn(server.loop_on_next());
 
     let external_event_peer = client
         .wait(|e| match e {
@@ -39,7 +39,7 @@ async fn server_gets_added_to_routing_table_by_client() {
     assert_eq!(routing_updated_peer, server_peer_id);
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn two_servers_add_each_other_to_routing_table() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
@@ -68,7 +68,7 @@ async fn two_servers_add_each_other_to_routing_table() {
     server1.listen().with_memory_addr_external().await;
     server2.connect(&mut server1).await;
 
-    async_std::task::spawn(server1.loop_on_next());
+    tokio::spawn(server1.loop_on_next());
 
     let peer = server2
         .wait(|e| match e {
@@ -80,7 +80,7 @@ async fn two_servers_add_each_other_to_routing_table() {
     assert_eq!(peer, server1_peer_id);
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn adding_an_external_addresses_activates_server_mode_on_existing_connections() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
@@ -118,7 +118,7 @@ async fn adding_an_external_addresses_activates_server_mode_on_existing_connecti
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn set_client_to_server_mode() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
@@ -160,7 +160,7 @@ async fn set_client_to_server_mode() {
 
     client.behaviour_mut().kad.set_mode(Some(Mode::Server));
 
-    async_std::task::spawn(client.loop_on_next());
+    tokio::spawn(client.loop_on_next());
 
     let info = server
         .wait(|e| match e {


### PR DESCRIPTION
## Description

Migrating tests in `protocols/kad` from `async_std` to `tokio` as per https://github.com/libp2p/rust-libp2p/issues/4449

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
