### PR TITLE
fix(gossipsub): don't panic on mcache while adding fanout peers

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.49.0
 
+- Fix fanout logic to include correctly scored peers and prevent panics when memcache is set to 0.
+  See [PR 6095](https://github.com/libp2p/rust-libp2p/pull/6095)
+
 - Feature gate metrics related code. This changes some `Behaviour` constructor methods.
   See [PR 6020](https://github.com/libp2p/rust-libp2p/pull/6020)
 - Send IDONTWANT before Publishing a new message.

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -2473,8 +2473,10 @@ where
                     get_random_peers(&self.connected_peers, topic_hash, needed_peers, |peer_id| {
                         !peers.contains(peer_id)
                             && !explicit_peers.contains(peer_id)
-                            && scores.get(peer_id).map(|r| r.score).unwrap_or_default()
-                                < publish_threshold
+                            && !self
+                                .peer_score
+                                .below_threshold(peer_id, |ts| ts.publish_threshold)
+                                .0
                     });
                 peers.extend(new_peers);
             }

--- a/protocols/gossipsub/src/mcache.rs
+++ b/protocols/gossipsub/src/mcache.rs
@@ -76,6 +76,9 @@ impl MessageCache {
     ///
     /// Returns true if the message didn't already exist in the cache.
     pub(crate) fn put(&mut self, message_id: &MessageId, msg: RawMessage) -> bool {
+        if self.history.is_empty() {
+            return true;
+        }
         match self.msgs.entry(message_id.clone()) {
             Entry::Occupied(_) => {
                 // Don't add duplicate entries to the cache.
@@ -187,6 +190,10 @@ impl MessageCache {
     /// Shift the history array down one and delete messages associated with the
     /// last entry.
     pub(crate) fn shift(&mut self) {
+        if self.history.is_empty() {
+            return;
+        }
+
         for entry in self.history.pop().expect("history is always > 1") {
             if let Some((msg, _)) = self.msgs.remove(&entry.mid) {
                 if !msg.validated {


### PR DESCRIPTION
## Description

Fanout peers may not be been added correctly because the scoring function was not negated. This PR changes it to be more consistent with other parts of the code base. 

Also, users can set the memcache size to be 0. When this happens, a few panics occur. I've added statements to prevent this.
