### PR TITLE
docs(tutorial): fix libp2p ping tutorial connection timeout

### DIFF
--- a/libp2p/src/tutorials/ping.rs
+++ b/libp2p/src/tutorials/ping.rs
@@ -232,7 +232,9 @@
 //!             yamux::Config::default,
 //!         )?
 //!         .with_behaviour(|_| ping::Behaviour::default())?
-//!         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX))) // Allows us to observe pings indefinitely.
+//!         .with_swarm_config(|cfg| {
+//!             cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX))
+//!         }) // Allows us to observe pings indefinitely.
 //!         .build();
 //!
 //!     Ok(())
@@ -285,7 +287,9 @@
 //!             yamux::Config::default,
 //!         )?
 //!         .with_behaviour(|_| ping::Behaviour::default())?
-//!         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX))) // Allows us to observe pings indefinitely.
+//!         .with_swarm_config(|cfg| {
+//!             cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX))
+//!         }) // Allows us to observe pings indefinitely.
 //!         .build();
 //!
 //!     // Tell the swarm to listen on all interfaces and a random, OS-assigned
@@ -331,7 +335,9 @@
 //!             yamux::Config::default,
 //!         )?
 //!         .with_behaviour(|_| ping::Behaviour::default())?
-//!         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX))) // Allows us to observe pings indefinitely.
+//!         .with_swarm_config(|cfg| {
+//!             cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX))
+//!         }) // Allows us to observe pings indefinitely.
 //!         .build();
 //!
 //!     // Tell the swarm to listen on all interfaces and a random, OS-assigned

--- a/libp2p/src/tutorials/ping.rs
+++ b/libp2p/src/tutorials/ping.rs
@@ -232,6 +232,7 @@
 //!             yamux::Config::default,
 //!         )?
 //!         .with_behaviour(|_| ping::Behaviour::default())?
+//!         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX))) // Allows us to observe pings indefinitely.
 //!         .build();
 //!
 //!     Ok(())
@@ -284,6 +285,7 @@
 //!             yamux::Config::default,
 //!         )?
 //!         .with_behaviour(|_| ping::Behaviour::default())?
+//!         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX))) // Allows us to observe pings indefinitely.
 //!         .build();
 //!
 //!     // Tell the swarm to listen on all interfaces and a random, OS-assigned
@@ -329,6 +331,7 @@
 //!             yamux::Config::default,
 //!         )?
 //!         .with_behaviour(|_| ping::Behaviour::default())?
+//!         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX))) // Allows us to observe pings indefinitely.
 //!         .build();
 //!
 //!     // Tell the swarm to listen on all interfaces and a random, OS-assigned

--- a/libp2p/src/tutorials/ping.rs
+++ b/libp2p/src/tutorials/ping.rs
@@ -205,12 +205,12 @@
 //! ## Idle connection timeout
 //!
 //! Now, for this example in particular, we need set the idle connection timeout.
-//! Otherwise, the connection will be closed immediately.
+//! The default connection timeout is 10 seconds.
 //!
 //! Whether you need to set this in your application too depends on your usecase.
 //! Typically, connections are kept alive if they are "in use" by a certain protocol.
 //! The ping protocol however is only an "auxiliary" kind of protocol.
-//! Thus, without any other behaviour in place, we would not be able to observe the pings.
+//! Thus, without any other behaviour in place, we would not be able to observe any pings after 10s.
 //!
 //! ```rust
 //! use std::{error::Error, time::Duration};


### PR DESCRIPTION
## Description

There is a special `Idle connection timeout` section in the ping tutorial which says that we should include connection timeout settings, but the settings are not included. 

I have checked previous versions and they had it so it was either lost by mistake, or the section is not relevant anymore.
This is a very minor PR to update the docs.

## Notes & open questions

N/A

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
