### PR TITLE
refactor(core): cleanup apply.rs, fix poll signature, and improve trace target

### DIFF
--- a/core/src/connection.rs
+++ b/core/src/connection.rs
@@ -89,7 +89,7 @@ pub enum ConnectedPoint {
         /// where there is no listener available to reuse a port from.
         port_use: PortUse,
     },
-    /// We received the node.
+    /// We accepted an incoming connection from the remote node.
     Listener {
         /// Local connection address.
         local_addr: Multiaddr,
@@ -131,10 +131,10 @@ impl ConnectedPoint {
 
     /// Returns true if the connection is relayed.
     pub fn is_relayed(&self) -> bool {
-        match self {
+        (match self {
             ConnectedPoint::Dialer { address, .. } => address,
             ConnectedPoint::Listener { local_addr, .. } => local_addr,
-        }
+        })
         .iter()
         .any(|p| p == Protocol::P2pCircuit)
     }

--- a/core/src/either.rs
+++ b/core/src/either.rs
@@ -109,10 +109,10 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.project() {
-            EitherFutureProj::First(a) => TryFuture::try_poll(a, cx)
+            EitherFutureProj::First(a) => a.try_poll(cx)
                 .map_ok(future::Either::Left)
                 .map_err(Either::Left),
-            EitherFutureProj::Second(a) => TryFuture::try_poll(a, cx)
+            EitherFutureProj::Second(a) => a.try_poll(cx)
                 .map_ok(future::Either::Right)
                 .map_err(Either::Right),
         }

--- a/core/src/upgrade/apply.rs
+++ b/core/src/upgrade/apply.rs
@@ -34,7 +34,6 @@ use crate::{
     Negotiated,
 };
 
-// TODO: Still needed?
 /// Applies an upgrade to the inbound and outbound direction of a connection or substream.
 pub(crate) fn apply<C, U>(
     conn: C,
@@ -122,7 +121,7 @@ where
 {
     type Output = Result<U::Output, UpgradeError<U::Error>>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<<Self as Future>::Output> {
         loop {
             match mem::replace(&mut self.inner, InboundUpgradeApplyState::Undefined) {
                 InboundUpgradeApplyState::Init {
@@ -230,7 +229,7 @@ where
                             return Poll::Pending;
                         }
                         Poll::Ready(Ok(x)) => {
-                            tracing::trace!(upgrade=%name, "Upgraded outbound stream");
+                            tracing::trace!(target: "libp2p::upgrade", upgrade=%name, "Upgraded outbound stream");
                             return Poll::Ready(Ok(x));
                         }
                         Poll::Ready(Err(e)) => {


### PR DESCRIPTION
-  Removed the stale `// TODO: Still needed?` comment from `apply.rs`.
-  Corrected the `poll()` function signature to explicitly define `Future::Output` for clarity.
-  Updated the `tracing::trace!` macro in `apply.rs` to include a specific target: `libp2p::upgrade`.
-  Minor wording improvement: clarified the `ConnectedPoint::Listener` variant comment in `connection.rs`.
-  Simplified `EitherFuture` poll implementation in `either.rs` by using `.try_poll()` directly.

These changes improve readability, maintainability, and tracing output consistency.

No logic changes. This is a safe refactor focused on polish and clarity.

---

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (comments improved)
- [x] I have verified that existing tests pass (no logic changed)
- [x] No changelog entry needed (internal cleanup)
