### PR TITLE
chore(metrics): update version and CHANGELOG.md

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "futures",
  "libp2p-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ libp2p-identity = { version = "0.2.10" }
 libp2p-kad = { version = "0.47.0", path = "protocols/kad" }
 libp2p-mdns = { version = "0.47.0", path = "protocols/mdns" }
 libp2p-memory-connection-limits = { version = "0.4.0", path = "misc/memory-connection-limits" }
-libp2p-metrics = { version = "0.16.1", path = "misc/metrics" }
+libp2p-metrics = { version = "0.17.0", path = "misc/metrics" }
 libp2p-mplex = { version = "0.43.1", path = "muxers/mplex" }
 libp2p-noise = { version = "0.46.1", path = "transports/noise" }
 libp2p-peer-store = { version = "0.1.0", path = "misc/peer-store" }

--- a/misc/metrics/CHANGELOG.md
+++ b/misc/metrics/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 0.16.1
+## 0.17.0
+
+- Update `prometheus-client` to `0.23.0`.
+  See [PR 5960](https://github.com/libp2p/rust-libp2p/pull/5960).
+
 - Add `ReservationClosed` as a relay metric.
   See [PR 5869](https://github.com/libp2p/rust-libp2p/pull/5869).
 

--- a/misc/metrics/Cargo.toml
+++ b/misc/metrics/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-metrics"
 edition.workspace = true
 rust-version = { workspace = true }
 description = "Metrics for libp2p"
-version = "0.16.1"
+version = "0.17.0"
 authors = ["Max Inden <mail@max-inden.de>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
@@ -22,13 +22,13 @@ relay = ["libp2p-relay"]
 futures = { workspace = true }
 web-time = { workspace = true }
 libp2p-core = { workspace = true }
-libp2p-dcutr =  { workspace = true, optional = true }
-libp2p-gossipsub =  { workspace = true, optional = true }
+libp2p-dcutr = { workspace = true, optional = true }
+libp2p-gossipsub = { workspace = true, optional = true }
 libp2p-identify = { workspace = true, optional = true }
 libp2p-identity = { workspace = true }
 libp2p-kad = { workspace = true, optional = true }
 libp2p-ping = { workspace = true, optional = true }
-libp2p-relay =  { workspace = true, optional = true }
+libp2p-relay = { workspace = true, optional = true }
 libp2p-swarm = { workspace = true }
 pin-project = "1.1.5"
 prometheus-client = { workspace = true }


### PR DESCRIPTION
## Description
which was missed on #5960, `libp2p-metrics` expose `prometheus_client::Registry` so this is a breaking change
