### PR TITLE
refactor(kad): Add `Key` to `InboundRequest::{AddProvider, PutRecord}`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2932,7 +2932,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.47.1"
+version = "0.48.0"
 dependencies = [
  "asynchronous-codec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ libp2p-floodsub = { version = "0.46.1", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.49.0", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.47.0", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.11" }
-libp2p-kad = { version = "0.47.1", path = "protocols/kad" }
+libp2p-kad = { version = "0.48.0", path = "protocols/kad" }
 libp2p-mdns = { version = "0.48.0", path = "protocols/mdns" }
 libp2p-memory-connection-limits = { version = "0.4.0", path = "misc/memory-connection-limits" }
 libp2p-metrics = { version = "0.17.0", path = "misc/metrics" }

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Configurable outbound_substreams_timeout.
   See [PR 6015](https://github.com/libp2p/rust-libp2p/pull/6015).
+- Add `Key` to `InboundRequest::{AddProvider, PutRecord}`.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
 
 ## 0.47.0
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.47.1
+## 0.48.0
 
 - Configurable outbound_substreams_timeout.
   See [PR 6015](https://github.com/libp2p/rust-libp2p/pull/6015).

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-kad"
 edition.workspace = true
 rust-version = { workspace = true }
 description = "Kademlia protocol for libp2p"
-version = "0.47.1"
+version = "0.48.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -1885,7 +1885,6 @@ where
         // first place.
 
         if !record.is_expired(now) {
-            
             let record_key = record.key.clone();
 
             // The record is cloned because of the weird libp2p protocol
@@ -1971,7 +1970,10 @@ where
 
                     self.queued_events
                         .push_back(ToSwarm::GenerateEvent(Event::InboundRequest {
-                            request: InboundRequest::AddProvider { record_key: key, record: None },
+                            request: InboundRequest::AddProvider {
+                                record_key: key,
+                                record: None,
+                            },
                         }));
                 }
                 StoreInserts::FilterBoth => {


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

This PR introduces `Key` to `InboundRequest::AddProvider` and `InboundRequest::PutRecord` to provide the record key when it is inserted into the `RecordStore`. 

Resolves #6048.

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

While one could just enable filtering, check the record for the key and then insert it into the store, I do feel this would provide information without requiring one to enable filtering and be responsible for inserting into the store.

Question:
1. Should we instead have it as `Option<Key>` so when if filtering is enabled, the field would return `None` and with it being . disabled, it would return `Some(_)`?  

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
