### PR TITLE
fix: add Gossipsub protocol to ALLOWED_PROTOCOLS in identify metrics

### DIFF
--- a/misc/metrics/src/identify.rs
+++ b/misc/metrics/src/identify.rs
@@ -18,6 +18,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+#[cfg(feature = "gossipsub")]
+use libp2p_gossipsub::GOSSIPSUB_PROTOCOL_ID;
+
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
@@ -37,9 +40,8 @@ use crate::protocol_stack;
 const ALLOWED_PROTOCOLS: &[StreamProtocol] = &[
     #[cfg(feature = "dcutr")]
     libp2p_dcutr::PROTOCOL_NAME,
-    // #[cfg(feature = "gossipsub")]
-    // TODO: Add Gossipsub protocol name
-    libp2p_identify::PROTOCOL_NAME,
+    #[cfg(feature = "gossipsub")]
+    GOSSIPSUB_PROTOCOL_ID,
     libp2p_identify::PUSH_PROTOCOL_NAME,
     #[cfg(feature = "kad")]
     libp2p_kad::PROTOCOL_NAME,


### PR DESCRIPTION
This PR addresses a TODO by adding the `GOSSIPSUB_PROTOCOL_ID` from `libp2p_gossipsub` to the `ALLOWED_PROTOCOLS` list used in the `identify` metrics module.

Previously, the Gossipsub protocol was commented out with a TODO placeholder. Now, it's conditionally included when the `gossipsub` feature is enabled, ensuring metrics can correctly account for Gossipsub-supporting peers.

### Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates (if needed)
