### PR TITLE
First draft of batch scheduling

### DIFF
--- a/protocols/gossipsub/src/error.rs
+++ b/protocols/gossipsub/src/error.rs
@@ -20,6 +20,7 @@
 
 //! Error types that can result from gossipsub.
 
+use crate::types::MessageId;
 use libp2p_identity::SigningError;
 
 /// Error associated with publishing a gossipsub message.
@@ -38,7 +39,12 @@ pub enum PublishError {
     TransformFailed(std::io::Error),
     /// Messages could not be sent because the queues for all peers were full. The usize represents
     /// the number of peers that were attempted.
-    AllQueuesFull(usize),
+    AllQueuesFull {
+        /// The messages that failed
+        failed_messages: Vec<MessageId>,
+        // The number of peers that we attempted to send to.
+        peers_to_publish_to: usize,
+    },
 }
 
 impl std::fmt::Display for PublishError {


### PR DESCRIPTION
## Description

This implements the concept of batch scheduling. The idea is derived here: https://ethresear.ch/t/improving-das-performance-with-gossipsub-batch-publishing/21713/6

The idea is to group multiple messages and re-arrange their order to better distribute the first message to peers.

However after I have written this, I think there is a smarter way to implement this in a more general sense that works across topics.

This has not been tested and should not be merged.