### PR TITLE
chore: favor hashlink::LruCache over lru::LruCache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,12 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,8 +1660,6 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash",
 ]
 
@@ -2560,6 +2552,7 @@ dependencies = [
  "futures",
  "futures-bounded",
  "futures-timer",
+ "hashlink",
  "libp2p-core",
  "libp2p-identify",
  "libp2p-identity",
@@ -2569,7 +2562,6 @@ dependencies = [
  "libp2p-swarm-test",
  "libp2p-tcp",
  "libp2p-yamux",
- "lru",
  "quick-protobuf",
  "quick-protobuf-codec",
  "thiserror 2.0.12",
@@ -2848,12 +2840,12 @@ dependencies = [
 name = "libp2p-peer-store"
 version = "0.1.0"
 dependencies = [
+ "hashlink",
  "libp2p",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
  "libp2p-swarm-test",
- "lru",
  "serde_json",
  "tokio",
 ]
@@ -3084,6 +3076,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "getrandom 0.2.15",
+ "hashlink",
  "libp2p-core",
  "libp2p-identify",
  "libp2p-identity",
@@ -3093,7 +3086,6 @@ dependencies = [
  "libp2p-swarm-derive",
  "libp2p-swarm-test",
  "libp2p-yamux",
- "lru",
  "multistream-select",
  "quickcheck-ext",
  "rand 0.8.5",
@@ -3389,15 +3381,6 @@ dependencies = [
  "scoped-tls",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.2",
 ]
 
 [[package]]

--- a/misc/peer-store/Cargo.toml
+++ b/misc/peer-store/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 rust-version.workspace = true
 
 [dependencies]
+hashlink = { workspace = true }
 libp2p-core = { workspace = true }
 libp2p-swarm = { workspace = true }
-lru = "0.12.3"
 libp2p-identity = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/protocols/dcutr/Cargo.toml
+++ b/protocols/dcutr/Cargo.toml
@@ -23,7 +23,7 @@ quick-protobuf = "0.8"
 quick-protobuf-codec = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-lru = "0.12.3"
+hashlink = { workspace = true }
 futures-bounded = { workspace = true }
 
 [dev-dependencies]

--- a/protocols/dcutr/src/behaviour.rs
+++ b/protocols/dcutr/src/behaviour.rs
@@ -23,11 +23,11 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     convert::Infallible,
-    num::NonZeroUsize,
     task::{Context, Poll},
 };
 
 use either::Either;
+use hashlink::LruCache;
 use libp2p_core::{
     connection::ConnectedPoint, multiaddr::Protocol, transport::PortUse, Endpoint, Multiaddr,
 };
@@ -38,7 +38,6 @@ use libp2p_swarm::{
     dummy, ConnectionDenied, ConnectionHandler, ConnectionId, NetworkBehaviour,
     NewExternalAddrCandidate, NotifyHandler, THandler, THandlerInEvent, THandlerOutEvent, ToSwarm,
 };
-use lru::LruCache;
 use thiserror::Error;
 
 use crate::{handler, protocol};
@@ -361,7 +360,7 @@ struct Candidates {
 impl Candidates {
     fn new(me: PeerId) -> Self {
         Self {
-            inner: LruCache::new(NonZeroUsize::new(20).expect("20 > 0")),
+            inner: LruCache::new(20),
             me,
         }
     }
@@ -375,7 +374,7 @@ impl Candidates {
             address.push(Protocol::P2p(self.me));
         }
 
-        self.inner.push(address, ());
+        self.inner.insert(address, ());
     }
 
     fn iter(&self) -> impl Iterator<Item = &Multiaddr> {

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -17,10 +17,10 @@ futures = { workspace = true }
 futures-timer = "3.0.3"
 getrandom = { workspace = true, features = ["js"], optional = true } # Explicit dependency to be used in `wasm-bindgen` feature
 web-time = { workspace = true }
+hashlink = { workspace = true }
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true }
 libp2p-swarm-derive = { workspace = true, optional = true }
-lru = "0.12.3"
 multistream-select = { workspace = true }
 rand = "0.8"
 smallvec = "1.13.2"


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

This PR replaces `lru::LruCache` with `hashlink::LruCache` to unify dependencies with similar functionalities. It also removes `lru` from `Cargo.lock`. (`hashlink` is also used to provide `LinkedHashMap` in `gossipsub`)

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
