### PR TITLE
fix(upnp): panic during a shutdown process

### DIFF
--- a/protocols/upnp/CHANGELOG.md
+++ b/protocols/upnp/CHANGELOG.md
@@ -3,6 +3,9 @@
 - update igd-next to 0.16.1
   See [PR 5944](https://github.com/libp2p/rust-libp2p/pull/5944).
 
+- Fix panic during a shutdown process.
+  See [PR 5998](https://github.com/libp2p/rust-libp2p/pull/5998).
+
 ## 0.4.0
 
 - update igd-next to 0.15.1.

--- a/protocols/upnp/src/behaviour.rs
+++ b/protocols/upnp/src/behaviour.rs
@@ -384,28 +384,33 @@ impl NetworkBehaviour for Behaviour {
         loop {
             match self.state {
                 GatewayState::Searching(ref mut fut) => match Pin::new(fut).poll(cx) {
-                    Poll::Ready(result) => {
-                        match result.expect("sender shouldn't have been dropped") {
-                            Ok(gateway) => {
-                                if !is_addr_global(gateway.external_addr) {
-                                    self.state =
-                                        GatewayState::NonRoutableGateway(gateway.external_addr);
-                                    tracing::debug!(
-                                        gateway_address=%gateway.external_addr,
-                                        "the gateway is not routable"
-                                    );
-                                    return Poll::Ready(ToSwarm::GenerateEvent(
-                                        Event::NonRoutableGateway,
-                                    ));
-                                }
-                                self.state = GatewayState::Available(gateway);
+                    Poll::Ready(Ok(result)) => match result {
+                        Ok(gateway) => {
+                            if !is_addr_global(gateway.external_addr) {
+                                self.state =
+                                    GatewayState::NonRoutableGateway(gateway.external_addr);
+                                tracing::debug!(
+                                    gateway_address=%gateway.external_addr,
+                                    "the gateway is not routable"
+                                );
+                                return Poll::Ready(ToSwarm::GenerateEvent(
+                                    Event::NonRoutableGateway,
+                                ));
                             }
-                            Err(err) => {
-                                tracing::debug!("could not find gateway: {err}");
-                                self.state = GatewayState::GatewayNotFound;
-                                return Poll::Ready(ToSwarm::GenerateEvent(Event::GatewayNotFound));
-                            }
+                            self.state = GatewayState::Available(gateway);
                         }
+                        Err(err) => {
+                            tracing::debug!("could not find gateway: {err}");
+                            self.state = GatewayState::GatewayNotFound;
+                            return Poll::Ready(ToSwarm::GenerateEvent(Event::GatewayNotFound));
+                        }
+                    },
+                    Poll::Ready(Err(err)) => {
+                        // The sender channel has been dropped. This typically indicates a shutdown
+                        // process is underway.
+                        tracing::debug!("sender has been dropped: {err}");
+                        self.state = GatewayState::GatewayNotFound;
+                        return Poll::Ready(ToSwarm::GenerateEvent(Event::GatewayNotFound));
                     }
                     Poll::Pending => return Poll::Pending,
                 },


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

upnp panics [here](https://github.com/libp2p/rust-libp2p/blob/8c8b3c3e174bcbc59055ee6694a5cfdbd8b6e7f2/protocols/upnp/src/behaviour.rs#L388) in case where the gateway state is `Searching` and the task executor is shutting down, since the [search_gateway](https://github.com/libp2p/rust-libp2p/blob/b187c14ef36744ea6b2f29740321b5fe896a50ef/protocols/upnp/src/tokio.rs#L99-L166) task is terminated and the sender channel has been dropped.

[Here](https://gist.github.com/ackintosh/95f60bb1fee8865965adde5a6e1ee0eb) is an example code that reproduces the issue based on the upnp example, along with the corresponding [error message](https://gist.github.com/ackintosh/95f60bb1fee8865965adde5a6e1ee0eb?permalink_comment_id=5546913#gistcomment-5546913).

Since this case is expected during shutdown, I believe upnp should avoid panicking and continue its operation.

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

Should we add new variant to `GatewayState` and `Event` for this?

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
