### PR TITLE
chore: prepare libp2p-upnp v0.6.0

### DIFF
--- a/protocols/upnp/CHANGELOG.md
+++ b/protocols/upnp/CHANGELOG.md
@@ -1,17 +1,15 @@
 ## 0.6.0
 
-- Change `Event::NewExternalAddr` and `Event::ExpiredExternalAddr` from tuple variants to struct variants 
-  that include both local and external addresses. This allows users to correlate which local listen 
+- Change `Event::NewExternalAddr` and `Event::ExpiredExternalAddr` from tuple variants to struct variants
+  that include both local and external addresses. This allows users to correlate which local listen
   address was mapped to which external address.
   - `Event::NewExternalAddr` now contains `local_addr` and `external_addr` fields
   - `Event::ExpiredExternalAddr` now contains `local_addr` and `external_addr` fields
   See [PR 6121](https://github.com/libp2p/rust-libp2p/pull/6121).
 
-## 0.5.1
-
 - Skip port mapping when an active port mapping is present.
-  Previously, the behavior would skip creating new mappings if any mapping 
-  (active or inactive or pending) existed for the same port. Now it correctly only 
+  Previously, the behavior would skip creating new mappings if any mapping
+  (active or inactive or pending) existed for the same port. Now it correctly only
   checks active mappings on the gateway.
   See [PR 6127](https://github.com/libp2p/rust-libp2p/pull/6127).
 


### PR DESCRIPTION
## Description

Changelog was incorrect as we didn't release version `0.5.1`
cc @RolandSherwin 