### PR TITLE
feat: Add complete examples to stream protocol README

### DIFF
--- a/protocols/stream/README.md
+++ b/protocols/stream/README.md
@@ -17,7 +17,13 @@ To accept streams for a particular [`StreamProtocol`](libp2p_swarm::StreamProtoc
 # use libp2p_swarm::{Swarm, StreamProtocol};
 # use libp2p_stream as stream;
 # use futures::StreamExt as _;
-let mut swarm: Swarm<stream::Behaviour> = todo!();
+let mut swarm = libp2p::SwarmBuilder::with_new_identity()
+    .with_tokio()
+    .with_tcp(Default::default(), libp2p_noise::Config::new, libp2p_yamux::Config::default)
+    .unwrap()
+    .with_behaviour(|_| stream::Behaviour::new())
+    .unwrap()
+    .build();
 
 let mut control = swarm.behaviour().new_control();
 let mut incoming = control.accept(StreamProtocol::new("/my-protocol")).unwrap();
@@ -55,8 +61,14 @@ To open a new outbound stream for a particular protocol, use [`Control::open_str
 # use libp2p_swarm::{Swarm, StreamProtocol};
 # use libp2p_stream as stream;
 # use libp2p_identity::PeerId;
-let mut swarm: Swarm<stream::Behaviour> = todo!();
-let peer_id: PeerId = todo!();
+let mut swarm = libp2p::SwarmBuilder::with_new_identity()
+    .with_tokio()
+    .with_tcp(Default::default(), libp2p_noise::Config::new, libp2p_yamux::Config::default)
+    .unwrap()
+    .with_behaviour(|_| stream::Behaviour::new())
+    .unwrap()
+    .build();
+let peer_id = PeerId::random();
 
 let mut control = swarm.behaviour().new_control();
 


### PR DESCRIPTION
## Description

This PR adds complete, working examples to the stream protocol README.md file by replacing placeholder todo!() implementations. The examples now show proper initialization of Swarm with the stream::Behaviour and demonstrate how to set up both inbound and outbound stream connections.
These improvements make the documentation more useful for developers who want to understand how to implement stream-oriented protocols with libp2p.

## Notes & open questions

None

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
