### PR TITLE
Rename `WsConfig` to `Config` in WebSocket Transport

### DIFF
--- a/transports/websocket/src/framed.rs
+++ b/transports/websocket/src/framed.rs
@@ -53,7 +53,7 @@ const MAX_DATA_SIZE: usize = 256 * 1024 * 1024;
 /// frame payloads which does not implement [`AsyncRead`] or
 /// [`AsyncWrite`]. See [`crate::Config`] if you require the latter.
 #[deprecated = "Use `Config` instead"]
-pub type WsConfig<T> = Config<T>;
+pub type Config<T> = Config<T>;
 
 #[derive(Debug)]
 pub struct Config<T> {

--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -134,7 +134,7 @@ use rw_stream_sink::RwStreamSink;
 /// # }
 /// ```
 #[deprecated = "Use `Config` instead"]
-pub type WsConfig<Transport> = Config<Transport>;
+pub type Config<Transport> = Config<Transport>;
 
 #[derive(Debug)]
 pub struct Config<T: Transport>


### PR DESCRIPTION

---


## Description
- Replaced all occurrences of the deprecated `WsConfig` type alias with `Config` in the WebSocket transport module.

---