### PR TITLE
feat: deprecate async_std support in DNS crate 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.45.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,6 @@ dependencies = [
  "async-global-executor",
  "async-io",
  "async-lock",
- "async-process",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
@@ -419,21 +418,6 @@ dependencies = [
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-std-resolver"
-version = "0.25.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abef525d07400182ad6d48b3097d8e88a40aed1f3a6e80f221b2b002cfad608"
-dependencies = [
- "async-std",
- "async-trait",
- "futures-io",
- "futures-util",
- "hickory-resolver",
- "pin-utils",
- "socket2",
 ]
 
 [[package]]
@@ -2811,10 +2795,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
- "async-std",
- "async-std-resolver",
  "async-trait",
  "futures",
  "hickory-resolver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ libp2p-autonat = { version = "0.14.1", path = "protocols/autonat" }
 libp2p-connection-limits = { version = "0.5.1", path = "misc/connection-limits" }
 libp2p-core = { version = "0.43.1", path = "core" }
 libp2p-dcutr = { version = "0.13.0", path = "protocols/dcutr" }
-libp2p-dns = { version = "0.45.0", path = "transports/dns" }
+libp2p-dns = { version = "0.44.0", path = "transports/dns" }
 libp2p-floodsub = { version = "0.46.1", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.49.0", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.47.0", path = "protocols/identify" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ libp2p-autonat = { version = "0.14.1", path = "protocols/autonat" }
 libp2p-connection-limits = { version = "0.5.1", path = "misc/connection-limits" }
 libp2p-core = { version = "0.43.1", path = "core" }
 libp2p-dcutr = { version = "0.13.0", path = "protocols/dcutr" }
-libp2p-dns = { version = "0.44.0", path = "transports/dns" }
+libp2p-dns = { version = "0.45.0", path = "transports/dns" }
 libp2p-floodsub = { version = "0.46.1", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.49.0", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.47.0", path = "protocols/identify" }

--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 - Remove QUIC from the `async-std` swarm builder, as `async-std` support was removed from `libp2p-quic` transport.
   See [PR 5954](https://github.com/libp2p/rust-libp2p/pull/5954)
+
+- Remove DNS from the `async-std` swarm builder, as `async-std` support was removed from `libp2p-dns` transport.
+  See [PR 5959](https://github.com/libp2p/rust-libp2p/pull/5959)
   
 ## 0.55.0
 

--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -53,7 +53,7 @@ full = [
     "upnp",
 ]
 
-async-std = ["libp2p-swarm/async-std", "libp2p-tcp?/async-io", "libp2p-dns?/async-std"]
+async-std = ["libp2p-swarm/async-std", "libp2p-tcp?/async-io"]
 autonat = ["dep:libp2p-autonat"]
 cbor = ["libp2p-request-response?/cbor"]
 dcutr = ["dep:libp2p-dcutr", "libp2p-metrics?/dcutr"]

--- a/libp2p/src/builder/phase/dns.rs
+++ b/libp2p/src/builder/phase/dns.rs
@@ -7,27 +7,6 @@ pub struct DnsPhase<T> {
     pub(crate) transport: T,
 }
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "async-std", feature = "dns"))]
-impl<T: AuthenticatedMultiplexedTransport> SwarmBuilder<super::provider::AsyncStd, DnsPhase<T>> {
-    pub fn with_dns(
-        self,
-    ) -> Result<
-        SwarmBuilder<
-            super::provider::AsyncStd,
-            WebsocketPhase<impl AuthenticatedMultiplexedTransport>,
-        >,
-        std::io::Error,
-    > {
-        Ok(SwarmBuilder {
-            keypair: self.keypair,
-            phantom: PhantomData,
-            phase: WebsocketPhase {
-                transport: libp2p_dns::async_std::Transport::system2(self.phase.transport)?,
-            },
-        })
-    }
-}
-
 #[cfg(all(not(target_arch = "wasm32"), feature = "tokio", feature = "dns"))]
 impl<T: AuthenticatedMultiplexedTransport> SwarmBuilder<super::provider::Tokio, DnsPhase<T>> {
     pub fn with_dns(
@@ -46,30 +25,6 @@ impl<T: AuthenticatedMultiplexedTransport> SwarmBuilder<super::provider::Tokio, 
                 transport: libp2p_dns::tokio::Transport::system(self.phase.transport)?,
             },
         })
-    }
-}
-
-#[cfg(all(not(target_arch = "wasm32"), feature = "async-std", feature = "dns"))]
-impl<T: AuthenticatedMultiplexedTransport> SwarmBuilder<super::provider::AsyncStd, DnsPhase<T>> {
-    pub fn with_dns_config(
-        self,
-        cfg: libp2p_dns::ResolverConfig,
-        opts: libp2p_dns::ResolverOpts,
-    ) -> SwarmBuilder<
-        super::provider::AsyncStd,
-        WebsocketPhase<impl AuthenticatedMultiplexedTransport>,
-    > {
-        SwarmBuilder {
-            keypair: self.keypair,
-            phantom: PhantomData,
-            phase: WebsocketPhase {
-                transport: libp2p_dns::async_std::Transport::custom2(
-                    self.phase.transport,
-                    cfg,
-                    opts,
-                ),
-            },
-        }
     }
 }
 

--- a/libp2p/src/builder/phase/other_transport.rs
+++ b/libp2p/src/builder/phase/other_transport.rs
@@ -66,22 +66,6 @@ impl<Provider, T: AuthenticatedMultiplexedTransport>
 }
 
 // Shortcuts
-#[cfg(all(not(target_arch = "wasm32"), feature = "async-std", feature = "dns"))]
-impl<T: AuthenticatedMultiplexedTransport>
-    SwarmBuilder<super::provider::AsyncStd, OtherTransportPhase<T>>
-{
-    pub fn with_dns(
-        self,
-    ) -> Result<
-        SwarmBuilder<
-            super::provider::AsyncStd,
-            WebsocketPhase<impl AuthenticatedMultiplexedTransport>,
-        >,
-        std::io::Error,
-    > {
-        self.without_any_other_transports().with_dns()
-    }
-}
 #[cfg(all(not(target_arch = "wasm32"), feature = "tokio", feature = "dns"))]
 impl<T: AuthenticatedMultiplexedTransport>
     SwarmBuilder<super::provider::Tokio, OtherTransportPhase<T>>
@@ -96,22 +80,6 @@ impl<T: AuthenticatedMultiplexedTransport>
         std::io::Error,
     > {
         self.without_any_other_transports().with_dns()
-    }
-}
-#[cfg(all(not(target_arch = "wasm32"), feature = "async-std", feature = "dns"))]
-impl<T: AuthenticatedMultiplexedTransport>
-    SwarmBuilder<super::provider::AsyncStd, OtherTransportPhase<T>>
-{
-    pub fn with_dns_config(
-        self,
-        cfg: libp2p_dns::ResolverConfig,
-        opts: libp2p_dns::ResolverOpts,
-    ) -> SwarmBuilder<
-        super::provider::AsyncStd,
-        WebsocketPhase<impl AuthenticatedMultiplexedTransport>,
-    > {
-        self.without_any_other_transports()
-            .with_dns_config(cfg, opts)
     }
 }
 #[cfg(all(not(target_arch = "wasm32"), feature = "tokio", feature = "dns"))]

--- a/libp2p/src/builder/phase/quic.rs
+++ b/libp2p/src/builder/phase/quic.rs
@@ -232,13 +232,7 @@ macro_rules! impl_quic_phase_with_websocket {
         }
     }
 }
-impl_quic_phase_with_websocket!(
-    "async-std",
-    super::provider::AsyncStd,
-    rw_stream_sink::RwStreamSink<
-        libp2p_websocket::BytesConnection<libp2p_tcp::async_io::TcpStream>,
-    >
-);
+
 impl_quic_phase_with_websocket!(
     "tokio",
     super::provider::Tokio,

--- a/libp2p/src/builder/phase/quic.rs
+++ b/libp2p/src/builder/phase/quic.rs
@@ -149,22 +149,6 @@ impl<Provider, T: AuthenticatedMultiplexedTransport> SwarmBuilder<Provider, Quic
             .with_behaviour(constructor)
     }
 }
-#[cfg(all(not(target_arch = "wasm32"), feature = "async-std", feature = "dns"))]
-impl<T: AuthenticatedMultiplexedTransport> SwarmBuilder<super::provider::AsyncStd, QuicPhase<T>> {
-    pub fn with_dns(
-        self,
-    ) -> Result<
-        SwarmBuilder<
-            super::provider::AsyncStd,
-            WebsocketPhase<impl AuthenticatedMultiplexedTransport>,
-        >,
-        std::io::Error,
-    > {
-        self.without_quic()
-            .without_any_other_transports()
-            .with_dns()
-    }
-}
 #[cfg(all(not(target_arch = "wasm32"), feature = "tokio", feature = "dns"))]
 impl<T: AuthenticatedMultiplexedTransport> SwarmBuilder<super::provider::Tokio, QuicPhase<T>> {
     pub fn with_dns(
@@ -179,21 +163,6 @@ impl<T: AuthenticatedMultiplexedTransport> SwarmBuilder<super::provider::Tokio, 
         self.without_quic()
             .without_any_other_transports()
             .with_dns()
-    }
-}
-#[cfg(all(not(target_arch = "wasm32"), feature = "async-std", feature = "dns"))]
-impl<T: AuthenticatedMultiplexedTransport> SwarmBuilder<super::provider::AsyncStd, QuicPhase<T>> {
-    pub fn with_dns_config(
-        self,
-        cfg: libp2p_dns::ResolverConfig,
-        opts: libp2p_dns::ResolverOpts,
-    ) -> SwarmBuilder<
-        super::provider::AsyncStd,
-        WebsocketPhase<impl AuthenticatedMultiplexedTransport>,
-    > {
-        self.without_quic()
-            .without_any_other_transports()
-            .with_dns_config(cfg, opts)
     }
 }
 #[cfg(all(not(target_arch = "wasm32"), feature = "tokio", feature = "dns"))]

--- a/libp2p/src/builder/phase/tcp.rs
+++ b/libp2p/src/builder/phase/tcp.rs
@@ -216,13 +216,6 @@ macro_rules! impl_tcp_phase_with_websocket {
     }
 }
 impl_tcp_phase_with_websocket!(
-    "async-std",
-    super::provider::AsyncStd,
-    rw_stream_sink::RwStreamSink<
-        libp2p_websocket::BytesConnection<libp2p_tcp::async_io::TcpStream>,
-    >
-);
-impl_tcp_phase_with_websocket!(
     "tokio",
     super::provider::Tokio,
     rw_stream_sink::RwStreamSink<libp2p_websocket::BytesConnection<libp2p_tcp::tokio::TcpStream>>

--- a/libp2p/src/builder/phase/websocket.rs
+++ b/libp2p/src/builder/phase/websocket.rs
@@ -116,16 +116,6 @@ macro_rules! impl_websocket_builder {
 }
 
 impl_websocket_builder!(
-    "async-std",
-    super::provider::AsyncStd,
-    libp2p_dns::async_std::Transport::system(libp2p_tcp::async_io::Transport::new(
-        libp2p_tcp::Config::default(),
-    )),
-    rw_stream_sink::RwStreamSink<
-        libp2p_websocket::BytesConnection<libp2p_tcp::async_io::TcpStream>,
-    >
-);
-impl_websocket_builder!(
     "tokio",
     super::provider::Tokio,
     // Note this is an unnecessary await for Tokio Websocket (i.e. tokio dns) in order to be

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.45.0
+
+- Removed `async_std` module [PR 5959](https://github.com/libp2p/rust-libp2p/pull/5959)
+
 ## 0.44.0
  
 - Report all transport errors in a dial attempt instead of only returning the last error. 

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,12 +1,10 @@
-## 0.45.0
+## 0.44.0
 
 - Removed `async_std` module [PR 5959](https://github.com/libp2p/rust-libp2p/pull/5959)
 
-## 0.44.0
- 
-- Report all transport errors in a dial attempt instead of only returning the last error. 
+- Report all transport errors in a dial attempt instead of only returning the last error.
   See [PR 5899](https://github.com/libp2p/rust-libp2p/pull/5899).
-  
+
 ## 0.43.0
 
 - Upgrade `async-std-resolver` and `hickory-resolver`.

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-dns"
 edition.workspace = true
 rust-version = { workspace = true }
 description = "DNS transport implementation for libp2p"
-version = "0.45.0"
+version = "0.44.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-dns"
 edition.workspace = true
 rust-version = { workspace = true }
 description = "DNS transport implementation for libp2p"
-version = "0.44.0"
+version = "0.45.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -11,7 +11,6 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-std-resolver = { workspace = true, features = ["system-config"], optional = true }
 async-trait = "0.1.80"
 futures = { workspace = true }
 libp2p-core = { workspace = true }
@@ -24,11 +23,9 @@ tracing = { workspace = true }
 [dev-dependencies]
 libp2p-identity = { workspace = true, features = ["rand"] }
 tokio = { workspace = true, features = ["rt", "time"] }
-async-std-crate = { package = "async-std", version = "1.6" }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [features]
-async-std = ["async-std-resolver"]
 tokio = ["hickory-resolver/tokio-runtime"]
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -21,7 +21,7 @@
 //! # [DNS name resolution](https://github.com/libp2p/specs/blob/master/addressing/README.md#ip-and-name-resolution)
 //! [`Transport`] for libp2p.
 //!
-//! This crate provides the type [`tokio::Transport`] based on [`hickory_resolver::Tokioresolver`].
+//! This crate provides the type [`tokio::Transport`] based on [`hickory_resolver::TokioResolver`].
 //!
 //! A [`Transport`] is an address-rewriting [`libp2p_core::Transport`] wrapper around
 //! an inner `Transport`. The composed transport behaves like the inner

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -21,9 +21,7 @@
 //! # [DNS name resolution](https://github.com/libp2p/specs/blob/master/addressing/README.md#ip-and-name-resolution)
 //! [`Transport`] for libp2p.
 //!
-//! This crate provides the type [`async_std::Transport`] and [`tokio::Transport`]
-//! for use with `async-std` and `tokio`,
-//! respectively.
+//! This crate provides the type [`tokio::Transport`] based on [`hickory_resolver::Tokioresolver`].
 //!
 //! A [`Transport`] is an address-rewriting [`libp2p_core::Transport`] wrapper around
 //! an inner `Transport`. The composed transport behaves like the inner
@@ -31,11 +29,12 @@
 //! `/dns6/...` and `/dnsaddr/...` components of the given `Multiaddr` through
 //! a DNS, replacing them with the resolved protocols (typically TCP/IP).
 //!
-//! The `async-std` feature and hence the [`async_std::Transport`] are
-//! enabled by default. Tokio users can furthermore opt-in
-//! to the `tokio-dns-over-rustls` and `tokio-dns-over-https-rustls`
-//! features. For more information about these features, please
-//! refer to the documentation of [trust-dns-resolver].
+//! The `tokio` feature and hence the [`tokio::Transport`] are enabled by default.
+//! Tokio users can furthermore opt-in to the `tokio-dns-over-rustls` and
+//! `tokio-dns-over-https-rustls` features.
+//! For more information about these features, please refer to the documentation
+//! of [trust-dns-resolver].
+//! Alternative runtimes or resolvers can be used though a manual implementation of [`Resolver`].
 //!
 //! On Unix systems, if no custom configuration is given, [trust-dns-resolver]
 //! will try to parse the `/etc/resolv.conf` file. This approach comes with a
@@ -55,63 +54,6 @@
 //! [trust-dns-resolver]: https://docs.rs/trust-dns-resolver/latest/trust_dns_resolver/#dns-over-tls-and-dns-over-https
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-
-#[cfg(feature = "async-std")]
-pub mod async_std {
-    use std::{io, sync::Arc};
-
-    use async_std_resolver::AsyncStdResolver;
-    use futures::FutureExt;
-    use hickory_resolver::{
-        config::{ResolverConfig, ResolverOpts},
-        system_conf,
-    };
-    use parking_lot::Mutex;
-
-    /// A `Transport` wrapper for performing DNS lookups when dialing `Multiaddr`esses
-    /// using `async-std` for all async I/O.
-    pub type Transport<T> = crate::Transport<T, AsyncStdResolver>;
-
-    impl<T> Transport<T> {
-        /// Creates a new [`Transport`] from the OS's DNS configuration and defaults.
-        pub async fn system(inner: T) -> Result<Transport<T>, io::Error> {
-            let (cfg, opts) = system_conf::read_system_conf()?;
-            Ok(Self::custom(inner, cfg, opts).await)
-        }
-
-        /// Creates a [`Transport`] with a custom resolver configuration and options.
-        pub async fn custom(inner: T, cfg: ResolverConfig, opts: ResolverOpts) -> Transport<T> {
-            Transport {
-                inner: Arc::new(Mutex::new(inner)),
-                resolver: async_std_resolver::resolver(cfg, opts).await,
-            }
-        }
-
-        // TODO: Replace `system` implementation with this
-        #[doc(hidden)]
-        pub fn system2(inner: T) -> Result<Transport<T>, io::Error> {
-            Ok(Transport {
-                inner: Arc::new(Mutex::new(inner)),
-                resolver: async_std_resolver::resolver_from_system_conf()
-                    .now_or_never()
-                    .expect(
-                        "async_std_resolver::resolver_from_system_conf did not resolve immediately",
-                    )?,
-            })
-        }
-
-        // TODO: Replace `custom` implementation with this
-        #[doc(hidden)]
-        pub fn custom2(inner: T, cfg: ResolverConfig, opts: ResolverOpts) -> Transport<T> {
-            Transport {
-                inner: Arc::new(Mutex::new(inner)),
-                resolver: async_std_resolver::resolver(cfg, opts)
-                    .now_or_never()
-                    .expect("async_std_resolver::resolver did not resolve immediately"),
-            }
-        }
-    }
-}
 
 #[cfg(feature = "tokio")]
 pub mod tokio {
@@ -193,8 +135,7 @@ const MAX_DNS_LOOKUPS: usize = 32;
 const MAX_TXT_RECORDS: usize = 16;
 
 /// A [`Transport`] for performing DNS lookups when dialing `Multiaddr`esses.
-/// You shouldn't need to use this type directly. Use [`tokio::Transport`] or
-/// [`async_std::Transport`] instead.
+/// You shouldn't need to use this type directly. Use [`tokio::Transport`] instead.
 #[derive(Debug)]
 pub struct Transport<T, R> {
     /// The underlying transport.
@@ -625,7 +566,7 @@ where
     }
 }
 
-#[cfg(all(test, any(feature = "tokio", feature = "async-std")))]
+#[cfg(all(test, feature = "tokio"))]
 mod tests {
     use futures::future::BoxFuture;
     use hickory_resolver::proto::{ProtoError, ProtoErrorKind};
@@ -640,19 +581,6 @@ mod tests {
 
     // These helpers will be compiled conditionally, depending on the async runtime in use.
 
-    #[cfg(feature = "async-std")]
-    fn test_async_std<T, F: Future<Output = ()>>(
-        transport: T,
-        test_fn: impl FnOnce(async_std::Transport<T>) -> F,
-    ) {
-        let config = ResolverConfig::quad9();
-        let opts = ResolverOpts::default();
-        let transport =
-            async_std_crate::task::block_on(async_std::Transport::custom(transport, config, opts));
-        async_std_crate::task::block_on(test_fn(transport));
-    }
-
-    #[cfg(feature = "tokio")]
     fn test_tokio<T, F: Future<Output = ()>>(
         transport: T,
         test_fn: impl FnOnce(tokio::Transport<T>) -> F,
@@ -818,11 +746,6 @@ mod tests {
             }
         }
 
-        #[cfg(feature = "async-std")]
-        {
-            test_async_std(CustomTransport, run);
-        }
-
         #[cfg(feature = "tokio")]
         {
             test_tokio(CustomTransport, run);
@@ -919,9 +842,6 @@ mod tests {
                 Ok(_) => panic!("Dial unexpectedly succeeded"),
             }
         }
-
-        #[cfg(feature = "async-std")]
-        test_async_std(AlwaysFailTransport, run_test);
 
         #[cfg(feature = "tokio")]
         test_tokio(AlwaysFailTransport, run_test);

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -746,10 +746,7 @@ mod tests {
             }
         }
 
-        #[cfg(feature = "tokio")]
-        {
-            test_tokio(CustomTransport, run);
-        }
+        test_tokio(CustomTransport, run);
     }
 
     #[test]
@@ -843,7 +840,6 @@ mod tests {
             }
         }
 
-        #[cfg(feature = "tokio")]
         test_tokio(AlwaysFailTransport, run_test);
     }
 }


### PR DESCRIPTION
ref https://github.com/libp2p/rust-libp2p/issues/5935

crate to update:
swarm, mDNS, and the transports TCP, QUIC and _**DNS**_.