### PR TITLE
chore: address clippy lints for cargo 1.87.0-beta / clippy 0.1.87

### DIFF
--- a/core/src/muxing/boxed.rs
+++ b/core/src/muxing/boxed.rs
@@ -85,7 +85,7 @@ fn into_io_error<E>(err: E) -> io::Error
 where
     E: Error + Send + Sync + 'static,
 {
-    io::Error::new(io::ErrorKind::Other, err)
+    io::Error::other(err)
 }
 
 impl StreamMuxerBox {

--- a/core/src/transport/boxed.rs
+++ b/core/src/transport/boxed.rs
@@ -171,5 +171,5 @@ impl<O> FusedStream for Boxed<O> {
 }
 
 fn box_err<E: Error + Send + Sync + 'static>(e: E) -> io::Error {
-    io::Error::new(io::ErrorKind::Other, e)
+    io::Error::other(e)
 }

--- a/examples/browser-webrtc/src/lib.rs
+++ b/examples/browser-webrtc/src/lib.rs
@@ -104,5 +104,5 @@ impl Body {
 }
 
 fn js_error(msg: &str) -> JsError {
-    io::Error::new(io::ErrorKind::Other, msg).into()
+    io::Error::other(msg).into()
 }

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -72,7 +72,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 // signing)
                 .message_id_fn(message_id_fn) // content-address messages. No two messages of the same content will be propagated.
                 .build()
-                .map_err(|msg| io::Error::new(io::ErrorKind::Other, msg))?; // Temporary hack because `build` does not return a proper `std::error::Error`.
+                .map_err(io::Error::other)?; // Temporary hack because `build` does not return a proper `std::error::Error`.
 
             // build a gossipsub network behaviour
             let gossipsub = gossipsub::Behaviour::new(

--- a/examples/ipfs-private/src/main.rs
+++ b/examples/ipfs-private/src/main.rs
@@ -138,7 +138,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             let gossipsub_config = gossipsub::ConfigBuilder::default()
                 .max_transmit_size(262144)
                 .build()
-                .map_err(|msg| io::Error::new(io::ErrorKind::Other, msg))?; // Temporary hack because `build` does not return a proper `std::error::Error`.
+                .map_err(io::Error::other)?; // Temporary hack because `build` does not return a proper `std::error::Error`.
             Ok(MyBehaviour {
                 gossipsub: gossipsub::Behaviour::new(
                     gossipsub::MessageAuthenticity::Signed(key.clone()),

--- a/examples/stream/src/main.rs
+++ b/examples/stream/src/main.rs
@@ -148,7 +148,7 @@ async fn send(mut stream: Stream) -> io::Result<()> {
     stream.read_exact(&mut buf).await?;
 
     if bytes != buf {
-        return Err(io::Error::new(io::ErrorKind::Other, "incorrect echo"));
+        return Err(io::Error::other("incorrect echo"));
     }
 
     stream.close().await?;

--- a/hole-punching-tests/src/main.rs
+++ b/hole-punching-tests/src/main.rs
@@ -333,10 +333,7 @@ impl FromStr for TransportProtocol {
         match mode {
             "tcp" => Ok(TransportProtocol::Tcp),
             "quic" => Ok(TransportProtocol::Quic),
-            _ => Err(io::Error::new(
-                io::ErrorKind::Other,
-                "Expected either 'tcp' or 'quic'",
-            )),
+            _ => Err(io::Error::other("Expected either 'tcp' or 'quic'")),
         }
     }
 }
@@ -353,10 +350,7 @@ impl FromStr for Mode {
         match mode {
             "dial" => Ok(Mode::Dial),
             "listen" => Ok(Mode::Listen),
-            _ => Err(io::Error::new(
-                io::ErrorKind::Other,
-                "Expected either 'dial' or 'listen'",
-            )),
+            _ => Err(io::Error::other("Expected either 'dial' or 'listen'")),
         }
     }
 }

--- a/misc/connection-limits/src/lib.rs
+++ b/misc/connection-limits/src/lib.rs
@@ -692,8 +692,7 @@ mod tests {
             _local_addr: &Multiaddr,
             _remote_addr: &Multiaddr,
         ) -> Result<THandler<Self>, ConnectionDenied> {
-            Err(ConnectionDenied::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            Err(ConnectionDenied::new(std::io::Error::other(
                 "ConnectionDenier",
             )))
         }
@@ -706,8 +705,7 @@ mod tests {
             _role_override: Endpoint,
             _port_use: PortUse,
         ) -> Result<THandler<Self>, ConnectionDenied> {
-            Err(ConnectionDenied::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            Err(ConnectionDenied::new(std::io::Error::other(
                 "ConnectionDenier",
             )))
         }

--- a/misc/multistream-select/src/negotiated.rs
+++ b/misc/multistream-select/src/negotiated.rs
@@ -368,7 +368,7 @@ impl From<NegotiationError> for io::Error {
         if let NegotiationError::ProtocolError(e) = err {
             return e.into();
         }
-        io::Error::new(io::ErrorKind::Other, err)
+        io::Error::other(err)
     }
 }
 

--- a/misc/quick-protobuf-codec/src/lib.rs
+++ b/misc/quick-protobuf-codec/src/lib.rs
@@ -59,8 +59,7 @@ fn write_length(message: &impl MessageWrite, dst: &mut BytesMut) {
 /// Write the message itself to `dst`.
 fn write_message(item: &impl MessageWrite, dst: &mut BytesMut) -> io::Result<()> {
     let mut writer = Writer::new(BytesMutWriterBackend::new(dst));
-    item.write_message(&mut writer)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    item.write_message(&mut writer).map_err(io::Error::other)?;
 
     Ok(())
 }

--- a/misc/server/src/main.rs
+++ b/misc/server/src/main.rs
@@ -141,7 +141,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     ..
                 } = e
                 {
-                    if protocols.iter().any(|p| *p == kad::PROTOCOL_NAME) {
+                    if protocols.contains(&kad::PROTOCOL_NAME) {
                         for addr in listen_addrs {
                             swarm
                                 .behaviour_mut()

--- a/misc/webrtc-utils/src/stream/state.rs
+++ b/misc/webrtc-utils/src/stream/state.rs
@@ -264,8 +264,7 @@ impl State {
                     write_closed: false,
                     ..
                 } => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
+                    return Err(io::Error::other(
                         "cannot close read half while closing write half",
                     ))
                 }
@@ -308,8 +307,7 @@ impl State {
                 State::ClosingWrite {
                     read_closed: false, ..
                 } => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
+                    return Err(io::Error::other(
                         "cannot close write half while closing read half",
                     ))
                 }

--- a/muxers/mplex/src/io.rs
+++ b/muxers/mplex/src/io.rs
@@ -713,8 +713,7 @@ where
                 substream=%id,
                 "Received unexpected `Open` frame for open substream",
             );
-            return self.on_error(io::Error::new(
-                io::ErrorKind::Other,
+            return self.on_error(io::Error::other(
                 "Protocol error: Received `Open` frame for open substream.",
             ));
         }
@@ -890,7 +889,7 @@ where
     /// i.e. is not closed and did not encounter a fatal error.
     fn guard_open(&self) -> io::Result<()> {
         match &self.status {
-            Status::Closed => Err(io::Error::new(io::ErrorKind::Other, "Connection is closed")),
+            Status::Closed => Err(io::Error::other("Connection is closed")),
             Status::Err(e) => Err(io::Error::new(e.kind(), e.to_string())),
             Status::Open => Ok(()),
         }
@@ -900,10 +899,7 @@ where
     /// has not been reached.
     fn check_max_pending_frames(&mut self) -> io::Result<()> {
         if self.pending_frames.len() >= self.config.max_substreams + EXTRA_PENDING_FRAMES {
-            return self.on_error(io::Error::new(
-                io::ErrorKind::Other,
-                "Too many pending frames.",
-            ));
+            return self.on_error(io::Error::other("Too many pending frames."));
         }
         Ok(())
     }

--- a/muxers/yamux/src/lib.rs
+++ b/muxers/yamux/src/lib.rs
@@ -437,11 +437,11 @@ impl From<Error> for io::Error {
         match err.0 {
             Either::Left(err) => match err {
                 yamux012::ConnectionError::Io(e) => e,
-                e => io::Error::new(io::ErrorKind::Other, e),
+                e => io::Error::other(e),
             },
             Either::Right(err) => match err {
                 yamux013::ConnectionError::Io(e) => e,
-                e => io::Error::new(io::ErrorKind::Other, e),
+                e => io::Error::other(e),
             },
         }
     }

--- a/protocols/autonat/src/v2/client/handler/dial_request.rs
+++ b/protocols/autonat/src/v2/client/handler/dial_request.rs
@@ -265,20 +265,13 @@ async fn start_stream_handle(
 
     match res.status {
         ResponseStatus::E_REQUEST_REJECTED => {
-            return Err(Error::Io(io::Error::new(
-                io::ErrorKind::Other,
-                "server rejected request",
-            )))
+            return Err(Error::Io(io::Error::other("server rejected request")))
         }
         ResponseStatus::E_DIAL_REFUSED => {
-            return Err(Error::Io(io::Error::new(
-                io::ErrorKind::Other,
-                "server refused dial",
-            )))
+            return Err(Error::Io(io::Error::other("server refused dial")))
         }
         ResponseStatus::E_INTERNAL_ERROR => {
-            return Err(Error::Io(io::Error::new(
-                io::ErrorKind::Other,
+            return Err(Error::Io(io::Error::other(
                 "server encountered internal error",
             )))
         }

--- a/protocols/autonat/src/v2/protocol.rs
+++ b/protocols/autonat/src/v2/protocol.rs
@@ -252,10 +252,7 @@ pub(crate) async fn dial_back(stream: impl AsyncWrite + Unpin, nonce: Nonce) -> 
     let msg = proto::DialBack { nonce };
     let mut framed = FramedWrite::new(stream, Codec::<proto::DialBack>::new(DIAL_BACK_MAX_SIZE));
 
-    framed
-        .send(msg)
-        .await
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    framed.send(msg).await.map_err(io::Error::other)?;
 
     Ok(())
 }
@@ -277,10 +274,7 @@ pub(crate) async fn dial_back_response(stream: impl AsyncWrite + Unpin) -> io::R
         stream,
         Codec::<proto::DialBackResponse>::new(DIAL_BACK_MAX_SIZE),
     );
-    framed
-        .send(msg)
-        .await
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    framed.send(msg).await.map_err(io::Error::other)?;
 
     Ok(())
 }

--- a/protocols/autonat/src/v2/server/handler/dial_back.rs
+++ b/protocols/autonat/src/v2/server/handler/dial_back.rs
@@ -127,6 +127,6 @@ async fn perform_dial_back(
     };
     back_channel
         .send(res)
-        .map_err(|_| io::Error::new(io::ErrorKind::Other, "send error"))?;
+        .map_err(|_| io::Error::other("send error"))?;
     Ok(())
 }

--- a/protocols/autonat/src/v2/server/handler/dial_request.rs
+++ b/protocols/autonat/src/v2/server/handler/dial_request.rs
@@ -214,8 +214,7 @@ async fn handle_request(
             tested_addr: observed_multiaddr,
             client,
             data_amount,
-            result: Err(io::Error::new(
-                io::ErrorKind::Other,
+            result: Err(io::Error::other(
                 "client is not conformint to protocol. the tested address is not the observed address",
             )),
         };

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1813,6 +1813,10 @@ where
         self.mcache.put(&msg_id, raw_message.clone());
 
         // Dispatch the message to the user if we are subscribed to any of the topics
+        #[expect(
+            clippy::map_entry,
+            reason = "False positive, see rust-lang/rust-clippy#14449."
+        )]
         if self.mesh.contains_key(&message.topic) {
             tracing::debug!("Sending received message to user");
             self.events

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1813,7 +1813,7 @@ where
         self.mcache.put(&msg_id, raw_message.clone());
 
         // Dispatch the message to the user if we are subscribed to any of the topics
-        #[expect(
+        #[allow(
             clippy::map_entry,
             reason = "False positive, see rust-lang/rust-clippy#14449."
         )]

--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -246,10 +246,10 @@ impl EnabledHandler {
 
         // process outbound stream
         loop {
-            match std::mem::replace(
-                &mut self.outbound_substream,
-                Some(OutboundSubstreamState::Poisoned),
-            ) {
+            match self
+                .outbound_substream
+                .replace(OutboundSubstreamState::Poisoned)
+            {
                 // outbound idle state
                 Some(OutboundSubstreamState::WaitingOutput(substream)) => {
                     if let Poll::Ready(Some(mut message)) = self.send_queue.poll_next_unpin(cx) {
@@ -344,10 +344,10 @@ impl EnabledHandler {
 
         // Handle inbound messages.
         loop {
-            match std::mem::replace(
-                &mut self.inbound_substream,
-                Some(InboundSubstreamState::Poisoned),
-            ) {
+            match self
+                .inbound_substream
+                .replace(InboundSubstreamState::Poisoned)
+            {
                 // inbound idle state
                 Some(InboundSubstreamState::WaitingInput(mut substream)) => {
                     match substream.poll_next_unpin(cx) {

--- a/protocols/gossipsub/src/peer_score.rs
+++ b/protocols/gossipsub/src/peer_score.rs
@@ -110,6 +110,10 @@ impl PeerStats {
         topic_hash: TopicHash,
         params: &PeerScoreParams,
     ) -> Option<&mut TopicStats> {
+        #[expect(
+            clippy::map_entry,
+            reason = "False positive, see rust-lang/rust-clippy#14449."
+        )]
         if params.topics.contains_key(&topic_hash) {
             Some(self.topics.entry(topic_hash).or_default())
         } else {

--- a/protocols/gossipsub/src/peer_score.rs
+++ b/protocols/gossipsub/src/peer_score.rs
@@ -110,7 +110,7 @@ impl PeerStats {
         topic_hash: TopicHash,
         params: &PeerScoreParams,
     ) -> Option<&mut TopicStats> {
-        #[expect(
+        #[allow(
             clippy::map_entry,
             reason = "False positive, see rust-lang/rust-clippy#14449."
         )]

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -2915,6 +2915,7 @@ pub type GetRecordResult = Result<GetRecordOk, GetRecordError>;
 
 /// The successful result of [`Behaviour::get_record`].
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum GetRecordOk {
     FoundRecord(PeerRecord),
     FinishedWithNoAdditionalRecord {

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -129,6 +129,7 @@ enum InboundSubstreamState {
 }
 
 impl InboundSubstreamState {
+    #[allow(clippy::result_large_err)]
     fn try_answer_with(
         &mut self,
         id: RequestId,

--- a/protocols/relay/src/copy_future.rs
+++ b/protocols/relay/src/copy_future.rs
@@ -76,10 +76,7 @@ where
 
         loop {
             if this.max_circuit_bytes > 0 && this.bytes_sent > this.max_circuit_bytes {
-                return Poll::Ready(Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Max circuit bytes reached.",
-                )));
+                return Poll::Ready(Err(io::Error::other("Max circuit bytes reached.")));
             }
 
             enum Status {

--- a/protocols/relay/src/priv_client.rs
+++ b/protocols/relay/src/priv_client.rs
@@ -26,7 +26,7 @@ pub(crate) mod transport;
 use std::{
     collections::{hash_map, HashMap, VecDeque},
     convert::Infallible,
-    io::{Error, ErrorKind, IoSlice},
+    io::{Error, IoSlice},
     pin::Pin,
     task::{Context, Poll},
 };
@@ -409,10 +409,7 @@ impl ConnectionState {
     pub(crate) fn new_inbound(circuit: inbound_stop::Circuit) -> Self {
         ConnectionState::InboundAccepting {
             accept: async {
-                let (substream, read_buffer) = circuit
-                    .accept()
-                    .await
-                    .map_err(|e| Error::new(ErrorKind::Other, e))?;
+                let (substream, read_buffer) = circuit.accept().await.map_err(Error::other)?;
                 Ok(ConnectionState::Operational {
                     read_buffer,
                     substream,

--- a/protocols/request-response/src/cbor.rs
+++ b/protocols/request-response/src/cbor.rs
@@ -179,9 +179,7 @@ pub mod codec {
 
     fn decode_into_io_error(err: cbor4ii::serde::DecodeError<Infallible>) -> io::Error {
         match err {
-            cbor4ii::serde::DecodeError::Core(DecodeError::Read(e)) => {
-                io::Error::new(io::ErrorKind::Other, e)
-            }
+            cbor4ii::serde::DecodeError::Core(DecodeError::Read(e)) => io::Error::other(e),
             cbor4ii::serde::DecodeError::Core(e @ DecodeError::Unsupported { .. }) => {
                 io::Error::new(io::ErrorKind::Unsupported, e)
             }
@@ -189,14 +187,12 @@ pub mod codec {
                 io::Error::new(io::ErrorKind::UnexpectedEof, e)
             }
             cbor4ii::serde::DecodeError::Core(e) => io::Error::new(io::ErrorKind::InvalidData, e),
-            cbor4ii::serde::DecodeError::Custom(e) => {
-                io::Error::new(io::ErrorKind::Other, e.to_string())
-            }
+            cbor4ii::serde::DecodeError::Custom(e) => io::Error::other(e.to_string()),
         }
     }
 
     fn encode_into_io_error(err: cbor4ii::serde::EncodeError<TryReserveError>) -> io::Error {
-        io::Error::new(io::ErrorKind::Other, err)
+        io::Error::other(err)
     }
 }
 

--- a/protocols/request-response/src/handler.rs
+++ b/protocols/request-response/src/handler.rs
@@ -205,7 +205,7 @@ where
         {
             self.pending_events.push_back(Event::OutboundStreamFailed {
                 request_id: message.request_id,
-                error: io::Error::new(io::ErrorKind::Other, "max sub-streams reached"),
+                error: io::Error::other("max sub-streams reached"),
             });
         }
     }

--- a/protocols/request-response/tests/error_reporting.rs
+++ b/protocols/request-response/tests/error_reporting.rs
@@ -412,7 +412,7 @@ impl TryFrom<u8> for Action {
             4 => Ok(Action::FailOnWriteResponse),
             5 => Ok(Action::TimeoutOnWriteResponse),
             6 => Ok(Action::FailOnMaxStreams),
-            _ => Err(io::Error::new(io::ErrorKind::Other, "invalid action")),
+            _ => Err(io::Error::other("invalid action")),
         }
     }
 }
@@ -441,9 +441,7 @@ impl Codec for TestCodec {
         assert_eq!(buf.len(), 1);
 
         match buf[0].try_into()? {
-            Action::FailOnReadRequest => {
-                Err(io::Error::new(io::ErrorKind::Other, "FailOnReadRequest"))
-            }
+            Action::FailOnReadRequest => Err(io::Error::other("FailOnReadRequest")),
             action => Ok(action),
         }
     }
@@ -466,9 +464,7 @@ impl Codec for TestCodec {
         assert_eq!(buf.len(), 1);
 
         match buf[0].try_into()? {
-            Action::FailOnReadResponse => {
-                Err(io::Error::new(io::ErrorKind::Other, "FailOnReadResponse"))
-            }
+            Action::FailOnReadResponse => Err(io::Error::other("FailOnReadResponse")),
             Action::TimeoutOnReadResponse => loop {
                 sleep(Duration::MAX).await;
             },
@@ -486,9 +482,7 @@ impl Codec for TestCodec {
         T: AsyncWrite + Unpin + Send,
     {
         match req {
-            Action::FailOnWriteRequest => {
-                Err(io::Error::new(io::ErrorKind::Other, "FailOnWriteRequest"))
-            }
+            Action::FailOnWriteRequest => Err(io::Error::other("FailOnWriteRequest")),
             action => {
                 let bytes = [action.into()];
                 io.write_all(&bytes).await?;
@@ -507,9 +501,7 @@ impl Codec for TestCodec {
         T: AsyncWrite + Unpin + Send,
     {
         match res {
-            Action::FailOnWriteResponse => {
-                Err(io::Error::new(io::ErrorKind::Other, "FailOnWriteResponse"))
-            }
+            Action::FailOnWriteResponse => Err(io::Error::other("FailOnWriteResponse")),
             Action::TimeoutOnWriteResponse => loop {
                 sleep(Duration::MAX).await;
             },

--- a/swarm/src/behaviour/peer_addresses.rs
+++ b/swarm/src/behaviour/peer_addresses.rs
@@ -317,10 +317,7 @@ mod tests {
             .map(|addr| {
                 (
                     addr.clone(),
-                    TransportError::Other(io::Error::new(
-                        io::ErrorKind::Other,
-                        MemoryTransportError::Unreachable,
-                    )),
+                    TransportError::Other(io::Error::other(MemoryTransportError::Unreachable)),
                 )
             })
             .collect();

--- a/swarm/src/connection.rs
+++ b/swarm/src/connection.rs
@@ -634,9 +634,7 @@ fn to_stream_upgrade_error<T>(e: NegotiationError) -> StreamUpgradeError<T> {
     match e {
         NegotiationError::Failed => StreamUpgradeError::NegotiationFailed,
         NegotiationError::ProtocolError(ProtocolError::IoError(e)) => StreamUpgradeError::Io(e),
-        NegotiationError::ProtocolError(other) => {
-            StreamUpgradeError::Io(io::Error::new(io::ErrorKind::Other, other))
-        }
+        NegotiationError::ProtocolError(other) => StreamUpgradeError::Io(io::Error::other(other)),
     }
 }
 

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -2334,10 +2334,7 @@ mod tests {
         // This constitutes a fairly typical error for chained transports.
         let error = DialError::Transport(vec![(
             "/ip4/127.0.0.1/tcp/80".parse().unwrap(),
-            TransportError::Other(io::Error::new(
-                io::ErrorKind::Other,
-                MemoryTransportError::Unreachable,
-            )),
+            TransportError::Other(io::Error::other(MemoryTransportError::Unreachable)),
         )]);
 
         let string = format!("{error}");

--- a/transports/noise/src/io/framed.rs
+++ b/transports/noise/src/io/framed.rs
@@ -86,8 +86,7 @@ impl Codec<snow::HandshakeState> {
     /// `XX` pattern, which is the only handshake protocol libp2p currently supports.
     pub(crate) fn into_transport(self) -> Result<(PublicKey, Codec<snow::TransportState>), Error> {
         let dh_remote_pubkey = self.session.get_remote_static().ok_or_else(|| {
-            Error::Io(io::Error::new(
-                io::ErrorKind::Other,
+            Error::Io(io::Error::other(
                 "expect key to always be present at end of XX session",
             ))
         })?;

--- a/transports/quic/src/transport.rs
+++ b/transports/quic/src/transport.rs
@@ -128,7 +128,7 @@ impl<P: Provider> GenTransport<P> {
                 let _ = endpoint_config;
                 let _ = server_config;
                 let _ = socket;
-                let err = std::io::Error::new(std::io::ErrorKind::Other, "no async runtime found");
+                let err = std::io::Error::other("no async runtime found");
                 Err(Error::Io(err))
             }
         }

--- a/transports/webrtc/src/tokio/req_res_chan.rs
+++ b/transports/webrtc/src/tokio/req_res_chan.rs
@@ -52,10 +52,8 @@ impl<Req, Res> Sender<Req, Res> {
             .await
             .send((req, sender))
             .await
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-        let res = receiver
-            .await
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            .map_err(io::Error::other)?;
+        let res = receiver.await.map_err(io::Error::other)?;
 
         Ok(res)
     }

--- a/transports/websocket-websys/src/web_context.rs
+++ b/transports/websocket-websys/src/web_context.rs
@@ -1,6 +1,3 @@
-// TODO: remove when https://github.com/rust-lang/rust-clippy/issues/12377 fix lands in stable clippy.
-#![allow(clippy::empty_docs)]
-
 use wasm_bindgen::prelude::*;
 use web_sys::window;
 

--- a/transports/websocket/src/framed.rs
+++ b/transports/websocket/src/framed.rs
@@ -781,7 +781,7 @@ where
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let item = ready!(self.receiver.poll_next_unpin(cx));
-        let item = item.map(|result| result.map_err(|e| io::Error::new(io::ErrorKind::Other, e)));
+        let item = item.map(|result| result.map_err(io::Error::other));
         Poll::Ready(item)
     }
 }
@@ -795,25 +795,25 @@ where
     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.sender)
             .poll_ready(cx)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            .map_err(io::Error::other)
     }
 
     fn start_send(mut self: Pin<&mut Self>, item: OutgoingData) -> io::Result<()> {
         Pin::new(&mut self.sender)
             .start_send(item)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            .map_err(io::Error::other)
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.sender)
             .poll_flush(cx)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            .map_err(io::Error::other)
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.sender)
             .poll_close(cx)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            .map_err(io::Error::other)
     }
 }
 

--- a/transports/websocket/src/quicksink.rs
+++ b/transports/websocket/src/quicksink.rs
@@ -354,7 +354,7 @@ mod tests {
     fn error_does_not_panic() {
         task::block_on(async {
             let sink = make_sink(io::stdout(), |mut _stdout, _action| async move {
-                Err(io::Error::new(io::ErrorKind::Other, "oh no"))
+                Err(io::Error::other("oh no"))
             });
 
             futures::pin_mut!(sink);

--- a/transports/webtransport-websys/src/utils.rs
+++ b/transports/webtransport-websys/src/utils.rs
@@ -64,5 +64,5 @@ pub(crate) fn parse_reader_response(resp: &JsValue) -> Result<Option<JsValue>, J
 }
 
 pub(crate) fn to_io_error(value: JsValue) -> io::Error {
-    io::Error::new(io::ErrorKind::Other, Error::from_js_value(value))
+    io::Error::other(Error::from_js_value(value))
 }


### PR DESCRIPTION
## Description

## Notes & open questions

There are currently some false positives for `clippy::map_entry`, see https://github.com/rust-lang/rust-clippy/issues/14449.
I've added an ~~`expect`~~ `allow` statement for them for now.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~A changelog entry has been made in the appropriate crates~~
