### PR TITLE
fix(gossipsub): only apply and log p3 and p6 when they are not zero

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Remove `Rpc` from the public API.
   See [PR 6091](https://github.com/libp2p/rust-libp2p/pull/6091)
-- Only apply and log p3 when it's not zero.
+- Only apply and log p3 and p6 when it's not zero.
   See [PR 6097](https://github.com/libp2p/rust-libp2p/pull/6097)
 
 ## 0.49.0

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Remove `Rpc` from the public API.
   See [PR 6091](https://github.com/libp2p/rust-libp2p/pull/6091)
+- Only apply and log p3 when it's not zero.
+  See [PR 6097](https://github.com/libp2p/rust-libp2p/pull/6097)
 
 ## 0.49.0
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Remove `Rpc` from the public API.
   See [PR 6091](https://github.com/libp2p/rust-libp2p/pull/6091)
-- Only apply and log p3 and p6 when it's not zero.
+- Fix applying P3 and P6 Score penalties when their weight is zero
   See [PR 6097](https://github.com/libp2p/rust-libp2p/pull/6097)
 
 ## 0.49.0


### PR DESCRIPTION
## Description

## Fix penalty logging when weights are zero

### Problem
Mesh deliveries deficit (P3) and IP colocation (P6) penalties were being logged and recorded in metrics even when their respective weights were zero, creating misleading logs that suggested peers were being penalized when no actual penalty was applied.

### Solution
Added weight checks (`!= 0.0`) to the main conditions for both P3 and P6 penalty calculations:
- P3: Added `&& topic_params.mesh_message_deliveries_weight != 0.0` 
- P6: Added `&& self.params.ip_colocation_factor_weight != 0.0`

This prevents unnecessary calculations and eliminates misleading penalty logs and metrics when weights have no effect.

## Notes & open questions

N/A

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
