### PR TITLE
Avoid panic when evicting external addresses in Swarm

### DIFF
--- a/swarm/src/behaviour/external_addresses.rs
+++ b/swarm/src/behaviour/external_addresses.rs
@@ -46,13 +46,17 @@ impl ExternalAddresses {
                 self.push_front(addr);
 
                 if self.addresses.len() > MAX_LOCAL_EXTERNAL_ADDRS {
-                    let expired = self.addresses.pop().expect("list to be not empty");
-
-                    tracing::debug!(
-                        external_address=%expired,
-                        address_limit=%MAX_LOCAL_EXTERNAL_ADDRS,
-                        "Removing previously confirmed external address because we reached the address limit"
-                    );
+                    if let Some(expired) = self.addresses.pop() {
+                        tracing::debug!(
+                            external_address=%expired,
+                            address_limit=%MAX_LOCAL_EXTERNAL_ADDRS,
+                            "Removing previously confirmed external address because we reached the address limit"
+                        );
+                    } else {
+                        tracing::warn!(
+                            "ExternalAddresses invariant violated: empty list on eviction path"
+                        );
+                    }
                 }
 
                 return true;


### PR DESCRIPTION

Replace a fallible `expect` on `pop()` with a safe `if let` to prevent potential panics when evicting external addresses.

### Rationale
Even though `len > MAX_LOCAL_EXTERNAL_ADDRS` should imply a non-empty vector, relying on `expect` risks crashing applications if invariants regress. This change makes the behavior robust without altering semantics.

### Changes
- `swarm/src/behaviour/external_addresses.rs`: use `if let Some(expired)` instead of `pop().expect(...)`.
- Log a `warn!` if the invariant is violated instead of panicking.

