### PR TITLE
fix typo: rename connec → connect

### DIFF
--- a/misc/multistream-select/src/length_delimited.rs
+++ b/misc/multistream-select/src/length_delimited.rs
@@ -496,7 +496,7 @@ mod tests {
             rt.block_on(async move {
                 let expected_frames = frames.clone();
                 let server = tokio::task::spawn(async move {
-                    let mut connec =
+                    let mut connect =
                         rw_stream_sink::RwStreamSink::new(LengthDelimited::new(server_connection));
 
                     let mut buf = vec![0u8; 0];
@@ -513,7 +513,7 @@ mod tests {
                 });
 
                 let client = tokio::task::spawn(async move {
-                    let mut connec = LengthDelimited::new(client_connection);
+                    let mut connect = LengthDelimited::new(client_connection);
                     for frame in frames {
                         connec.send(From::from(frame)).await.unwrap();
                     }


### PR DESCRIPTION


**Description:**  
This pull request corrects a minor typo in the variable name from `connec` to `connect` within the tests of `misc/multistream-select/src/length_delimited.rs` 