### PR TITLE
feat(relay): emit event when client connections are dropped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "asynchronous-codec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ libp2p-identity = { version = "0.2.10" }
 libp2p-kad = { version = "0.47.0", path = "protocols/kad" }
 libp2p-mdns = { version = "0.47.0", path = "protocols/mdns" }
 libp2p-memory-connection-limits = { version = "0.4.0", path = "misc/memory-connection-limits" }
-libp2p-metrics = { version = "0.16.0", path = "misc/metrics" }
+libp2p-metrics = { version = "0.16.1", path = "misc/metrics" }
 libp2p-mplex = { version = "0.43.1", path = "muxers/mplex" }
 libp2p-noise = { version = "0.46.0", path = "transports/noise" }
 libp2p-perf = { version = "0.4.0", path = "protocols/perf" }
@@ -94,7 +94,7 @@ libp2p-ping = { version = "0.46.0", path = "protocols/ping" }
 libp2p-plaintext = { version = "0.43.0", path = "transports/plaintext" }
 libp2p-pnet = { version = "0.26.0", path = "transports/pnet" }
 libp2p-quic = { version = "0.12.0", path = "transports/quic" }
-libp2p-relay = { version = "0.19.1", path = "protocols/relay" }
+libp2p-relay = { version = "0.20.0", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.16.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.28.1", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.6", path = "misc/server" }

--- a/misc/metrics/CHANGELOG.md
+++ b/misc/metrics/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.16.1
+- Add `ReservationClosed` as a relay metric.
+  See [PR 5869](https://github.com/libp2p/rust-libp2p/pull/5869).
+
 ## 0.16.0
 
 <!-- Update to libp2p-core v0.43.0 -->

--- a/misc/metrics/CHANGELOG.md
+++ b/misc/metrics/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.16.1
+## 0.16.1
 - Add `ReservationClosed` as a relay metric.
   See [PR 5869](https://github.com/libp2p/rust-libp2p/pull/5869).
 

--- a/misc/metrics/Cargo.toml
+++ b/misc/metrics/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-metrics"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Metrics for libp2p"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Max Inden <mail@max-inden.de>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/misc/metrics/src/relay.rs
+++ b/misc/metrics/src/relay.rs
@@ -54,6 +54,7 @@ enum EventType {
     ReservationReqAcceptFailed,
     ReservationReqDenied,
     ReservationReqDenyFailed,
+    ReservationClosed,
     ReservationTimedOut,
     CircuitReqDenied,
     CircuitReqDenyFailed,
@@ -76,6 +77,7 @@ impl From<&libp2p_relay::Event> for EventType {
             libp2p_relay::Event::ReservationReqDenyFailed { .. } => {
                 EventType::ReservationReqDenyFailed
             }
+            libp2p_relay::Event::ReservationClosed { .. } => EventType::ReservationClosed,
             libp2p_relay::Event::ReservationTimedOut { .. } => EventType::ReservationTimedOut,
             libp2p_relay::Event::CircuitReqDenied { .. } => EventType::CircuitReqDenied,
             #[allow(deprecated)]

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.19.1
+## 0.20.0
 
 - Remove duplicated forwarding of pending events to connection handler.
+- Emit `relay::Event::ReservationClosed` when an active reservation is dropped due to the connection closing.
+  See [PR 5869](https://github.com/libp2p/rust-libp2p/pull/5869).
 
 ## 0.19.0
 

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-relay"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Communications relaying for libp2p"
-version = "0.19.1"
+version = "0.20.0"
 authors = ["Parity Technologies <admin@parity.io>", "Max Inden <mail@max-inden.de>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
## Description
When a relay server has no more connection with a reserved client, it would remove the reservation and the drop the circuits without any information passed to the server. It will be useful to for a server to track all its reservations and to know when they're removed (without keeping track of the connections themselves). 

This PR aims to notify the server when a reservation closes, with the emission of the following event
```
    /// A reservation has been closed.
    ReservationClosed { src_peer_id: PeerId },
```

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
