### PR TITLE
fix: patch 0.55 to fix hickory-resolver tokio bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,8 +127,8 @@ getrandom = "0.2"
 if-watch = "3.2.1"
 # hickory-proto = { version = "0.25.2", default-features = false }
 # hickory-resolver = { version = "0.25.2", default-features = false }
-hickory-proto = { version = "^0.25.0-alpha.4", default-features = false }
-hickory-resolver = { version = "^0.25.0-alpha.4", features = ["tokio"] }
+hickory-proto = { version = "0.25.0", default-features = false }
+hickory-resolver = { version = "0.25.0", features = ["tokio"] }
 multiaddr = "0.18.1"
 multihash = "0.19.1"
 multistream-select = { version = "0.13.0", path = "misc/multistream-select" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,8 +125,10 @@ futures-bounded = { version = "0.2.4" }
 futures-rustls = { version = "0.26.0", default-features = false }
 getrandom = "0.2"
 if-watch = "3.2.1"
-hickory-proto = { version = "0.25.2", default-features = false }
-hickory-resolver = { version = "0.25.2", default-features = false }
+# hickory-proto = { version = "0.25.2", default-features = false }
+# hickory-resolver = { version = "0.25.2", default-features = false }
+hickory-proto = { version = "^0.25.0-alpha.4", default-features = false }
+hickory-resolver = { version = "^0.25.0-alpha.4", features = ["tokio"] }
 multiaddr = "0.18.1"
 multihash = "0.19.1"
 multistream-select = { version = "0.13.0", path = "misc/multistream-select" }


### PR DESCRIPTION
## Description

Malachite v0.3.0 uses:
```
libp2p = "0.55.0"
├── libp2p-dns = "0.43.0"
│   ├── hickory-resolver = "0.25.0-alpha.4"
│   └── [features]
│       └── tokio = ["hickory-resolver/tokio-runtime"]  ← 🐛 THE BUG
```

Reth v1.4.8 uses:
```
reth-dns-discovery = "1.4.8"
└── hickory-resolver = "^0.25.0"  (no problematic features)
```
## Notes & open questions

Why This Happens:

Malachite uses libp2p with tokio support
libp2p enables the tokio feature on libp2p-dns
libp2p-dns v0.43.0 incorrectly requests hickory-resolver/tokio-runtime
hickory-resolver 0.25.x renamed this feature to just tokio
Cargo fails because the feature doesn't exist

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
