### PR TITLE
feat(request-response): add `Behaviour::send_request_with_addresses()`

### DIFF
--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -3,6 +3,9 @@
 - fix: public cbor/json codec module
   See [PR 5830](https://github.com/libp2p/rust-libp2p/pull/5830).
 
+- feat: add `Behaviour::send_request_with_addresses()`
+  See [PR 5938](https://github.com/libp2p/rust-libp2p/issues/5938).
+
 ## 0.28.0
 
 - Deprecate `void` crate.

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -431,15 +431,15 @@ where
     /// > in another `NetworkBehaviour` that provides peer and
     /// > address discovery, or known addresses of peers must be
     /// > managed via [`libp2p_swarm::Swarm::add_peer_address`].
-    /// > Addresses are automatically removed when dial attempts 
+    /// > Addresses are automatically removed when dial attempts
     /// > to them fail.
     /// > Alternatively, [`Behaviour::send_request_with_addresses`]
-    /// > can be used. 
+    /// > can be used.
     pub fn send_request(&mut self, peer: &PeerId, request: TCodec::Request) -> OutboundRequestId {
         self.send_request_with_addresses(peer, request, Vec::new())
     }
 
-    /// Like [`Behaviour::send_request`], but additionally using the provided addresses 
+    /// Like [`Behaviour::send_request`], but additionally using the provided addresses
     /// if a connection needs to be established.
     pub fn send_request_with_addresses(
         &mut self,

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -431,18 +431,16 @@ where
     /// > in another `NetworkBehaviour` that provides peer and
     /// > address discovery, or known addresses of peers must be
     /// > managed via [`libp2p_swarm::Swarm::add_peer_address`].
+    /// > Addresses are automatically removed when dial attempts 
+    /// > to them fail.
     /// > Alternatively, [`Behaviour::send_request_with_addresses`]
-    /// > can be used. Addresses are automatically removed when
-    /// > dial attempts to them fail.
+    /// > can be used. 
     pub fn send_request(&mut self, peer: &PeerId, request: TCodec::Request) -> OutboundRequestId {
         self.send_request_with_addresses(peer, request, Vec::new())
     }
 
-    /// Initiates sending a request, using provided addresses if a connection needs to be
-    /// established.
-    ///
-    /// This is very similar to [`Behaviour::send_request`], but uses provided addresses when
-    /// dialing currently not connected peer.
+    /// Like [`Behaviour::send_request`], but additionally using the provided addresses 
+    /// if a connection needs to be established.
     pub fn send_request_with_addresses(
         &mut self,
         peer: &PeerId,

--- a/protocols/request-response/src/lib.rs
+++ b/protocols/request-response/src/lib.rs
@@ -431,9 +431,24 @@ where
     /// > in another `NetworkBehaviour` that provides peer and
     /// > address discovery, or known addresses of peers must be
     /// > managed via [`libp2p_swarm::Swarm::add_peer_address`].
-    /// > Addresses are automatically removed when dial attempts
-    /// > to them fail.
+    /// > Alternatively, [`Behaviour::send_request_with_addresses`]
+    /// > can be used. Addresses are automatically removed when
+    /// > dial attempts to them fail.
     pub fn send_request(&mut self, peer: &PeerId, request: TCodec::Request) -> OutboundRequestId {
+        self.send_request_with_addresses(peer, request, Vec::new())
+    }
+
+    /// Initiates sending a request, using provided addresses if a connection needs to be
+    /// established.
+    ///
+    /// This is very similar to [`Behaviour::send_request`], but uses provided addresses when
+    /// dialing currently not connected peer.
+    pub fn send_request_with_addresses(
+        &mut self,
+        peer: &PeerId,
+        request: TCodec::Request,
+        addresses: Vec<Multiaddr>,
+    ) -> OutboundRequestId {
         let request_id = self.next_outbound_request_id();
         let request = OutboundMessage {
             request_id,
@@ -443,7 +458,10 @@ where
 
         if let Some(request) = self.try_send_request(peer, request) {
             self.pending_events.push_back(ToSwarm::Dial {
-                opts: DialOpts::peer_id(*peer).build(),
+                opts: DialOpts::peer_id(*peer)
+                    .addresses(addresses)
+                    .extend_addresses_through_behaviour()
+                    .build(),
             });
             self.pending_outbound_requests
                 .entry(*peer)


### PR DESCRIPTION
## Description

This is agreed alternative to https://github.com/libp2p/rust-libp2p/pull/5692, which resolves https://github.com/libp2p/rust-libp2p/issues/5634

## Notes & open questions

https://github.com/libp2p/rust-libp2p/pull/5692 was open for a long time, and it was requested that I add an additional method that simply takes addresses as an extra parameter, so this is exactly what I did here.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
