### PR TITLE
chore(dns): Upgrade `hickory-resolver` to version 0.25.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,17 +365,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "async-signal"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,6 +1056,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,7 +1194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1942,11 +1937,10 @@ checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hickory-proto"
-version = "0.25.0-alpha.5"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d00147af6310f4392a31680db52a3ed45a2e0f68eb18e8c3fe5537ecc96d9e2"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
- "async-recursion",
  "async-trait",
  "cfg-if",
  "data-encoding",
@@ -1958,6 +1952,7 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand 0.9.0",
+ "ring",
  "socket2",
  "thiserror 2.0.12",
  "tinyvec",
@@ -1968,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.0-alpha.5"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5762f69ebdbd4ddb2e975cd24690bf21fe6b2604039189c26acddbc427f12887"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4043,6 +4038,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "oorandom"
@@ -6921,7 +6920,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,8 +126,8 @@ futures-bounded = { version = "0.2.4" }
 futures-rustls = { version = "0.26.0", default-features = false }
 getrandom = "0.2"
 if-watch = "3.2.1"
-hickory-proto = { version = "0.25.0-alpha.4", default-features = false }
-hickory-resolver = { version = "0.25.0-alpha.4", default-features = false }
+hickory-proto = { version = "0.25.2", default-features = false }
+hickory-resolver = { version = "0.25.2", default-features = false }
 multiaddr = "0.18.1"
 multihash = "0.19.1"
 multistream-select = { version = "0.13.0", path = "misc/multistream-select" }

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## 0.44.0
- 
-- Report all transport errors in a dial attempt instead of only returning the last error. 
+
+- Report all transport errors in a dial attempt instead of only returning the last error.
   See [PR 5899](https://github.com/libp2p/rust-libp2p/pull/5899).
-  
+- Upgrade `hickory-resolver` to version 0.25.2.
+  See [PR 6065](https://github.com/libp2p/rust-libp2p/pull/6065).
+
 ## 0.43.0
 
 - Upgrade `async-std-resolver` and `hickory-resolver`.

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -29,7 +29,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [features]
 async-std = ["async-std-resolver"]
-tokio = ["hickory-resolver/tokio-runtime"]
+tokio = ["hickory-resolver/tokio"]
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -117,6 +117,7 @@ pub mod async_std {
 pub mod tokio {
     use std::sync::Arc;
 
+    use hickory_resolver::name_server::TokioConnectionProvider;
     use hickory_resolver::{system_conf, TokioResolver};
     use parking_lot::Mutex;
 
@@ -140,7 +141,12 @@ pub mod tokio {
         ) -> Transport<T> {
             Transport {
                 inner: Arc::new(Mutex::new(inner)),
-                resolver: TokioResolver::tokio(cfg, opts),
+                resolver: TokioResolver::builder_with_config(
+                    cfg,
+                    TokioConnectionProvider::default(),
+                )
+                .with_options(opts)
+                .build(),
             }
         }
     }


### PR DESCRIPTION
## Description

Upgrade the `hickory-resolver` dependency of `libp2p-dns` to its latest stable version at this time: 0.25.2

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
