### PR TITLE
fix(rendezvous): log instead of panic when sending response to client

### DIFF
--- a/protocols/rendezvous/CHANGELOG.md
+++ b/protocols/rendezvous/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.16.1 
+## 0.16.1
 - Emit `ToSwarm::NewExternalAddrOfPeer` for newly discovered peers.
   See [PR 5138](https://github.com/libp2p/rust-libp2p/pull/5138).
+- Log error instead of panicking when sending response to channel fails
+  See [PR 6002](https://github.com/libp2p/rust-libp2p/pull/6002).
 
 ## 0.16.0
 

--- a/protocols/rendezvous/src/server.rs
+++ b/protocols/rendezvous/src/server.rs
@@ -189,9 +189,12 @@ impl NetworkBehaviour for Behaviour {
                             handle_request(peer_id, request, &mut self.registrations)
                         {
                             if let Some(resp) = response {
-                                self.inner
-                                    .send_response(channel, resp)
-                                    .expect("Send response");
+                                if let Err(resp) = self.inner.send_response(channel, resp) {
+                                    tracing::debug!(
+                                        %peer_id,
+                                        "Failed to send response, peer disconnected {resp:?}"
+                                    );
+                                }
                             }
 
                             return Poll::Ready(ToSwarm::GenerateEvent(event));


### PR DESCRIPTION
## Description
Log error instead of panicking when sending response to channel fails

Related: https://github.com/libp2p/rust-libp2p/issues/5997

## Notes & open questions

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
