### PR TITLE
fix: deprecated #[clap] attributes with #[arg] and #[command]

### DIFF
--- a/examples/autonat/src/bin/autonat_client.rs
+++ b/examples/autonat/src/bin/autonat_client.rs
@@ -34,15 +34,15 @@ use libp2p::{
 use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]
-#[clap(name = "libp2p autonat")]
+#[command(name = "libp2p autonat")]
 struct Opt {
-    #[clap(long)]
+    #[arg(long)]
     listen_port: Option<u16>,
 
-    #[clap(long)]
+    #[arg(long)]
     server_address: Multiaddr,
 
-    #[clap(long)]
+    #[arg(long)]
     server_peer_id: PeerId,
 }
 

--- a/examples/autonat/src/bin/autonat_server.rs
+++ b/examples/autonat/src/bin/autonat_server.rs
@@ -34,9 +34,9 @@ use libp2p::{
 use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]
-#[clap(name = "libp2p autonat")]
+#[command(name = "libp2p autonat")]
 struct Opt {
-    #[clap(long)]
+    #[arg(long)]
     listen_port: Option<u16>,
 }
 

--- a/examples/autonatv2/src/bin/autonatv2_client.rs
+++ b/examples/autonatv2/src/bin/autonatv2_client.rs
@@ -14,18 +14,18 @@ use rand::rngs::OsRng;
 use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]
-#[clap(name = "libp2p autonatv2 client")]
+#[command(name = "libp2p autonatv2 client")]
 struct Opt {
     /// Port where the client will listen for incoming connections.
-    #[clap(short = 'p', long, default_value_t = 0)]
+    #[arg(short = 'p', long, default_value_t = 0)]
     listen_port: u16,
 
     /// Address of the server where want to connect to.
-    #[clap(short = 'a', long)]
+    #[arg(short = 'a', long)]
     server_address: Multiaddr,
 
     /// Probe interval in seconds.
-    #[clap(short = 't', long, default_value = "2")]
+    #[arg(short = 't', long, default_value = "2")]
     probe_interval: u64,
 }
 


### PR DESCRIPTION
## Description

This PR updates deprecated #[clap(...)] attributes to their modern equivalents in clap 4.x.
The current codebase still uses outdated syntax that has been deprecated since version 4.0.


<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
