### PR TITLE
refactor(kad): replace BTreeMap::remove(Iter::next_back) with pop_last

### DIFF
--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -2481,11 +2481,7 @@ where
                                 let distance = source_key.distance(&target_key);
                                 cache_candidates.insert(distance, source);
                                 if cache_candidates.len() > max_peers as usize {
-                                    // TODO: `pop_last()` would be nice once stabilised.
-                                    // See https://github.com/rust-lang/rust/issues/62924.
-                                    let last =
-                                        *cache_candidates.keys().next_back().expect("len > 0");
-                                    cache_candidates.remove(&last);
+                                    cache_candidates.pop_last();
                                 }
                             }
                         }


### PR DESCRIPTION
## Description
Refactor according to note: 
https://github.com/libp2p/rust-libp2p/blob/1206fef09885d024323479d0383c37c4fe281c7c/protocols/kad/src/behaviour.rs#L2483-L2489

since https://github.com/rust-lang/rust/issues/62924 has been stabilized.
<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions
Internal change: no public API changes.   
No other similar usage was found regarding `BTreeMap` or `BTreeSet`.  
Should we expect the poped value to be `Some`?
<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~A changelog entry has been made in the appropriate crates~~
