### PR TITLE
fix(identity): drop `rand_core` feature in `ed25519-dalek`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1280,7 +1280,6 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -2827,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -6823,7 +6822,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ libp2p-dns = { version = "0.44.0", path = "transports/dns" }
 libp2p-floodsub = { version = "0.46.1", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.49.0", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.47.0", path = "protocols/identify" }
-libp2p-identity = { version = "0.2.11" }
+libp2p-identity = { version = "0.2.12" }
 libp2p-kad = { version = "0.47.1", path = "protocols/kad" }
 libp2p-mdns = { version = "0.48.0", path = "protocols/mdns" }
 libp2p-memory-connection-limits = { version = "0.4.0", path = "misc/memory-connection-limits" }

--- a/identity/CHANGELOG.md
+++ b/identity/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.12
+
+- Avoid depending on the `rand_core` feature in `ed25519-dalek` crate.
+  See [PR 6070](https://github.com/libp2p/rust-libp2p/pull/6070)
+
 ## 0.2.11
 
 - Switch from `libsecp256` to `k256` for secp256k1 support.

--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-identity"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021" # MUST NOT inherit from workspace because we don't want to publish breaking changes to `libp2p-identity`.
 description = "Data structures and algorithms for identifying peers in libp2p."
 rust-version = "1.73.0" # MUST NOT inherit from workspace because we don't want to publish breaking changes to `libp2p-identity`.
@@ -37,7 +37,7 @@ ecdsa = ["dep:p256", "dep:zeroize", "dep:sec1", "dep:sha2", "dep:hkdf"]
 rsa = ["dep:ring", "dep:asn1_der", "dep:rand", "dep:zeroize"]
 ed25519 = ["dep:ed25519-dalek", "dep:zeroize", "dep:sha2", "dep:hkdf"]
 peerid = ["dep:multihash", "dep:bs58", "dep:thiserror", "dep:sha2", "dep:hkdf"]
-rand = ["dep:rand", "ed25519-dalek?/rand_core"]
+rand = ["dep:rand"]
 
 [dev-dependencies]
 quickcheck = { workspace = true }

--- a/identity/src/ed25519.rs
+++ b/identity/src/ed25519.rs
@@ -186,7 +186,7 @@ impl SecretKey {
     pub fn generate() -> SecretKey {
         use rand::RngCore as _;
 
-        let mut secret = [0; ed25519::SECRET_KEY_LENGTH];
+        let mut secret = ed25519::SecretKey::default();
         rand::rngs::OsRng.fill_bytes(&mut secret);
         SecretKey(secret)
     }

--- a/identity/src/ed25519.rs
+++ b/identity/src/ed25519.rs
@@ -184,8 +184,11 @@ impl SecretKey {
     /// Generate a new Ed25519 secret key.
     #[cfg(feature = "rand")]
     pub fn generate() -> SecretKey {
-        let signing = ed25519::SigningKey::generate(&mut rand::rngs::OsRng);
-        SecretKey(signing.to_bytes())
+        use rand::RngCore as _;
+
+        let mut secret = [0; ed25519::SECRET_KEY_LENGTH];
+        rand::rngs::OsRng.fill_bytes(&mut secret);
+        SecretKey(secret)
     }
 
     /// Try to parse an Ed25519 secret key from a byte slice


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

This PR 
- drops `rand_core` feature dependency from `ed25519-dalek` crate to unblock upgrading `rand` crate to `v0.9`.

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
