### PR TITLE
chore(libp2p): don't re-export libp2p-peer-store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2466,7 +2466,6 @@ dependencies = [
  "libp2p-metrics",
  "libp2p-mplex",
  "libp2p-noise",
- "libp2p-peer-store",
  "libp2p-ping",
  "libp2p-plaintext",
  "libp2p-pnet",

--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -28,7 +28,6 @@ full = [
     "memory-connection-limits",
     "metrics",
     "noise",
-    "peer-store",
     "ping",
     "plaintext",
     "pnet",
@@ -68,7 +67,6 @@ mdns = ["dep:libp2p-mdns"]
 memory-connection-limits = ["dep:libp2p-memory-connection-limits"]
 metrics = ["dep:libp2p-metrics"]
 noise = ["dep:libp2p-noise"]
-peer-store = ["dep:libp2p-peer-store"]
 ping = ["dep:libp2p-ping", "libp2p-metrics?/ping"]
 plaintext = ["dep:libp2p-plaintext"]
 pnet = ["dep:libp2p-pnet"]
@@ -111,7 +109,6 @@ libp2p-identity = { workspace = true, features = ["rand"] }
 libp2p-kad = { workspace = true, optional = true }
 libp2p-metrics = { workspace = true, optional = true }
 libp2p-noise = { workspace = true, optional = true }
-libp2p-peer-store = { workspace = true, optional = true }
 libp2p-ping = { workspace = true, optional = true }
 libp2p-plaintext = { workspace = true, optional = true }
 libp2p-pnet = { workspace = true, optional = true }

--- a/libp2p/src/lib.rs
+++ b/libp2p/src/lib.rs
@@ -81,9 +81,6 @@ pub use libp2p_metrics as metrics;
 #[cfg(feature = "noise")]
 #[doc(inline)]
 pub use libp2p_noise as noise;
-#[cfg(feature = "peer-store")]
-#[doc(inline)]
-pub use libp2p_peer_store as peer_store;
 #[cfg(feature = "ping")]
 #[doc(inline)]
 pub use libp2p_ping as ping;


### PR DESCRIPTION
## Description

`publish` is still set to `false` in `libp2p-peer-store`, so we shouldn't re-export it from the main `libp2p` crate.

## Notes & open questions

We can always re-add it and publish it independently of the main `libp2p` release.

@dknopik @drHuangMHT what's your opinion on the state of `libp2p-peer-store`? Should we release it soon or do you think it still requires some iterations?

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
