### PR TITLE
chore: fix minor typos and wording in Autonat and mDNS comments

### DIFF
--- a/protocols/autonat/src/v1/behaviour.rs
+++ b/protocols/autonat/src/v1/behaviour.rs
@@ -64,7 +64,7 @@ pub struct Config {
     /// Interval in which the NAT status should be re-tried if it is currently unknown
     /// or max confidence was not reached yet.
     pub retry_interval: Duration,
-    /// Throttle period for re-using a peer as server for a dial-request.
+    /// Throttle period for reusing a peer as server for a dial-request.
     pub throttle_server_period: Duration,
     /// Use connected peers as servers for probes.
     pub use_connected: bool,

--- a/protocols/autonat/tests/test_client.rs
+++ b/protocols/autonat/tests/test_client.rs
@@ -229,7 +229,7 @@ async fn test_throttle_server_period() {
                 refresh_interval: TEST_REFRESH_INTERVAL,
                 confidence_max: MAX_CONFIDENCE,
                 only_global_ips: false,
-                // Throttle servers so they can not be re-used for dial request.
+                // Throttle servers so they can not be reused for dial request.
                 throttle_server_period: Duration::from_secs(1000),
                 boot_delay: Duration::from_millis(100),
                 ..Default::default()

--- a/protocols/mdns/src/behaviour/iface/dns.rs
+++ b/protocols/mdns/src/behaviour/iface/dns.rs
@@ -82,7 +82,7 @@ pub(crate) fn build_query() -> MdnsPacket {
     // Number of questions.
     append_u16(&mut out, 0x1);
 
-    // Number of answers, authorities, and additionals.
+    // Number of answers, authorities, and additional.
     append_u16(&mut out, 0x0);
     append_u16(&mut out, 0x0);
     append_u16(&mut out, 0x0);
@@ -176,7 +176,7 @@ pub(crate) fn build_service_discovery_response(id: u16, ttl: Duration) -> MdnsPa
     append_u16(&mut out, id);
     // 0x84 flag for an answer.
     append_u16(&mut out, 0x8400);
-    // Number of questions, answers, authorities, additionals.
+    // Number of questions, answers, authorities, additional.
     append_u16(&mut out, 0x0);
     append_u16(&mut out, 0x1);
     append_u16(&mut out, 0x0);
@@ -214,7 +214,7 @@ fn query_response_packet(id: u16, peer_id: &[u8], records: &[Vec<u8>], ttl: u32)
     append_u16(&mut out, id);
     // 0x84 flag for an answer.
     append_u16(&mut out, 0x8400);
-    // Number of questions, answers, authorities, additionals.
+    // Number of questions, answers, authorities, additional.
     append_u16(&mut out, 0x0);
     append_u16(&mut out, 0x1);
     append_u16(&mut out, 0x0);

--- a/protocols/mdns/src/behaviour/iface/query.rs
+++ b/protocols/mdns/src/behaviour/iface/query.rs
@@ -236,7 +236,7 @@ impl MdnsPeer {
     pub(crate) fn new(packet: &Message, record_value: &Name, ttl: u32) -> Option<MdnsPeer> {
         let mut my_peer_id: Option<PeerId> = None;
         let addrs = packet
-            .additionals()
+            .additional()
             .iter()
             .filter_map(|add_record| {
                 if add_record.name() != record_value {


### PR DESCRIPTION

- Autonat: use “reusing” instead of “re-using”.
- mDNS: correct pluralization — “additional” (not “additionals”).


