### PR TITLE
fix(webrtc): turn down the webrtc log spam

### DIFF
--- a/transports/webrtc/CHANGELOG.md
+++ b/transports/webrtc/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.9.0-alpha
 
 <!-- Update to libp2p-core v0.43.0 -->
+- Turn down the log spam slightly.
+  See [PR 5966](https://github.com/libp2p/rust-libp2p/pull/5966)
 
 ## 0.8.0-alpha
 

--- a/transports/webrtc/src/tokio/connection.rs
+++ b/transports/webrtc/src/tokio/connection.rs
@@ -119,7 +119,7 @@ impl Connection {
                                 Ok(detached) => {
                                     let mut tx = tx.lock().await;
                                     if let Err(e) = tx.try_send(detached.clone()) {
-                                        tracing::error!(channel=%id, "Can't send data channel: {}", e);
+                                        tracing::warn!(channel=%id, "Can't send data channel: {}", e);
                                         // We're not accepting data channels fast enough =>
                                         // close this channel.
                                         //
@@ -286,7 +286,7 @@ pub(crate) async fn register_data_channel_open_handler(
                 match data_channel.detach().await {
                     Ok(detached) => {
                         if let Err(e) = data_channel_tx.send(detached.clone()) {
-                            tracing::error!(channel=%id, "Can't send data channel: {:?}", e);
+                            tracing::warn!(channel=%id, "Can't send data channel: {:?}", e);
                             if let Err(e) = detached.close().await {
                                 tracing::error!(channel=%id, "Failed to close data channel: {}", e);
                             }


### PR DESCRIPTION
## Description

This PR changes a couple `tracing::error!`'s to `tracing::warn!`'s in the
webrtc code so that it won't spam the log so much. The error messages are still
available if you run your app with `RUST_LOG=warn` but if you run with the
default `error` level you will no longer get spammed.

## Notes & open questions

Nope.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates

Signed-off-by: Dave Grantham <dwg@linuxprogrammer.org>
