### PR TITLE
feat(webrtc): fin-ack functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3240,7 +3240,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-webrtc-utils"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "asynchronous-codec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ libp2p-tls = { version = "0.6.2", path = "transports/tls" }
 libp2p-uds = { version = "0.43.0", path = "transports/uds" }
 libp2p-upnp = { version = "0.5.0", path = "protocols/upnp" }
 libp2p-webrtc = { version = "0.9.0-alpha.1", path = "transports/webrtc" }
-libp2p-webrtc-utils = { version = "0.4.0", path = "misc/webrtc-utils" }
+libp2p-webrtc-utils = { version = "0.4.1", path = "misc/webrtc-utils" }
 libp2p-webrtc-websys = { version = "0.4.0", path = "transports/webrtc-websys" }
 libp2p-websocket = { version = "0.45.1", path = "transports/websocket" }
 libp2p-websocket-websys = { version = "0.5.0", path = "transports/websocket-websys" }

--- a/misc/webrtc-utils/CHANGELOG.md
+++ b/misc/webrtc-utils/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.1
+
+- FIN_ACK support for WebRTC streams.
+  See [PR 6084](https://github.com/libp2p/rust-libp2p/pull/6084).
+
 ## 0.4.0
 
 <!-- Update to libp2p-core v0.43.0 -->

--- a/misc/webrtc-utils/Cargo.toml
+++ b/misc/webrtc-utils/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "libp2p-webrtc-utils"
 repository = "https://github.com/libp2p/rust-libp2p"
 rust-version = { workspace = true }
-version = "0.4.0"
+version = "0.4.1"
 publish = true
 
 [dependencies]

--- a/misc/webrtc-utils/src/generated/message.proto
+++ b/misc/webrtc-utils/src/generated/message.proto
@@ -12,9 +12,13 @@ message Message {
     // The sender abruptly terminates the sending part of the stream. The
     // receiver can discard any data that it already received on that stream.
     RESET = 2;
+    // Sending the FIN_ACK flag acknowledges the previous receipt of a message
+    // with the FIN flag set. Receiving a FIN_ACK flag gives the recipient
+    // confidence that the remote has received all sent messages.
+    FIN_ACK = 3;
   }
 
-  optional Flag flag=1;
+  optional Flag flag = 1;
 
   optional bytes message = 2;
 }

--- a/misc/webrtc-utils/src/generated/webrtc/pb.rs
+++ b/misc/webrtc-utils/src/generated/webrtc/pb.rs
@@ -57,6 +57,7 @@ pub enum Flag {
     FIN = 0,
     STOP_SENDING = 1,
     RESET = 2,
+    FIN_ACK = 3,
 }
 
 impl Default for Flag {
@@ -71,6 +72,7 @@ impl From<i32> for Flag {
             0 => Flag::FIN,
             1 => Flag::STOP_SENDING,
             2 => Flag::RESET,
+            3 => Flag::FIN_ACK,
             _ => Self::default(),
         }
     }
@@ -82,6 +84,7 @@ impl<'a> From<&'a str> for Flag {
             "FIN" => Flag::FIN,
             "STOP_SENDING" => Flag::STOP_SENDING,
             "RESET" => Flag::RESET,
+            "FIN_ACK" => Flag::FIN_ACK,
             _ => Self::default(),
         }
     }

--- a/misc/webrtc-utils/src/stream/state.rs
+++ b/misc/webrtc-utils/src/stream/state.rs
@@ -35,9 +35,19 @@ pub(crate) enum State {
         inner: Closing,
     },
     ClosingWrite {
-        /// Whether the write side of our channel was already closed.
+        /// Whether the read side of our channel was already closed.
         read_closed: bool,
         inner: Closing,
+    },
+    /// We've received a FIN and need to send a FIN_ACK
+    ReadClosedNeedFinAck {
+        /// Whether the write side of our channel was already closed.
+        write_closed: bool,
+    },
+    /// We've sent a FIN and are waiting for a FIN_ACK
+    WriteSentFinWaitingForAck {
+        /// Whether the read side of our channel was already closed.
+        read_closed: bool,
     },
     BothClosed {
         reset: bool,
@@ -61,9 +71,15 @@ impl State {
 
         match (current, flag) {
             (Self::Open, Flag::FIN) => {
-                *self = Self::ReadClosed;
+                *self = Self::ReadClosedNeedFinAck { write_closed: false };
             }
             (Self::WriteClosed, Flag::FIN) => {
+                *self = Self::ReadClosedNeedFinAck { write_closed: true };
+            }
+            (Self::WriteSentFinWaitingForAck { read_closed: false }, Flag::FIN) => {
+                *self = Self::ReadClosedNeedFinAck { write_closed: false };
+            }
+            (Self::WriteSentFinWaitingForAck { read_closed: true }, Flag::FIN) => {
                 *self = Self::BothClosed { reset: false };
             }
             (Self::Open, Flag::STOP_SENDING) => {
@@ -71,6 +87,28 @@ impl State {
             }
             (Self::ReadClosed, Flag::STOP_SENDING) => {
                 *self = Self::BothClosed { reset: false };
+            }
+            (Self::ReadClosedNeedFinAck { write_closed: false }, Flag::STOP_SENDING) => {
+                *self = Self::ReadClosedNeedFinAck { write_closed: true };
+            }
+            (Self::ReadClosedNeedFinAck { write_closed: true }, Flag::STOP_SENDING) => {
+                // Already closed, ignore
+            }
+            (Self::WriteSentFinWaitingForAck { read_closed: _ }, Flag::STOP_SENDING) => {
+                *self = Self::WriteSentFinWaitingForAck { read_closed: true };
+            }
+            (Self::WriteSentFinWaitingForAck { read_closed: false }, Flag::FIN_ACK) => {
+                *self = Self::WriteClosed;
+            }
+            (Self::WriteSentFinWaitingForAck { read_closed: true }, Flag::FIN_ACK) => {
+                *self = Self::BothClosed { reset: false };
+            }
+            (Self::ClosingWrite { read_closed, inner: Closing::MessageSent }, Flag::FIN_ACK) => {
+                *self = if read_closed {
+                    Self::BothClosed { reset: false }
+                } else {
+                    Self::WriteClosed
+                };
             }
             (_, Flag::RESET) => {
                 buffer.clear();
@@ -88,7 +126,7 @@ impl State {
             } => {
                 debug_assert!(matches!(inner, Closing::MessageSent));
 
-                *self = State::BothClosed { reset: false };
+                *self = State::WriteSentFinWaitingForAck { read_closed: true };
             }
             State::ClosingWrite {
                 read_closed: false,
@@ -96,7 +134,13 @@ impl State {
             } => {
                 debug_assert!(matches!(inner, Closing::MessageSent));
 
-                *self = State::WriteClosed;
+                *self = State::WriteSentFinWaitingForAck { read_closed: false };
+            }
+            State::ReadClosedNeedFinAck { .. } => {
+                unreachable!("write_closed called on ReadClosedNeedFinAck state")
+            }
+            State::WriteSentFinWaitingForAck { .. } => {
+                unreachable!("write_closed called on WriteSentFinWaitingForAck state")
             }
             State::Open
             | State::ReadClosed
@@ -117,6 +161,12 @@ impl State {
                     read_closed: *read_closed,
                     inner: Closing::MessageSent,
                 };
+            }
+            State::ReadClosedNeedFinAck { .. } => {
+                unreachable!("close_write_message_sent called on ReadClosedNeedFinAck state")
+            }
+            State::WriteSentFinWaitingForAck { .. } => {
+                unreachable!("close_write_message_sent called on WriteSentFinWaitingForAck state")
             }
             State::Open
             | State::ReadClosed
@@ -146,6 +196,12 @@ impl State {
 
                 *self = State::ReadClosed;
             }
+            State::ReadClosedNeedFinAck { .. } => {
+                unreachable!("read_closed called on ReadClosedNeedFinAck state")
+            }
+            State::WriteSentFinWaitingForAck { .. } => {
+                unreachable!("read_closed called on WriteSentFinWaitingForAck state")
+            }
             State::Open
             | State::ReadClosed
             | State::WriteClosed
@@ -169,6 +225,12 @@ impl State {
                     inner: Closing::MessageSent,
                 };
             }
+            State::ReadClosedNeedFinAck { .. } => {
+                unreachable!("close_read_message_sent called on ReadClosedNeedFinAck state")
+            }
+            State::WriteSentFinWaitingForAck { .. } => {
+                unreachable!("close_read_message_sent called on WriteSentFinWaitingForAck state")
+            }
             State::Open
             | State::ReadClosed
             | State::WriteClosed
@@ -184,7 +246,7 @@ impl State {
     /// This is necessary for read-closed streams because we would otherwise
     /// not read any more flags from the socket.
     pub(crate) fn read_flags_in_async_write(&self) -> bool {
-        matches!(self, Self::ReadClosed)
+        matches!(self, Self::ReadClosed | Self::ReadClosedNeedFinAck { .. } | Self::WriteSentFinWaitingForAck { .. })
     }
 
     /// Acts as a "barrier" for [`futures::AsyncRead::poll_read`].
@@ -196,11 +258,14 @@ impl State {
             | WriteClosed
             | ClosingWrite {
                 read_closed: false, ..
-            } => return Ok(()),
+            }
+            | WriteSentFinWaitingForAck { read_closed: false } => return Ok(()),
             ClosingWrite {
                 read_closed: true, ..
             }
             | ReadClosed
+            | ReadClosedNeedFinAck { .. }
+            | WriteSentFinWaitingForAck { read_closed: true }
             | ClosingRead { .. }
             | BothClosed { reset: false } => io::ErrorKind::BrokenPipe,
             BothClosed { reset: true } => io::ErrorKind::ConnectionReset,
@@ -216,6 +281,7 @@ impl State {
         let kind = match self {
             Open
             | ReadClosed
+            | ReadClosedNeedFinAck { write_closed: false }
             | ClosingRead {
                 write_closed: false,
                 ..
@@ -224,6 +290,8 @@ impl State {
                 write_closed: true, ..
             }
             | WriteClosed
+            | ReadClosedNeedFinAck { write_closed: true }
+            | WriteSentFinWaitingForAck { .. }
             | ClosingWrite { .. }
             | BothClosed { reset: false } => io::ErrorKind::BrokenPipe,
             BothClosed { reset: true } => io::ErrorKind::ConnectionReset,
@@ -240,6 +308,10 @@ impl State {
 
                 State::ClosingWrite { inner, .. } => return Ok(Some(*inner)),
 
+                State::WriteSentFinWaitingForAck { .. } => {
+                    return Err(io::Error::other("waiting for FIN_ACK before closing"))
+                }
+
                 State::Open => {
                     *self = Self::ClosingWrite {
                         read_closed: false,
@@ -251,6 +323,15 @@ impl State {
                         read_closed: true,
                         inner: Closing::Requested,
                     };
+                }
+                State::ReadClosedNeedFinAck { write_closed: false } => {
+                    *self = Self::ClosingWrite {
+                        read_closed: true,
+                        inner: Closing::Requested,
+                    };
+                }
+                State::ReadClosedNeedFinAck { write_closed: true } => {
+                    return Err(io::ErrorKind::BrokenPipe.into())
                 }
 
                 State::ClosingRead {
@@ -284,6 +365,8 @@ impl State {
 
                 State::ClosingRead { inner, .. } => return Ok(Some(*inner)),
 
+                State::ReadClosedNeedFinAck { .. } => return Ok(None),
+
                 State::Open => {
                     *self = Self::ClosingRead {
                         write_closed: false,
@@ -295,6 +378,15 @@ impl State {
                         write_closed: true,
                         inner: Closing::Requested,
                     };
+                }
+                State::WriteSentFinWaitingForAck { read_closed: false } => {
+                    *self = Self::ClosingRead {
+                        write_closed: false,
+                        inner: Closing::Requested,
+                    };
+                }
+                State::WriteSentFinWaitingForAck { read_closed: true } => {
+                    return Err(io::ErrorKind::BrokenPipe.into())
                 }
 
                 State::ClosingWrite {
@@ -318,6 +410,28 @@ impl State {
             }
         }
     }
+
+    /// Returns whether the state requires sending a FIN_ACK.
+    /// This should be called by the stream implementation to check if it needs to send a FIN_ACK.
+    pub(crate) fn needs_fin_ack(&self) -> bool {
+        matches!(self, Self::ReadClosedNeedFinAck { .. })
+    }
+
+    /// Marks that a FIN_ACK has been sent in response to a received FIN.
+    /// This transitions from ReadClosedNeedFinAck to ReadClosed.
+    pub(crate) fn fin_ack_sent(&mut self) {
+        match self {
+            State::ReadClosedNeedFinAck { write_closed: false } => {
+                *self = State::ReadClosed;
+            }
+            State::ReadClosedNeedFinAck { write_closed: true } => {
+                *self = State::BothClosed { reset: false };
+            }
+            _ => {
+                unreachable!("fin_ack_sent called on wrong state")
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -331,6 +445,7 @@ mod tests {
         let mut open = State::Open;
 
         open.handle_inbound_flag(Flag::FIN, &mut Bytes::default());
+        // After receiving FIN, we're in ReadClosedNeedFinAck state but read barrier should still prevent reading
         let error = open.read_barrier().unwrap_err();
 
         assert_eq!(error.kind(), ErrorKind::BrokenPipe)
@@ -477,8 +592,14 @@ mod tests {
         open.close_write_message_sent();
         open.write_closed();
 
-        let maybe = open.close_write_barrier().unwrap();
+        // After write_closed(), we're waiting for FIN_ACK, so close_write_barrier should return error
+        let result = open.close_write_barrier();
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "waiting for FIN_ACK before closing");
 
+        // After receiving FIN_ACK, we should be in WriteClosed state
+        open.handle_inbound_flag(Flag::FIN_ACK, &mut Bytes::default());
+        let maybe = open.close_write_barrier().unwrap();
         assert!(maybe.is_none())
     }
 
@@ -503,5 +624,150 @@ mod tests {
         open.handle_inbound_flag(Flag::RESET, &mut buffer);
 
         assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn fin_requires_fin_ack() {
+        let mut open = State::Open;
+
+        open.handle_inbound_flag(Flag::FIN, &mut Bytes::default());
+
+        assert!(open.needs_fin_ack());
+        assert!(matches!(open, State::ReadClosedNeedFinAck { write_closed: false }));
+    }
+
+    #[test]
+    fn fin_ack_sent_transitions_to_read_closed() {
+        let mut state = State::ReadClosedNeedFinAck { write_closed: false };
+
+        state.fin_ack_sent();
+
+        assert!(!state.needs_fin_ack());
+        assert!(matches!(state, State::ReadClosed));
+    }
+
+    #[test]
+    fn fin_ack_sent_with_write_closed_transitions_to_both_closed() {
+        let mut state = State::ReadClosedNeedFinAck { write_closed: true };
+
+        state.fin_ack_sent();
+
+        assert!(!state.needs_fin_ack());
+        assert!(matches!(state, State::BothClosed { reset: false }));
+    }
+
+    #[test]
+    fn fin_ack_completes_write_close() {
+        let mut state = State::WriteSentFinWaitingForAck { read_closed: false };
+
+        state.handle_inbound_flag(Flag::FIN_ACK, &mut Bytes::default());
+
+        assert!(matches!(state, State::WriteClosed));
+    }
+
+    #[test]
+    fn fin_ack_with_read_closed_transitions_to_both_closed() {
+        let mut state = State::WriteSentFinWaitingForAck { read_closed: true };
+
+        state.handle_inbound_flag(Flag::FIN_ACK, &mut Bytes::default());
+
+        assert!(matches!(state, State::BothClosed { reset: false }));
+    }
+
+    #[test]
+    fn simultaneous_fin_exchange() {
+        let mut state = State::WriteSentFinWaitingForAck { read_closed: false };
+
+        // Receive FIN while waiting for FIN_ACK
+        state.handle_inbound_flag(Flag::FIN, &mut Bytes::default());
+
+        assert!(state.needs_fin_ack());
+        assert!(matches!(state, State::ReadClosedNeedFinAck { write_closed: false }));
+
+        // Send FIN_ACK 
+        state.fin_ack_sent();
+
+        assert!(matches!(state, State::ReadClosed));
+    }
+
+    #[test]
+    fn write_close_waits_for_fin_ack() {
+        let mut state = State::WriteSentFinWaitingForAck { read_closed: false };
+
+        let result = state.close_write_barrier();
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "waiting for FIN_ACK before closing");
+    }
+
+    #[test]
+    fn read_flags_in_async_write_with_fin_ack_states() {
+        let state_need_ack = State::ReadClosedNeedFinAck { write_closed: false };
+        let state_waiting_ack = State::WriteSentFinWaitingForAck { read_closed: false };
+
+        assert!(state_need_ack.read_flags_in_async_write());
+        assert!(state_waiting_ack.read_flags_in_async_write());
+    }
+
+    #[test]
+    fn complete_fin_ack_handshake_example() {
+        // This test demonstrates the complete FIN_ACK handshake as described in the spec:
+        // NodeA closes for writing, NodeB delays allowing the channel to close until it
+        // also finishes writing.
+
+        let mut node_a = State::Open;
+        let mut node_b = State::Open;
+
+        // NodeA wants to close for writing
+        node_a.close_write_barrier().unwrap();
+        node_a.close_write_message_sent();
+        node_a.write_closed();
+        
+        // NodeA is now waiting for FIN_ACK
+        assert!(matches!(node_a, State::WriteSentFinWaitingForAck { read_closed: false }));
+
+        // NodeB receives the FIN from NodeA
+        node_b.handle_inbound_flag(Flag::FIN, &mut Bytes::default());
+        
+        // NodeB should now need to send a FIN_ACK
+        assert!(node_b.needs_fin_ack());
+        assert!(matches!(node_b, State::ReadClosedNeedFinAck { write_closed: false }));
+
+        // NodeB sends FIN_ACK (simulated by calling fin_ack_sent)
+        node_b.fin_ack_sent();
+        assert!(matches!(node_b, State::ReadClosed));
+
+        // NodeA receives the FIN_ACK
+        node_a.handle_inbound_flag(Flag::FIN_ACK, &mut Bytes::default());
+        
+        // NodeA's write side is now closed
+        assert!(matches!(node_a, State::WriteClosed));
+
+        // NodeB also wants to close for writing
+        node_b.close_write_barrier().unwrap();
+        node_b.close_write_message_sent(); 
+        node_b.write_closed();
+
+        // NodeB is now waiting for FIN_ACK 
+        assert!(matches!(node_b, State::WriteSentFinWaitingForAck { read_closed: true }));
+
+        // NodeA receives the FIN from NodeB
+        node_a.handle_inbound_flag(Flag::FIN, &mut Bytes::default());
+        
+        // NodeA should now need to send a FIN_ACK
+        assert!(node_a.needs_fin_ack());
+        assert!(matches!(node_a, State::ReadClosedNeedFinAck { write_closed: true }));
+
+        // NodeA sends FIN_ACK 
+        node_a.fin_ack_sent();
+        assert!(matches!(node_a, State::BothClosed { reset: false }));
+
+        // NodeB receives the FIN_ACK
+        node_b.handle_inbound_flag(Flag::FIN_ACK, &mut Bytes::default());
+        
+        // NodeB is now fully closed
+        assert!(matches!(node_b, State::BothClosed { reset: false }));
+
+        // Both nodes have successfully closed the channel without data loss
     }
 }


### PR DESCRIPTION
## Description

ref #4600 

This may not be the ideal and best solution, always open to suggestions and comments :)

### Changes:
- Added `FIN_ACK = 3` flag to WebRTC protobuf message definition
- Extended state machine with ReadClosedNeedFinAck and WriteSentFinWaitingForAck states
- Modified stream implementation to automatically send `FIN_ACK `upon receiving `FIN`
- Updated close logic to wait for `FIN_ACK` before considering write-half closed
- Added comprehensive tests for `FIN_ACK` handshake scenarios

### Behaviour:
- When receiving `FIN` → automatically send `FIN_ACK`
- When sending `FIN` → wait for `FIN_ACK` before closing write-half
- Supports simultaneous close from both ends without data loss
- Maintains backwards compatibility with existing WebRTC implementations

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
