### PR TITLE
fix(peer-store/memory-store): don't store remote address as listener

### DIFF
--- a/misc/peer-store/src/memory_store.rs
+++ b/misc/peer-store/src/memory_store.rs
@@ -304,9 +304,7 @@ impl Config {
     }
     /// If set to `true`, the store will remove addresses if the swarm indicates a dial failure.
     /// More specifically:
-    /// - Failed dials indicated in
-    ///   [`ConnectionEstablished`]'s
-    ///   `failed_addresses` will be removed.
+    /// - Failed dials indicated in [`ConnectionEstablished`]'s `failed_addresses` will be removed.
     /// - [`DialError::LocalPeerId`] causes the full peer entry to be removed.
     /// - On [`DialError::WrongPeerId`], the address will be removed from the incorrect peer's
     ///   record and re-added to the correct peer's record.

--- a/misc/peer-store/src/memory_store.rs
+++ b/misc/peer-store/src/memory_store.rs
@@ -201,11 +201,11 @@ impl<T> Store for MemoryStore<T> {
                 if self.config.remove_addr_on_dial_error {
                     for failed_addr in *failed_addresses {
                         is_record_updated |=
-                            self.remove_address_silent(&peer_id, failed_addr, false);
+                            self.remove_address_silent(peer_id, failed_addr, false);
                     }
                 }
                 is_record_updated |=
-                    self.update_address_silent(&peer_id, endpoint.get_remote_address(), false);
+                    self.update_address_silent(peer_id, endpoint.get_remote_address(), false);
                 if is_record_updated {
                     self.push_event_and_wake(crate::store::Event::RecordUpdated(*peer_id));
                 }
@@ -305,7 +305,7 @@ impl Config {
     /// If set to `true`, the store will remove addresses if the swarm indicates a dial failure.
     /// More specifically:
     /// - Failed dials indicated in
-    ///   [`ConnectionEstablished`](libp2p_swarm::behaviour::ConnectionEstablished)'s
+    ///   [`ConnectionEstablished`]'s
     ///   `failed_addresses` will be removed.
     /// - [`DialError::LocalPeerId`] causes the full peer entry to be removed.
     /// - On [`DialError::WrongPeerId`], the address will be removed from the incorrect peer's


### PR DESCRIPTION
## Description

On connection establishment, only the dialer should store the remote's address in the peer store. 
From the listener perspective, there is no information if the observed remote address is actually a listening address of the peer. 

## Notes & open questions

cc @dknopik

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~A changelog entry has been made in the appropriate crates~~
