### PR TITLE
feat(swarm-test): remove `async-std` support

### DIFF
--- a/swarm-test/CHANGELOG.md
+++ b/swarm-test/CHANGELOG.md
@@ -4,7 +4,7 @@
   See [PR 6024](https://github.com/libp2p/rust-libp2p/pull/6024).
 - Remove `async_std` runtime support with `Swarm::new_ephemeral`.
   Use `Swarm::new_ephemeral_tokio` instead.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/6024)
+  See [PR 6064](https://github.com/libp2p/rust-libp2p/pull/6064)
 
 ## 0.5.0
 

--- a/swarm-test/CHANGELOG.md
+++ b/swarm-test/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Default to `tokio` runtime.
   See [PR 6024](https://github.com/libp2p/rust-libp2p/pull/6024).
+- Remove `async_std` runtime support with `Swarm::new_ephemeral`.
+  Use `Swarm::new_ephemeral_tokio` instead.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/6024)
 
 ## 0.5.0
 


### PR DESCRIPTION
## Description

Remove support for `async_std` in `swarm-test`.

## Notes & open questions

Depends on #6063.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] A changelog entry has been made in the appropriate crates
