### PR TITLE
chore(gossipsub): update CHANGELOG.md

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -6,7 +6,7 @@
 ## 0.49.2
 
 - Relax `Behaviour::with_metrics` requirements, do not require DataTransform and TopicSubscriptionFilter to also impl Default
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/6097)
+  See [PR 6097](https://github.com/libp2p/rust-libp2p/pull/6097)
 
 ## 0.49.1
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,10 +1,14 @@
 ## 0.50.0
 
+- Remove `Rpc` from the public API.
+  See [PR 6091](https://github.com/libp2p/rust-libp2p/pull/6091)
+
+## 0.49.2
+
 - Relax `Behaviour::with_metrics` requirements, do not require DataTransform and TopicSubscriptionFilter to also impl Default
   See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/6097)
 
-- Remove `Rpc` from the public API.
-  See [PR 6091](https://github.com/libp2p/rust-libp2p/pull/6091)
+## 0.49.1
 
 - Fix applying P3 and P6 Score penalties when their weight is zero
   See [PR 6097](https://github.com/libp2p/rust-libp2p/pull/6097)


### PR DESCRIPTION
to reflect `v0.49.1` and `v0.49.2` releases