### PR TITLE
docs(core): add example to TransportTimeout

### DIFF
--- a/core/src/transport/timeout.rs
+++ b/core/src/transport/timeout.rs
@@ -22,7 +22,23 @@
 //!
 //! The connection setup includes all protocol upgrades applied on the
 //! underlying `Transport`.
-// TODO: add example
+//!
+//! # Example
+//!
+//! ```no_run
+//! use std::time::Duration;
+//!
+//! use libp2p_core::{
+//!     transport::{timeout::TransportTimeout, ListenerId, MemoryTransport},
+//!     Transport as _,
+//! };
+//!
+//! let base = MemoryTransport::default();
+//! let mut timeout = TransportTimeout::new(base, Duration::from_secs(1));
+//!
+//! // Listen and dial as usual; the setup will be subject to timeouts.
+//! let _ = timeout.listen_on(ListenerId::next(), "/memory/0".parse().unwrap());
+//! ```
 
 use std::{
     error, fmt, io,


### PR DESCRIPTION
Add a concise doc example to `TransportTimeout`.

- Marked as `no_run`.
- Uses `ListenerId::next()` and `MemoryTransport`.
- Imports grouped to satisfy rustfmt.

## Rationale

Provide a minimal illustration of using `TransportTimeout` without changing behavior or public API.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates

No behavior change.