### PR TITLE
docs(roadmap): clarify community-driven roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 Below is a high level roadmap for the rust-libp2p project.
 Items are ordered by priority (high to low).
 
-This is a living document. We believe new feature growth should be driven by our user community. Many of the items below are contributions made by downstream users.
+This is a living document. We believe the roadmap should be shaped by the needs of our user community. Many of the items below are contributions made by downstream users.
 Input is always welcome e.g. via GitHub issues or pull requests.
 
 This is the roadmap of the Rust implementation of libp2p.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 Below is a high level roadmap for the rust-libp2p project.
 Items are ordered by priority (high to low).
 
-This is a living document.
+This is a living document. We believe new feature growth should be driven by our user community. Many of the items below are contributions made by downstream users.
 Input is always welcome e.g. via GitHub issues or pull requests.
 
 This is the roadmap of the Rust implementation of libp2p.


### PR DESCRIPTION
Minor change to README.md, to reflect a conversation with @jxs on his perspective of how the rust-libp2p roadmap is shaped. Maintainers, feel free to edit directly.