### PR TITLE
chore(libp2p-mplex): use tokio instead of async_std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3021,7 +3021,6 @@ dependencies = [
 name = "libp2p-mplex"
 version = "0.43.1"
 dependencies = [
- "async-std",
  "asynchronous-codec",
  "bytes",
  "criterion",
@@ -3036,6 +3035,7 @@ dependencies = [
  "quickcheck-ext",
  "rand 0.8.5",
  "smallvec",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "unsigned-varint",

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -24,7 +24,7 @@ tracing = { workspace = true }
 unsigned-varint = { workspace = true, features = ["asynchronous_codec"] }
 
 [dev-dependencies]
-async-std = { version = "1.7.0", features = ["attributes"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 criterion = "0.5"
 futures = { workspace = true }
 libp2p-identity = { workspace = true, features = ["rand"] }

--- a/muxers/mplex/src/io.rs
+++ b/muxers/mplex/src/io.rs
@@ -1150,10 +1150,10 @@ const EXTRA_PENDING_FRAMES: usize = 1000;
 mod tests {
     use std::{collections::HashSet, num::NonZeroU8, ops::DerefMut, pin::Pin};
 
-    use async_std::task;
     use asynchronous_codec::{Decoder, Encoder};
     use bytes::BytesMut;
     use quickcheck::*;
+    use tokio::runtime::Runtime;
 
     use super::*;
 
@@ -1265,7 +1265,8 @@ mod tests {
             };
             let mut m = Multiplexed::new(conn, cfg.clone());
 
-            task::block_on(future::poll_fn(move |cx| {
+            let rt = Runtime::new().unwrap();
+            rt.block_on(future::poll_fn(move |cx| {
                 // Receive all inbound streams.
                 for i in 0..cfg.max_substreams {
                     match m.poll_next_stream(cx) {
@@ -1383,7 +1384,8 @@ mod tests {
 
             // Run the test.
             let mut opened = HashSet::new();
-            task::block_on(future::poll_fn(move |cx| {
+            let rt = Runtime::new().unwrap();
+            rt.block_on(future::poll_fn(move |cx| {
                 // Open a number of streams.
                 for _ in 0..num_streams {
                     let id = ready!(m.poll_open_stream(cx)).unwrap();

--- a/muxers/mplex/tests/compliance.rs
+++ b/muxers/mplex/tests/compliance.rs
@@ -1,6 +1,6 @@
 use libp2p_mplex::Config;
 
-#[async_std::test]
+#[tokio::test]
 async fn close_implies_flush() {
     let (alice, bob) =
         libp2p_muxer_test_harness::connected_muxers_on_memory_ring_buffer::<Config, _, _>().await;
@@ -8,7 +8,7 @@ async fn close_implies_flush() {
     libp2p_muxer_test_harness::close_implies_flush(alice, bob).await;
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn read_after_close() {
     let (alice, bob) =
         libp2p_muxer_test_harness::connected_muxers_on_memory_ring_buffer::<Config, _, _>().await;


### PR DESCRIPTION
## Description

ref #4449 

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
