### PR TITLE
chore: fix spelling mistakes using crate-ci/typos

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -326,7 +326,7 @@ See [PR 4568].
 
 - Remove `TInEvent` and `TOutEvent` trait parameters on most public types.
   `TInEvent` and `TOutEvent` are implied through `THandler` and thus
-  superflucious. Both are removed in favor of a derivation through `THandler`
+  superfluous. Both are removed in favor of a derivation through `THandler`
   (see [PR 2183]).
 
 - Require `ConnectionHandler::{InEvent,OutEvent,Error}` to implement `Debug`
@@ -445,7 +445,7 @@ See [PR 4568].
 - New configurable connection limits for established connections and
   dedicated connection counters. Removed the connection limit dedicated
   to outgoing pending connection _per peer_. Connection limits are now
-  represented by `u32` intead of `usize` types.
+  represented by `u32` instead of `usize` types.
   [PR 1848](https://github.com/libp2p/rust-libp2p/pull/1848/).
 
 - Update `multihash`.

--- a/core/src/signed_envelope.rs
+++ b/core/src/signed_envelope.rs
@@ -49,7 +49,7 @@ impl SignedEnvelope {
     /// Extract the payload and signing key of this [`SignedEnvelope`].
     ///
     /// You must provide the correct domain-separation string and expected payload type in order to
-    /// get the payload. This guards against accidental mis-use of the payload where the
+    /// get the payload. This guards against accidental misuse of the payload where the
     /// signature was created for a different purpose or payload type.
     ///
     /// It is the caller's responsibility to check that the signing key is what

--- a/core/src/transport.rs
+++ b/core/src/transport.rs
@@ -104,7 +104,7 @@ pub struct DialOpts {
 /// by a [`Transport`] through an upgrade mechanism that is initiated via
 /// [`upgrade`](Transport::upgrade).
 ///
-/// Note for implementors: Futures returned by [`Transport::dial`] should only
+/// Note for implementers: Futures returned by [`Transport::dial`] should only
 /// do work once polled for the first time. E.g. in the case of TCP, connecting
 /// to the remote should not happen immediately on [`Transport::dial`] but only
 /// once the returned [`Future`] is polled. The caller of [`Transport::dial`]

--- a/core/src/transport/upgrade.rs
+++ b/core/src/transport/upgrade.rs
@@ -185,7 +185,7 @@ where
     }
 }
 
-/// An transport with peer authentication, obtained from [`Builder::authenticate`].
+/// A transport with peer authentication, obtained from [`Builder::authenticate`].
 #[derive(Clone)]
 pub struct Authenticated<T>(Builder<T>);
 

--- a/docs/maintainer-handbook.md
+++ b/docs/maintainer-handbook.md
@@ -1,6 +1,6 @@
 # Maintainer handbook
 
-This document describes what ever maintainer of the repository should know.
+This document describes whatever maintainer of the repository should know.
 
 ## GitHub settings
 

--- a/examples/file-sharing/README.md
+++ b/examples/file-sharing/README.md
@@ -29,7 +29,7 @@ Let's understand the flow of the file sharing process:
 
 The File Sharing application has the following architectural properties:
 
-- **Clean and Clonable Interface**: The application provides a clean and clonable async/await interface, allowing users to interact with the network layer seamlessly.
+- **Clean and Cloneable Interface**: The application provides a clean and cloneable async/await interface, allowing users to interact with the network layer seamlessly.
   The `Client` module encapsulates the necessary functionality for network communication.
 
 - **Efficient Network Handling**: The application operates with a single task that drives the network layer.

--- a/identity/src/rsa.rs
+++ b/identity/src/rsa.rs
@@ -105,7 +105,7 @@ impl PublicKey {
         self.0.clone()
     }
 
-    /// Encode the RSA public key in DER as a X.509 SubjectPublicKeyInfo structure,
+    /// Encode the RSA public key in DER as an X.509 SubjectPublicKeyInfo structure,
     /// as defined in [RFC5280].
     ///
     /// [RFC5280]: https://tools.ietf.org/html/rfc5280#section-4.1

--- a/interop-tests/README.md
+++ b/interop-tests/README.md
@@ -39,7 +39,7 @@ To run the webrtc-direct test, you'll need the `chromedriver` in your `$PATH`, c
 # Running all interop tests locally with Compose
 
 To run this test against all released libp2p versions you'll need to have the
-(libp2p/test-plans)[https://github.com/libp2p/test-plans] checked out. Then do
+[libp2p/test-plans](https://github.com/libp2p/test-plans) checked out. Then do
 the following (from the root directory of this repository):
 
 1. Build the image: `docker build -t rust-libp2p-head . -f interop-tests/Dockerfile`.

--- a/misc/multistream-select/src/protocol.rs
+++ b/misc/multistream-select/src/protocol.rs
@@ -120,7 +120,7 @@ impl fmt::Display for Protocol {
 /// A multistream-select protocol message.
 ///
 /// Multistream-select protocol messages are exchanged with the goal
-/// of agreeing on a application-layer protocol to use on an I/O stream.
+/// of agreeing on an application-layer protocol to use on an I/O stream.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Message {
     /// A header message identifies the multistream-select protocol

--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ## 0.13.0
 
-- Due to the refactor of `Transport` it's no longer required to create a seperate transport for
+- Due to the refactor of `Transport` it's no longer required to create a separate transport for
 AutoNAT where port reuse is disabled. This information is now passed by the behaviour.
   See [PR 4568](https://github.com/libp2p/rust-libp2p/pull/4568).
 - Introduce the new AutoNATv2 protocol.
@@ -34,7 +34,7 @@ AutoNAT where port reuse is disabled. This information is now passed by the beha
 ## 0.12.0
 
 - Remove `Clone`, `PartialEq` and `Eq` implementations on `Event` and its sub-structs.
-  The `Event` also contains errors which are not clonable or comparable.
+  The `Event` also contains errors which are not cloneable or comparable.
   See [PR 3914](https://github.com/libp2p/rust-libp2p/pull/3914).
 
 ## 0.11.0
@@ -84,7 +84,7 @@ AutoNAT where port reuse is disabled. This information is now passed by the beha
 
 - Update to `libp2p-request-response` `v0.23.0`.
 
-- Replace `Behaviour`'s `NetworkBehaviour` implemention `inject_*` methods with the new `on_*` methods.
+- Replace `Behaviour`'s `NetworkBehaviour` implementation `inject_*` methods with the new `on_*` methods.
   See [PR 3011].
 
 - Update `rust-version` to reflect the actual MSRV: 1.62.0. See [PR 3090].

--- a/protocols/autonat/src/v2.rs
+++ b/protocols/autonat/src/v2.rs
@@ -4,7 +4,7 @@
 //!
 //! The new version fixes the issues of the first version:
 //! - The server now always dials back over a newly allocated port. This greatly reduces the risk of
-//!   false positives that often occurred in the first version, when the clinet-server connection
+//!   false positives that often occurred in the first version, when the client-server connection
 //!   occurred over a hole-punched port.
 //! - The server protects against DoS attacks by requiring the client to send more data to the
 //!   server then the dial back puts on the client, thus making the protocol unatractive for an

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -75,10 +75,10 @@
 
 - Update to `libp2p-swarm` `v0.41.0`.
 
-- Replace `Behaviour`'s `NetworkBehaviour` implemention `inject_*` methods with the new `on_*` methods.
+- Replace `Behaviour`'s `NetworkBehaviour` implementation `inject_*` methods with the new `on_*` methods.
   See [PR 3011].
 
-- Replace `direct::Handler` and `relayed::Handler`'s `ConnectionHandler` implemention `inject_*`
+- Replace `direct::Handler` and `relayed::Handler`'s `ConnectionHandler` implementation `inject_*`
   methods with the new `on_*` methods. See [PR 3085].
 
 - Update `rust-version` to reflect the actual MSRV: 1.62.0. See [PR 3090].

--- a/protocols/floodsub/CHANGELOG.md
+++ b/protocols/floodsub/CHANGELOG.md
@@ -36,7 +36,7 @@
 
 - Update to `libp2p-swarm` `v0.41.0`.
 
-- Replace `Floodsub`'s `NetworkBehaviour` implemention `inject_*` methods with the new `on_*` methods.
+- Replace `Floodsub`'s `NetworkBehaviour` implementation `inject_*` methods with the new `on_*` methods.
   See [PR 3011].
 
 - Update `rust-version` to reflect the actual MSRV: 1.62.0. See [PR 3090].

--- a/protocols/floodsub/src/generated/rpc.proto
+++ b/protocols/floodsub/src/generated/rpc.proto
@@ -7,7 +7,7 @@ message RPC {
 	repeated Message publish = 2;
 
 	message SubOpts {
-		optional bool subscribe = 1; // subscribe or unsubcribe
+		optional bool subscribe = 1; // subscribe or unsubscribe
 		optional string topic_id = 2;
 	}
 }

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -39,7 +39,7 @@
 - Fix `cargo clippy` warnings in `rustc 1.84.0-beta.1`.
   See [PR 5700](https://github.com/libp2p/rust-libp2p/pull/5700).
 
-- Fixe an issue where an `InsufficientPeers` error could occur under certain conditions, despite having peers subscribed to a topic.
+- Fix an issue where an `InsufficientPeers` error could occur under certain conditions, despite having peers subscribed to a topic.
   See [PR 5793](https://github.com/libp2p/rust-libp2p/pull/5793).
 
 <!-- Update to libp2p-core v0.43.0 -->
@@ -75,7 +75,7 @@
 - Deprecate `gossipsub::Config::idle_timeout` in favor of `SwarmBuilder::idle_connection_timeout`.
   See [PR 4648].
 
-<!-- Interal changes:
+<!-- Internal changes:
 
 - Allow new clippy lint.
 
@@ -91,7 +91,7 @@
 
 ## 0.45.1
 
-- Add getter function to o  btain `TopicScoreParams`.
+- Add getter function to obtain `TopicScoreParams`.
   See [PR 4231].
 
 [PR 4231]: https://github.com/libp2p/rust-libp2p/pull/4231

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -2339,7 +2339,7 @@ fn test_accept_only_outbound_peer_grafts_when_mesh_full() {
     assert_eq!(gs.mesh[&topics[0]].len(), config.mesh_n_high());
 
     // create an outbound and an inbound peer
-    let (inbound, _in_reciver) = add_peer(&mut gs, &topics, false, false);
+    let (inbound, _in_receiver) = add_peer(&mut gs, &topics, false, false);
     let (outbound, _out_receiver) = add_peer(&mut gs, &topics, true, false);
 
     // send grafts

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -940,7 +940,7 @@ impl std::fmt::Debug for Config {
             &self.published_message_ids_cache_time,
         );
         let _ = builder.field(
-            "idontwant_message_size_threhold",
+            "idontwant_message_size_threshold",
             &self.idontwant_message_size_threshold,
         );
         let _ = builder.field("idontwant_on_publish", &self.idontwant_on_publish);

--- a/protocols/gossipsub/src/peer_score/tests.rs
+++ b/protocols/gossipsub/src/peer_score/tests.rs
@@ -862,7 +862,7 @@ fn test_score_ip_colocation() {
 }
 
 #[test]
-fn test_score_behaviour_penality() {
+fn test_score_behaviour_penalty() {
     // Create parameters with reasonable default values
     let behaviour_penalty_weight = -1.0;
     let behaviour_penalty_decay = 0.99;

--- a/protocols/gossipsub/src/topic.rs
+++ b/protocols/gossipsub/src/topic.rs
@@ -51,14 +51,14 @@ impl Hasher for Sha256Hash {
     fn hash(topic_string: String) -> TopicHash {
         use quick_protobuf::MessageWrite;
 
-        let topic_descripter = proto::TopicDescriptor {
+        let topic_descriptor = proto::TopicDescriptor {
             name: Some(topic_string),
             auth: None,
             enc: None,
         };
-        let mut bytes = Vec::with_capacity(topic_descripter.get_size());
+        let mut bytes = Vec::with_capacity(topic_descriptor.get_size());
         let mut writer = Writer::new(&mut bytes);
-        topic_descripter
+        topic_descriptor
             .write_message(&mut writer)
             .expect("Encoding to succeed");
         let hash = BASE64_STANDARD.encode(Sha256::digest(&bytes));

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -124,10 +124,10 @@
 
 - Update to `libp2p-swarm` `v0.41.0`.
 
-- Replace `Behaviour`'s `NetworkBehaviour` implemention `inject_*` methods with the new `on_*` methods.
+- Replace `Behaviour`'s `NetworkBehaviour` implementation `inject_*` methods with the new `on_*` methods.
   See [PR 3011].
 
-- Replace `Handler`'s `ConnectionHandler` implemention `inject_*` methods with the new `on_*` methods.
+- Replace `Handler`'s `ConnectionHandler` implementation `inject_*` methods with the new `on_*` methods.
   See [PR 3085].
 
 - Update `rust-version` to reflect the actual MSRV: 1.62.0. See [PR 3090].
@@ -191,7 +191,7 @@
 
 - Update to `libp2p-swarm` `v0.36.0`.
 
-- Expose explicits errors via `UpgradeError` instead of generic `io::Error`. See [PR 2630].
+- Expose explicit errors via `UpgradeError` instead of generic `io::Error`. See [PR 2630].
 
 [PR 2630]: https://github.com/libp2p/rust-libp2p/pull/2630
 ## 0.35.0

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.47.0
 
-- Expose a kad query facility allowing specify num_results dynamicaly.
+- Expose a kad query facility allowing specify num_results dynamically.
   See [PR 5555](https://github.com/libp2p/rust-libp2p/pull/5555).
 - Add `mode` getter on `Behaviour`.
   See [PR 5573](https://github.com/libp2p/rust-libp2p/pull/5573).

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -72,12 +72,12 @@
 - Update to `if-watch` `3.0.0` and both rename `TokioMdns` to `Behaviour` living in `tokio::Behaviour`,
 and move and rename `Mdns` to `async_io::Behaviour`. See [PR 3096].
 
-- Remove the remaning `Mdns` prefixes from types as per [discussion 2174].
+- Remove the remaining `Mdns` prefixes from types as per [discussion 2174].
   I.e the `Mdns` prefix has been removed from various types like `MdnsEvent`.
   Users should prefer importing the mdns protocol as a module (`use libp2p::mdns;`),
   and refer to its types via `mdns::`. For example: `mdns::Behaviour` or `mdns::Event`.
 
-- Replace `GenMdns`'s `NetworkBehaviour` implemention `inject_*` methods with the new `on_*` methods.
+- Replace `GenMdns`'s `NetworkBehaviour` implementation `inject_*` methods with the new `on_*` methods.
   See [PR 3011].
 
 - Use `trust-dns-proto` to parse DNS messages. See [PR 3102].

--- a/protocols/perf/src/protocol.rs
+++ b/protocols/perf/src/protocol.rs
@@ -67,7 +67,7 @@ async fn send_receive_inner<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
     stream.write_all(&to_receive_bytes).await?;
 
     let write_start = Instant::now();
-    let mut intermittant_start = Instant::now();
+    let mut intermittent_start = Instant::now();
     let mut sent = 0;
     let mut intermittent_sent = 0;
 
@@ -82,13 +82,13 @@ async fn send_receive_inner<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
                     delay.reset(REPORT_INTERVAL);
                     progress
                         .send(Intermediate {
-                            duration: intermittant_start.elapsed(),
+                            duration: intermittent_start.elapsed(),
                             sent: sent - intermittent_sent,
                             received: 0,
                         })
                         .await
                         .expect("receiver not to be dropped");
-                    intermittant_start = Instant::now();
+                    intermittent_start = Instant::now();
                     intermittent_sent = sent;
                 }
                 Either::Right((n, _)) => break n?,
@@ -102,13 +102,13 @@ async fn send_receive_inner<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
                 delay.reset(REPORT_INTERVAL);
                 progress
                     .send(Intermediate {
-                        duration: intermittant_start.elapsed(),
+                        duration: intermittent_start.elapsed(),
                         sent: sent - intermittent_sent,
                         received: 0,
                     })
                     .await
                     .expect("receiver not to be dropped");
-                intermittant_start = Instant::now();
+                intermittent_start = Instant::now();
                 intermittent_sent = sent;
             }
             Either::Right((Ok(_), _)) => break,
@@ -128,13 +128,13 @@ async fn send_receive_inner<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
                     delay.reset(REPORT_INTERVAL);
                     progress
                         .send(Intermediate {
-                            duration: intermittant_start.elapsed(),
+                            duration: intermittent_start.elapsed(),
                             sent: sent - intermittent_sent,
                             received: received - intermittend_received,
                         })
                         .await
                         .expect("receiver not to be dropped");
-                    intermittant_start = Instant::now();
+                    intermittent_start = Instant::now();
                     intermittent_sent = sent;
                     intermittend_received = received;
                 }

--- a/protocols/ping/CHANGELOG.md
+++ b/protocols/ping/CHANGELOG.md
@@ -64,10 +64,10 @@
 
 - Update to `libp2p-swarm` `v0.41.0`.
 
-- Replace `Behaviour`'s `NetworkBehaviour` implemention `inject_*` methods with the new `on_*` methods.
+- Replace `Behaviour`'s `NetworkBehaviour` implementation `inject_*` methods with the new `on_*` methods.
   See [PR 3011].
 
-- Replace `Handler`'s `ConnectionHandler` implemention `inject_*` methods with the new `on_*` methods.
+- Replace `Handler`'s `ConnectionHandler` implementation `inject_*` methods with the new `on_*` methods.
   See [PR 3085].
 
 - Update `rust-version` to reflect the actual MSRV: 1.62.0. See [PR 3090].
@@ -158,7 +158,7 @@
 - Update dependencies.
 
 - Don't close connection if ping protocol is unsupported by remote.
-  Previously, a failed protocol negotation for ping caused a force close of the connection.
+  Previously, a failed protocol negotiation for ping caused a force close of the connection.
   As a result, all nodes in a network had to support ping.
   To allow networks where some nodes don't support ping, we now emit
   `PingFailure::Unsupported` once for every connection on which ping is not supported.

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -135,10 +135,10 @@
 
 - Update to `libp2p-swarm` `v0.41.0`.
 
-- Replace `Client` and `Relay`'s `NetworkBehaviour` implemention `inject_*` methods with the new `on_*` methods.
+- Replace `Client` and `Relay`'s `NetworkBehaviour` implementation `inject_*` methods with the new `on_*` methods.
   See [PR 3011].
 
-- Replace `client::Handler` and `relay::Handler`'s `ConnectionHandler` implemention `inject_*` methods
+- Replace `client::Handler` and `relay::Handler`'s `ConnectionHandler` implementation `inject_*` methods
   with the new `on_*` methods. See [PR 3085].
 
 - Update `rust-version` to reflect the actual MSRV: 1.62.0. See [PR 3090].
@@ -197,7 +197,7 @@
   circuit requests with one per peer. And deny new circuits before accepting new
   circuits. See [PR 2698].
 
-- Expose explicits errors via `UpgradeError` instead of generic `io::Error`. See
+- Expose explicit errors via `UpgradeError` instead of generic `io::Error`. See
   [PR 2698].
 
 [PR 2698]: https://github.com/libp2p/rust-libp2p/pull/2698/

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -127,10 +127,10 @@
 
 - Update to `libp2p-swarm` `v0.41.0`.
 
-- Replace `RequestResponse`'s `NetworkBehaviour` implemention `inject_*` methods with the new `on_*` methods.
+- Replace `RequestResponse`'s `NetworkBehaviour` implementation `inject_*` methods with the new `on_*` methods.
   See [PR 3011].
 
-- Replace `RequestResponseHandler`'s `ConnectionHandler` implemention `inject_*` methods
+- Replace `RequestResponseHandler`'s `ConnectionHandler` implementation `inject_*` methods
   with the new `on_*` methods. See [PR 3085].
 
 - Update `rust-version` to reflect the actual MSRV: 1.62.0. See [PR 3090].

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -427,7 +427,7 @@ where
     /// connection is established.
     ///
     /// > **Note**: In order for such a dialing attempt to succeed,
-    /// > the `RequestResonse` protocol must either be embedded
+    /// > the `RequestResponse` protocol must either be embedded
     /// > in another `NetworkBehaviour` that provides peer and
     /// > address discovery, or known addresses of peers must be
     /// > managed via [`Behaviour::add_address`] and

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -77,7 +77,7 @@
   See [PR 4755](https://github.com/libp2p/rust-libp2p/pull/4755).
 - Add `PeerCondition::DisconnectedAndNotDialing` variant, combining pre-existing conditions.
   This is the new default.
-  A new dialing attempt is iniated _only if_ the peer is both considered disconnected and there is currently no ongoing dialing attempt.
+  A new dialing attempt is initiated _only if_ the peer is both considered disconnected and there is currently no ongoing dialing attempt.
   See [PR 4225](https://github.com/libp2p/rust-libp2p/pull/4225).
 - Remove deprecated `keep_alive_timeout` in `OneShotHandlerConfig`.
   See [PR 4677](https://github.com/libp2p/rust-libp2p/pull/4677).
@@ -129,7 +129,7 @@
 - Improve error message when `DialPeerCondition` prevents a dial.
   See [PR 4409].
 
-- Introduce `SwarmBuilder::idle_conncetion_timeout` and deprecate `keep_alive::Behaviour` as a result.
+- Introduce `SwarmBuilder::idle_connection_timeout` and deprecate `keep_alive::Behaviour` as a result.
   See [PR 4161].
 
 [PR 4426]: https://github.com/libp2p/rust-libp2p/pull/4426
@@ -955,7 +955,7 @@
   pending outbound upgrades. As a result only those upgrades are polled that are
   ready to progress.
 
-  Implementors of `InboundUpgrade` and `OutboundUpgrade` need to ensure to wake
+  Implementers of `InboundUpgrade` and `OutboundUpgrade` need to ensure to wake
   up the underlying task once they are ready to make progress as they won't be
   polled otherwise.
 

--- a/swarm/src/handler.rs
+++ b/swarm/src/handler.rs
@@ -95,7 +95,7 @@ use crate::{connection::AsStrHashEq, StreamProtocol};
 /// implemented by the handler can include conditions for terminating the connection.
 /// The lifetime of successfully negotiated substreams is fully controlled by the handler.
 ///
-/// Implementors of this trait should keep in mind that the connection can be closed at any time.
+/// Implementers of this trait should keep in mind that the connection can be closed at any time.
 /// When a connection is closed gracefully, the substreams used by the handler may still
 /// continue reading data until the remote closes its side of the connection.
 #[expect(deprecated)] // TODO: Remove when {In, Out}boundOpenInfo is fully removed.

--- a/swarm/src/test.rs
+++ b/swarm/src/test.rs
@@ -240,8 +240,8 @@ where
             assert_eq!(
                 self.on_connection_established
                     .iter()
-                    .filter(|(.., reported_aditional_connections)| {
-                        *reported_aditional_connections == 0
+                    .filter(|(.., reported_additional_connections)| {
+                        *reported_additional_connections == 0
                     })
                     .count(),
                 expected_connections

--- a/transports/webtransport-websys/CHANGELOG.md
+++ b/transports/webtransport-websys/CHANGELOG.md
@@ -25,6 +25,6 @@
 
 ## 0.1.0
 
-* Initial implementation of WebTranport transport using web-sys bindings. See [PR 4015].
+* Initial implementation of WebTransport transport using web-sys bindings. See [PR 4015].
 
 [PR 4015]: https://github.com/libp2p/rust-libp2p/pull/4015


### PR DESCRIPTION
## Description

Fix spelling mistakes and typos in all source files using the [crate-ci/typos](https://github.com/crate-ci/typos) CLI tool.

## Notes & open questions

Also includes/ bundles all fixes from `typo-fix`-labeled PRs.

Should we add `crate-ci/typos` as a CI check? 
It would prevent future spelling/ typo mistakes. However, it doesn't catch all grammar mistakes, and there is a risk of false positive (which can be solved with a config file, but still might be annoying for contributors).

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~A changelog entry has been made in the appropriate crates~~ _No public function is affected._
