### PR TITLE
fix(gossipsub): Remove penalty for duplicate publish messages

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 0.50.0
+- Remove peer penalty for duplicate messages.
+  See [PR 6112](https://github.com/libp2p/rust-libp2p/pull/6112)
 
 - Remove `Rpc` from the public API.
   See [PR 6091](https://github.com/libp2p/rust-libp2p/pull/6091)

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -322,10 +322,6 @@ pub struct Behaviour<D = IdentityTransform, F = AllowAllSubscriptionFilter> {
     /// Counts the number of `IWANT` that we sent the each peer since the last heartbeat.
     count_sent_iwant: HashMap<PeerId, usize>,
 
-    /// Short term cache for published message ids. This is used for penalizing peers sending
-    /// our own messages back if the messages are anonymous or use a random author.
-    published_message_ids: DuplicateCache<MessageId>,
-
     /// The filter used to handle message subscriptions.
     subscription_filter: F,
 
@@ -461,7 +457,6 @@ where
             count_received_ihave: HashMap::new(),
             count_sent_iwant: HashMap::new(),
             connected_peers: HashMap::new(),
-            published_message_ids: DuplicateCache::new(config.published_message_ids_cache_time()),
             config,
             subscription_filter,
             data_transform,
@@ -735,14 +730,6 @@ where
 
         // Consider the message as delivered for gossip promises.
         self.gossip_promises.message_delivered(&msg_id);
-
-        // If the message is anonymous or has a random author add it to the published message ids
-        // cache.
-        if let PublishConfig::RandomAuthor | PublishConfig::Anonymous = self.publish_config {
-            if !self.config.allow_self_origin() {
-                self.published_message_ids.insert(msg_id.clone());
-            }
-        }
 
         // Send to peers we know are subscribed to the topic.
         let mut publish_failed = true;
@@ -1719,7 +1706,7 @@ where
                 own_id != propagation_source
                     && raw_message.source.as_ref().is_some_and(|s| s == own_id)
             } else {
-                self.published_message_ids.contains(msg_id)
+                false
             };
 
         if self_published {

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -127,7 +127,6 @@ pub struct Config {
     max_ihave_length: usize,
     max_ihave_messages: usize,
     iwant_followup_time: Duration,
-    published_message_ids_cache_time: Duration,
     connection_handler_queue_len: usize,
     connection_handler_publish_duration: Duration,
     connection_handler_forward_duration: Duration,
@@ -444,11 +443,6 @@ impl Config {
         self.protocol.protocol_ids.contains(&FLOODSUB_PROTOCOL)
     }
 
-    /// Published message ids time cache duration. The default is 10 seconds.
-    pub fn published_message_ids_cache_time(&self) -> Duration {
-        self.published_message_ids_cache_time
-    }
-
     /// The max number of messages a `ConnectionHandler` can buffer. The default is 5000.
     pub fn connection_handler_queue_len(&self) -> usize {
         self.connection_handler_queue_len
@@ -546,7 +540,6 @@ impl Default for ConfigBuilder {
                 max_ihave_length: 5000,
                 max_ihave_messages: 10,
                 iwant_followup_time: Duration::from_secs(3),
-                published_message_ids_cache_time: Duration::from_secs(10),
                 connection_handler_queue_len: 5000,
                 connection_handler_publish_duration: Duration::from_secs(5),
                 connection_handler_forward_duration: Duration::from_secs(1),
@@ -1008,15 +1001,6 @@ impl ConfigBuilder {
         self
     }
 
-    /// Published message ids time cache duration. The default is 10 seconds.
-    pub fn published_message_ids_cache_time(
-        &mut self,
-        published_message_ids_cache_time: Duration,
-    ) -> &mut Self {
-        self.config.published_message_ids_cache_time = published_message_ids_cache_time;
-        self
-    }
-
     /// The max number of messages a `ConnectionHandler` can buffer. The default is 5000.
     pub fn connection_handler_queue_len(&mut self, len: usize) -> &mut Self {
         self.config.connection_handler_queue_len = len;
@@ -1177,10 +1161,6 @@ impl std::fmt::Debug for Config {
         let _ = builder.field("max_ihave_length", &self.max_ihave_length);
         let _ = builder.field("max_ihave_messages", &self.max_ihave_messages);
         let _ = builder.field("iwant_followup_time", &self.iwant_followup_time);
-        let _ = builder.field(
-            "published_message_ids_cache_time",
-            &self.published_message_ids_cache_time,
-        );
         let _ = builder.field(
             "idontwant_message_size_threshold",
             &self.idontwant_message_size_threshold,


### PR DESCRIPTION
## Description

We had a mechanism designed to punish peers that send messages to us with the same message-id. This was a mitigation to prevent peers from sending us back messages we just published. However, in content-based networks, there is often the scenario (which is not explicitly forbidden in gossipsub) where there can be multiple publishers of the same message. 

This mechanism was downscoring honest nodes in this system. This PR removes this mechanism. If we want to have something like this, we can tie it now to nodes sending messages after recieving IDONTWANT's from us. This has its own pitfalls and I leave for a future PR. 

cc @dknopik 