### PR TITLE
fix: RELEASED_VERSION in bash script

### DIFF
--- a/scripts/ensure-version-bump-and-changelog.sh
+++ b/scripts/ensure-version-bump-and-changelog.sh
@@ -10,7 +10,7 @@ MERGE_BASE=$(git merge-base "$HEAD_SHA" "$PR_BASE") # Find the merge base. This 
 SRC_DIFF_TO_BASE=$(git diff "$HEAD_SHA".."$MERGE_BASE" --name-status -- "$DIR_TO_CRATE/src" "$DIR_TO_CRATE/Cargo.toml")
 CHANGELOG_DIFF=$(git diff "$HEAD_SHA".."$MERGE_BASE" --name-only -- "$DIR_TO_CRATE/CHANGELOG.md")
 
-RELEASED_VERSION=$(git tag --sort=version:refname | grep "^$CRATE-v" | tail -n1 | grep -Po "\d+\.\d+\.\d+(-.+)?")
+RELEASED_VERSION=$(curl -s -A "Github Action" https://crates.io/api/v1/crates/$CRATE | jq -r .crate.newest_version)
 
 
 # If the source files of this crate weren't touched in this PR, exit early.


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

This PR fixes the logic of retrieving `RELEASED_VERSION` in `ensure-version-bump-and-changelog.sh`. The current logic breaks when a crate version is not tagged in the repo. e.g. in https://github.com/libp2p/rust-libp2p/actions/runs/16322151084/job/46102571787?pr=6102#step:13:35

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
