### PR TITLE
fix(ci): mergify script

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,3 +1,6 @@
+merge_queue:
+  max_parallel_checks: 1
+
 pull_request_rules:
   - name: Ask to resolve conflict
     conditions:


### PR DESCRIPTION
Ci is currently blocked with the message:
`"The branch protection setting Require branches to be up to date before merging is not compatible with max_parallel_checks>1, queue_conditions != merge_conditions and must be unset."`

This PR aims to fix that