### PR TITLE
chore: rename `InsufficientPeers` to `NoPeersSubscribedToTopic` in gossipsub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2866,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "async-channel 2.3.1",
  "asynchronous-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ libp2p-core = { version = "0.43.0", path = "core" }
 libp2p-dcutr = { version = "0.13.0", path = "protocols/dcutr" }
 libp2p-dns = { version = "0.43.0", path = "transports/dns" }
 libp2p-floodsub = { version = "0.46.1", path = "protocols/floodsub" }
-libp2p-gossipsub = { version = "0.48.1", path = "protocols/gossipsub" }
+libp2p-gossipsub = { version = "0.48.2", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.47.0", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.10" }
 libp2p-kad = { version = "0.47.0", path = "protocols/kad" }

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.48.2
+- Make `PublishError.InsufficientPeers` more self-explanatory by renaming it to `PublishError.NoPeersSubscribedToTopic`.
+  See [PR]()
+
 ## 0.48.1
 - Allow whitelisting topics for metrics to ensure metrics are recorded correctly for these topics.
   See [PR 5895](https://github.com/libp2p/rust-libp2p/pull/5895)

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-gossipsub"
 edition = "2021"
 rust-version = { workspace = true }
 description = "Gossipsub protocol for libp2p"
-version = "0.48.1"
+version = "0.48.2"
 authors = ["Age Manning <Age@AgeManning.com>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -632,7 +632,7 @@ where
             .peekable();
 
         if peers_on_topic.peek().is_none() {
-            return Err(PublishError::InsufficientPeers);
+            return Err(PublishError::NoPeersSubscribedToTopic);
         }
 
         let mut recipient_peers = HashSet::new();
@@ -755,7 +755,7 @@ where
         }
 
         if recipient_peers.is_empty() {
-            return Err(PublishError::InsufficientPeers);
+            return Err(PublishError::NoPeersSubscribedToTopic);
         }
 
         if publish_failed {

--- a/protocols/gossipsub/src/error.rs
+++ b/protocols/gossipsub/src/error.rs
@@ -29,8 +29,8 @@ pub enum PublishError {
     Duplicate,
     /// An error occurred whilst signing the message.
     SigningError(SigningError),
-    /// There were no peers to send this message to.
-    InsufficientPeers,
+    /// There were no peers listening on that topic to send this message to.
+    NoPeersSubscribedToTopic,
     /// The overall message was too large. This could be due to excessive topics or an excessive
     /// message size.
     MessageTooLarge,


### PR DESCRIPTION
## Description

Closes #5907 

ref https://github.com/ChainSafe/js-libp2p-gossipsub/pull/487

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates