### PR TITLE
docs: fix typos and improve wording across comments, tests, and strings

### DIFF
--- a/core/src/either.rs
+++ b/core/src/either.rs
@@ -184,12 +184,12 @@ where
         use TransportError::*;
         match self {
             Either::Left(a) => match a.dial(addr, opts) {
-                Ok(connec) => Ok(EitherFuture::First(connec)),
+                Ok(connection) => Ok(EitherFuture::First(connection)),
                 Err(MultiaddrNotSupported(addr)) => Err(MultiaddrNotSupported(addr)),
                 Err(Other(err)) => Err(Other(Either::Left(err))),
             },
             Either::Right(b) => match b.dial(addr, opts) {
-                Ok(connec) => Ok(EitherFuture::Second(connec)),
+                Ok(connection) => Ok(EitherFuture::Second(connection)),
                 Err(MultiaddrNotSupported(addr)) => Err(MultiaddrNotSupported(addr)),
                 Err(Other(err)) => Err(Other(Either::Right(err))),
             },

--- a/core/src/transport/choice.rs
+++ b/core/src/transport/choice.rs
@@ -110,7 +110,7 @@ where
             std::any::type_name::<A>()
         );
         let addr = match self.0.dial(addr, opts) {
-            Ok(connec) => return Ok(EitherFuture::First(connec)),
+            Ok(connection) => return Ok(EitherFuture::First(connection)),
             Err(TransportError::MultiaddrNotSupported(addr)) => {
                 tracing::debug!(
                     address=%addr,
@@ -130,7 +130,7 @@ where
             std::any::type_name::<A>()
         );
         let addr = match self.1.dial(addr, opts) {
-            Ok(connec) => return Ok(EitherFuture::Second(connec)),
+            Ok(connection) => return Ok(EitherFuture::Second(connection)),
             Err(TransportError::MultiaddrNotSupported(addr)) => {
                 tracing::debug!(
                     address=%addr,

--- a/misc/multistream-select/src/length_delimited.rs
+++ b/misc/multistream-select/src/length_delimited.rs
@@ -496,7 +496,7 @@ mod tests {
             rt.block_on(async move {
                 let expected_frames = frames.clone();
                 let server = tokio::task::spawn(async move {
-                    let mut connec =
+                    let mut connection =
                         rw_stream_sink::RwStreamSink::new(LengthDelimited::new(server_connection));
 
                     let mut buf = vec![0u8; 0];
@@ -507,15 +507,15 @@ mod tests {
                         if buf.len() < expected.len() {
                             buf.resize(expected.len(), 0);
                         }
-                        let n = connec.read(&mut buf).await.unwrap();
+                        let n = connection.read(&mut buf).await.unwrap();
                         assert_eq!(&buf[..n], &expected[..]);
                     }
                 });
 
                 let client = tokio::task::spawn(async move {
-                    let mut connec = LengthDelimited::new(client_connection);
+                    let mut connection = LengthDelimited::new(client_connection);
                     for frame in frames {
-                        connec.send(From::from(frame)).await.unwrap();
+                        connection.send(From::from(frame)).await.unwrap();
                     }
                 });
 

--- a/protocols/autonat/src/v1/behaviour.rs
+++ b/protocols/autonat/src/v1/behaviour.rs
@@ -64,7 +64,7 @@ pub struct Config {
     /// Interval in which the NAT status should be re-tried if it is currently unknown
     /// or max confidence was not reached yet.
     pub retry_interval: Duration,
-    /// Throttle period for re-using a peer as server for a dial-request.
+    /// Throttle period for reusing a peer as server for a dial-request.
     pub throttle_server_period: Duration,
     /// Use connected peers as servers for probes.
     pub use_connected: bool,

--- a/protocols/autonat/tests/test_client.rs
+++ b/protocols/autonat/tests/test_client.rs
@@ -229,7 +229,7 @@ async fn test_throttle_server_period() {
                 refresh_interval: TEST_REFRESH_INTERVAL,
                 confidence_max: MAX_CONFIDENCE,
                 only_global_ips: false,
-                // Throttle servers so they can not be re-used for dial request.
+                // Throttle servers so they can not be reused for dial request.
                 throttle_server_period: Duration::from_secs(1000),
                 boot_delay: Duration::from_millis(100),
                 ..Default::default()

--- a/protocols/kad/src/query/peers/closest.rs
+++ b/protocols/kad/src/query/peers/closest.rs
@@ -713,7 +713,7 @@ mod tests {
                 _ => panic!("No peer."),
             };
             iter.on_success(&peer1, closer.clone());
-            // Duplicate result from te same peer.
+            // Duplicate result from the same peer.
             iter.on_success(&peer1, closer.clone());
 
             // If there is a second peer, let it also report the same "closer" peer.

--- a/protocols/mdns/src/behaviour/iface/dns.rs
+++ b/protocols/mdns/src/behaviour/iface/dns.rs
@@ -82,7 +82,7 @@ pub(crate) fn build_query() -> MdnsPacket {
     // Number of questions.
     append_u16(&mut out, 0x1);
 
-    // Number of answers, authorities, and additionals.
+    // Number of answers, authorities, and additional records.
     append_u16(&mut out, 0x0);
     append_u16(&mut out, 0x0);
     append_u16(&mut out, 0x0);
@@ -176,7 +176,7 @@ pub(crate) fn build_service_discovery_response(id: u16, ttl: Duration) -> MdnsPa
     append_u16(&mut out, id);
     // 0x84 flag for an answer.
     append_u16(&mut out, 0x8400);
-    // Number of questions, answers, authorities, additionals.
+    // Number of questions, answers, authorities, and additional records.
     append_u16(&mut out, 0x0);
     append_u16(&mut out, 0x1);
     append_u16(&mut out, 0x0);
@@ -214,7 +214,7 @@ fn query_response_packet(id: u16, peer_id: &[u8], records: &[Vec<u8>], ttl: u32)
     append_u16(&mut out, id);
     // 0x84 flag for an answer.
     append_u16(&mut out, 0x8400);
-    // Number of questions, answers, authorities, additionals.
+    // Number of questions, answers, authorities, and additional records.
     append_u16(&mut out, 0x0);
     append_u16(&mut out, 0x1);
     append_u16(&mut out, 0x0);

--- a/transports/tls/src/certificate.rs
+++ b/transports/tls/src/certificate.rs
@@ -185,7 +185,7 @@ fn parse_unverified(der_input: &[u8]) -> Result<P2pCertificate<'_>, webpki::Erro
         }
 
         if oid == &p2p_ext_oid {
-            // The public host key and the signature are ANS.1-encoded
+            // The public host key and the signature are ASN.1-encoded
             // into the SignedKey data structure, which is carried
             // in the libp2p Public Key Extension.
             // SignedKey ::= SEQUENCE {
@@ -254,7 +254,7 @@ fn make_libp2p_extension(
             .map_err(|_| rcgen::Error::RingUnspecified)?
     };
 
-    // The public host key and the signature are ANS.1-encoded
+    // The public host key and the signature are ASN.1-encoded
     // into the SignedKey data structure, which is carried
     // in the libp2p Public Key Extension.
     // SignedKey ::= SEQUENCE {

--- a/transports/webrtc/src/tokio/upgrade.rs
+++ b/transports/webrtc/src/tokio/upgrade.rs
@@ -181,7 +181,7 @@ fn setting_engine(
 
     // Select only the first address of the local candidates.
     // See https://github.com/libp2p/rust-libp2p/pull/5448#discussion_r2017418520.
-    // TODO: remove when https://github.com/webrtc-rs/webrtc/issues/662 get's addressed.
+    // TODO: remove when https://github.com/webrtc-rs/webrtc/issues/662 gets addressed.
     se.set_ip_filter(Box::new({
         let once = AtomicBool::new(true);
         move |_ip| {


### PR DESCRIPTION
This PR corrects assorted typos, wording, and naming issues across multiple files in `rust-libp2p`.  
Examples of changes include:  
- **Core/Transport**: renamed variables (`connec` → `connection`) for clarity.  
- **Tests**: updated references in `length_delimited.rs` (`connec` → `connection`) for consistency.  
- **Autonat**: fixed `re-used` → `reused`.  
- **Kademlia**: corrected typo `te same peer` → `the same peer`.  
- **mDNS**: clarified comments (`additionals` → `additional records`).  
- **TLS**: fixed `ANS.1-encoded` → `ASN.1-encoded`.  
- **WebRTC**: corrected `get's` → `gets`.  

No functional or logic changes — only spelling and comment corrections for readability and consistency.
