### PR TITLE
feat(gossipsub): upgrade internal message queue,

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Fix incorrect default values in ConfigBuilder
   See [PR 6113](https://github.com/libp2p/rust-libp2p/pull/6113)
 
+- Switch the internal `async-channel` used to dispatch messages from `NetworkBehaviour` to the `ConnectionHandler`
+  with an internal priority queue. See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX)
+
 ## 0.49.2
 
 - Relax `Behaviour::with_metrics` requirements, do not require DataTransform and TopicSubscriptionFilter to also impl Default
@@ -34,6 +37,7 @@
 
 - Feature gate metrics related code. This changes some `Behaviour` constructor methods.
   See [PR 6020](https://github.com/libp2p/rust-libp2p/pull/6020)
+
 - Send IDONTWANT before Publishing a new message.
   See [PR 6017](https://github.com/libp2p/rust-libp2p/pull/6017)
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -18,7 +18,7 @@
   See [PR 6173](https://github.com/libp2p/rust-libp2p/pull/6173).
 
 - Switch the internal `async-channel` used to dispatch messages from `NetworkBehaviour` to the `ConnectionHandler`
-  with an internal priority queue. See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/6175)
+  with an internal priority queue. See [PR 6175](https://github.com/libp2p/rust-libp2p/pull/6175)
 
 ## 0.49.2
 

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -61,7 +61,7 @@ use crate::{
     mcache::MessageCache,
     peer_score::{PeerScore, PeerScoreParams, PeerScoreState, PeerScoreThresholds, RejectReason},
     protocol::SIGNING_PREFIX,
-    rpc::Sender,
+    queue::Queue,
     rpc_proto::proto,
     subscription_filter::{AllowAllSubscriptionFilter, TopicSubscriptionFilter},
     time_cache::DuplicateCache,
@@ -751,6 +751,7 @@ where
             if self.send_message(
                 *peer_id,
                 RpcOut::Publish {
+                    message_id: msg_id.clone(),
                     message: raw_message.clone(),
                     timeout: Delay::new(self.config.publish_queue_duration()),
                 },
@@ -1341,6 +1342,7 @@ where
                     self.send_message(
                         *peer_id,
                         RpcOut::Forward {
+                            message_id: id.clone(),
                             message: msg,
                             timeout: Delay::new(self.config.forward_queue_duration()),
                         },
@@ -2081,9 +2083,9 @@ where
         // steady-state size of the queues.
         #[cfg(feature = "metrics")]
         if let Some(m) = &mut self.metrics {
-            for sender_queue in self.connected_peers.values().map(|v| &v.sender) {
-                m.observe_priority_queue_size(sender_queue.priority_queue_len());
-                m.observe_non_priority_queue_size(sender_queue.non_priority_queue_len());
+            for sender_queue in self.connected_peers.values().map(|v| &v.messages) {
+                m.observe_priority_queue_size(sender_queue.priority_len());
+                m.observe_non_priority_queue_size(sender_queue.non_priority_len());
             }
         }
 
@@ -2499,6 +2501,11 @@ where
         // Report expired messages
         for (peer_id, failed_messages) in self.failed_messages.drain() {
             tracing::debug!("Peer couldn't consume messages: {:?}", failed_messages);
+            #[cfg(feature = "metrics")]
+            if let Some(metrics) = self.metrics.as_mut() {
+                metrics.observe_failed_priority_messages(failed_messages.priority);
+                metrics.observe_failed_non_priority_messages(failed_messages.non_priority);
+            }
             self.events
                 .push_back(ToSwarm::GenerateEvent(Event::SlowPeer {
                     peer_id,
@@ -2746,6 +2753,7 @@ where
                 self.send_message(
                     *peer_id,
                     RpcOut::Forward {
+                        message_id: msg_id.clone(),
                         message: message.clone(),
                         timeout: Delay::new(self.config.forward_queue_duration()),
                     },
@@ -2874,8 +2882,9 @@ where
             return false;
         }
 
-        // Try sending the message to the connection handler.
-        match peer.sender.send_message(rpc) {
+        // Try sending the message to the connection handler,
+        // High priority messages should not fail.
+        match peer.messages.try_push(rpc) {
             Ok(()) => true,
             Err(rpc) => {
                 // Sending failed because the channel is full.
@@ -2883,24 +2892,10 @@ where
 
                 // Update failed message counter.
                 let failed_messages = self.failed_messages.entry(peer_id).or_default();
-                match rpc {
-                    RpcOut::Publish { .. } => {
-                        failed_messages.priority += 1;
-                        failed_messages.publish += 1;
-                    }
-                    RpcOut::Forward { .. } => {
-                        failed_messages.non_priority += 1;
-                        failed_messages.forward += 1;
-                    }
-                    RpcOut::IWant(_) | RpcOut::IHave(_) | RpcOut::IDontWant(_) => {
-                        failed_messages.non_priority += 1;
-                    }
-                    RpcOut::Graft(_)
-                    | RpcOut::Prune(_)
-                    | RpcOut::Subscribe(_)
-                    | RpcOut::Unsubscribe(_) => {
-                        unreachable!("Channel for highpriority control messages is unbounded and should always be open.")
-                    }
+                if rpc.priority() {
+                    failed_messages.priority += 1;
+                } else {
+                    failed_messages.non_priority += 1;
                 }
 
                 // Update peer score.
@@ -3125,23 +3120,22 @@ where
         // The protocol negotiation occurs once a message is sent/received. Once this happens we
         // update the type of peer that this is in order to determine which kind of routing should
         // occur.
-        let connected_peer = self
-            .connected_peers
-            .entry(peer_id)
-            .or_insert_with(|| PeerDetails {
-                kind: PeerKind::Floodsub,
-                connections: vec![],
-                outbound: false,
-                sender: Sender::new(self.config.connection_handler_queue_len()),
-                topics: Default::default(),
-                dont_send: LinkedHashMap::new(),
-            });
+        let connected_peer = self.connected_peers.entry(peer_id).or_insert(PeerDetails {
+            kind: PeerKind::Floodsub,
+            connections: vec![],
+            outbound: false,
+            messages: Queue::new(self.config.connection_handler_queue_len()),
+            topics: Default::default(),
+            dont_send: LinkedHashMap::new(),
+        });
         // Add the new connection
         connected_peer.connections.push(connection_id);
 
+        // This clones a reference to the Queue so any new handlers reference the same underlying
+        // queue. No data is actually cloned here.
         Ok(Handler::new(
             self.config.protocol_config(),
-            connected_peer.sender.new_receiver(),
+            connected_peer.messages.clone(),
         ))
     }
 
@@ -3153,25 +3147,24 @@ where
         _: Endpoint,
         _: PortUse,
     ) -> Result<THandler<Self>, ConnectionDenied> {
-        let connected_peer = self
-            .connected_peers
-            .entry(peer_id)
-            .or_insert_with(|| PeerDetails {
-                kind: PeerKind::Floodsub,
-                connections: vec![],
-                // Diverging from the go implementation we only want to consider a peer as outbound
-                // peer if its first connection is outbound.
-                outbound: !self.px_peers.contains(&peer_id),
-                sender: Sender::new(self.config.connection_handler_queue_len()),
-                topics: Default::default(),
-                dont_send: LinkedHashMap::new(),
-            });
+        let connected_peer = self.connected_peers.entry(peer_id).or_insert(PeerDetails {
+            kind: PeerKind::Floodsub,
+            connections: vec![],
+            // Diverging from the go implementation we only want to consider a peer as outbound peer
+            // if its first connection is outbound.
+            outbound: !self.px_peers.contains(&peer_id),
+            messages: Queue::new(self.config.connection_handler_queue_len()),
+            topics: Default::default(),
+            dont_send: LinkedHashMap::new(),
+        });
         // Add the new connection
         connected_peer.connections.push(connection_id);
 
+        // This clones a reference to the Queue so any new handlers reference the same underlying
+        // queue. No data is actually cloned here.
         Ok(Handler::new(
             self.config.protocol_config(),
-            connected_peer.sender.new_receiver(),
+            connected_peer.messages.clone(),
         ))
     }
 
@@ -3213,6 +3206,8 @@ where
                     }
                 }
             }
+            // rpc is only used for metrics code.
+            #[allow(unused_variables)]
             HandlerEvent::MessageDropped(rpc) => {
                 // Account for this in the scoring logic
                 if let PeerScoreState::Active(peer_score) = &mut self.peer_score {
@@ -3221,32 +3216,7 @@ where
 
                 // Keep track of expired messages for the application layer.
                 let failed_messages = self.failed_messages.entry(propagation_source).or_default();
-                failed_messages.timeout += 1;
-                match rpc {
-                    RpcOut::Publish { .. } => {
-                        failed_messages.publish += 1;
-                    }
-                    RpcOut::Forward { .. } => {
-                        failed_messages.forward += 1;
-                    }
-                    _ => {}
-                }
-
-                // Record metrics on the failure.
-                #[cfg(feature = "metrics")]
-                if let Some(metrics) = self.metrics.as_mut() {
-                    match rpc {
-                        RpcOut::Publish { message, .. } => {
-                            metrics.publish_msg_dropped(&message.topic);
-                            metrics.timeout_msg_dropped(&message.topic);
-                        }
-                        RpcOut::Forward { message, .. } => {
-                            metrics.forward_msg_dropped(&message.topic);
-                            metrics.timeout_msg_dropped(&message.topic);
-                        }
-                        _ => {}
-                    }
-                }
+                failed_messages.non_priority += 1;
             }
             HandlerEvent::Message {
                 rpc,
@@ -3345,10 +3315,17 @@ where
                                     "Could not handle IDONTWANT, peer doesn't exist in connected peer list");
                                 continue;
                             };
+
+                            // Remove messages from the queue.
+                            #[allow(unused)]
+                            let removed = peer.messages.remove_data_messages(&message_ids);
+
                             #[cfg(feature = "metrics")]
                             if let Some(metrics) = self.metrics.as_mut() {
                                 metrics.register_idontwant(message_ids.len());
+                                metrics.register_removed_messages(removed);
                             }
+
                             for message_id in message_ids {
                                 peer.dont_send.insert(message_id, Instant::now());
                                 // Don't exceed capacity.

--- a/protocols/gossipsub/src/lib.rs
+++ b/protocols/gossipsub/src/lib.rs
@@ -105,7 +105,7 @@ mod mcache;
 mod metrics;
 mod peer_score;
 mod protocol;
-mod rpc;
+mod queue;
 mod rpc_proto;
 mod subscription_filter;
 mod time_cache;

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -659,6 +659,7 @@ mod tests {
             let rpc = RpcOut::Publish {
                 message: message.clone(),
                 timeout: Delay::new(Duration::from_secs(1)),
+                message_id: MessageId(vec![0, 0]),
             };
 
             let mut codec =

--- a/protocols/gossipsub/src/queue.rs
+++ b/protocols/gossipsub/src/queue.rs
@@ -1,0 +1,294 @@
+// Copyright 2020 Sigma Prime Pty Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use std::{
+    collections::{HashMap, VecDeque},
+    pin::Pin,
+    sync::{atomic::AtomicUsize, Arc, Mutex},
+    task::{Context, Poll, Waker},
+};
+
+use crate::{types::RpcOut, MessageId};
+
+const CONTROL_MSGS_LIMIT: usize = 20_000;
+
+/// An async priority queue used to dispatch messages from the `NetworkBehaviour`
+/// Provides a clean abstraction over high-priority (unbounded), control (bounded),
+/// and non priority (bounded) message queues.
+#[derive(Debug)]
+pub(crate) struct Queue {
+    /// High-priority unbounded queue (Subscribe, Unsubscribe)
+    pub(crate) priority: Shared,
+    /// Control messages bounded queue (Graft, Prune, IDontWant)
+    pub(crate) control: Shared,
+    /// Low-priority bounded queue (Publish, Forward, IHave, IWant)
+    pub(crate) non_priority: Shared,
+    /// The id of the current reference of the counter.
+    pub(crate) id: usize,
+    /// The total number of references for the queue.
+    pub(crate) count: Arc<AtomicUsize>,
+}
+
+impl Queue {
+    /// Create a new `Queue` with `capacity`.
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            priority: Shared::new(),
+            control: Shared::with_capacity(CONTROL_MSGS_LIMIT),
+            non_priority: Shared::with_capacity(capacity),
+            id: 1,
+            count: Arc::new(AtomicUsize::new(1)),
+        }
+    }
+
+    /// Try to push a message to the Queue, return Err if the queue is full,
+    /// which will only happen for control and non priority messages.
+    pub(crate) fn try_push(&mut self, message: RpcOut) -> Result<(), Box<RpcOut>> {
+        match message {
+            RpcOut::Subscribe(_) | RpcOut::Unsubscribe(_) => {
+                self.priority
+                    .try_push(message)
+                    .expect("Shared is unbounded");
+                Ok(())
+            }
+            RpcOut::Graft(_) | RpcOut::Prune(_) | RpcOut::IDontWant(_) => {
+                self.control.try_push(message)
+            }
+            RpcOut::Publish { .. }
+            | RpcOut::Forward { .. }
+            | RpcOut::IHave(_)
+            | RpcOut::IWant(_) => self.non_priority.try_push(message),
+        }
+    }
+
+    /// Remove pending low priority Publish and Forward messages.
+    /// Returns the number of messages removed.
+    pub(crate) fn remove_data_messages(&mut self, message_ids: &[MessageId]) -> usize {
+        let mut count = 0;
+        self.non_priority.retain(|message| match message {
+            RpcOut::Publish { message_id, .. } | RpcOut::Forward { message_id, .. } => {
+                if message_ids.contains(message_id) {
+                    count += 1;
+                    false
+                } else {
+                    true
+                }
+            }
+            _ => true,
+        });
+        count
+    }
+
+    /// Pop an element from the queue.
+    pub(crate) fn poll_pop(&mut self, cx: &mut Context) -> Poll<RpcOut> {
+        // First we try the priority messages.
+        if let Poll::Ready(rpc) = Pin::new(&mut self.priority).poll_pop(cx) {
+            return Poll::Ready(rpc);
+        }
+
+        // Then we try the control messages.
+        if let Poll::Ready(rpc) = Pin::new(&mut self.control).poll_pop(cx) {
+            return Poll::Ready(rpc);
+        }
+
+        // Finally we try the non priority messages
+        if let Poll::Ready(rpc) = Pin::new(&mut self.non_priority).poll_pop(cx) {
+            return Poll::Ready(rpc);
+        }
+
+        Poll::Pending
+    }
+
+    /// Check if the queue is empty.
+    pub(crate) fn is_empty(&self) -> bool {
+        if !self.priority.is_empty() {
+            return false;
+        }
+
+        if !self.control.is_empty() {
+            return false;
+        }
+
+        if !self.non_priority.is_empty() {
+            return false;
+        }
+
+        true
+    }
+
+    /// Returns the length of the priority queue.
+    #[cfg(feature = "metrics")]
+    pub(crate) fn priority_len(&self) -> usize {
+        self.priority.len() + self.control.len()
+    }
+
+    /// Returns the length of the non priority queue.
+    #[cfg(feature = "metrics")]
+    pub(crate) fn non_priority_len(&self) -> usize {
+        self.non_priority.len()
+    }
+
+    /// Attempts to pop a message from the queue.
+    /// returns None if the queue is empty.
+    #[cfg(test)]
+    pub(crate) fn try_pop(&mut self) -> Option<RpcOut> {
+        // Try priority first
+        self.priority
+            .try_pop()
+            // Then control messages
+            .or_else(|| self.control.try_pop())
+            // Finally non priority
+            .or_else(|| self.non_priority.try_pop())
+    }
+}
+
+impl Clone for Queue {
+    fn clone(&self) -> Self {
+        let new_id = self.count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Self {
+            priority: Shared {
+                inner: self.priority.inner.clone(),
+                capacity: self.priority.capacity,
+                id: new_id,
+            },
+            control: Shared {
+                inner: self.control.inner.clone(),
+                capacity: self.control.capacity,
+                id: new_id,
+            },
+            non_priority: Shared {
+                inner: self.non_priority.inner.clone(),
+                capacity: self.non_priority.capacity,
+                id: new_id,
+            },
+            id: self.id,
+            count: self.count.clone(),
+        }
+    }
+}
+
+/// The internal shared part of the queue,
+/// that allows for shallow copies of the queue among each connection of the remote.
+#[derive(Debug)]
+pub(crate) struct Shared {
+    inner: Arc<Mutex<SharedInner>>,
+    capacity: Option<usize>,
+    id: usize,
+}
+
+impl Shared {
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(SharedInner {
+                queue: VecDeque::new(),
+                pending_pops: Default::default(),
+            })),
+            capacity: Some(capacity),
+            id: 1,
+        }
+    }
+
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(SharedInner {
+                queue: VecDeque::new(),
+                pending_pops: Default::default(),
+            })),
+            capacity: None,
+            id: 1,
+        }
+    }
+
+    /// Pop an element from the queue.
+    pub(crate) fn poll_pop(self: std::pin::Pin<&mut Self>, cx: &mut Context) -> Poll<RpcOut> {
+        let mut guard = self.inner.lock().expect("lock to not be poisoned");
+        match guard.queue.pop_front() {
+            Some(t) => Poll::Ready(t),
+            None => {
+                guard
+                    .pending_pops
+                    .entry(self.id)
+                    .or_insert(cx.waker().clone());
+                Poll::Pending
+            }
+        }
+    }
+
+    pub(crate) fn try_push(&mut self, message: RpcOut) -> Result<(), Box<RpcOut>> {
+        let mut guard = self.inner.lock().expect("lock to not be poisoned");
+        if self
+            .capacity
+            .is_some_and(|capacity| guard.queue.len() >= capacity)
+        {
+            return Err(Box::new(message));
+        }
+
+        guard.queue.push_back(message);
+        // Wake pending registered pops.
+        for (_, s) in guard.pending_pops.drain() {
+            s.wake();
+        }
+
+        Ok(())
+    }
+
+    /// Retain only the elements specified by the predicate.
+    /// In other words, remove all elements e for which f(&e) returns false. The elements are
+    /// visited in unsorted (and unspecified) order. Returns the cleared messages.
+    pub(crate) fn retain<F: FnMut(&RpcOut) -> bool>(&mut self, f: F) {
+        let mut shared = self.inner.lock().expect("lock to not be poisoned");
+        shared.queue.retain(f);
+    }
+
+    /// Check if the queue is empty.
+    pub(crate) fn is_empty(&self) -> bool {
+        let guard = self.inner.lock().expect("lock to not be poisoned");
+        guard.queue.len() == 0
+    }
+
+    /// Returns the length of the queue.
+    #[cfg(feature = "metrics")]
+    pub(crate) fn len(&self) -> usize {
+        let guard = self.inner.lock().expect("lock to not be poisoned");
+        guard.queue.len()
+    }
+
+    /// Attempts to pop an message from the queue.
+    /// returns None if the queue is empty.
+    #[cfg(test)]
+    pub(crate) fn try_pop(&mut self) -> Option<RpcOut> {
+        let mut guard = self.inner.lock().expect("lock to not be poisoned");
+        guard.queue.pop_front()
+    }
+}
+
+impl Drop for Shared {
+    fn drop(&mut self) {
+        let mut guard = self.inner.lock().expect("lock to not be poisoned");
+        guard.pending_pops.remove(&self.id);
+    }
+}
+
+/// The shared stated by the `NetworkBehaviour`s and the `ConnectionHandler`s.
+#[derive(Debug)]
+struct SharedInner {
+    queue: VecDeque<RpcOut>,
+    pending_pops: HashMap<usize, Waker>,
+}


### PR DESCRIPTION
## Description
This is the up-streaming of https://github.com/sigp/rust-libp2p/pull/570 which has been beeing used by https://github.com/sigp/lighthouse/ for some weeks now:

This started with an attempt to solve libp2p#5751 using the previous internal async-channel. 
After multiple ideas were discussed off band, replacing the async-channel with an internal more tailored priority queue seemed inevitable. This priority queue allows us to implement the cancellation of in flight IDONTWANT's very cleanly with the `remove_data_messages` function. Clearing the stale messages likewise becomes simpler as we also make use of `remove_data_messages` .

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
