### PR TITLE
chore(autonat::v2::client): typo, FIXME, clarity

### DIFF
--- a/protocols/autonat/tests/autonatv2.rs
+++ b/protocols/autonat/tests/autonatv2.rs
@@ -309,7 +309,6 @@ async fn dial_back_to_non_libp2p() {
 
     let (alice_bytes_sent, bob_bytes_sent) = tokio::join!(alice_task, bob_task);
     assert_eq!(alice_bytes_sent, bob_bytes_sent);
-    bob.behaviour_mut().autonat.validate_addr(&addr);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Description

- fix a log entry typo
- remove from the <tests> the call to the method which added no value (as it doesn't change the test neither semantically neither practically)
  - and the method itself (as it had "FIXME" on it)
- remove excessive early `return` (as they deceive into looking that the block returns some different type)

## Notes & open questions

I'm marking "A changelog entry has been made in the appropriate crates" in the checklist since it feels more like this method ditching doesn't need to be logged as a change; sorry if I'm wrong on this!

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
