### PR TITLE
chore(gossipsub): add DEFAULT_MAX_TRANSMIT_SIZE const

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Improve `max_messages_per_rpc` consistency by ensuring RPC control messages also adhere to the existing limits.
   See [PR 5826](https://github.com/libp2p/rust-libp2p/pull/5826)
 
+- Create `DEFAULT_MAX_TRANSMIT_SIZE` and use it in the code and docs. The main motivation is to fix the incorrect value mentioned in the docs and prevent it from happening again. See [PR 5906](https://github.com/libp2p/rust-libp2p/pull/5906)
+
 ## 0.48.0
 
 - Allow broadcasting `IDONTWANT` messages when publishing to avoid downloading data that is already available.

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -177,7 +177,7 @@ impl Config {
         self.check_explicit_peers_ticks
     }
 
-    /// The maximum byte size for each gossipsub RPC (default is 65536 bytes).
+    /// The maximum byte size for each gossipsub RPC (default is [`crate::protocol::DEFAULT_MAX_TRANSMIT_SIZE`] bytes).
     ///
     /// This represents the maximum size of the published message. It is additionally wrapped
     /// in a protobuf struct, so the actual wire size may be a bit larger. It must be at least
@@ -619,7 +619,7 @@ impl ConfigBuilder {
         self
     }
 
-    /// The maximum byte size for each gossip (default is 2048 bytes).
+    /// The maximum byte size for each gossip (default is [`crate::protocol::DEFAULT_MAX_TRANSMIT_SIZE`] bytes).
     pub fn max_transmit_size(&mut self, max_transmit_size: usize) -> &mut Self {
         self.config.protocol.max_transmit_size = max_transmit_size;
         self

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -177,7 +177,8 @@ impl Config {
         self.check_explicit_peers_ticks
     }
 
-    /// The maximum byte size for each gossipsub RPC (default is [`crate::protocol::DEFAULT_MAX_TRANSMIT_SIZE`] bytes).
+    /// The maximum byte size for each gossipsub RPC (default is
+    /// [`crate::protocol::DEFAULT_MAX_TRANSMIT_SIZE`] bytes).
     ///
     /// This represents the maximum size of the published message. It is additionally wrapped
     /// in a protobuf struct, so the actual wire size may be a bit larger. It must be at least
@@ -619,7 +620,8 @@ impl ConfigBuilder {
         self
     }
 
-    /// The maximum byte size for each gossip (default is [`crate::protocol::DEFAULT_MAX_TRANSMIT_SIZE`] bytes).
+    /// The maximum byte size for each gossip (default is
+    /// [`crate::protocol::DEFAULT_MAX_TRANSMIT_SIZE`] bytes).
     pub fn max_transmit_size(&mut self, max_transmit_size: usize) -> &mut Self {
         self.config.protocol.max_transmit_size = max_transmit_size;
         self

--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -136,3 +136,5 @@ pub type Rpc = self::types::Rpc;
 
 pub type IdentTopic = Topic<self::topic::IdentityHash>;
 pub type Sha256Topic = Topic<self::topic::Sha256Hash>;
+
+pub use crate::protocol::DEFAULT_MAX_TRANSMIT_SIZE;

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -61,7 +61,7 @@ pub(crate) const FLOODSUB_PROTOCOL: ProtocolId = ProtocolId {
     kind: PeerKind::Floodsub,
 };
 
-pub(crate) const DEFAULT_MAX_TRANSMIT_SIZE: usize = 65536;
+pub const DEFAULT_MAX_TRANSMIT_SIZE: usize = 65536;
 
 /// Implementation of [`InboundUpgrade`] and [`OutboundUpgrade`] for the Gossipsub protocol.
 #[derive(Debug, Clone)]

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -61,6 +61,8 @@ pub(crate) const FLOODSUB_PROTOCOL: ProtocolId = ProtocolId {
     kind: PeerKind::Floodsub,
 };
 
+pub(crate) const DEFAULT_MAX_TRANSMIT_SIZE: usize = 65536;
+
 /// Implementation of [`InboundUpgrade`] and [`OutboundUpgrade`] for the Gossipsub protocol.
 #[derive(Debug, Clone)]
 pub struct ProtocolConfig {
@@ -75,7 +77,7 @@ pub struct ProtocolConfig {
 impl Default for ProtocolConfig {
     fn default() -> Self {
         Self {
-            max_transmit_size: 65536,
+            max_transmit_size: DEFAULT_MAX_TRANSMIT_SIZE,
             validation_mode: ValidationMode::Strict,
             protocol_ids: vec![
                 GOSSIPSUB_1_2_0_PROTOCOL,


### PR DESCRIPTION
## Description

Create `DEFAULT_MAX_TRANSMIT_SIZE` and use it in the code and docs. The main motivation is to fix the incorrect value mentioned in the docs and prevent it from happening again.

## Notes & open questions

No

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
