### PR TITLE
chore(libp2p-uds): use tokio instead of async_std in tests

### DIFF
--- a/transports/uds/Cargo.toml
+++ b/transports/uds/Cargo.toml
@@ -19,6 +19,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.10"
+tokio = { workspace = true, features = ["rt", "macros", "io-util"] }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/transports/uds/src/lib.rs
+++ b/transports/uds/src/lib.rs
@@ -242,7 +242,7 @@ fn multiaddr_to_path(addr: &Multiaddr) -> Result<PathBuf, ()> {
     }
 }
 
-#[cfg(all(test, feature = "async-std"))]
+#[cfg(all(test, feature = "tokio"))]
 mod tests {
     use std::{borrow::Cow, path::Path};
 
@@ -252,8 +252,9 @@ mod tests {
         transport::{DialOpts, ListenerId, PortUse},
         Endpoint, Transport,
     };
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    use super::{multiaddr_to_path, UdsConfig};
+    use super::{multiaddr_to_path, TokioUdsConfig};
 
     #[test]
     fn multiaddr_to_path_conversion() {
@@ -271,8 +272,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn communicating_between_dialer_and_listener() {
+    #[tokio::test]
+    async fn communicating_between_dialer_and_listener() {
         let temp_dir = tempfile::tempdir().unwrap();
         let socket = temp_dir.path().join("socket");
         let addr = Multiaddr::from(Protocol::Unix(Cow::Owned(
@@ -281,8 +282,8 @@ mod tests {
 
         let (tx, rx) = oneshot::channel();
 
-        async_std::task::spawn(async move {
-            let mut transport = UdsConfig::new().boxed();
+        let listener = async move {
+            let mut transport = TokioUdsConfig::new().boxed();
             transport.listen_on(ListenerId::next(), addr).unwrap();
 
             let listen_addr = transport
@@ -303,10 +304,10 @@ mod tests {
             let mut buf = [0u8; 3];
             sock.read_exact(&mut buf).await.unwrap();
             assert_eq!(buf, [1, 2, 3]);
-        });
+        };
 
-        async_std::task::block_on(async move {
-            let mut uds = UdsConfig::new();
+        let dialer = async move {
+            let mut uds = TokioUdsConfig::new();
             let addr = rx.await.unwrap();
             let mut socket = uds
                 .dial(
@@ -320,13 +321,15 @@ mod tests {
                 .await
                 .unwrap();
             let _ = socket.write(&[1, 2, 3]).await.unwrap();
-        });
+        };
+
+        tokio::join!(listener, dialer);
     }
 
     #[test]
     #[ignore] // TODO: for the moment unix addresses fail to parse
     fn larger_addr_denied() {
-        let mut uds = UdsConfig::new();
+        let mut uds = TokioUdsConfig::new();
 
         let addr = "/unix//foo/bar".parse::<Multiaddr>().unwrap();
         assert!(uds.listen_on(ListenerId::next(), addr).is_err());


### PR DESCRIPTION
## Description

ref #4449 

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
