### PR TITLE
fix(identify): Remove peer from cache on `DialError::WrongPeerId` event

### DIFF
--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 - Implement optional `signedPeerRecord` support for identify messages.
   See [PR 5785](https://github.com/libp2p/rust-libp2p/pull/5785)
-- Fix `Identify::discovered_peers` to remove peers on `DialError::WrongPeerId` events
+- Fix `Identify::discovered_peers` to remove peers on `DialError::{WrongPeerId, LocalPeerId}` events.
+  See [PR 5890](https://github.com/libp2p/rust-libp2p/pull/5890).
 
 ## 0.46.0
 

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Implement optional `signedPeerRecord` support for identify messages.
   See [PR 5785](https://github.com/libp2p/rust-libp2p/pull/5785)
+- Fix `Identify::discovered_peers` to remove peers on `DialError::WrongPeerId` events
 
 ## 0.46.0
 

--- a/protocols/identify/src/behaviour.rs
+++ b/protocols/identify/src/behaviour.rs
@@ -603,13 +603,8 @@ impl NetworkBehaviour for Behaviour {
                                 cache.remove(&peer_id, addr);
                             }
                         }
-                        DialError::WrongPeerId {
-                            endpoint: ConnectedPoint::Dialer { address, .. },
-                            ..
-                        }
-                        | DialError::LocalPeerId {
-                            endpoint: ConnectedPoint::Dialer { address, .. },
-                        } => {
+                        DialError::WrongPeerId { address, .. }
+                        | DialError::LocalPeerId { address } => {
                             cache.remove(&peer_id, address);
                         }
                         _ => (),

--- a/protocols/identify/src/behaviour.rs
+++ b/protocols/identify/src/behaviour.rs
@@ -606,6 +606,9 @@ impl NetworkBehaviour for Behaviour {
                         DialError::WrongPeerId {
                             endpoint: ConnectedPoint::Dialer { address, .. },
                             ..
+                        }
+                        | DialError::LocalPeerId {
+                            endpoint: ConnectedPoint::Dialer { address, .. },
                         } => {
                             cache.remove(&peer_id, address);
                         }

--- a/protocols/identify/src/behaviour.rs
+++ b/protocols/identify/src/behaviour.rs
@@ -149,7 +149,7 @@ pub struct Config {
     /// How many entries of discovered peers to keep before we discard
     /// the least-recently used one.
     ///
-    /// Disabled by default.
+    /// Defaults to 100
     cache_size: usize,
 
     /// Whether to include our listen addresses in our responses. If enabled,
@@ -591,13 +591,26 @@ impl NetworkBehaviour for Behaviour {
                 self.outbound_connections_with_ephemeral_port
                     .remove(&connection_id);
             }
-            FromSwarm::DialFailure(DialFailure { peer_id, error, .. }) => {
-                if let (Some(peer_id), Some(cache), DialError::Transport(errors)) =
-                    (peer_id, self.discovered_peers.0.as_mut(), error)
-                {
-                    for (addr, _error) in errors {
-                        cache.remove(&peer_id, addr);
-                    }
+            FromSwarm::DialFailure(DialFailure {
+                peer_id: Some(peer_id),
+                error,
+                ..
+            }) => {
+                if let Some(cache) = self.discovered_peers.0.as_mut() {
+                    match error {
+                        DialError::Transport(errors) => {
+                            for (addr, _error) in errors {
+                                cache.remove(&peer_id, addr);
+                            }
+                        }
+                        DialError::WrongPeerId {
+                            endpoint: ConnectedPoint::Dialer { address, .. },
+                            ..
+                        } => {
+                            cache.remove(&peer_id, address);
+                        }
+                        _ => (),
+                    };
                 }
             }
             _ => {}


### PR DESCRIPTION
## Description

This PR handles the `DialError::WrongPeerID` event in `identify` protocol.
Scenario:
Consider a network with two nodes, N1 and N2, where N2 periodically initiates a connection/substream to N1. Now, if N1 is shut down and a new node, N3, starts up on the same transport address but with a different keypair, the identify protocol in N2 will continue to associate the old (PeerId, Multiaddr) pair in its cache. However, since N1 no longer exists and N3 has a different identity, this cached entry is now invalid.

This PR ensures that the protocol properly detects and handles such situations, preventing stale peer information from causing connectivity issues.


## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
