### PR TITLE
fix(gossipsub): fixed incorrect default values in ConfigBuilder

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Fix `unsubscribe_backoff` expecting number of seconds instead of `Duration`
   See [PR 6124](https://github.com/libp2p/rust-libp2p/pull/6124)
 
+- Fix incorrect default values in ConfigBuilder
+  See [PR 6113](https://github.com/libp2p/rust-libp2p/pull/6113)
+
 ## 0.49.2
 
 - Relax `Behaviour::with_metrics` requirements, do not require DataTransform and TopicSubscriptionFilter to also impl Default
@@ -23,9 +26,6 @@
 
 - Fix mesh not being constructed even when not adding any peer.
   See [PR 6100](https://github.com/libp2p/rust-libp2p/pull/6100)
-
-- Fix incorrect default values in ConfigBuilder
-  See [PR 6113](https://github.com/libp2p/rust-libp2p/pull/6113)
 
 ## 0.49.0
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Fix mesh not being constructed even when not adding any peer.
   See [PR 6100](https://github.com/libp2p/rust-libp2p/pull/6100)
 
+- Fix incorrect default values in ConfigBuilder
+  See [PR 6113](https://github.com/libp2p/rust-libp2p/pull/6113)
+
 ## 0.49.0
 
 - Feature gate metrics related code. This changes some `Behaviour` constructor methods.

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -770,10 +770,12 @@ impl ConfigBuilder {
 
     /// The maximum byte size for each gossip (default is 65536 bytes).
     ///
-    /// ```
+    /// ```rust
     /// use libp2p_gossipsub::ConfigBuilder;
     /// let mut config = ConfigBuilder::default();
     /// assert_eq!(config.build().unwrap().max_transmit_size(), 65536);
+    /// config.max_transmit_size(1 << 20);
+    /// assert_eq!(config.build().unwrap().max_transmit_size(), 1 << 20);
     /// ```
     pub fn max_transmit_size(&mut self, max_transmit_size: usize) -> &mut Self {
         self.config.protocol.default_max_transmit_size = max_transmit_size;

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -768,13 +768,19 @@ impl ConfigBuilder {
         self
     }
 
-    /// The maximum byte size for each gossip (default is 2048 bytes).
+    /// The maximum byte size for each gossip (default is 65536 bytes).
+    /// 
+    /// ```
+    /// use libp2p_gossipsub::ConfigBuilder;
+    /// let mut config = ConfigBuilder::default();
+    /// assert_eq!(config.build().unwrap().max_transmit_size(), 65536);
+    /// ```
     pub fn max_transmit_size(&mut self, max_transmit_size: usize) -> &mut Self {
         self.config.protocol.default_max_transmit_size = max_transmit_size;
         self
     }
 
-    /// The maximum byte size for each gossip for a given topic. (default is 2048 bytes).
+    /// The maximum byte size for each gossip for a given topic. (default is 65536 bytes).
     pub fn max_transmit_size_for_topic(
         &mut self,
         max_transmit_size: usize,

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -769,7 +769,7 @@ impl ConfigBuilder {
     }
 
     /// The maximum byte size for each gossip (default is 65536 bytes).
-    /// 
+    ///
     /// ```
     /// use libp2p_gossipsub::ConfigBuilder;
     /// let mut config = ConfigBuilder::default();
@@ -780,7 +780,8 @@ impl ConfigBuilder {
         self
     }
 
-    /// The maximum byte size for each gossip for a given topic. (default is 65536 bytes).
+    /// The maximum byte size for each gossip for a given topic. (default is
+    /// [`Self::max_transmit_size`]).
     pub fn max_transmit_size_for_topic(
         &mut self,
         max_transmit_size: usize,


### PR DESCRIPTION
## Description

Fixed minor doc issue in ConfigBuilder
Fixes https://github.com/libp2p/rust-libp2p/issues/6111

## Notes & open questions

None

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
