### PR TITLE
chore(kad): rename substreams_timeout

### DIFF
--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.47.1
 
-- Configurable substreams_timeout.
+- Configurable substreams_timeout for outbound substreams.
   See [PR 6015](https://github.com/libp2p/rust-libp2p/pull/6015).
 
 ## 0.47.0

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## 0.47.1
 
-- Configurable substreams_timeout for outbound substreams.
+- Configurable outbound_substreams_timeout.
   See [PR 6015](https://github.com/libp2p/rust-libp2p/pull/6015).
-
+- Rename `outbound_substreams_timeout` to `substreams_timeout` for future-proofness. 
+  See [PR 6076](https://github.com/libp2p/rust-libp2p/pull/6076).
 ## 0.47.0
 
 - Expose a kad query facility allowing specify num_results dynamically.

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.47.1
 
-- Configurable outbound_substreams_timeout.
+- Configurable substreams_timeout.
   See [PR 6015](https://github.com/libp2p/rust-libp2p/pull/6015).
 
 ## 0.47.0

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -382,13 +382,12 @@ impl Config {
         self
     }
 
-    /// Modifies the timeout duration of outbount_substreams.
+    /// Modifies the timeout duration of outbound substreams.
     ///
     /// * Default to `10` seconds.
     /// * May need to increase this value when sending large records with poor connection.
-    pub fn set_outbound_substreams_timeout(&mut self, timeout: Duration) -> &mut Self {
-        self.protocol_config
-            .set_outbound_substreams_timeout(timeout);
+    pub fn set_substreams_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.protocol_config.set_substreams_timeout(timeout);
         self
     }
 

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -453,7 +453,7 @@ impl Handler {
             }
         }
 
-        let outbound_substreams_timeout = protocol_config.outbound_substreams_timeout_s();
+        let substreams_timeout = protocol_config.substreams_timeout_s();
 
         Handler {
             protocol_config,
@@ -463,7 +463,7 @@ impl Handler {
             next_connec_unique_id: UniqueConnecId(0),
             inbound_substreams: Default::default(),
             outbound_substreams: futures_bounded::FuturesTupleSet::new(
-                outbound_substreams_timeout,
+                substreams_timeout,
                 MAX_NUM_STREAMS,
             ),
             pending_streams: Default::default(),

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -50,7 +50,7 @@ pub(crate) const DEFAULT_PROTO_NAME: StreamProtocol = StreamProtocol::new("/ipfs
 /// The default maximum size for a varint length-delimited packet.
 pub(crate) const DEFAULT_MAX_PACKET_SIZE: usize = 16 * 1024;
 /// The default timeout of outbound_substreams to be 10 (seconds).
-const DEFAULT_OUTBOUND_SUBSTREAMS_TIMEOUT_S: Duration = Duration::from_secs(10);
+const DEFAULT_SUBSTREAMS_TIMEOUT_S: Duration = Duration::from_secs(10);
 /// Status of our connection to a node reported by the Kademlia protocol.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum ConnectionType {
@@ -148,7 +148,7 @@ pub struct ProtocolConfig {
     /// Maximum allowed size of a packet.
     max_packet_size: usize,
     /// Specifies the outbound_substreams timeout in seconds
-    outbound_substreams_timeout_s: Duration,
+    substreams_timeout_s: Duration,
 }
 
 impl ProtocolConfig {
@@ -157,7 +157,7 @@ impl ProtocolConfig {
         ProtocolConfig {
             protocol_names: vec![protocol_name],
             max_packet_size: DEFAULT_MAX_PACKET_SIZE,
-            outbound_substreams_timeout_s: DEFAULT_OUTBOUND_SUBSTREAMS_TIMEOUT_S,
+            substreams_timeout_s: DEFAULT_SUBSTREAMS_TIMEOUT_S,
         }
     }
 
@@ -171,14 +171,14 @@ impl ProtocolConfig {
         self.max_packet_size = size;
     }
 
-    /// Modifies outbount_substreams timeout.
-    pub fn set_outbound_substreams_timeout(&mut self, timeout: Duration) {
-        self.outbound_substreams_timeout_s = timeout;
+    /// Modifies the outbound substreams timeout.
+    pub fn set_substreams_timeout(&mut self, timeout: Duration) {
+        self.substreams_timeout_s = timeout;
     }
 
-    /// Getter of outbount_substreams_timeout_s.
-    pub fn outbound_substreams_timeout_s(&self) -> Duration {
-        self.outbound_substreams_timeout_s
+    /// Getter of substreams_timeout_s.
+    pub fn substreams_timeout_s(&self) -> Duration {
+        self.substreams_timeout_s
     }
 }
 


### PR DESCRIPTION
## Description

#6015 made the timeout for outbound substreams in kademlia configurable by introducing a `outbound_substreams_timeout` config option.
There is currently an open PR #6009 that plans to also apply that timeout to inbound substream, in which case we probably want toe rename the config option to `substreams_timeout` (without the prefix). 
Because we plan to release soon and might not get #6009 in in-time, I propose that we already do the renaming now, to avoid breaking the API again with the next release.

## Notes & open questions

I directly changed the initial changelog entry of #6009 to avoid confusion. Is that okay or should a add a separate changelog entry for the renaming?

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~A changelog entry has been made in the appropriate crates~~
