### PR TITLE
chore(swarm): use tokio instead of async_std

### DIFF
--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -40,14 +40,14 @@ wasm-bindgen = ["dep:wasm-bindgen-futures", "dep:getrandom"]
 [dev-dependencies]
 either = "1.11.0"
 futures = { workspace = true }
-libp2p-identify = { path = "../protocols/identify" }                # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
+libp2p-identify = { path = "../protocols/identify" }                 # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
 libp2p-identity = { workspace = true, features = ["ed25519"] }
-libp2p-kad = { path = "../protocols/kad" }                          # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
-libp2p-ping = { path = "../protocols/ping" }                        # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
-libp2p-plaintext = { path = "../transports/plaintext" }             # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
-libp2p-swarm-derive = { path = "../swarm-derive" }                  # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
-libp2p-swarm-test = { path = "../swarm-test" }                      # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
-libp2p-yamux = { path = "../muxers/yamux" }                         # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
+libp2p-kad = { path = "../protocols/kad" }                           # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
+libp2p-ping = { path = "../protocols/ping" }                         # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
+libp2p-plaintext = { path = "../transports/plaintext" }              # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
+libp2p-swarm-derive = { path = "../swarm-derive" }                   # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
+libp2p-swarm-test = { path = "../swarm-test", features = ["tokio"] } # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
+libp2p-yamux = { path = "../muxers/yamux" }                          # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
 quickcheck = { workspace = true }
 criterion = { version = "0.5", features = ["async_tokio"] }
 trybuild = "1.0.95"

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -40,14 +40,14 @@ wasm-bindgen = ["dep:wasm-bindgen-futures", "dep:getrandom"]
 [dev-dependencies]
 either = "1.11.0"
 futures = { workspace = true }
-libp2p-identify = { path = "../protocols/identify" }                 # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
+libp2p-identify = { path = "../protocols/identify" }                # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
 libp2p-identity = { workspace = true, features = ["ed25519"] }
-libp2p-kad = { path = "../protocols/kad" }                           # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
-libp2p-ping = { path = "../protocols/ping" }                         # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
-libp2p-plaintext = { path = "../transports/plaintext" }              # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
-libp2p-swarm-derive = { path = "../swarm-derive" }                   # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
-libp2p-swarm-test = { path = "../swarm-test", features = ["tokio"] } # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
-libp2p-yamux = { path = "../muxers/yamux" }                          # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
+libp2p-kad = { path = "../protocols/kad" }                          # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
+libp2p-ping = { path = "../protocols/ping" }                        # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
+libp2p-plaintext = { path = "../transports/plaintext" }             # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
+libp2p-swarm-derive = { path = "../swarm-derive" }                  # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
+libp2p-swarm-test = { path = "../swarm-test", features = ["tokio"] }# Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
+libp2p-yamux = { path = "../muxers/yamux" }                         # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
 quickcheck = { workspace = true }
 criterion = { version = "0.5", features = ["async_tokio"] }
 trybuild = "1.0.95"

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -38,7 +38,6 @@ async-std = ["dep:async-std"]
 wasm-bindgen = ["dep:wasm-bindgen-futures", "dep:getrandom"]
 
 [dev-dependencies]
-async-std = { version = "1.6.2", features = ["attributes"] }
 either = "1.11.0"
 futures = { workspace = true }
 libp2p-identify = { path = "../protocols/identify" }                # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.

--- a/swarm/tests/connection_close.rs
+++ b/swarm/tests/connection_close.rs
@@ -12,7 +12,7 @@ use libp2p_swarm::{
 };
 use libp2p_swarm_test::SwarmExt;
 
-#[async_std::test]
+#[tokio::test]
 async fn sends_remaining_events_to_behaviour_on_connection_close() {
     let mut swarm1 = Swarm::new_ephemeral(|_| Behaviour::new(3));
     let mut swarm2 = Swarm::new_ephemeral(|_| Behaviour::new(3));

--- a/swarm/tests/connection_close.rs
+++ b/swarm/tests/connection_close.rs
@@ -14,8 +14,8 @@ use libp2p_swarm_test::SwarmExt;
 
 #[tokio::test]
 async fn sends_remaining_events_to_behaviour_on_connection_close() {
-    let mut swarm1 = Swarm::new_ephemeral(|_| Behaviour::new(3));
-    let mut swarm2 = Swarm::new_ephemeral(|_| Behaviour::new(3));
+    let mut swarm1 = Swarm::new_ephemeral_tokio(|_| Behaviour::new(3));
+    let mut swarm2 = Swarm::new_ephemeral_tokio(|_| Behaviour::new(3));
 
     swarm2.listen().with_memory_addr_external().await;
     swarm1.connect(&mut swarm2).await;

--- a/swarm/tests/listener.rs
+++ b/swarm/tests/listener.rs
@@ -17,7 +17,7 @@ use libp2p_swarm::{
 };
 use libp2p_swarm_test::SwarmExt;
 
-#[async_std::test]
+#[tokio::test]
 async fn behaviour_listener() {
     let mut swarm = Swarm::new_ephemeral(|_| Behaviour::default());
     let addr: Multiaddr = Protocol::Memory(0).into();

--- a/swarm/tests/listener.rs
+++ b/swarm/tests/listener.rs
@@ -19,7 +19,7 @@ use libp2p_swarm_test::SwarmExt;
 
 #[tokio::test]
 async fn behaviour_listener() {
-    let mut swarm = Swarm::new_ephemeral(|_| Behaviour::default());
+    let mut swarm = Swarm::new_ephemeral_tokio(|_| Behaviour::default());
     let addr: Multiaddr = Protocol::Memory(0).into();
     let id = swarm.behaviour_mut().listen(addr.clone());
 


### PR DESCRIPTION
## Description

ref #4449

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
