### PR TITLE
relay: Replace panic on oversize max_circuit_duration with explicit error

### DIFF
--- a/protocols/relay/src/protocol/inbound_hop.rs
+++ b/protocols/relay/src/protocol/inbound_hop.rs
@@ -44,6 +44,8 @@ pub enum Error {
     MissingPeer,
     #[error("Unexpected message type 'status'")]
     UnexpectedTypeStatus,
+     #[error("max_circuit_duration exceeds u32::MAX seconds")]
+    MaxCircuitDurationTooLarge,
 }
 
 pub struct ReservationReq {
@@ -78,7 +80,7 @@ impl ReservationReq {
                     self.max_circuit_duration
                         .as_secs()
                         .try_into()
-                        .expect("`max_circuit_duration` not to exceed `u32::MAX`."),
+                        .map_err(|_| Error::MaxCircuitDurationTooLarge)?,
                 ),
                 data: Some(self.max_circuit_bytes),
             }),


### PR DESCRIPTION


Description
### Summary
Prevent process crashes caused by misconfigured max_circuit_duration by returning a typed error instead of panicking.

### Rationale
A configuration with max_circuit_duration > u32::MAX seconds previously triggered a panic via expect(...). This turns a simple misconfiguration into a node crash. Returning an explicit error is safer and more predictable.

### Changes
- Added new error variant: `MaxCircuitDurationTooLarge`.
- Replaced `expect(...)` with `try_into().map_err(...)` in:
  - `protocols/relay/src/protocol/inbound_hop.rs`
  - `protocols/relay/src/protocol/outbound_stop.rs`
- Mapped the new error to `Status::CONNECTION_FAILED` in `outbound_stop::Error::to_status`.

