### PR TITLE
fix(kad): Remove no longer constructed GetRecordError::QuorumFailed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.48.1"
+version = "0.49.0"
 dependencies = [
  "asynchronous-codec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ libp2p-floodsub = { version = "0.47.0", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.50.0", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.47.0", path = "protocols/identify" }
 libp2p-identity = { version = "0.2.12" }
-libp2p-kad = { version = "0.48.1", path = "protocols/kad" }
+libp2p-kad = { version = "0.49.0", path = "protocols/kad" }
 libp2p-mdns = { version = "0.48.0", path = "protocols/mdns" }
 libp2p-memory-connection-limits = { version = "0.5.0", path = "misc/memory-connection-limits" }
 libp2p-metrics = { version = "0.17.0", path = "misc/metrics" }

--- a/misc/metrics/src/kad.rs
+++ b/misc/metrics/src/kad.rs
@@ -318,7 +318,6 @@ struct GetRecordResult {
 #[derive(EncodeLabelValue, Hash, Clone, Eq, PartialEq, Debug)]
 enum GetRecordError {
     NotFound,
-    QuorumFailed,
     Timeout,
 }
 
@@ -327,9 +326,6 @@ impl From<&libp2p_kad::GetRecordError> for GetRecordResult {
         match error {
             libp2p_kad::GetRecordError::NotFound { .. } => GetRecordResult {
                 error: GetRecordError::NotFound,
-            },
-            libp2p_kad::GetRecordError::QuorumFailed { .. } => GetRecordResult {
-                error: GetRecordError::QuorumFailed,
             },
             libp2p_kad::GetRecordError::Timeout { .. } => GetRecordResult {
                 error: GetRecordError::Timeout,

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.49.0
+
+- Remove no longer constructed GetRecordError::QuorumFailed.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX)
+
 ## 0.48.1
 
 - Implement `Copy` for `QueryStats` and `ProgressStep`

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.49.0
 
 - Remove no longer constructed GetRecordError::QuorumFailed.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX)
+  See [PR 6106](https://github.com/libp2p/rust-libp2p/pull/6106)
 
 ## 0.48.1
 

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-kad"
 edition.workspace = true
 rust-version = { workspace = true }
 description = "Kademlia protocol for libp2p"
-version = "0.48.1"
+version = "0.49.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/kad/src/behaviour.rs
+++ b/protocols/kad/src/behaviour.rs
@@ -2951,12 +2951,6 @@ pub enum GetRecordError {
         key: record::Key,
         closest_peers: Vec<PeerId>,
     },
-    #[error("the quorum failed; needed {quorum} peers")]
-    QuorumFailed {
-        key: record::Key,
-        records: Vec<PeerRecord>,
-        quorum: NonZeroUsize,
-    },
     #[error("the request timed out")]
     Timeout { key: record::Key },
 }
@@ -2965,7 +2959,6 @@ impl GetRecordError {
     /// Gets the key of the record for which the operation failed.
     pub fn key(&self) -> &record::Key {
         match self {
-            GetRecordError::QuorumFailed { key, .. } => key,
             GetRecordError::Timeout { key, .. } => key,
             GetRecordError::NotFound { key, .. } => key,
         }
@@ -2975,7 +2968,6 @@ impl GetRecordError {
     /// consuming the error.
     pub fn into_key(self) -> record::Key {
         match self {
-            GetRecordError::QuorumFailed { key, .. } => key,
             GetRecordError::Timeout { key, .. } => key,
             GetRecordError::NotFound { key, .. } => key,
         }


### PR DESCRIPTION
## Description
It was left dangling after `Quorum` was removed on https://github.com/libp2p/rust-libp2p/pull/2712. See also https://github.com/libp2p/rust-libp2p/discussions/6044 for more info on the context