### PR TITLE
fix: swarm/src/lib.rs:tracing::debug!(%local_peer_id)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3068,7 +3068,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "criterion",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ libp2p-rendezvous = { version = "0.17.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.29.0", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.7", path = "misc/server" }
 libp2p-stream = { version = "0.4.0-alpha", path = "protocols/stream" }
-libp2p-swarm = { version = "0.47.0", path = "swarm" }
+libp2p-swarm = { version = "0.47.1", path = "swarm" }
 libp2p-swarm-derive = { version = "=0.35.1", path = "swarm-derive" } # `libp2p-swarm-derive` may not be compatible with different `libp2p-swarm` non-breaking releases. E.g. `libp2p-swarm` might introduce a new enum variant `FromSwarm` (which is `#[non-exhaustive]`) in a non-breaking release. Older versions of `libp2p-swarm-derive` would not forward this enum variant within the `NetworkBehaviour` hierarchy. Thus the version pinning is required.
 libp2p-swarm-test = { version = "0.6.0", path = "swarm-test" }
 libp2p-tcp = { version = "0.44.0", path = "transports/tcp" }

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.47.1
+
+- Fix `src/lib.rs:tracing::debug!(%local_peer_id)`.
+  See [PR 6123](https://github.com/libp2p/rust-libp2p/pull/6123)
+
 ## 0.47.0
 
 - Remove `async-std` support.

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-swarm"
 edition.workspace = true
 rust-version = { workspace = true }
 description = "The libp2p swarm"
-version = "0.47.0"
+version = "0.47.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -353,7 +353,7 @@ where
         local_peer_id: PeerId,
         config: Config,
     ) -> Self {
-        tracing::info!(%local_peer_id);
+        tracing::debug!(%local_peer_id);
 
         Swarm {
             local_peer_id,


### PR DESCRIPTION
let devs capture local_peer_id manually - don't force an info! log