### PR TITLE
chore(ci): update cargo semver-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,9 +309,8 @@ jobs:
       RUSTFLAGS: ''
     steps:
       - uses: actions/checkout@v4
-      - run: wget -q -O- https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v0.39.0/cargo-semver-checks-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C ~/.cargo/bin
-        shell: bash
-      - uses: obi1kenobi/cargo-semver-checks-action@7272cc2caa468d3e009a2b0a9cc366839348237b # v2.6
+      - uses: obi1kenobi/cargo-semver-checks-action@v2
+      - run: cargo semver-checks
 
   rustfmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
update the way we fetch `cargo-semver-checks` so that we don't have to constantly be updating it every time it releases a new version