### PR TITLE
chore: fix RUSTSEC-2025-0009 in libp2p-tls and libp2p-websocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.6"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "shlex",
 ]
@@ -2936,7 +2936,7 @@ dependencies = [
  "quick-protobuf",
  "quickcheck-ext",
  "rand 0.8.5",
- "ring 0.17.8",
+ "ring 0.17.13",
  "rmp-serde",
  "sec1",
  "serde",
@@ -3208,7 +3208,7 @@ dependencies = [
  "quickcheck",
  "quinn",
  "rand 0.8.5",
- "ring 0.17.8",
+ "ring 0.17.13",
  "rustls 0.23.20",
  "socket2",
  "thiserror 2.0.9",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tls"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -3412,8 +3412,8 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "libp2p-yamux",
- "rcgen",
- "ring 0.17.8",
+ "rcgen 0.13.2",
+ "ring 0.17.13",
  "rustls 0.23.20",
  "rustls-webpki 0.101.7",
  "thiserror 2.0.9",
@@ -3463,7 +3463,7 @@ dependencies = [
  "multihash",
  "quickcheck",
  "rand 0.8.5",
- "rcgen",
+ "rcgen 0.11.3",
  "stun 0.7.0",
  "thiserror 2.0.9",
  "tokio",
@@ -3529,7 +3529,7 @@ dependencies = [
  "libp2p-tcp",
  "parking_lot",
  "pin-project-lite",
- "rcgen",
+ "rcgen 0.13.2",
  "rw-stream-sink",
  "soketto",
  "thiserror 2.0.9",
@@ -4716,7 +4716,7 @@ dependencies = [
  "bytes",
  "getrandom 0.2.15",
  "rand 0.8.5",
- "ring 0.17.8",
+ "ring 0.17.13",
  "rustc-hash",
  "rustls 0.23.20",
  "rustls-pki-types",
@@ -4891,6 +4891,19 @@ dependencies = [
  "ring 0.16.20",
  "time",
  "x509-parser 0.15.1",
+ "yasna",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring 0.17.13",
+ "rustls-pki-types",
+ "time",
  "yasna",
 ]
 
@@ -5077,7 +5090,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin 0.5.2",
+ "spin",
  "untrusted 0.7.1",
  "web-sys",
  "winapi",
@@ -5085,15 +5098,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
@@ -5271,7 +5283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring 0.17.13",
  "rustls-webpki 0.101.7",
  "sct",
 ]
@@ -5283,7 +5295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "once_cell",
- "ring 0.17.8",
+ "ring 0.17.13",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
@@ -5314,7 +5326,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.13",
  "untrusted 0.9.0",
 ]
 
@@ -5324,7 +5336,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.13",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
@@ -5396,7 +5408,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
+ "ring 0.17.13",
  "untrusted 0.9.0",
 ]
 
@@ -5685,7 +5697,7 @@ dependencies = [
  "chacha20poly1305",
  "curve25519-dalek",
  "rand_core 0.6.4",
- "ring 0.17.8",
+ "ring 0.17.13",
  "rustc_version",
  "sha2 0.10.8",
  "subtle",
@@ -5721,12 +5733,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -5812,7 +5818,7 @@ dependencies = [
  "lazy_static",
  "md-5",
  "rand 0.8.5",
- "ring 0.17.8",
+ "ring 0.17.13",
  "subtle",
  "thiserror 1.0.69",
  "tokio",
@@ -5831,7 +5837,7 @@ dependencies = [
  "lazy_static",
  "md-5",
  "rand 0.8.5",
- "ring 0.17.8",
+ "ring 0.17.13",
  "subtle",
  "thiserror 1.0.69",
  "tokio",
@@ -6511,7 +6517,7 @@ dependencies = [
  "log",
  "md-5",
  "rand 0.8.5",
- "ring 0.17.8",
+ "ring 0.17.13",
  "stun 0.5.1",
  "thiserror 1.0.69",
  "tokio",
@@ -6878,7 +6884,7 @@ dependencies = [
  "log",
  "pem",
  "rand 0.8.5",
- "rcgen",
+ "rcgen 0.11.3",
  "regex",
  "ring 0.16.20",
  "rtcp",
@@ -6942,7 +6948,7 @@ dependencies = [
  "pem",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "rcgen",
+ "rcgen 0.11.3",
  "ring 0.16.20",
  "rustls 0.21.12",
  "sec1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,8 +133,8 @@ multistream-select = { version = "0.13.0", path = "misc/multistream-select" }
 prometheus-client = "0.22.2"
 quick-protobuf-codec = { version = "0.3.1", path = "misc/quick-protobuf-codec" }
 quickcheck = { package = "quickcheck-ext", path = "misc/quickcheck-ext" }
-rcgen = "0.11.3"
-ring = "0.17.8"
+rcgen = "0.13"
+ring = "0.17.12"
 rw-stream-sink = { version = "0.4.0", path = "misc/rw-stream-sink" }
 thiserror = "2"
 tokio = { version = "1.38", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ libp2p-swarm = { version = "0.47.0", path = "swarm" }
 libp2p-swarm-derive = { version = "=0.35.1", path = "swarm-derive" } # `libp2p-swarm-derive` may not be compatible with different `libp2p-swarm` non-breaking releases. E.g. `libp2p-swarm` might introduce a new enum variant `FromSwarm` (which is `#[non-exhaustive]`) in a non-breaking release. Older versions of `libp2p-swarm-derive` would not forward this enum variant within the `NetworkBehaviour` hierarchy. Thus the version pinning is required.
 libp2p-swarm-test = { version = "0.5.0", path = "swarm-test" }
 libp2p-tcp = { version = "0.43.0", path = "transports/tcp" }
-libp2p-tls = { version = "0.6.0", path = "transports/tls" }
+libp2p-tls = { version = "0.6.1", path = "transports/tls" }
 libp2p-uds = { version = "0.42.0", path = "transports/uds" }
 libp2p-upnp = { version = "0.4.0", path = "protocols/upnp" }
 libp2p-webrtc = { version = "0.9.0-alpha", path = "transports/webrtc" }

--- a/transports/tls/CHANGELOG.md
+++ b/transports/tls/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.1
+
+- Upgrade `rcgen` to `v0.13`
+  See [PR 5917](https://github.com/libp2p/rust-libp2p/pull/5917).
+
 ## 0.6.0
 
 <!-- Update to libp2p-core v0.43.0 -->

--- a/transports/tls/Cargo.toml
+++ b/transports/tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-tls"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = { workspace = true }
 description = "TLS configuration based on libp2p TLS specs."

--- a/transports/webrtc/Cargo.toml
+++ b/transports/webrtc/Cargo.toml
@@ -22,7 +22,7 @@ libp2p-identity = { workspace = true }
 libp2p-webrtc-utils = { workspace = true }
 multihash = { workspace = true }
 rand = "0.8"
-rcgen = { workspace = true }
+rcgen = "0.11"
 stun = "0.7"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["net"], optional = true }

--- a/transports/websocket/CHANGELOG.md
+++ b/transports/websocket/CHANGELOG.md
@@ -2,6 +2,9 @@
 - Rename types to match naming convention in [discussion 2174](https://github.com/libp2p/rust-libp2p/discussions/2174).
   See [PR 5873](https://github.com/libp2p/rust-libp2p/pull/5873).
 
+- Upgrade `rcgen` to `v0.13`
+  See [PR 5917](https://github.com/libp2p/rust-libp2p/pull/5917).
+
 ## 0.45.0
 
 - fix: Return `Error::InvalidMultiaddr` when dialed to a `/dnsaddr` address

--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -81,7 +81,10 @@ use rw_stream_sink::RwStreamSink;
 ///         .unwrap(),
 /// );
 ///
-/// let rcgen::CertifiedKey { cert: rcgen_cert, key_pair } = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+/// let rcgen::CertifiedKey {
+///     cert: rcgen_cert,
+///     key_pair,
+/// } = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
 /// let priv_key = websocket::tls::PrivateKey::new(key_pair.serialize_der());
 /// let cert = websocket::tls::Certificate::new(rcgen_cert.der().to_vec());
 /// transport.set_tls_config(websocket::tls::Config::new(priv_key, vec![cert]).unwrap());

--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -70,7 +70,6 @@ use rw_stream_sink::RwStreamSink;
 /// # use libp2p_dns as dns;
 /// # use libp2p_tcp as tcp;
 /// # use libp2p_websocket as websocket;
-/// # use rcgen::generate_simple_self_signed;
 /// # use std::pin::Pin;
 /// #
 /// # #[async_std::main]
@@ -82,9 +81,9 @@ use rw_stream_sink::RwStreamSink;
 ///         .unwrap(),
 /// );
 ///
-/// let rcgen_cert = generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
-/// let priv_key = websocket::tls::PrivateKey::new(rcgen_cert.serialize_private_key_der());
-/// let cert = websocket::tls::Certificate::new(rcgen_cert.serialize_der().unwrap());
+/// let rcgen::CertifiedKey { cert: rcgen_cert, key_pair } = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+/// let priv_key = websocket::tls::PrivateKey::new(key_pair.serialize_der());
+/// let cert = websocket::tls::Certificate::new(rcgen_cert.der().to_vec());
 /// transport.set_tls_config(websocket::tls::Config::new(priv_key, vec![cert]).unwrap());
 ///
 /// let id = transport


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

This PR tries to fix [RUSTSEC-2025-0009](https://rustsec.org/advisories/RUSTSEC-2025-0009.html) in `libp2p-tls` and `libp2p-websocket` by bumping `rcgen`.

Note: Upgrading `rcgen` in `libp2p-webrtc` is non-trival, so it's not included in this PR.

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
