### PR TITLE
chore(rw-stream-sink): use tokio instead of async-std in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5231,10 +5231,10 @@ checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 name = "rw-stream-sink"
 version = "0.4.0"
 dependencies = [
- "async-std",
  "futures",
  "pin-project",
  "static_assertions",
+ "tokio",
 ]
 
 [[package]]

--- a/misc/rw-stream-sink/Cargo.toml
+++ b/misc/rw-stream-sink/Cargo.toml
@@ -16,7 +16,7 @@ pin-project = "1.1.5"
 static_assertions = "1"
 
 [dev-dependencies]
-async-std = "1.0"
+tokio = { workspace = true, features = ["rt", "macros"] }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's. 
 # More information: https://docs.rs/about/builds#cross-compiling


### PR DESCRIPTION
## Description

ref https://github.com/libp2p/rust-libp2p/issues/4449

I think this is the last one in this issue. If you let me know, I can use "closes" to close the issue.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
