### PR TITLE
fix(upnp): add exponential backoff for failed port mappings

### DIFF
--- a/protocols/upnp/CHANGELOG.md
+++ b/protocols/upnp/CHANGELOG.md
@@ -6,6 +6,11 @@
   checks active mappings on the gateway.
   See [PR 6127](https://github.com/libp2p/rust-libp2p/pull/6127).
 
+- Fix excessive retry attempts for failed port mappings by implementing exponential backoff.
+  Failed mappings now retry up to 5 times with increasing delays (30s to 480s) before giving up.
+  This prevents continuous retry loops.
+  See [PR 6128](https://github.com/libp2p/rust-libp2p/pull/6128).
+
 ## 0.5.0
 
 - update igd-next to 0.16.1


### PR DESCRIPTION
## Description
This commit aims to fix an infinite retry loop of failed mappings. We now have an exponential backoff and would retry any failed mappings upto 5 times before giving up.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates