### PR TITLE
chore(request-reponse): use tokio test-swarm

### DIFF
--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -32,7 +32,7 @@ cbor = ["dep:serde", "dep:cbor4ii", "libp2p-swarm/macros"]
 anyhow = "1.0.86"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 rand = "0.8"
-libp2p-swarm-test = { path = "../../swarm-test", features = ["async-std"]}
+libp2p-swarm-test = { path = "../../swarm-test" }
 futures_ringbuf = "0.4.0"
 serde = { version = "1.0", features = ["derive"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/protocols/request-response/tests/error_reporting.rs
+++ b/protocols/request-response/tests/error_reporting.rs
@@ -520,8 +520,9 @@ fn new_swarm_with_config(
 ) -> (PeerId, Swarm<request_response::Behaviour<TestCodec>>) {
     let protocols = iter::once((StreamProtocol::new("/test/1"), ProtocolSupport::Full));
 
-    let swarm =
-        Swarm::new_ephemeral(|_| request_response::Behaviour::<TestCodec>::new(protocols, cfg));
+    let swarm = Swarm::new_ephemeral_tokio(|_| {
+        request_response::Behaviour::<TestCodec>::new(protocols, cfg)
+    });
     let peed_id = *swarm.local_peer_id();
 
     (peed_id, swarm)

--- a/protocols/request-response/tests/peer_address.rs
+++ b/protocols/request-response/tests/peer_address.rs
@@ -18,11 +18,11 @@ async fn dial_succeeds_after_adding_peers_address() {
     let protocols = iter::once((StreamProtocol::new("/ping/1"), ProtocolSupport::Full));
     let config = request_response::Config::default();
 
-    let mut swarm = Swarm::new_ephemeral(|_| {
+    let mut swarm = Swarm::new_ephemeral_tokio(|_| {
         request_response::cbor::Behaviour::<Ping, Pong>::new(protocols.clone(), config.clone())
     });
 
-    let mut swarm2 = Swarm::new_ephemeral(|_| {
+    let mut swarm2 = Swarm::new_ephemeral_tokio(|_| {
         request_response::cbor::Behaviour::<Ping, Pong>::new(protocols.clone(), config.clone())
     });
 

--- a/protocols/request-response/tests/ping.rs
+++ b/protocols/request-response/tests/ping.rs
@@ -41,7 +41,7 @@ async fn is_response_outbound() {
     let ping = Ping("ping".to_string().into_bytes());
     let offline_peer = PeerId::random();
 
-    let mut swarm1 = Swarm::new_ephemeral(|_| {
+    let mut swarm1 = Swarm::new_ephemeral_tokio(|_| {
         request_response::cbor::Behaviour::<Ping, Pong>::new(
             [(StreamProtocol::new("/ping/1"), ProtocolSupport::Full)],
             request_response::Config::default(),
@@ -90,11 +90,11 @@ async fn ping_protocol() {
     let protocols = iter::once((StreamProtocol::new("/ping/1"), ProtocolSupport::Full));
     let cfg = request_response::Config::default();
 
-    let mut swarm1 = Swarm::new_ephemeral(|_| {
+    let mut swarm1 = Swarm::new_ephemeral_tokio(|_| {
         request_response::cbor::Behaviour::<Ping, Pong>::new(protocols.clone(), cfg.clone())
     });
     let peer1_id = *swarm1.local_peer_id();
-    let mut swarm2 = Swarm::new_ephemeral(|_| {
+    let mut swarm2 = Swarm::new_ephemeral_tokio(|_| {
         request_response::cbor::Behaviour::<Ping, Pong>::new(protocols, cfg)
     });
     let peer2_id = *swarm2.local_peer_id();
@@ -187,11 +187,11 @@ async fn ping_protocol_explicit_address() {
     let protocols = iter::once((StreamProtocol::new("/ping/1"), ProtocolSupport::Full));
     let cfg = request_response::Config::default();
 
-    let mut swarm1 = Swarm::new_ephemeral(|_| {
+    let mut swarm1 = Swarm::new_ephemeral_tokio(|_| {
         request_response::cbor::Behaviour::<Ping, Pong>::new(protocols.clone(), cfg.clone())
     });
     let peer1_id = *swarm1.local_peer_id();
-    let mut swarm2 = Swarm::new_ephemeral(|_| {
+    let mut swarm2 = Swarm::new_ephemeral_tokio(|_| {
         request_response::cbor::Behaviour::<Ping, Pong>::new(protocols, cfg)
     });
     let peer2_id = *swarm2.local_peer_id();
@@ -305,11 +305,11 @@ async fn emits_inbound_connection_closed_failure() {
     let protocols = iter::once((StreamProtocol::new("/ping/1"), ProtocolSupport::Full));
     let cfg = request_response::Config::default();
 
-    let mut swarm1 = Swarm::new_ephemeral(|_| {
+    let mut swarm1 = Swarm::new_ephemeral_tokio(|_| {
         request_response::cbor::Behaviour::<Ping, Pong>::new(protocols.clone(), cfg.clone())
     });
     let peer1_id = *swarm1.local_peer_id();
-    let mut swarm2 = Swarm::new_ephemeral(|_| {
+    let mut swarm2 = Swarm::new_ephemeral_tokio(|_| {
         request_response::cbor::Behaviour::<Ping, Pong>::new(protocols, cfg)
     });
     let peer2_id = *swarm2.local_peer_id();
@@ -371,11 +371,11 @@ async fn emits_inbound_connection_closed_if_channel_is_dropped() {
     let protocols = iter::once((StreamProtocol::new("/ping/1"), ProtocolSupport::Full));
     let cfg = request_response::Config::default();
 
-    let mut swarm1 = Swarm::new_ephemeral(|_| {
+    let mut swarm1 = Swarm::new_ephemeral_tokio(|_| {
         request_response::cbor::Behaviour::<Ping, Pong>::new(protocols.clone(), cfg.clone())
     });
     let peer1_id = *swarm1.local_peer_id();
-    let mut swarm2 = Swarm::new_ephemeral(|_| {
+    let mut swarm2 = Swarm::new_ephemeral_tokio(|_| {
         request_response::cbor::Behaviour::<Ping, Pong>::new(protocols, cfg)
     });
     let peer2_id = *swarm2.local_peer_id();
@@ -432,11 +432,11 @@ async fn concurrent_ping_protocol() {
     let protocols = iter::once((StreamProtocol::new("/ping/1"), ProtocolSupport::Full));
     let cfg = request_response::Config::default();
 
-    let mut swarm1 = Swarm::new_ephemeral(|_| {
+    let mut swarm1 = Swarm::new_ephemeral_tokio(|_| {
         request_response::cbor::Behaviour::<Ping, Pong>::new(protocols.clone(), cfg.clone())
     });
     let peer1_id = *swarm1.local_peer_id();
-    let mut swarm2 = Swarm::new_ephemeral(|_| {
+    let mut swarm2 = Swarm::new_ephemeral_tokio(|_| {
         request_response::cbor::Behaviour::<Ping, Pong>::new(protocols, cfg)
     });
     let peer2_id = *swarm2.local_peer_id();


### PR DESCRIPTION
## Description

Amendment to #5857.
#5857 changed the tests in `libp2p-request-response` to use `tokio` as executor.
We forgot to also change the test-swarm's executor to use `tokio` instead of `async_std` (see #6024), so this PR fixes it.

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~A changelog entry has been made in the appropriate crates~~
