### PR TITLE
chore(swarm-tests): remove `async-std` feature

### DIFF
--- a/swarm-test/Cargo.toml
+++ b/swarm-test/Cargo.toml
@@ -26,7 +26,6 @@ futures-timer = "3.0.3"
 [features]
 default = ["tokio"]
 
-async-std = ["libp2p-swarm/async-std", "libp2p-tcp/async-io"]
 tokio = ["libp2p-swarm/tokio", "libp2p-tcp/tokio"]
 
 [lints]


### PR DESCRIPTION
## Description

Amendment to #6064.
#6064 removed the `async-std`-based variant for creating a test-swarm, so the `async-std` feature is now not needed anymore.

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~A changelog entry has been made in the appropriate crates~~
