### PR TITLE
feat(kad): configurable outbound_substreams timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2932,7 +2932,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "asynchronous-codec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ libp2p-floodsub = { version = "0.46.1", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.49.0", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.47.0", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.11" }
-libp2p-kad = { version = "0.47.0", path = "protocols/kad" }
+libp2p-kad = { version = "0.47.1", path = "protocols/kad" }
 libp2p-mdns = { version = "0.47.0", path = "protocols/mdns" }
 libp2p-memory-connection-limits = { version = "0.4.0", path = "misc/memory-connection-limits" }
 libp2p-metrics = { version = "0.17.0", path = "misc/metrics" }

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.47.1
+
+- Configurable outbound_substreams_timeout.
+  See [PR 6015](https://github.com/libp2p/rust-libp2p/pull/6015).
+
 ## 0.47.0
 
 - Expose a kad query facility allowing specify num_results dynamically.
@@ -15,7 +20,7 @@
 - Remove deprecated default constructor for `ProtocolConfig`.
   See [PR 5774](https://github.com/libp2p/rust-libp2p/pull/5774).
 - Add lazy cleanup for expired provider records in `Behavior::get_providers` and `Behavior::provider_peers`.
-  See [PR 5980](https://github.com/libp2p/rust-libp2p/pull/5980)
+  See [PR 5980](https://github.com/libp2p/rust-libp2p/pull/5980).
 
 <!-- Update to libp2p-core v0.43.0 -->
 

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-kad"
 edition.workspace = true
 rust-version = { workspace = true }
 description = "Kademlia protocol for libp2p"
-version = "0.47.0"
+version = "0.47.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -382,6 +382,16 @@ impl Config {
         self
     }
 
+    /// Modifies the timeout duration of outbount_substreams.
+    ///
+    /// * Default to `10` seconds.
+    /// * May need to increase this value when sending large records with poor connection.
+    pub fn set_outbound_substreams_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.protocol_config
+            .set_outbound_substreams_timeout(timeout);
+        self
+    }
+
     /// Sets the k-bucket insertion strategy for the Kademlia routing table.
     pub fn set_kbucket_inserts(&mut self, inserts: BucketInserts) -> &mut Self {
         self.kbucket_inserts = inserts;

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -24,7 +24,6 @@ use std::{
     marker::PhantomData,
     pin::Pin,
     task::{Context, Poll, Waker},
-    time::Duration,
 };
 
 use either::Either;
@@ -454,6 +453,8 @@ impl Handler {
             }
         }
 
+        let outbound_substreams_timeout = protocol_config.outbound_substreams_timeout_s();
+
         Handler {
             protocol_config,
             mode,
@@ -462,7 +463,7 @@ impl Handler {
             next_connec_unique_id: UniqueConnecId(0),
             inbound_substreams: Default::default(),
             outbound_substreams: futures_bounded::FuturesTupleSet::new(
-                Duration::from_secs(10),
+                outbound_substreams_timeout,
                 MAX_NUM_STREAMS,
             ),
             pending_streams: Default::default(),

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -49,6 +49,8 @@ use crate::{
 pub(crate) const DEFAULT_PROTO_NAME: StreamProtocol = StreamProtocol::new("/ipfs/kad/1.0.0");
 /// The default maximum size for a varint length-delimited packet.
 pub(crate) const DEFAULT_MAX_PACKET_SIZE: usize = 16 * 1024;
+/// The default timeout of outbound_substreams to be 10 (seconds).
+const DEFAULT_OUTBOUND_SUBSTREAMS_TIMEOUT_S: Duration = Duration::from_secs(10);
 /// Status of our connection to a node reported by the Kademlia protocol.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum ConnectionType {
@@ -145,6 +147,8 @@ pub struct ProtocolConfig {
     protocol_names: Vec<StreamProtocol>,
     /// Maximum allowed size of a packet.
     max_packet_size: usize,
+    /// Specifies the outbound_substreams timeout in seconds
+    outbound_substreams_timeout_s: Duration,
 }
 
 impl ProtocolConfig {
@@ -153,6 +157,7 @@ impl ProtocolConfig {
         ProtocolConfig {
             protocol_names: vec![protocol_name],
             max_packet_size: DEFAULT_MAX_PACKET_SIZE,
+            outbound_substreams_timeout_s: DEFAULT_OUTBOUND_SUBSTREAMS_TIMEOUT_S,
         }
     }
 
@@ -164,6 +169,16 @@ impl ProtocolConfig {
     /// Modifies the maximum allowed size of a single Kademlia packet.
     pub fn set_max_packet_size(&mut self, size: usize) {
         self.max_packet_size = size;
+    }
+
+    /// Modifies outbount_substreams timeout.
+    pub fn set_outbound_substreams_timeout(&mut self, timeout: Duration) {
+        self.outbound_substreams_timeout_s = timeout;
+    }
+
+    /// Getter of outbount_substreams_timeout_s.
+    pub fn outbound_substreams_timeout_s(&self) -> Duration {
+        self.outbound_substreams_timeout_s
     }
 }
 


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

When testing `put_record_to` with poor connectioin but large packet size (around 4MB), the `put_record_to` frequently got failed and the PutRecordToError::stats showing always failed at 10s.
```
"kad_event::PutRecordError::QuorumFailed", required quorum 2, stored on [], QueryStats { requests: 5, success: 0, failure: 5, start: Some(Instant { tv_sec: 121323, tv_nsec: 961187829 }), end: Some(Instant { tv_sec: 121334, tv_nsec: 188694869 }) } - ProgressStep { count: 1, last: true }
``` 
However, this timeout is not defined by request/response protocol timeout (which in our case increased to 30s already).

Further digging through the libp2p code, it turned out this timeout is actually affected by outbound_substreams timeout.
We tested with increase to 30s, do see much less put_record_to failure and QueryStats showing extended completion duration (larger than 10s, and in case of failed, to be 30s).

Hence raised this PR to provide a configurable approach of the timeout.

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

Ideally, the configurate shall via function call.
However, it seems it will be via the kad::ProtocolConfig , which could having issue of:
* extra traffic bytes (if ProtocolConfig to be exchanged on every connection)
* backward conpartibility, in case peer is in old version and can't parse the new ProtocolConfig 

Would like a guide if there is other way to do this configure setup more user friendly.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] A changelog entry has been made in the appropriate crates
