### PR TITLE
feat(kad): enable putting `Record` without `publisher`

### DIFF
--- a/examples/ipfs-kad/src/main.rs
+++ b/examples/ipfs-kad/src/main.rs
@@ -97,9 +97,9 @@ async fn main() -> Result<()> {
             pk_record_key.put_slice(swarm.local_peer_id().to_bytes().as_slice());
 
             let mut pk_record = kad::Record::new(
-                pk_record_key, 
-                local_key.public().encode_protobuf(), 
-                Some(*swarm.local_peer_id())
+                pk_record_key,
+                local_key.public().encode_protobuf(),
+                Some(*swarm.local_peer_id()),
             );
             pk_record.expires = Some(Instant::now().add(Duration::from_secs(60)));
 

--- a/examples/ipfs-kad/src/main.rs
+++ b/examples/ipfs-kad/src/main.rs
@@ -96,9 +96,11 @@ async fn main() -> Result<()> {
             pk_record_key.put_slice("/pk/".as_bytes());
             pk_record_key.put_slice(swarm.local_peer_id().to_bytes().as_slice());
 
-            let mut pk_record =
-                kad::Record::new(pk_record_key, local_key.public().encode_protobuf());
-            pk_record.publisher = Some(*swarm.local_peer_id());
+            let mut pk_record = kad::Record::new(
+                pk_record_key, 
+                local_key.public().encode_protobuf(), 
+                Some(*swarm.local_peer_id())
+            );
             pk_record.expires = Some(Instant::now().add(Duration::from_secs(60)));
 
             swarm

--- a/misc/metrics/CHANGELOG.md
+++ b/misc/metrics/CHANGELOG.md
@@ -1,3 +1,5 @@
+- tiny adaptation for #6176
+
 ## 0.17.1
 
 - Fix panic in swarm metrics when `ConnectionClosed` events are received for connections that were established before metrics collection started.

--- a/misc/metrics/src/kad.rs
+++ b/misc/metrics/src/kad.rs
@@ -254,7 +254,7 @@ impl super::Recorder<libp2p_kad::Event> for Metrics {
                 }
             }
 
-            libp2p_kad::Event::InboundRequest { request } => {
+            libp2p_kad::Event::InboundRequest(request) => {
                 self.inbound_requests.get_or_create(&request.into()).inc();
             }
             _ => {}

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Allow putting `Record` with `publisher: None` sacrificing republishing.
+
 ## 0.49.0
 
 - Remove no longer constructed GetRecordError::QuorumFailed.

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -261,7 +261,7 @@ pub enum HandlerEvent {
         query_id: QueryId,
     },
 
-    /// Request to put a value in the dht records
+    /// Request to put a value in the DHT records
     PutRecord {
         record: Record,
         /// Identifier of the request. Needs to be passed back when answering.
@@ -316,8 +316,8 @@ impl error::Error for HandlerQueryErr {
 /// Event to send to the handler.
 #[derive(Debug)]
 pub enum HandlerIn {
-    /// Resets the (sub)stream associated with the given request ID,
-    /// thus signaling an error to the remote.
+    /// Resets the (sub)stream associated with the given request ID, thus signaling an error to the
+    /// remote.
     ///
     /// Explicitly resetting the (sub)stream associated with a request
     /// can be used as an alternative to letting requests simply time
@@ -399,7 +399,7 @@ pub enum HandlerIn {
         request_id: RequestId,
     },
 
-    /// Put a value into the dht records.
+    /// Put a value into the DHT records.
     PutRecord {
         record: Record,
         /// ID of the query that generated this request.
@@ -624,21 +624,19 @@ impl ConnectionHandler for Handler {
                         _ => false,
                     })
                 {
-                    state.close();
+                    state.close()
                 }
             }
-            HandlerIn::FindNodeReq { key, query_id } => {
-                let msg = KadRequestMsg::FindNode { key };
-                self.pending_messages.push_back((msg, query_id));
-            }
+            HandlerIn::FindNodeReq { key, query_id } => self
+                .pending_messages
+                .push_back((KadRequestMsg::FindNode { key }, query_id)),
             HandlerIn::FindNodeRes {
                 closer_peers,
                 request_id,
             } => self.answer_pending_request(request_id, KadResponseMsg::FindNode { closer_peers }),
-            HandlerIn::GetProvidersReq { key, query_id } => {
-                let msg = KadRequestMsg::GetProviders { key };
-                self.pending_messages.push_back((msg, query_id));
-            }
+            HandlerIn::GetProvidersReq { key, query_id } => self
+                .pending_messages
+                .push_back((KadRequestMsg::GetProviders { key }, query_id)),
             HandlerIn::GetProvidersRes {
                 closer_peers,
                 provider_peers,
@@ -654,38 +652,31 @@ impl ConnectionHandler for Handler {
                 key,
                 provider,
                 query_id,
-            } => {
-                let msg = KadRequestMsg::AddProvider { key, provider };
-                self.pending_messages.push_back((msg, query_id));
-            }
-            HandlerIn::GetRecord { key, query_id } => {
-                let msg = KadRequestMsg::GetValue { key };
-                self.pending_messages.push_back((msg, query_id));
-            }
-            HandlerIn::PutRecord { record, query_id } => {
-                let msg = KadRequestMsg::PutValue { record };
-                self.pending_messages.push_back((msg, query_id));
-            }
+            } => self
+                .pending_messages
+                .push_back((KadRequestMsg::AddProvider { key, provider }, query_id)),
+            HandlerIn::GetRecord { key, query_id } => self
+                .pending_messages
+                .push_back((KadRequestMsg::GetValue { key }, query_id)),
+            HandlerIn::PutRecord { record, query_id } => self
+                .pending_messages
+                .push_back((KadRequestMsg::PutValue { record }, query_id)),
             HandlerIn::GetRecordRes {
                 record,
                 closer_peers,
                 request_id,
-            } => {
-                self.answer_pending_request(
-                    request_id,
-                    KadResponseMsg::GetValue {
-                        record,
-                        closer_peers,
-                    },
-                );
-            }
+            } => self.answer_pending_request(
+                request_id,
+                KadResponseMsg::GetValue {
+                    record,
+                    closer_peers,
+                },
+            ),
             HandlerIn::PutRecordRes {
                 key,
                 request_id,
                 value,
-            } => {
-                self.answer_pending_request(request_id, KadResponseMsg::PutValue { key, value });
-            }
+            } => self.answer_pending_request(request_id, KadResponseMsg::PutValue { key, value }),
             HandlerIn::ReconfigureMode { new_mode } => {
                 let peer = self.remote_peer_id;
 

--- a/protocols/kad/src/jobs.rs
+++ b/protocols/kad/src/jobs.rs
@@ -22,8 +22,8 @@
 //!
 //! ## Record Persistence & Expiry
 //!
-//! To ensure persistence of records in the DHT, a Kademlia node
-//! must periodically (re-)publish and (re-)replicate its records:
+//! To ensure persistence of records in the DHT, a Kademlia node must periodically (re-)publish and
+//! (re-)replicate its records:
 //!
 //!   1. (Re-)publishing: The original publisher or provider of a record must regularly re-publish
 //!      in order to prolong the expiration.
@@ -31,14 +31,13 @@
 //!   2. (Re-)replication: Every node storing a replica of a record must regularly re-replicate it
 //!      to the closest nodes to the key in order to ensure the record is present at these nodes.
 //!
-//! Re-publishing primarily ensures persistence of the record beyond its
-//! initial TTL, for as long as the publisher stores (or provides) the record,
-//! whilst (re-)replication primarily ensures persistence for the duration
-//! of the TTL in the light of topology changes. Consequently, replication
-//! intervals should be shorter than publication intervals and
+//! Re-publishing primarily ensures persistence of the record beyond its initial TTL, for as long as
+//! the publisher stores (or provides) the record, whilst (re-)replication primarily ensures
+//! persistence for the duration of the TTL in the light of topology changes. Consequently,
+//! replication intervals should be shorter than publication intervals and
 //! publication intervals should be shorter than the TTL.
 //!
-//! This module implements two periodic jobs:
+//! This module implements two periodic jobs.
 //!
 //!   * [`PutRecordJob`]: For (re-)publication and (re-)replication of regular (value-)records.
 //!
@@ -50,14 +49,13 @@
 //! nodes to the key, where `k` is the replication factor.
 //!
 //! Furthermore, these jobs perform double-duty by removing expired records
-//! from the `RecordStore` on every run. Expired records are never emitted
+//! from the [`RecordStore`] on every run. Expired records are never emitted
 //! by the jobs.
 //!
-//! > **Note**: The current implementation takes a snapshot of the records
-//! > to replicate from the `RecordStore` when it starts and thus, to account
-//! > for the worst case, it temporarily requires additional memory proportional
-//! > to the size of all stored records. As a job runs, the records are moved
-//! > out of the job to the consumer, where they can be dropped after being sent.
+//! > **Note**: The current implementation takes a snapshot of the records to replicate from the
+//! > `RecordStore` when it starts and thus, to account for the worst case, it temporarily requires
+//! > additional memory proportional to the size of all stored records. As a job runs, the records
+//! > are moved out of the job to the consumer, where they can be dropped after being sent.
 
 use std::{
     collections::HashSet,
@@ -192,9 +190,8 @@ impl PutRecordJob {
 
     /// Polls the job for records to replicate.
     ///
-    /// Must be called in the context of a task. When `NotReady` is returned,
-    /// the current task is registered to be notified when the job is ready
-    /// to be run.
+    /// Must be called in the context of a task. When `NotReady` is returned, the current task is
+    /// registered to be notified when the job is ready to be run.
     pub(crate) fn poll<T>(
         &mut self,
         cx: &mut Context<'_>,

--- a/protocols/kad/src/protocol.rs
+++ b/protocols/kad/src/protocol.rs
@@ -556,14 +556,6 @@ fn record_from_proto(record: proto::Record) -> Result<Record, io::Error> {
     let key = record::Key::from(record.key);
     let value = record.value;
 
-    let publisher = if !record.publisher.is_empty() {
-        PeerId::from_bytes(&record.publisher)
-            .map(Some)
-            .map_err(|_| invalid_data("Invalid publisher peer ID."))?
-    } else {
-        None
-    };
-
     let expires = if record.ttl > 0 {
         Some(Instant::now() + Duration::from_secs(record.ttl as u64))
     } else {
@@ -573,7 +565,14 @@ fn record_from_proto(record: proto::Record) -> Result<Record, io::Error> {
     Ok(Record {
         key,
         value,
-        publisher,
+        publisher: if record.publisher.is_empty() {
+            None
+        } else {
+            Some(
+                PeerId::from_bytes(&record.publisher)
+                    .map_err(|_| invalid_data("Invalid publisher peer ID."))?,
+            )
+        },
         expires,
     })
 }

--- a/protocols/kad/src/query.rs
+++ b/protocols/kad/src/query.rs
@@ -41,11 +41,11 @@ use crate::{
     QueryInfo, ALPHA_VALUE, K_VALUE,
 };
 
-/// A `QueryPool` provides an aggregate state machine for driving `Query`s to completion.
+/// A `QueryPool` provides an aggregate state machine for driving [`Query`] to completion.
 ///
-/// Internally, a `Query` is in turn driven by an underlying `QueryPeerIter`
-/// that determines the peer selection strategy, i.e. the order in which the
-/// peers involved in the query should be contacted.
+/// Internally, a `Query` is in turn driven by an underlying [`QueryPeerIter`] that determines the
+/// peer selection strategy, i.e. the order in which the peers involved in the query should be
+/// contacted.
 pub(crate) struct QueryPool {
     next_id: usize,
     config: QueryConfig,
@@ -56,8 +56,8 @@ pub(crate) struct QueryPool {
 pub(crate) enum QueryPoolState<'a> {
     /// The pool is idle, i.e. there are no queries to process.
     Idle,
-    /// At least one query is waiting for results. `Some(request)` indicates
-    /// that a new request is now being waited on.
+    /// At least one query is waiting for results. `Some(request)` indicates that a new request is
+    /// now being waited on.
     Waiting(Option<(&'a mut Query, PeerId)>),
     /// A query has finished.
     Finished(Query),
@@ -163,8 +163,7 @@ impl QueryPool {
             QueryPeerIter::Closest(ClosestPeersIter::with_config(cfg, target, peers))
         };
 
-        let query = Query::new(id, peer_iter, info);
-        self.queries.insert(id, query);
+        self.queries.insert(id, Query::new(id, peer_iter, info));
     }
 
     fn next_query_id(&mut self) -> QueryId {

--- a/protocols/kad/src/record.rs
+++ b/protocols/kad/src/record.rs
@@ -90,14 +90,14 @@ pub struct Record {
 
 impl Record {
     /// Creates a new record for insertion into the DHT.
-    pub fn new<K>(key: K, value: Vec<u8>) -> Self
+    pub fn new<K>(key: K, value: Vec<u8>, publisher: Option<PeerId>) -> Self
     where
         K: Into<Key>,
     {
         Record {
             key: key.into(),
             value,
-            publisher: None,
+            publisher,
             expires: None,
         }
     }


### PR DESCRIPTION
## Description

The change is about allowing putting `Record` with `publisher: None` sacrificing republishing.

Sorry for so many lateral changes: I had to delve deeper to understand that the change would actually work and during active reading was eliminating redundant pieces which confuse comprehension with misleading supposition (looking for further use of a variable when it is actually just a parameter/argument was most common impediment).

## Notes & open questions

I don't have a fine test for this in mind as it doesn't really do anything (because replication context doesn't yield an event). Simultaneously I'm not really satisfied with the approach I took to adapt/fix the test (retaining only `Record` with `publisher: Some`); but I need a hint if that's possible to do better due to the same fact of how silent replication is.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
