### PR TITLE
chore(libp2p): add #[allow(allow_deadcode)]

### DIFF
--- a/libp2p/src/builder/phase.rs
+++ b/libp2p/src/builder/phase.rs
@@ -35,7 +35,7 @@ use super::{
     select_muxer::SelectMuxerUpgrade, select_security::SelectSecurityUpgrade, SwarmBuilder,
 };
 
-#[allow(unreachable_pub)]
+#[allow(unreachable_pub, dead_code)]
 pub trait IntoSecurityUpgrade<C> {
     type Upgrade;
     type Error;
@@ -77,7 +77,7 @@ where
     }
 }
 
-#[allow(unreachable_pub)]
+#[allow(unreachable_pub, dead_code)]
 pub trait IntoMultiplexerUpgrade<C> {
     type Upgrade;
 

--- a/libp2p/src/builder/select_muxer.rs
+++ b/libp2p/src/builder/select_muxer.rs
@@ -34,6 +34,7 @@ use libp2p_core::{
 pub struct SelectMuxerUpgrade<A, B>(A, B);
 
 impl<A, B> SelectMuxerUpgrade<A, B> {
+    #[allow(dead_code)]
     pub fn new(a: A, b: B) -> Self {
         SelectMuxerUpgrade(a, b)
     }

--- a/libp2p/src/builder/select_security.rs
+++ b/libp2p/src/builder/select_security.rs
@@ -42,6 +42,7 @@ impl<A, B> SelectSecurityUpgrade<A, B> {
     /// Combines two upgrades into an `SelectUpgrade`.
     ///
     /// The protocols supported by the first element have a higher priority.
+    #[allow(dead_code)]
     pub fn new(a: A, b: B) -> Self {
         SelectSecurityUpgrade(a, b)
     }


### PR DESCRIPTION
CI is currently broken following a similar issue to #4879,
this eventually fixes it