### PR TITLE
fix typo: rename `connec` to `connect`

### DIFF
--- a/core/src/either.rs
+++ b/core/src/either.rs
@@ -184,12 +184,12 @@ where
         use TransportError::*;
         match self {
             Either::Left(a) => match a.dial(addr, opts) {
-                Ok(connec) => Ok(EitherFuture::First(connec)),
+                Ok(connect) => Ok(EitherFuture::First(connect)),
                 Err(MultiaddrNotSupported(addr)) => Err(MultiaddrNotSupported(addr)),
                 Err(Other(err)) => Err(Other(Either::Left(err))),
             },
             Either::Right(b) => match b.dial(addr, opts) {
-                Ok(connec) => Ok(EitherFuture::Second(connec)),
+                Ok(connect) => Ok(EitherFuture::Second(connect)),
                 Err(MultiaddrNotSupported(addr)) => Err(MultiaddrNotSupported(addr)),
                 Err(Other(err)) => Err(Other(Either::Right(err))),
             },

--- a/core/src/transport/choice.rs
+++ b/core/src/transport/choice.rs
@@ -110,7 +110,7 @@ where
             std::any::type_name::<A>()
         );
         let addr = match self.0.dial(addr, opts) {
-            Ok(connec) => return Ok(EitherFuture::First(connec)),
+            Ok(connect) => return Ok(EitherFuture::First(connect)),
             Err(TransportError::MultiaddrNotSupported(addr)) => {
                 tracing::debug!(
                     address=%addr,
@@ -130,7 +130,7 @@ where
             std::any::type_name::<A>()
         );
         let addr = match self.1.dial(addr, opts) {
-            Ok(connec) => return Ok(EitherFuture::Second(connec)),
+            Ok(connect) => return Ok(EitherFuture::Second(connect)),
             Err(TransportError::MultiaddrNotSupported(addr)) => {
                 tracing::debug!(
                     address=%addr,

--- a/misc/multistream-select/src/length_delimited.rs
+++ b/misc/multistream-select/src/length_delimited.rs
@@ -496,7 +496,7 @@ mod tests {
             rt.block_on(async move {
                 let expected_frames = frames.clone();
                 let server = tokio::task::spawn(async move {
-                    let mut connec =
+                    let mut connect =
                         rw_stream_sink::RwStreamSink::new(LengthDelimited::new(server_connection));
 
                     let mut buf = vec![0u8; 0];
@@ -507,15 +507,15 @@ mod tests {
                         if buf.len() < expected.len() {
                             buf.resize(expected.len(), 0);
                         }
-                        let n = connec.read(&mut buf).await.unwrap();
+                        let n = connect.read(&mut buf).await.unwrap();
                         assert_eq!(&buf[..n], &expected[..]);
                     }
                 });
 
                 let client = tokio::task::spawn(async move {
-                    let mut connec = LengthDelimited::new(client_connection);
+                    let mut connect = LengthDelimited::new(client_connection);
                     for frame in frames {
-                        connec.send(From::from(frame)).await.unwrap();
+                        connect.send(From::from(frame)).await.unwrap();
                     }
                 });
 


### PR DESCRIPTION


---


## Description
This pull request corrects a typo by renaming the variable `connec` to `connect`.

**Files updated:**
- `core/src/either.rs`
- `core/src/transport/choice.rs`
- `core/src/transport/length_delimited.rs`

