### PR TITLE
feat(relay): emit new ReservationRemoved event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "asynchronous-codec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ libp2p-ping = { version = "0.46.0", path = "protocols/ping" }
 libp2p-plaintext = { version = "0.43.0", path = "transports/plaintext" }
 libp2p-pnet = { version = "0.26.0", path = "transports/pnet" }
 libp2p-quic = { version = "0.12.0", path = "transports/quic" }
-libp2p-relay = { version = "0.19.1", path = "protocols/relay" }
+libp2p-relay = { version = "0.20.0", path = "protocols/relay" }
 libp2p-rendezvous = { version = "0.16.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.28.1", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.6", path = "misc/server" }

--- a/misc/metrics/src/relay.rs
+++ b/misc/metrics/src/relay.rs
@@ -55,6 +55,7 @@ enum EventType {
     ReservationReqDenied,
     ReservationReqDenyFailed,
     ReservationTimedOut,
+    ReservationRemoved,
     CircuitReqDenied,
     CircuitReqDenyFailed,
     CircuitReqOutboundConnectFailed,
@@ -77,6 +78,7 @@ impl From<&libp2p_relay::Event> for EventType {
                 EventType::ReservationReqDenyFailed
             }
             libp2p_relay::Event::ReservationTimedOut { .. } => EventType::ReservationTimedOut,
+            libp2p_relay::Event::ReservationRemoved { .. } => EventType::ReservationRemoved,
             libp2p_relay::Event::CircuitReqDenied { .. } => EventType::CircuitReqDenied,
             #[allow(deprecated)]
             libp2p_relay::Event::CircuitReqOutboundConnectFailed { .. } => {

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.20.0
+
+- Emit new `libp2p::relay::Event::ReservationRemoved` when the client connection is dropped.
+  See [PR 5874](https://github.com/libp2p/rust-libp2p/pull/5874).
+
 ## 0.19.1
 
 - Remove duplicated forwarding of pending events to connection handler.

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-relay"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Communications relaying for libp2p"
-version = "0.19.1"
+version = "0.20.0"
 authors = ["Parity Technologies <admin@parity.io>", "Max Inden <mail@max-inden.de>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/relay/src/behaviour.rs
+++ b/protocols/relay/src/behaviour.rs
@@ -195,6 +195,8 @@ pub enum Event {
     },
     /// An inbound reservation has timed out.
     ReservationTimedOut { src_peer_id: PeerId },
+    /// A reservation has been removed.
+    ReservationRemoved { src_peer_id: PeerId },
     /// An inbound circuit request has been denied.
     CircuitReqDenied {
         src_peer_id: PeerId,
@@ -280,6 +282,11 @@ impl Behaviour {
             peer.get_mut().remove(&connection_id);
             if peer.get().is_empty() {
                 peer.remove();
+
+                self.queued_actions
+                    .push_back(ToSwarm::GenerateEvent(Event::ReservationRemoved {
+                        src_peer_id: peer_id,
+                    }));
             }
         }
 


### PR DESCRIPTION

## Description

Introduce a new event that is sent when the reservation is removed.
Together with ReservationTimedOut this can be used to track the total
amount of current reservations on a relay server.

## Notes & open questions

I consider this a breaking change because the `libp2p::relay::Event` does not have `#[non_exhaustive]`.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
