### PR TITLE
docs(request-response): document default message size limits

### DIFF
--- a/protocols/request-response/src/cbor.rs
+++ b/protocols/request-response/src/cbor.rs
@@ -27,9 +27,8 @@
 /// - Maximum request size: 1,048,576 bytes (1 MiB)
 /// - Maximum response size: 10,485,760 bytes (10 MiB)
 ///
-/// These limits can be customized using the `codec::Codec` methods:
-/// - `set_request_size_maximum`
-/// - `set_response_size_maximum`
+/// These limits can be customized with [`codec::Codec::set_request_size_maximum`]
+/// and [`codec::Codec::set_response_size_maximum`].
 ///
 /// # Example
 ///

--- a/protocols/request-response/src/cbor.rs
+++ b/protocols/request-response/src/cbor.rs
@@ -21,6 +21,16 @@
 /// A request-response behaviour using [`cbor4ii::serde`] for serializing and
 /// deserializing the messages.
 ///
+/// # Default Size Limits
+///
+/// The codec uses the following default size limits:
+/// - Maximum request size: 1,048,576 bytes (1 MiB)
+/// - Maximum response size: 10,485,760 bytes (10 MiB)
+///
+/// These limits can be customized using the `codec::Codec` methods:
+/// - `set_request_size_maximum`
+/// - `set_response_size_maximum`
+///
 /// # Example
 ///
 /// ```

--- a/protocols/request-response/src/json.rs
+++ b/protocols/request-response/src/json.rs
@@ -27,9 +27,8 @@
 /// - Maximum request size: 1,048,576 bytes (1 MiB)
 /// - Maximum response size: 10,485,760 bytes (10 MiB)
 ///
-/// These limits can be customized using the `codec::Codec` methods:
-/// - `set_request_size_maximum`
-/// - `set_response_size_maximum`
+/// These limits can be customized with [`codec::Codec::set_request_size_maximum`]
+/// and [`codec::Codec::set_response_size_maximum`].
 ///
 /// # Example
 ///

--- a/protocols/request-response/src/json.rs
+++ b/protocols/request-response/src/json.rs
@@ -21,6 +21,16 @@
 /// A request-response behaviour using [`serde_json`] for serializing and deserializing the
 /// messages.
 ///
+/// # Default Size Limits
+///
+/// The codec uses the following default size limits:
+/// - Maximum request size: 1,048,576 bytes (1 MiB)
+/// - Maximum response size: 10,485,760 bytes (10 MiB)
+///
+/// These limits can be customized using the `codec::Codec` methods:
+/// - `set_request_size_maximum`
+/// - `set_response_size_maximum`
+///
 /// # Example
 ///
 /// ```


### PR DESCRIPTION
## Description


Fixes https://github.com/libp2p/rust-libp2p/issues/5383

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->


## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
