### PR TITLE
fix(gossipsub): Always construct mesh

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 - Remove `Rpc` from the public API.
   See [PR 6091](https://github.com/libp2p/rust-libp2p/pull/6091)
+
 - Fix applying P3 and P6 Score penalties when their weight is zero
   See [PR 6097](https://github.com/libp2p/rust-libp2p/pull/6097)
 
-## 0.49.0
-
 - Fix fanout logic to include correctly scored peers and prevent panics when memcache is set to 0.
   See [PR 6095](https://github.com/libp2p/rust-libp2p/pull/6095)
+
+- Fix mesh not being constructed even when not adding any peer.
+  See [PR 6100](https://github.com/libp2p/rust-libp2p/pull/6100)
+
+## 0.49.0
 
 - Feature gate metrics related code. This changes some `Behaviour` constructor methods.
   See [PR 6020](https://github.com/libp2p/rust-libp2p/pull/6020)

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -519,7 +519,6 @@ where
     /// Returns [`Ok(true)`] if the subscription worked. Returns [`Ok(false)`] if we were already
     /// subscribed.
     pub fn subscribe<H: Hasher>(&mut self, topic: &Topic<H>) -> Result<bool, SubscriptionError> {
-        tracing::debug!(%topic, "Subscribing to topic");
         let topic_hash = topic.hash();
         if !self.subscription_filter.can_subscribe(&topic_hash) {
             return Err(SubscriptionError::NotAllowed);
@@ -548,7 +547,6 @@ where
     ///
     /// Returns `true` if we were subscribed to this topic.
     pub fn unsubscribe<H: Hasher>(&mut self, topic: &Topic<H>) -> bool {
-        tracing::debug!(%topic, "Unsubscribing from topic");
         let topic_hash = topic.hash();
 
         if !self.mesh.contains_key(&topic_hash) {
@@ -978,14 +976,15 @@ where
 
     /// Gossipsub JOIN(topic) - adds topic peers to mesh and sends them GRAFT messages.
     fn join(&mut self, topic_hash: &TopicHash) {
-        tracing::debug!(topic=%topic_hash, "Running JOIN for topic");
-
         let mut added_peers = HashSet::new();
         let mesh_n = self.config.mesh_n_for_topic(topic_hash);
         #[cfg(feature = "metrics")]
         if let Some(m) = self.metrics.as_mut() {
             m.joined(topic_hash)
         }
+
+        // Always construct a mesh regardless if we find peers or not.
+        self.mesh.entry(topic_hash.clone()).or_default();
 
         // check if we have mesh_n peers in fanout[topic] and add them to the mesh if we do,
         // removing the fanout entry.
@@ -1907,7 +1906,7 @@ where
         subscriptions: &[Subscription],
         propagation_source: &PeerId,
     ) {
-        tracing::debug!(
+        tracing::trace!(
             source=%propagation_source,
             "Handling subscriptions: {:?}",
             subscriptions,
@@ -2087,7 +2086,6 @@ where
 
     /// Heartbeat function which shifts the memcache and updates the mesh.
     fn heartbeat(&mut self) {
-        tracing::debug!("Starting heartbeat");
         #[cfg(feature = "metrics")]
         let start = Instant::now();
 
@@ -2531,7 +2529,6 @@ where
             }
         }
 
-        tracing::debug!("Completed Heartbeat");
         #[cfg(feature = "metrics")]
         if let Some(metrics) = self.metrics.as_mut() {
             let duration = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);


### PR DESCRIPTION
## Description

There is a case where we subscribe to a topic but never create a mesh. This can happen for example when we set the mesh degree to 0, then we don't add any peers and the mesh never gets constructed. We then never send subscriptions to peers and essentially the subscription never existed. 

This PR ensures the mesh is always constructed when the user subscribes. 

This PR also improves the logging to downgrade some logs and remove unnecessary logs.
