### PR TITLE
feat(gossipsub): allow whitelisting topics for metrics

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.48.1
 - Allow whitelisting topics for metrics to ensure metrics are recorded correctly for these topics.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX)
+  See [PR 5895](https://github.com/libp2p/rust-libp2p/pull/5895)
 
 - Improve `max_messages_per_rpc` consistency by ensuring RPC control messages also adhere to the existing limits.
   See [PR 5826](https://github.com/libp2p/rust-libp2p/pull/5826)

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 0.48.1
+- Allow whitelisting topics for metrics to ensure metrics are recorded correctly for these topics.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX)
+
 - Improve `max_messages_per_rpc` consistency by ensuring RPC control messages also adhere to the existing limits.
   See [PR 5826](https://github.com/libp2p/rust-libp2p/pull/5826)
 

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -3053,6 +3053,13 @@ where
             }
         }
     }
+
+    /// Register topics to ensure metrics are recorded correctly for these topics.
+    pub fn register_topics_for_metrics(&mut self, topics: Vec<TopicHash>) {
+        if let Some(metrics) = &mut self.metrics {
+            metrics.register_allowed_topics(topics);
+        }
+    }
 }
 
 fn get_ip_addr(addr: &Multiaddr) -> Option<IpAddr> {

--- a/protocols/gossipsub/src/metrics.rs
+++ b/protocols/gossipsub/src/metrics.rs
@@ -648,6 +648,13 @@ impl Metrics {
             metric.set(metric.get() - 1);
         }
     }
+
+    /// Registers a set of topics that we want to store calculate metrics for.
+    pub(crate) fn register_allowed_topics(&mut self, topics: Vec<TopicHash>) {
+        for topic_hash in topics {
+            self.topic_info.insert(topic_hash, true);
+        }
+    }
 }
 
 /// Reasons why a peer was included in the mesh.


### PR DESCRIPTION
## Description
Some topic subscription metrics were are not registered due to the max topics registered metrics config option.

This PR allows whitelisting topics we want store metrics for.
This is is helpful in the Ethereum network to make sure we cover all the attestation subnets