### PR TITLE
chore(libp2p-websocket): use tokio instead of async-std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3499,7 +3499,6 @@ dependencies = [
 name = "libp2p-websocket"
 version = "0.45.1"
 dependencies = [
- "async-std",
  "either",
  "futures",
  "futures-rustls",
@@ -3513,6 +3512,7 @@ dependencies = [
  "rw-stream-sink",
  "soketto",
  "thiserror 2.0.12",
+ "tokio",
  "tracing",
  "url",
  "webpki-roots",

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -27,9 +27,9 @@ webpki-roots = "0.26"
 
 [dev-dependencies]
 libp2p-tcp = { workspace = true, features = ["async-io"] }
-libp2p-dns = { workspace = true, features = ["async-std"] }
+libp2p-dns = { workspace = true, features = ["tokio"] }
 libp2p-identity = { workspace = true, features = ["rand"] }
-async-std = { version = "1.6.5", features = ["attributes"] }
+tokio = { workspace = true, features = ["rt", "macros", "io-std", "io-util"] }
 rcgen = { workspace = true }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.

--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -72,12 +72,11 @@ use rw_stream_sink::RwStreamSink;
 /// # use libp2p_websocket as websocket;
 /// # use std::pin::Pin;
 /// #
-/// # #[async_std::main]
+/// # #[tokio::main]
 /// # async fn main() {
 ///
 /// let mut transport = websocket::Config::new(
-///     dns::async_std::Transport::system(tcp::async_io::Transport::new(tcp::Config::default()))
-///         .await
+///     dns::tokio::Transport::system(tcp::async_io::Transport::new(tcp::Config::default()))
 ///         .unwrap(),
 /// );
 ///
@@ -115,7 +114,7 @@ use rw_stream_sink::RwStreamSink;
 /// # use libp2p_websocket as websocket;
 /// # use std::pin::Pin;
 /// #
-/// # #[async_std::main]
+/// # #[tokio::main]
 /// # async fn main() {
 ///
 /// let mut transport =


### PR DESCRIPTION
## Description

ref #4449 

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
