### PR TITLE
fix(gossipsub): relax Behaviour::with_metrics,

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.50.0
 
+- Relax `Behaviour::with_metrics` requirements, do not require DataTransform and TopicSubscriptionFilter to also impl Default
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/6097)
+
 - Remove `Rpc` from the public API.
   See [PR 6091](https://github.com/libp2p/rust-libp2p/pull/6091)
 

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -360,18 +360,6 @@ where
             D::default(),
         )
     }
-
-    /// Allow the [`Behaviour`] to also record metrics.
-    /// Metrics can be evaluated by passing a reference to a [`Registry`].
-    #[cfg(feature = "metrics")]
-    pub fn with_metrics(
-        mut self,
-        metrics_registry: &mut Registry,
-        metrics_config: MetricsConfig,
-    ) -> Self {
-        self.metrics = Some(Metrics::new(metrics_registry, metrics_config));
-        self
-    }
 }
 
 impl<D, F> Behaviour<D, F>
@@ -468,6 +456,18 @@ where
             failed_messages: Default::default(),
             gossip_promises: Default::default(),
         })
+    }
+
+    /// Allow the [`Behaviour`] to also record metrics.
+    /// Metrics can be evaluated by passing a reference to a [`Registry`].
+    #[cfg(feature = "metrics")]
+    pub fn with_metrics(
+        mut self,
+        metrics_registry: &mut Registry,
+        metrics_config: MetricsConfig,
+    ) -> Self {
+        self.metrics = Some(Metrics::new(metrics_registry, metrics_config));
+        self
     }
 }
 


### PR DESCRIPTION
do not require `DataTransform` and `TopicSubscriptionFilter` to also impl `Default`
