### PR TITLE
chore: swarm executor should match runtime in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-test"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,6 +2996,7 @@ dependencies = [
  "libp2p-swarm-test",
  "memory-stats",
  "sysinfo",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ libp2p-server = { version = "0.12.7", path = "misc/server" }
 libp2p-stream = { version = "0.3.0-alpha.1", path = "protocols/stream" }
 libp2p-swarm = { version = "0.47.0", path = "swarm" }
 libp2p-swarm-derive = { version = "=0.35.1", path = "swarm-derive" } # `libp2p-swarm-derive` may not be compatible with different `libp2p-swarm` non-breaking releases. E.g. `libp2p-swarm` might introduce a new enum variant `FromSwarm` (which is `#[non-exhaustive]`) in a non-breaking release. Older versions of `libp2p-swarm-derive` would not forward this enum variant within the `NetworkBehaviour` hierarchy. Thus the version pinning is required.
-libp2p-swarm-test = { version = "0.5.0", path = "swarm-test" }
+libp2p-swarm-test = { version = "0.6.0", path = "swarm-test" }
 libp2p-tcp = { version = "0.43.0", path = "transports/tcp" }
 libp2p-tls = { version = "0.6.2", path = "transports/tls" }
 libp2p-uds = { version = "0.42.0", path = "transports/uds" }

--- a/misc/allow-block-list/src/lib.rs
+++ b/misc/allow-block-list/src/lib.rs
@@ -305,8 +305,8 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_dial_blocked_peer() {
-        let mut dialer = Swarm::new_ephemeral(|_| Behaviour::<BlockedPeers>::default());
-        let mut listener = Swarm::new_ephemeral(|_| Behaviour::<BlockedPeers>::default());
+        let mut dialer = Swarm::new_ephemeral_tokio(|_| Behaviour::<BlockedPeers>::default());
+        let mut listener = Swarm::new_ephemeral_tokio(|_| Behaviour::<BlockedPeers>::default());
         listener.listen().with_memory_addr_external().await;
 
         dialer.behaviour_mut().block_peer(*listener.local_peer_id());
@@ -319,8 +319,8 @@ mod tests {
 
     #[tokio::test]
     async fn can_dial_unblocked_peer() {
-        let mut dialer = Swarm::new_ephemeral(|_| Behaviour::<BlockedPeers>::default());
-        let mut listener = Swarm::new_ephemeral(|_| Behaviour::<BlockedPeers>::default());
+        let mut dialer = Swarm::new_ephemeral_tokio(|_| Behaviour::<BlockedPeers>::default());
+        let mut listener = Swarm::new_ephemeral_tokio(|_| Behaviour::<BlockedPeers>::default());
         listener.listen().with_memory_addr_external().await;
 
         dialer.behaviour_mut().block_peer(*listener.local_peer_id());
@@ -333,8 +333,8 @@ mod tests {
 
     #[tokio::test]
     async fn blocked_peer_cannot_dial_us() {
-        let mut dialer = Swarm::new_ephemeral(|_| Behaviour::<BlockedPeers>::default());
-        let mut listener = Swarm::new_ephemeral(|_| Behaviour::<BlockedPeers>::default());
+        let mut dialer = Swarm::new_ephemeral_tokio(|_| Behaviour::<BlockedPeers>::default());
+        let mut listener = Swarm::new_ephemeral_tokio(|_| Behaviour::<BlockedPeers>::default());
         listener.listen().with_memory_addr_external().await;
 
         listener.behaviour_mut().block_peer(*dialer.local_peer_id());
@@ -355,8 +355,8 @@ mod tests {
 
     #[tokio::test]
     async fn connections_get_closed_upon_blocked() {
-        let mut dialer = Swarm::new_ephemeral(|_| Behaviour::<BlockedPeers>::default());
-        let mut listener = Swarm::new_ephemeral(|_| Behaviour::<BlockedPeers>::default());
+        let mut dialer = Swarm::new_ephemeral_tokio(|_| Behaviour::<BlockedPeers>::default());
+        let mut listener = Swarm::new_ephemeral_tokio(|_| Behaviour::<BlockedPeers>::default());
         listener.listen().with_memory_addr_external().await;
         dialer.connect(&mut listener).await;
 
@@ -381,8 +381,8 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_dial_peer_unless_allowed() {
-        let mut dialer = Swarm::new_ephemeral(|_| Behaviour::<AllowedPeers>::default());
-        let mut listener = Swarm::new_ephemeral(|_| Behaviour::<AllowedPeers>::default());
+        let mut dialer = Swarm::new_ephemeral_tokio(|_| Behaviour::<AllowedPeers>::default());
+        let mut listener = Swarm::new_ephemeral_tokio(|_| Behaviour::<AllowedPeers>::default());
         listener.listen().with_memory_addr_external().await;
 
         let DialError::Denied { cause } = dial(&mut dialer, &listener).unwrap_err() else {
@@ -396,8 +396,8 @@ mod tests {
 
     #[tokio::test]
     async fn cannot_dial_disallowed_peer() {
-        let mut dialer = Swarm::new_ephemeral(|_| Behaviour::<AllowedPeers>::default());
-        let mut listener = Swarm::new_ephemeral(|_| Behaviour::<AllowedPeers>::default());
+        let mut dialer = Swarm::new_ephemeral_tokio(|_| Behaviour::<AllowedPeers>::default());
+        let mut listener = Swarm::new_ephemeral_tokio(|_| Behaviour::<AllowedPeers>::default());
         listener.listen().with_memory_addr_external().await;
 
         dialer.behaviour_mut().allow_peer(*listener.local_peer_id());
@@ -413,8 +413,8 @@ mod tests {
 
     #[tokio::test]
     async fn not_allowed_peer_cannot_dial_us() {
-        let mut dialer = Swarm::new_ephemeral(|_| Behaviour::<AllowedPeers>::default());
-        let mut listener = Swarm::new_ephemeral(|_| Behaviour::<AllowedPeers>::default());
+        let mut dialer = Swarm::new_ephemeral_tokio(|_| Behaviour::<AllowedPeers>::default());
+        let mut listener = Swarm::new_ephemeral_tokio(|_| Behaviour::<AllowedPeers>::default());
         listener.listen().with_memory_addr_external().await;
 
         dialer
@@ -450,8 +450,8 @@ mod tests {
 
     #[tokio::test]
     async fn connections_get_closed_upon_disallow() {
-        let mut dialer = Swarm::new_ephemeral(|_| Behaviour::<AllowedPeers>::default());
-        let mut listener = Swarm::new_ephemeral(|_| Behaviour::<AllowedPeers>::default());
+        let mut dialer = Swarm::new_ephemeral_tokio(|_| Behaviour::<AllowedPeers>::default());
+        let mut listener = Swarm::new_ephemeral_tokio(|_| Behaviour::<AllowedPeers>::default());
         listener.listen().with_memory_addr_external().await;
         dialer.behaviour_mut().allow_peer(*listener.local_peer_id());
         listener.behaviour_mut().allow_peer(*dialer.local_peer_id());

--- a/misc/connection-limits/src/lib.rs
+++ b/misc/connection-limits/src/lib.rs
@@ -416,7 +416,7 @@ mod tests {
 
         let outgoing_limit = rand::thread_rng().gen_range(1..10);
 
-        let mut network = Swarm::new_ephemeral(|_| {
+        let mut network = Swarm::new_ephemeral_tokio(|_| {
             Behaviour::new(
                 ConnectionLimits::default().with_max_pending_outgoing(Some(outgoing_limit)),
             )
@@ -439,8 +439,8 @@ mod tests {
         (network, addr, outgoing_limit)
     }
 
-    #[test]
-    fn max_outgoing() {
+    #[tokio::test]
+    async fn max_outgoing() {
         let (mut network, addr, outgoing_limit) = fill_outgoing();
         match network
             .dial(
@@ -469,8 +469,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn outgoing_limit_bypass() {
+    #[tokio::test]
+    async fn outgoing_limit_bypass() {
         let (mut network, addr, _) = fill_outgoing();
         let bypassed_peer = PeerId::random();
         network
@@ -513,12 +513,12 @@ mod tests {
     #[test]
     fn max_established_incoming() {
         fn prop(Limit(limit): Limit) {
-            let mut swarm1 = Swarm::new_ephemeral(|_| {
+            let mut swarm1 = Swarm::new_ephemeral_tokio(|_| {
                 Behaviour::new(
                     ConnectionLimits::default().with_max_established_incoming(Some(limit)),
                 )
             });
-            let mut swarm2 = Swarm::new_ephemeral(|_| {
+            let mut swarm2 = Swarm::new_ephemeral_tokio(|_| {
                 Behaviour::new(
                     ConnectionLimits::default().with_max_established_incoming(Some(limit)),
                 )
@@ -556,17 +556,17 @@ mod tests {
     #[test]
     fn bypass_established_incoming() {
         fn prop(Limit(limit): Limit) {
-            let mut swarm1 = Swarm::new_ephemeral(|_| {
+            let mut swarm1 = Swarm::new_ephemeral_tokio(|_| {
                 Behaviour::new(
                     ConnectionLimits::default().with_max_established_incoming(Some(limit)),
                 )
             });
-            let mut swarm2 = Swarm::new_ephemeral(|_| {
+            let mut swarm2 = Swarm::new_ephemeral_tokio(|_| {
                 Behaviour::new(
                     ConnectionLimits::default().with_max_established_incoming(Some(limit)),
                 )
             });
-            let mut swarm3 = Swarm::new_ephemeral(|_| {
+            let mut swarm3 = Swarm::new_ephemeral_tokio(|_| {
                 Behaviour::new(
                     ConnectionLimits::default().with_max_established_incoming(Some(limit)),
                 )
@@ -623,10 +623,10 @@ mod tests {
     /// ([`SwarmEvent::ConnectionEstablished`]) can the connection be seen as established.
     #[tokio::test]
     async fn support_other_behaviour_denying_connection() {
-        let mut swarm1 = Swarm::new_ephemeral(|_| {
+        let mut swarm1 = Swarm::new_ephemeral_tokio(|_| {
             Behaviour::new_with_connection_denier(ConnectionLimits::default())
         });
-        let mut swarm2 = Swarm::new_ephemeral(|_| Behaviour::new(ConnectionLimits::default()));
+        let mut swarm2 = Swarm::new_ephemeral_tokio(|_| Behaviour::new(ConnectionLimits::default()));
 
         // Have swarm2 dial swarm1.
         let (listen_addr, _) = swarm1.listen().await;

--- a/misc/connection-limits/src/lib.rs
+++ b/misc/connection-limits/src/lib.rs
@@ -626,7 +626,8 @@ mod tests {
         let mut swarm1 = Swarm::new_ephemeral_tokio(|_| {
             Behaviour::new_with_connection_denier(ConnectionLimits::default())
         });
-        let mut swarm2 = Swarm::new_ephemeral_tokio(|_| Behaviour::new(ConnectionLimits::default()));
+        let mut swarm2 =
+            Swarm::new_ephemeral_tokio(|_| Behaviour::new(ConnectionLimits::default()));
 
         // Have swarm2 dial swarm1.
         let (listen_addr, _) = swarm1.listen().await;

--- a/misc/memory-connection-limits/Cargo.toml
+++ b/misc/memory-connection-limits/Cargo.toml
@@ -18,7 +18,7 @@ sysinfo = "0.33"
 tracing = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "time"] }
 libp2p-identify = { workspace = true }
 libp2p-swarm-derive = { path = "../../swarm-derive" }
 libp2p-swarm-test = { path = "../../swarm-test" }

--- a/misc/memory-connection-limits/Cargo.toml
+++ b/misc/memory-connection-limits/Cargo.toml
@@ -18,6 +18,7 @@ sysinfo = "0.33"
 tracing = { workspace = true }
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["macros"] }
 libp2p-identify = { workspace = true }
 libp2p-swarm-derive = { path = "../../swarm-derive" }
 libp2p-swarm-test = { path = "../../swarm-test" }

--- a/misc/memory-connection-limits/tests/max_bytes.rs
+++ b/misc/memory-connection-limits/tests/max_bytes.rs
@@ -29,12 +29,12 @@ use libp2p_swarm::{dial_opts::DialOpts, DialError, Swarm};
 use libp2p_swarm_test::SwarmExt;
 use util::*;
 
-#[test]
-fn max_bytes() {
+#[tokio::test]
+async fn max_bytes() {
     const CONNECTION_LIMIT: usize = 20;
     let max_allowed_bytes = CONNECTION_LIMIT * 1024 * 1024;
 
-    let mut network = Swarm::new_ephemeral(|_| TestBehaviour {
+    let mut network = Swarm::new_ephemeral_tokio(|_| TestBehaviour {
         connection_limits: Behaviour::with_max_bytes(max_allowed_bytes),
         mem_consumer: ConsumeMemoryBehaviour1MBPending0Established::default(),
     });
@@ -69,8 +69,9 @@ fn max_bytes() {
             .expect("Unexpected connection limit.");
     }
 
-    std::thread::sleep(Duration::from_millis(100)); // Memory stats are only updated every 100ms internally, ensure they are up-to-date when we try
-                                                    // to exceed it.
+    // Memory stats are only updated every 100ms internally,
+    // ensure they are up-to-date when we try to exceed it.
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
     match network
         .dial(

--- a/misc/memory-connection-limits/tests/max_percentage.rs
+++ b/misc/memory-connection-limits/tests/max_percentage.rs
@@ -33,14 +33,14 @@ use libp2p_swarm_test::SwarmExt;
 use sysinfo::{MemoryRefreshKind, RefreshKind};
 use util::*;
 
-#[test]
-fn max_percentage() {
+#[tokio::test]
+async fn max_percentage() {
     const CONNECTION_LIMIT: usize = 20;
     let system_info = sysinfo::System::new_with_specifics(
         RefreshKind::default().with_memory(MemoryRefreshKind::default().with_ram()),
     );
 
-    let mut network = Swarm::new_ephemeral(|_| TestBehaviour {
+    let mut network = Swarm::new_ephemeral_tokio(|_| TestBehaviour {
         connection_limits: Behaviour::with_max_percentage(0.1),
         mem_consumer: ConsumeMemoryBehaviour1MBPending0Established::default(),
     });
@@ -78,7 +78,7 @@ fn max_percentage() {
 
     // Memory stats are only updated every 100ms internally,
     // ensure they are up-to-date when we try to exceed it.
-    std::thread::sleep(Duration::from_millis(100));
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
     match network
         .dial(

--- a/protocols/autonat/tests/autonatv2.rs
+++ b/protocols/autonat/tests/autonatv2.rs
@@ -414,7 +414,7 @@ async fn dial_back_to_not_supporting() {
 }
 
 async fn new_server() -> Swarm<CombinedServer> {
-    let mut node = Swarm::new_ephemeral(|identity| CombinedServer {
+    let mut node = Swarm::new_ephemeral_tokio(|identity| CombinedServer {
         autonat: libp2p_autonat::v2::server::Behaviour::default(),
         identify: libp2p_identify::Behaviour::new(libp2p_identify::Config::new(
             "/libp2p-test/1.0.0".into(),
@@ -427,7 +427,7 @@ async fn new_server() -> Swarm<CombinedServer> {
 }
 
 async fn new_client() -> Swarm<CombinedClient> {
-    let mut node = Swarm::new_ephemeral(|identity| CombinedClient {
+    let mut node = Swarm::new_ephemeral_tokio(|identity| CombinedClient {
         autonat: libp2p_autonat::v2::client::Behaviour::new(
             OsRng,
             Config::default().with_probe_interval(Duration::from_millis(100)),
@@ -456,7 +456,7 @@ struct CombinedClient {
 }
 
 async fn new_dummy() -> Swarm<libp2p_identify::Behaviour> {
-    let mut node = Swarm::new_ephemeral(|identity| {
+    let mut node = Swarm::new_ephemeral_tokio(|identity| {
         libp2p_identify::Behaviour::new(libp2p_identify::Config::new(
             "/libp2p-test/1.0.0".into(),
             identity.public().clone(),

--- a/protocols/autonat/tests/test_client.rs
+++ b/protocols/autonat/tests/test_client.rs
@@ -35,7 +35,7 @@ const TEST_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 
 #[tokio::test]
 async fn test_auto_probe() {
-    let mut client = Swarm::new_ephemeral(|key| {
+    let mut client = Swarm::new_ephemeral_tokio(|key| {
         Behaviour::new(
             key.public().to_peer_id(),
             Config {
@@ -137,7 +137,7 @@ async fn test_auto_probe() {
 
 #[tokio::test]
 async fn test_confidence() {
-    let mut client = Swarm::new_ephemeral(|key| {
+    let mut client = Swarm::new_ephemeral_tokio(|key| {
         Behaviour::new(
             key.public().to_peer_id(),
             Config {
@@ -221,7 +221,7 @@ async fn test_confidence() {
 
 #[tokio::test]
 async fn test_throttle_server_period() {
-    let mut client = Swarm::new_ephemeral(|key| {
+    let mut client = Swarm::new_ephemeral_tokio(|key| {
         Behaviour::new(
             key.public().to_peer_id(),
             Config {
@@ -272,7 +272,7 @@ async fn test_throttle_server_period() {
 
 #[tokio::test]
 async fn test_use_connected_as_server() {
-    let mut client = Swarm::new_ephemeral(|key| {
+    let mut client = Swarm::new_ephemeral_tokio(|key| {
         Behaviour::new(
             key.public().to_peer_id(),
             Config {
@@ -310,7 +310,7 @@ async fn test_use_connected_as_server() {
 
 #[tokio::test]
 async fn test_outbound_failure() {
-    let mut client = Swarm::new_ephemeral(|key| {
+    let mut client = Swarm::new_ephemeral_tokio(|key| {
         Behaviour::new(
             key.public().to_peer_id(),
             Config {
@@ -379,7 +379,7 @@ async fn test_outbound_failure() {
 
 #[tokio::test]
 async fn test_global_ips_config() {
-    let mut client = Swarm::new_ephemeral(|key| {
+    let mut client = Swarm::new_ephemeral_tokio(|key| {
         Behaviour::new(
             key.public().to_peer_id(),
             Config {
@@ -413,7 +413,7 @@ async fn test_global_ips_config() {
 }
 
 async fn new_server_swarm() -> (PeerId, Multiaddr, JoinHandle<()>) {
-    let mut swarm = Swarm::new_ephemeral(|key| {
+    let mut swarm = Swarm::new_ephemeral_tokio(|key| {
         Behaviour::new(
             key.public().to_peer_id(),
             Config {

--- a/protocols/autonat/tests/test_server.rs
+++ b/protocols/autonat/tests/test_server.rs
@@ -359,7 +359,7 @@ async fn new_server_swarm(config: Option<Config>) -> (Swarm<Behaviour>, PeerId, 
     // Don't do any outbound probes.
     config.boot_delay = Duration::from_secs(60);
 
-    let mut server = Swarm::new_ephemeral(|key| Behaviour::new(key.public().to_peer_id(), config));
+    let mut server = Swarm::new_ephemeral_tokio(|key| Behaviour::new(key.public().to_peer_id(), config));
     let peer_id = *server.local_peer_id();
     let (_, addr) = server.listen().await;
 
@@ -367,7 +367,7 @@ async fn new_server_swarm(config: Option<Config>) -> (Swarm<Behaviour>, PeerId, 
 }
 
 async fn new_client_swarm(server_id: PeerId, server_addr: Multiaddr) -> (Swarm<Behaviour>, PeerId) {
-    let mut client = Swarm::new_ephemeral(|key| {
+    let mut client = Swarm::new_ephemeral_tokio(|key| {
         Behaviour::new(
             key.public().to_peer_id(),
             Config {

--- a/protocols/autonat/tests/test_server.rs
+++ b/protocols/autonat/tests/test_server.rs
@@ -359,7 +359,8 @@ async fn new_server_swarm(config: Option<Config>) -> (Swarm<Behaviour>, PeerId, 
     // Don't do any outbound probes.
     config.boot_delay = Duration::from_secs(60);
 
-    let mut server = Swarm::new_ephemeral_tokio(|key| Behaviour::new(key.public().to_peer_id(), config));
+    let mut server =
+        Swarm::new_ephemeral_tokio(|key| Behaviour::new(key.public().to_peer_id(), config));
     let peer_id = *server.local_peer_id();
     let (_, addr) = server.listen().await;
 

--- a/protocols/dcutr/tests/lib.rs
+++ b/protocols/dcutr/tests/lib.rs
@@ -101,7 +101,7 @@ async fn connect() {
 }
 
 fn build_relay() -> Swarm<Relay> {
-    Swarm::new_ephemeral(|identity| {
+    Swarm::new_ephemeral_tokio(|identity| {
         let local_peer_id = identity.public().to_peer_id();
 
         Relay {
@@ -152,7 +152,7 @@ fn build_client() -> Swarm<Client> {
             )),
         },
         local_peer_id,
-        Config::with_async_std_executor(),
+        Config::with_tokio_executor(),
     )
 }
 

--- a/protocols/gossipsub/tests/smoke.rs
+++ b/protocols/gossipsub/tests/smoke.rs
@@ -112,7 +112,7 @@ async fn build_node() -> Swarm<gossipsub::Behaviour> {
     // reduce the default values of the heartbeat, so that all nodes will receive gossip in a
     // timely fashion.
 
-    let mut swarm = Swarm::new_ephemeral(|identity| {
+    let mut swarm = Swarm::new_ephemeral_tokio(|identity| {
         let peer_id = identity.public().to_peer_id();
 
         let config = gossipsub::ConfigBuilder::default()

--- a/protocols/identify/tests/smoke.rs
+++ b/protocols/identify/tests/smoke.rs
@@ -17,7 +17,7 @@ async fn periodic_identify() {
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
 
-    let mut swarm1 = Swarm::new_ephemeral(|identity| {
+    let mut swarm1 = Swarm::new_ephemeral_tokio(|identity| {
         identify::Behaviour::new(
             identify::Config::new("a".to_string(), identity.public())
                 .with_agent_version("b".to_string()),
@@ -25,7 +25,7 @@ async fn periodic_identify() {
     });
     let swarm1_peer_id = *swarm1.local_peer_id();
 
-    let mut swarm2 = Swarm::new_ephemeral(|identity| {
+    let mut swarm2 = Swarm::new_ephemeral_tokio(|identity| {
         identify::Behaviour::new(
             identify::Config::new("c".to_string(), identity.public())
                 .with_agent_version("d".to_string()),
@@ -88,14 +88,14 @@ async fn only_emits_address_candidate_once_per_connection() {
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
 
-    let mut swarm1 = Swarm::new_ephemeral(|identity| {
+    let mut swarm1 = Swarm::new_ephemeral_tokio(|identity| {
         identify::Behaviour::new(
             identify::Config::new("a".to_string(), identity.public())
                 .with_agent_version("b".to_string())
                 .with_interval(Duration::from_secs(1)),
         )
     });
-    let mut swarm2 = Swarm::new_ephemeral(|identity| {
+    let mut swarm2 = Swarm::new_ephemeral_tokio(|identity| {
         identify::Behaviour::new(
             identify::Config::new("c".to_string(), identity.public())
                 .with_agent_version("d".to_string()),
@@ -160,7 +160,7 @@ async fn emits_unique_listen_addresses() {
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
 
-    let mut swarm1 = Swarm::new_ephemeral(|identity| {
+    let mut swarm1 = Swarm::new_ephemeral_tokio(|identity| {
         identify::Behaviour::new(
             identify::Config::new("a".to_string(), identity.public())
                 .with_agent_version("b".to_string())
@@ -168,7 +168,7 @@ async fn emits_unique_listen_addresses() {
                 .with_cache_size(10),
         )
     });
-    let mut swarm2 = Swarm::new_ephemeral(|identity| {
+    let mut swarm2 = Swarm::new_ephemeral_tokio(|identity| {
         identify::Behaviour::new(
             identify::Config::new("c".to_string(), identity.public())
                 .with_agent_version("d".to_string()),
@@ -232,7 +232,7 @@ async fn hides_listen_addresses() {
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
 
-    let mut swarm1 = Swarm::new_ephemeral(|identity| {
+    let mut swarm1 = Swarm::new_ephemeral_tokio(|identity| {
         identify::Behaviour::new(
             identify::Config::new("a".to_string(), identity.public())
                 .with_agent_version("b".to_string())
@@ -240,7 +240,7 @@ async fn hides_listen_addresses() {
                 .with_cache_size(10),
         )
     });
-    let mut swarm2 = Swarm::new_ephemeral(|identity| {
+    let mut swarm2 = Swarm::new_ephemeral_tokio(|identity| {
         identify::Behaviour::new(
             identify::Config::new("c".to_string(), identity.public())
                 .with_agent_version("d".to_string())
@@ -303,10 +303,10 @@ async fn identify_push() {
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
 
-    let mut swarm1 = Swarm::new_ephemeral(|identity| {
+    let mut swarm1 = Swarm::new_ephemeral_tokio(|identity| {
         identify::Behaviour::new(identify::Config::new("a".to_string(), identity.public()))
     });
-    let mut swarm2 = Swarm::new_ephemeral(|identity| {
+    let mut swarm2 = Swarm::new_ephemeral_tokio(|identity| {
         identify::Behaviour::new(
             identify::Config::new("a".to_string(), identity.public())
                 .with_agent_version("b".to_string()),
@@ -355,10 +355,10 @@ async fn discover_peer_after_disconnect() {
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
 
-    let mut swarm1 = Swarm::new_ephemeral(|identity| {
+    let mut swarm1 = Swarm::new_ephemeral_tokio(|identity| {
         identify::Behaviour::new(identify::Config::new("a".to_string(), identity.public()))
     });
-    let mut swarm2 = Swarm::new_ephemeral(|identity| {
+    let mut swarm2 = Swarm::new_ephemeral_tokio(|identity| {
         identify::Behaviour::new(
             identify::Config::new("a".to_string(), identity.public())
                 .with_agent_version("b".to_string()),
@@ -410,13 +410,13 @@ async fn configured_interval_starts_after_first_identify() {
 
     let identify_interval = Duration::from_secs(5);
 
-    let mut swarm1 = Swarm::new_ephemeral(|identity| {
+    let mut swarm1 = Swarm::new_ephemeral_tokio(|identity| {
         identify::Behaviour::new(
             identify::Config::new("a".to_string(), identity.public())
                 .with_interval(identify_interval),
         )
     });
-    let mut swarm2 = Swarm::new_ephemeral(|identity| {
+    let mut swarm2 = Swarm::new_ephemeral_tokio(|identity| {
         identify::Behaviour::new(
             identify::Config::new("a".to_string(), identity.public())
                 .with_agent_version("b".to_string()),
@@ -448,13 +448,13 @@ async fn reject_mismatched_public_key() {
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
 
-    let mut honest_swarm = Swarm::new_ephemeral(|identity| {
+    let mut honest_swarm = Swarm::new_ephemeral_tokio(|identity| {
         identify::Behaviour::new(
             identify::Config::new("a".to_string(), identity.public())
                 .with_interval(Duration::from_secs(1)),
         )
     });
-    let mut spoofing_swarm = Swarm::new_ephemeral(|_unused_identity| {
+    let mut spoofing_swarm = Swarm::new_ephemeral_tokio(|_unused_identity| {
         let arbitrary_public_key = Keypair::generate_ed25519().public();
         identify::Behaviour::new(
             identify::Config::new("a".to_string(), arbitrary_public_key)

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -37,7 +37,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 futures-timer = "3.0"
 libp2p-identify = { path = "../identify" }
 libp2p-noise = { workspace = true }
-libp2p-swarm = { path = "../../swarm", features = ["macros"] }
+libp2p-swarm = { path = "../../swarm", features = ["macros", "async-std"] }
 libp2p-swarm-test = { path = "../../swarm-test" }
 libp2p-yamux = { workspace = true }
 quickcheck = { workspace = true }

--- a/protocols/kad/tests/client_mode.rs
+++ b/protocols/kad/tests/client_mode.rs
@@ -13,8 +13,8 @@ async fn server_gets_added_to_routing_table_by_client() {
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
 
-    let mut client = Swarm::new_ephemeral(MyBehaviour::new);
-    let mut server = Swarm::new_ephemeral(MyBehaviour::new);
+    let mut client = Swarm::new_ephemeral_tokio(MyBehaviour::new);
+    let mut server = Swarm::new_ephemeral_tokio(MyBehaviour::new);
 
     server.listen().with_memory_addr_external().await;
     client.connect(&mut server).await;
@@ -45,8 +45,8 @@ async fn two_servers_add_each_other_to_routing_table() {
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
 
-    let mut server1 = Swarm::new_ephemeral(MyBehaviour::new);
-    let mut server2 = Swarm::new_ephemeral(MyBehaviour::new);
+    let mut server1 = Swarm::new_ephemeral_tokio(MyBehaviour::new);
+    let mut server2 = Swarm::new_ephemeral_tokio(MyBehaviour::new);
 
     server2.listen().with_memory_addr_external().await;
     server1.connect(&mut server2).await;
@@ -86,8 +86,8 @@ async fn adding_an_external_addresses_activates_server_mode_on_existing_connecti
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
 
-    let mut client = Swarm::new_ephemeral(MyBehaviour::new);
-    let mut server = Swarm::new_ephemeral(MyBehaviour::new);
+    let mut client = Swarm::new_ephemeral_tokio(MyBehaviour::new);
+    let mut server = Swarm::new_ephemeral_tokio(MyBehaviour::new);
     let server_peer_id = *server.local_peer_id();
 
     let (memory_addr, _) = server.listen().await;
@@ -124,10 +124,10 @@ async fn set_client_to_server_mode() {
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
 
-    let mut client = Swarm::new_ephemeral(MyBehaviour::new);
+    let mut client = Swarm::new_ephemeral_tokio(MyBehaviour::new);
     client.behaviour_mut().kad.set_mode(Some(Mode::Client));
 
-    let mut server = Swarm::new_ephemeral(MyBehaviour::new);
+    let mut server = Swarm::new_ephemeral_tokio(MyBehaviour::new);
 
     server.listen().with_memory_addr_external().await;
     client.connect(&mut server).await;

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -38,11 +38,11 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [[test]]
 name = "use-async-std"
-required-features = ["async-io"]
+required-features = ["async-io", "libp2p-swarm-test/async-std"]
 
 [[test]]
 name = "use-tokio"
-required-features = ["tokio"]
+required-features = ["tokio", "libp2p-swarm-test/tokio"]
 
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.

--- a/protocols/mdns/tests/use-tokio.rs
+++ b/protocols/mdns/tests/use-tokio.rs
@@ -111,7 +111,7 @@ async fn run_discovery_test(config: Config) {
 
 async fn create_swarm(config: Config) -> Swarm<Behaviour> {
     let mut swarm =
-        Swarm::new_ephemeral(|key| Behaviour::new(config, key.public().to_peer_id()).unwrap());
+        Swarm::new_ephemeral_tokio(|key| Behaviour::new(config, key.public().to_peer_id()).unwrap());
 
     // Manually listen on all interfaces because mDNS only works for non-loopback addresses.
     let expected_listener_id = swarm

--- a/protocols/mdns/tests/use-tokio.rs
+++ b/protocols/mdns/tests/use-tokio.rs
@@ -110,8 +110,9 @@ async fn run_discovery_test(config: Config) {
 }
 
 async fn create_swarm(config: Config) -> Swarm<Behaviour> {
-    let mut swarm =
-        Swarm::new_ephemeral_tokio(|key| Behaviour::new(config, key.public().to_peer_id()).unwrap());
+    let mut swarm = Swarm::new_ephemeral_tokio(|key| {
+        Behaviour::new(config, key.public().to_peer_id()).unwrap()
+    });
 
     // Manually listen on all interfaces because mDNS only works for non-loopback addresses.
     let expected_listener_id = swarm

--- a/protocols/perf/tests/lib.rs
+++ b/protocols/perf/tests/lib.rs
@@ -32,9 +32,9 @@ async fn perf() {
         .with_env_filter(EnvFilter::from_default_env())
         .try_init();
 
-    let mut server = Swarm::new_ephemeral(|_| server::Behaviour::new());
+    let mut server = Swarm::new_ephemeral_tokio(|_| server::Behaviour::new());
     let server_peer_id = *server.local_peer_id();
-    let mut client = Swarm::new_ephemeral(|_| client::Behaviour::new());
+    let mut client = Swarm::new_ephemeral_tokio(|_| client::Behaviour::new());
 
     server.listen().with_memory_addr_external().await;
     client.connect(&mut server).await;

--- a/protocols/ping/tests/ping.rs
+++ b/protocols/ping/tests/ping.rs
@@ -32,8 +32,8 @@ async fn ping_pong() {
     fn prop(count: NonZeroU8) {
         let cfg = ping::Config::new().with_interval(Duration::from_millis(10));
 
-        let mut swarm1 = Swarm::new_ephemeral(|_| ping::Behaviour::new(cfg.clone()));
-        let mut swarm2 = Swarm::new_ephemeral(|_| ping::Behaviour::new(cfg.clone()));
+        let mut swarm1 = Swarm::new_ephemeral_tokio(|_| ping::Behaviour::new(cfg.clone()));
+        let mut swarm2 = Swarm::new_ephemeral_tokio(|_| ping::Behaviour::new(cfg.clone()));
 
         tokio::spawn(async move {
             swarm1.listen().with_memory_addr_external().await;
@@ -63,8 +63,8 @@ fn assert_ping_rtt_less_than_50ms(e: ping::Event) {
 
 #[tokio::test]
 async fn unsupported_doesnt_fail() {
-    let mut swarm1 = Swarm::new_ephemeral(|_| dummy::Behaviour);
-    let mut swarm2 = Swarm::new_ephemeral(|_| ping::Behaviour::new(ping::Config::new()));
+    let mut swarm1 = Swarm::new_ephemeral_tokio(|_| dummy::Behaviour);
+    let mut swarm2 = Swarm::new_ephemeral_tokio(|_| ping::Behaviour::new(ping::Config::new()));
 
     let result = {
         swarm1.listen().with_memory_addr_external().await;

--- a/protocols/rendezvous/tests/rendezvous.rs
+++ b/protocols/rendezvous/tests/rendezvous.rs
@@ -91,7 +91,7 @@ async fn should_return_error_when_no_external_addresses() {
         .try_init();
     let namespace = rendezvous::Namespace::from_static("some-namespace");
     let server = new_server(rendezvous::server::Config::default()).await;
-    let mut client = Swarm::new_ephemeral(rendezvous::client::Behaviour::new);
+    let mut client = Swarm::new_ephemeral_tokio(rendezvous::client::Behaviour::new);
 
     let actual = client
         .behaviour_mut()
@@ -456,14 +456,14 @@ async fn new_server_with_connected_clients<const N: usize>(
 }
 
 async fn new_client() -> Swarm<rendezvous::client::Behaviour> {
-    let mut client = Swarm::new_ephemeral(rendezvous::client::Behaviour::new);
+    let mut client = Swarm::new_ephemeral_tokio(rendezvous::client::Behaviour::new);
     client.listen().with_memory_addr_external().await; // we need to listen otherwise we don't have addresses to register
 
     client
 }
 
 async fn new_server(config: rendezvous::server::Config) -> Swarm<rendezvous::server::Behaviour> {
-    let mut server = Swarm::new_ephemeral(|_| rendezvous::server::Behaviour::new(config));
+    let mut server = Swarm::new_ephemeral_tokio(|_| rendezvous::server::Behaviour::new(config));
 
     server.listen().with_memory_addr_external().await;
 
@@ -471,7 +471,7 @@ async fn new_server(config: rendezvous::server::Config) -> Swarm<rendezvous::ser
 }
 
 async fn new_combined_node() -> Swarm<Combined> {
-    let mut node = Swarm::new_ephemeral(|identity| Combined {
+    let mut node = Swarm::new_ephemeral_tokio(|identity| Combined {
         client: rendezvous::client::Behaviour::new(identity),
         server: rendezvous::server::Behaviour::new(rendezvous::server::Config::default()),
     });
@@ -487,7 +487,7 @@ async fn new_impersonating_client() -> Swarm<rendezvous::client::Behaviour> {
     // As such, the best we can do is hand eve a completely different keypair from what she is using
     // to authenticate her connection.
     let someone_else = identity::Keypair::generate_ed25519();
-    let mut eve = Swarm::new_ephemeral(move |_| rendezvous::client::Behaviour::new(someone_else));
+    let mut eve = Swarm::new_ephemeral_tokio(move |_| rendezvous::client::Behaviour::new(someone_else));
     eve.listen().with_memory_addr_external().await;
 
     eve

--- a/protocols/rendezvous/tests/rendezvous.rs
+++ b/protocols/rendezvous/tests/rendezvous.rs
@@ -487,7 +487,8 @@ async fn new_impersonating_client() -> Swarm<rendezvous::client::Behaviour> {
     // As such, the best we can do is hand eve a completely different keypair from what she is using
     // to authenticate her connection.
     let someone_else = identity::Keypair::generate_ed25519();
-    let mut eve = Swarm::new_ephemeral_tokio(move |_| rendezvous::client::Behaviour::new(someone_else));
+    let mut eve =
+        Swarm::new_ephemeral_tokio(move |_| rendezvous::client::Behaviour::new(someone_else));
     eve.listen().with_memory_addr_external().await;
 
     eve

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -32,7 +32,7 @@ cbor = ["dep:serde", "dep:cbor4ii", "libp2p-swarm/macros"]
 anyhow = "1.0.86"
 async-std = { version = "1.6.2", features = ["attributes"] }
 rand = "0.8"
-libp2p-swarm-test = { path = "../../swarm-test" }
+libp2p-swarm-test = { path = "../../swarm-test", features = ["async-std"]}
 futures_ringbuf = "0.4.0"
 serde = { version = "1.0", features = ["derive"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/protocols/stream/tests/lib.rs
+++ b/protocols/stream/tests/lib.rs
@@ -23,8 +23,8 @@ async fn dropping_incoming_streams_deregisters() {
         .with_test_writer()
         .try_init();
 
-    let mut swarm1 = Swarm::new_ephemeral(|_| stream::Behaviour::new());
-    let mut swarm2 = Swarm::new_ephemeral(|_| stream::Behaviour::new());
+    let mut swarm1 = Swarm::new_ephemeral_tokio(|_| stream::Behaviour::new());
+    let mut swarm2 = Swarm::new_ephemeral_tokio(|_| stream::Behaviour::new());
 
     let mut control = swarm1.behaviour().new_control();
     let mut incoming = swarm2.behaviour().new_control().accept(PROTOCOL).unwrap();
@@ -61,7 +61,7 @@ async fn dropping_incoming_streams_deregisters() {
 
 #[tokio::test]
 async fn dial_errors_are_propagated() {
-    let swarm1 = Swarm::new_ephemeral(|_| stream::Behaviour::new());
+    let swarm1 = Swarm::new_ephemeral_tokio(|_| stream::Behaviour::new());
 
     let mut control = swarm1.behaviour().new_control();
     tokio::spawn(swarm1.loop_on_next());

--- a/swarm-test/CHANGELOG.md
+++ b/swarm-test/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.6.0
 
 - Default to `tokio` runtime.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+  See [PR 6024](https://github.com/libp2p/rust-libp2p/pull/6024).
 
 ## 0.5.0
 

--- a/swarm-test/CHANGELOG.md
+++ b/swarm-test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.0
+
+- Default to `tokio` runtime.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+
 ## 0.5.0
 
 - Add `tokio` runtime support and make `tokio` and `async-std` runtimes optional behind features.

--- a/swarm-test/Cargo.toml
+++ b/swarm-test/Cargo.toml
@@ -24,7 +24,7 @@ tracing = { workspace = true }
 futures-timer = "3.0.3"
 
 [features]
-default = ["async-std"]
+default = ["async-std", "tokio"]
 
 async-std = ["libp2p-swarm/async-std", "libp2p-tcp/async-io"]
 tokio = ["libp2p-swarm/tokio", "libp2p-tcp/tokio"]

--- a/swarm-test/Cargo.toml
+++ b/swarm-test/Cargo.toml
@@ -24,7 +24,7 @@ tracing = { workspace = true }
 futures-timer = "3.0.3"
 
 [features]
-default = ["async-std", "tokio"]
+default = ["tokio"]
 
 async-std = ["libp2p-swarm/async-std", "libp2p-tcp/async-io"]
 tokio = ["libp2p-swarm/tokio", "libp2p-tcp/tokio"]

--- a/swarm-test/Cargo.toml
+++ b/swarm-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-swarm-test"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version = { workspace = true }
 license = "MIT"

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -47,7 +47,7 @@ libp2p-kad = { path = "../protocols/kad" }                          # Using `pat
 libp2p-ping = { path = "../protocols/ping" }                        # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
 libp2p-plaintext = { path = "../transports/plaintext" }             # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
 libp2p-swarm-derive = { path = "../swarm-derive" }                  # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
-libp2p-swarm-test = { path = "../swarm-test" }                      # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
+libp2p-swarm-test = { path = "../swarm-test", features = ["async-std"]}                      # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
 libp2p-yamux = { path = "../muxers/yamux" }                         # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
 quickcheck = { workspace = true }
 criterion = { version = "0.5", features = ["async_tokio"] }


### PR DESCRIPTION
## Description

We've changed most of our tests to use the `tokio` runtime: #4449.
All of these tests, however, were using `swarm_test::Swarm::new_ephemeral`, which actually creates a `Swarm` with `async_std` executor.

This PR changes all test that are using tokio as runtime to use `swarm_test::Swarm::new_ephemeral_tokio`, so that the executor used by the swarm matches the test's executor.

It also defaults `swarm-test` to the `tokio` feature.

## Notes & open questions

> It also defaults `swarm-test` to the `tokio` feature.

Done to prevent that in future PRs and tests `Swarm::new_ephemeral` is accidentally used again. Crates will need to explicitly enable the `async-std` feature if they actually want to use that executor.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
