### PR TITLE
fix(gossipsub): Changed unsubscribe_backoff to expect Duration

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Remove `Rpc` from the public API.
   See [PR 6091](https://github.com/libp2p/rust-libp2p/pull/6091)
 
+- Fix `unsubscribe_backoff` expecting number of seconds instead of `Duration`
+  See [PR 6124](https://github.com/libp2p/rust-libp2p/pull/6124)
+
 ## 0.49.2
 
 - Relax `Behaviour::with_metrics` requirements, do not require DataTransform and TopicSubscriptionFilter to also impl Default
@@ -20,10 +23,6 @@
 
 - Fix mesh not being constructed even when not adding any peer.
   See [PR 6100](https://github.com/libp2p/rust-libp2p/pull/6100)
-
-- Fix `unsubscribe_backoff` expecting number of seconds instead of `Duration`
-  See [PR 6124](https://github.com/libp2p/rust-libp2p/pull/6124)
-
 
 ## 0.49.0
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Fix mesh not being constructed even when not adding any peer.
   See [PR 6100](https://github.com/libp2p/rust-libp2p/pull/6100)
 
+- Fix `unsubscribe_backoff` expecting number of seconds instead of `Duration`
+  See [PR 6124](https://github.com/libp2p/rust-libp2p/pull/6124)
+
+
 ## 0.49.0
 
 - Feature gate metrics related code. This changes some `Behaviour` constructor methods.

--- a/protocols/gossipsub/src/behaviour/tests.rs
+++ b/protocols/gossipsub/src/behaviour/tests.rs
@@ -2185,7 +2185,7 @@ fn test_unsubscribe_backoff() {
         .backoff_slack(1)
         // ensure a prune_backoff > unsubscribe_backoff
         .prune_backoff(Duration::from_secs(5))
-        .unsubscribe_backoff(1)
+        .unsubscribe_backoff(Duration::from_secs(1))
         .heartbeat_interval(HEARTBEAT_INTERVAL)
         .build()
         .unwrap();

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -865,8 +865,8 @@ impl ConfigBuilder {
     /// This is how long to wait before resubscribing to the topic. A short backoff period in case
     /// of an unsubscribe event allows reaching a healthy mesh in a more timely manner. The default
     /// is 10 seconds.
-    pub fn unsubscribe_backoff(&mut self, unsubscribe_backoff: u64) -> &mut Self {
-        self.config.unsubscribe_backoff = Duration::from_secs(unsubscribe_backoff);
+    pub fn unsubscribe_backoff(&mut self, unsubscribe_backoff: Duration) -> &mut Self {
+        self.config.unsubscribe_backoff = unsubscribe_backoff;
         self
     }
 


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

Gossipsub config back-off takes a duration as a number of seconds instead of `std::time::Duration`, this PR fixes that.

Fixes https://github.com/libp2p/rust-libp2p/issues/6120

## Notes & open questions

Allows using sub second and more specific unsubscribe_backoff times

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
