### PR TITLE
feat(gossipsub): add detailed peer score parameter tracking

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.50.0
 
+- Add `PeerScoreParameters` struct and `Behaviour::peer_score_params()` to expose
+  the individual weighted contributions (P1–P7, slow peer penalty) that make up a
+  peer's gossipsub score. Useful for debugging and external tooling.
+  See [PR 6189](https://github.com/libp2p/rust-libp2p/pull/6189).
+
 - Rename metric `topic_msg_sent_bytes` to `topic_msg_last_sent_bytes` for accuracy.
   See [PR 6283](https://github.com/libp2p/rust-libp2p/pull/6283)
 

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -59,7 +59,10 @@ use crate::{
     gossip_promises::GossipPromises,
     handler::{Handler, HandlerEvent, HandlerIn},
     mcache::MessageCache,
-    peer_score::{PeerScore, PeerScoreParams, PeerScoreState, PeerScoreThresholds, RejectReason},
+    peer_score::{
+        PeerScore, PeerScoreParameters, PeerScoreParams, PeerScoreState, PeerScoreThresholds,
+        RejectReason,
+    },
     protocol::SIGNING_PREFIX,
     queue::Queue,
     rpc_proto::proto,
@@ -508,6 +511,14 @@ where
     pub fn peer_score(&self, peer_id: &PeerId) -> Option<f64> {
         match &self.peer_score {
             PeerScoreState::Active(peer_score) => Some(peer_score.score_report(peer_id).score),
+            PeerScoreState::Disabled => None,
+        }
+    }
+
+    /// Returns the detailed gossipsub score parameters for a given peer, if one exists.
+    pub fn peer_score_params(&self, peer_id: &PeerId) -> Option<PeerScoreParameters> {
+        match &self.peer_score {
+            PeerScoreState::Active(peer_score) => Some(peer_score.score_report(peer_id).params),
             PeerScoreState::Disabled => None,
         }
     }

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -508,9 +508,13 @@ where
     }
 
     /// Returns the gossipsub score for a given peer, if one exists.
+    ///
+    /// Returns `None` if peer scoring is disabled or the peer is unknown.
     pub fn peer_score(&self, peer_id: &PeerId) -> Option<f64> {
         match &self.peer_score {
-            PeerScoreState::Active(peer_score) => Some(peer_score.score_report(peer_id).score),
+            PeerScoreState::Active(peer_score) => {
+                Some(peer_score.score_report(peer_id)?.score)
+            }
             PeerScoreState::Disabled => None,
         }
     }
@@ -520,10 +524,12 @@ where
     /// Returns `None` if peer scoring is disabled or the peer is unknown.
     /// Each field in [`PeerScoreParameters`] reflects a weighted contribution
     /// from the corresponding term in the gossipsub v1.1 scoring function.
-    /// The `final_score` field equals [`Self::peer_score`] for the same peer.
+    /// The `score` field equals [`Self::peer_score`] for the same peer.
     pub fn peer_score_params(&self, peer_id: &PeerId) -> Option<PeerScoreParameters> {
         match &self.peer_score {
-            PeerScoreState::Active(peer_score) => Some(peer_score.score_report(peer_id).params),
+            PeerScoreState::Active(peer_score) => {
+                Some(peer_score.score_report(peer_id)?.params)
+            }
             PeerScoreState::Disabled => None,
         }
     }
@@ -2133,7 +2139,7 @@ where
                 #[allow(unused_variables)]
                 let report = scores
                     .entry(peer_id)
-                    .or_insert_with(|| peer_score.score_report(peer_id));
+                    .or_insert_with(|| peer_score.score_report(peer_id).unwrap_or_default());
 
                 #[cfg(feature = "metrics")]
                 if let Some(metrics) = self.metrics.as_mut() {

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -515,7 +515,12 @@ where
         }
     }
 
-    /// Returns the detailed gossipsub score parameters for a given peer, if one exists.
+    /// Returns a breakdown of the individual score components for a peer.
+    ///
+    /// Returns `None` if peer scoring is disabled or the peer is unknown.
+    /// Each field in [`PeerScoreParameters`] reflects a weighted contribution
+    /// from the corresponding term in the gossipsub v1.1 scoring function.
+    /// The `final_score` field equals [`Self::peer_score`] for the same peer.
     pub fn peer_score_params(&self, peer_id: &PeerId) -> Option<PeerScoreParameters> {
         match &self.peer_score {
             PeerScoreState::Active(peer_score) => Some(peer_score.score_report(peer_id).params),

--- a/protocols/gossipsub/src/behaviour/tests/gossip.rs
+++ b/protocols/gossipsub/src/behaviour/tests/gossip.rs
@@ -756,7 +756,7 @@ fn test_iwant_penalties() {
     gs.heartbeat();
 
     for (peer, _queue) in &other_peers {
-        assert_eq!(gs.as_peer_score_mut().score_report(peer).score, 0.0);
+        assert_eq!(gs.as_peer_score_mut().score_report(peer).unwrap().score, 0.0);
     }
 
     // receive the first twenty of the other peers then send their response
@@ -786,7 +786,7 @@ fn test_iwant_penalties() {
     let mut double_penalized = 0;
 
     for (i, (peer, _queue)) in other_peers.iter().enumerate() {
-        let score = gs.as_peer_score_mut().score_report(peer).score;
+        let score = gs.as_peer_score_mut().score_report(peer).unwrap().score;
         if score == 0.0 {
             not_penalized += 1;
         } else if score == -1.0 {

--- a/protocols/gossipsub/src/behaviour/tests/scoring.rs
+++ b/protocols/gossipsub/src/behaviour/tests/scoring.rs
@@ -50,6 +50,7 @@ use crate::{
     IdentTopic as Topic,
 };
 
+
 #[test]
 fn test_prune_negative_scored_peers() {
     let config = Config::default();
@@ -2103,4 +2104,92 @@ fn test_subscribe_and_graft_with_negative_score() {
 
     // nobody got penalized
     assert!(gs1.as_peer_score_mut().score_report(&p2).score >= original_score);
+}
+
+// Tests for PeerScoreParameters / peer_score_params().
+
+/// `peer_score_params` returns `None` when scoring is disabled.
+#[test]
+fn test_peer_score_params_disabled() {
+    let (gs, peers, _, _) = DefaultBehaviourTestBuilder::default()
+        .peer_no(1)
+        .topics(vec!["test".into()])
+        .to_subscribe(true)
+        .create_network();
+
+    // No scoring configured — must return None.
+    assert!(gs.peer_score_params(&peers[0]).is_none());
+}
+
+/// `peer_score_params` returns `Some` for a known peer when scoring is enabled,
+/// and the `final_score` field matches `peer_score`.
+#[test]
+fn test_peer_score_params_consistency_with_peer_score() {
+    let (gs, peers, _, _) = DefaultBehaviourTestBuilder::default()
+        .peer_no(1)
+        .topics(vec!["test".into()])
+        .to_subscribe(true)
+        .scoring(Some((
+            PeerScoreParams::default(),
+            PeerScoreThresholds::default(),
+        )))
+        .create_network();
+
+    let peer = peers[0];
+
+    let params = gs
+        .peer_score_params(&peer)
+        .expect("scoring enabled; peer should have params");
+    let score = gs
+        .peer_score(&peer)
+        .expect("scoring enabled; peer should have a score");
+
+    assert_eq!(
+        params.final_score, score,
+        "final_score in PeerScoreParameters must equal peer_score()"
+    );
+}
+
+/// Applying a behavioural penalty is reflected in `p7` and `final_score`.
+#[test]
+fn test_peer_score_params_p7_reflects_penalty() {
+    let score_params = PeerScoreParams::default();
+    // behaviour_penalty_weight is negative; one penalty above threshold should
+    // produce a non-zero (negative) p7 contribution.
+    let (mut gs, peers, _, _) = DefaultBehaviourTestBuilder::default()
+        .peer_no(1)
+        .topics(vec!["test".into()])
+        .to_subscribe(true)
+        .scoring(Some((score_params.clone(), PeerScoreThresholds::default())))
+        .create_network();
+
+    let peer = peers[0];
+
+    // Baseline: no penalty yet.
+    let before = gs
+        .peer_score_params(&peer)
+        .expect("scoring enabled");
+    assert_eq!(before.p7, 0.0, "p7 should be zero before any penalty");
+
+    // Apply enough penalties to exceed the threshold.
+    let penalties_needed =
+        (score_params.behaviour_penalty_threshold as usize).saturating_add(1).max(1);
+    for _ in 0..penalties_needed {
+        gs.as_peer_score_mut().add_penalty(&peer, 1);
+    }
+
+    let after = gs
+        .peer_score_params(&peer)
+        .expect("scoring enabled");
+
+    assert!(
+        after.p7 < 0.0,
+        "p7 should be negative after behavioural penalty (got {})",
+        after.p7
+    );
+    assert_eq!(
+        after.final_score,
+        gs.peer_score(&peer).unwrap(),
+        "final_score must stay consistent with peer_score() after penalty"
+    );
 }

--- a/protocols/gossipsub/src/behaviour/tests/scoring.rs
+++ b/protocols/gossipsub/src/behaviour/tests/scoring.rs
@@ -864,12 +864,12 @@ fn test_scoring_p1() {
     // refresh scores
     gs.as_peer_score_mut().refresh_scores();
     assert!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score
             >= 2.0 * topic_params.time_in_mesh_weight * topic_params.topic_weight,
         "score should be at least 2 * time_in_mesh_weight * topic_weight"
     );
     assert!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score
             < 3.0 * topic_params.time_in_mesh_weight * topic_params.topic_weight,
         "score should be less than 3 * time_in_mesh_weight * topic_weight"
     );
@@ -879,7 +879,7 @@ fn test_scoring_p1() {
     // refresh scores
     gs.as_peer_score_mut().refresh_scores();
     assert!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score
             >= 2.0 * topic_params.time_in_mesh_weight * topic_params.topic_weight,
         "score should be at least 4 * time_in_mesh_weight * topic_weight"
     );
@@ -889,7 +889,7 @@ fn test_scoring_p1() {
     // refresh scores
     gs.as_peer_score_mut().refresh_scores();
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score,
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score,
         topic_params.time_in_mesh_cap
             * topic_params.time_in_mesh_weight
             * topic_params.topic_weight,
@@ -939,13 +939,13 @@ fn test_scoring_p2() {
     deliver_message(&mut gs, 1, m1);
 
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score,
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score,
         1.0 * topic_params.first_message_deliveries_weight * topic_params.topic_weight,
         "score should be exactly first_message_deliveries_weight * topic_weight"
     );
 
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[1]).score,
+        gs.as_peer_score_mut().score_report(&peers[1]).unwrap().score,
         0.0,
         "there should be no score for second message deliveries * topic_weight"
     );
@@ -954,7 +954,7 @@ fn test_scoring_p2() {
     deliver_message(&mut gs, 1, random_message(&mut seq, &topics));
     deliver_message(&mut gs, 1, random_message(&mut seq, &topics));
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[1]).score,
+        gs.as_peer_score_mut().score_report(&peers[1]).unwrap().score,
         2.0 * topic_params.first_message_deliveries_weight * topic_params.topic_weight,
         "score should be exactly 2 * first_message_deliveries_weight * topic_weight"
     );
@@ -963,7 +963,7 @@ fn test_scoring_p2() {
     gs.as_peer_score_mut().refresh_scores();
 
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score,
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score,
         1.0 * topic_params.first_message_deliveries_decay
             * topic_params.first_message_deliveries_weight
             * topic_params.topic_weight,
@@ -972,7 +972,7 @@ fn test_scoring_p2() {
     );
 
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[1]).score,
+        gs.as_peer_score_mut().score_report(&peers[1]).unwrap().score,
         2.0 * topic_params.first_message_deliveries_decay
             * topic_params.first_message_deliveries_weight
             * topic_params.topic_weight,
@@ -986,7 +986,7 @@ fn test_scoring_p2() {
     }
 
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[1]).score,
+        gs.as_peer_score_mut().score_report(&peers[1]).unwrap().score,
         topic_params.first_message_deliveries_cap
             * topic_params.first_message_deliveries_weight
             * topic_params.topic_weight,
@@ -1065,7 +1065,7 @@ fn test_scoring_p3() {
     expected_message_deliveries *= 0.9; // decay
 
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score,
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score,
         (5f64 - expected_message_deliveries).powi(2) * -2.0 * 0.7
     );
 
@@ -1076,7 +1076,7 @@ fn test_scoring_p3() {
 
     expected_message_deliveries = 10.0;
 
-    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).score, 0.0);
+    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score, 0.0);
 
     // apply 10 decays
     for _ in 0..10 {
@@ -1085,7 +1085,7 @@ fn test_scoring_p3() {
     }
 
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score,
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score,
         (5f64 - expected_message_deliveries).powi(2) * -2.0 * 0.7
     );
 }
@@ -1162,7 +1162,7 @@ fn test_scoring_p3b() {
     // the score should now consider p3b
     let mut expected_b3 = (5f64 - expected_message_deliveries).powi(2);
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score,
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score,
         100.0 + expected_b3 * -3.0 * 0.7
     );
 
@@ -1178,7 +1178,7 @@ fn test_scoring_p3b() {
     expected_b3 *= 0.95;
 
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score,
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score,
         100.0 + (expected_b3 * -3.0 + (5f64 - expected_message_deliveries).powi(2) * -2.0) * 0.7
     );
 }
@@ -1233,7 +1233,7 @@ fn test_scoring_p4_valid_message() {
     // Transform the inbound message
     let message1 = &gs.data_transform.inbound_transform(m1).unwrap();
 
-    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).score, 0.0);
+    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score, 0.0);
 
     // message m1 gets validated
     gs.report_message_validation_result(
@@ -1242,7 +1242,7 @@ fn test_scoring_p4_valid_message() {
         MessageAcceptance::Accept,
     );
 
-    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).score, 0.0);
+    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score, 0.0);
 }
 
 #[test]
@@ -1302,7 +1302,7 @@ fn test_scoring_p4_invalid_signature() {
     );
 
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score,
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score,
         -2.0 * 0.7
     );
 }
@@ -1356,7 +1356,7 @@ fn test_scoring_p4_message_from_self() {
 
     deliver_message(&mut gs, 0, m);
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score,
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score,
         -2.0 * 0.7
     );
 }
@@ -1408,7 +1408,7 @@ fn test_scoring_p4_ignored_message() {
     let m1 = random_message(&mut seq, &topics);
     deliver_message(&mut gs, 0, m1.clone());
 
-    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).score, 0.0);
+    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score, 0.0);
 
     // Transform the inbound message
     let message1 = &gs.data_transform.inbound_transform(m1).unwrap();
@@ -1420,7 +1420,7 @@ fn test_scoring_p4_ignored_message() {
         MessageAcceptance::Ignore,
     );
 
-    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).score, 0.0);
+    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score, 0.0);
 }
 
 #[test]
@@ -1470,7 +1470,7 @@ fn test_scoring_p4_application_invalidated_message() {
     let m1 = random_message(&mut seq, &topics);
     deliver_message(&mut gs, 0, m1.clone());
 
-    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).score, 0.0);
+    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score, 0.0);
 
     // Transform the inbound message
     let message1 = &gs.data_transform.inbound_transform(m1).unwrap();
@@ -1483,7 +1483,7 @@ fn test_scoring_p4_application_invalidated_message() {
     );
 
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score,
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score,
         -2.0 * 0.7
     );
 }
@@ -1541,8 +1541,8 @@ fn test_scoring_p4_application_invalid_message_from_two_peers() {
     // peer 1 delivers same message
     deliver_message(&mut gs, 1, m1);
 
-    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).score, 0.0);
-    assert_eq!(gs.as_peer_score_mut().score_report(&peers[1]).score, 0.0);
+    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score, 0.0);
+    assert_eq!(gs.as_peer_score_mut().score_report(&peers[1]).unwrap().score, 0.0);
 
     // message m1 gets rejected
     gs.report_message_validation_result(
@@ -1552,11 +1552,11 @@ fn test_scoring_p4_application_invalid_message_from_two_peers() {
     );
 
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score,
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score,
         -2.0 * 0.7
     );
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[1]).score,
+        gs.as_peer_score_mut().score_report(&peers[1]).unwrap().score,
         -2.0 * 0.7
     );
 }
@@ -1620,7 +1620,7 @@ fn test_scoring_p4_three_application_invalid_messages() {
     // Transform the inbound message
     let message3 = &gs.data_transform.inbound_transform(m3).unwrap();
 
-    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).score, 0.0);
+    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score, 0.0);
 
     // messages gets rejected
     gs.report_message_validation_result(
@@ -1643,7 +1643,7 @@ fn test_scoring_p4_three_application_invalid_messages() {
 
     // number of invalid messages gets squared
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score,
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score,
         9.0 * -2.0 * 0.7
     );
 }
@@ -1697,7 +1697,7 @@ fn test_scoring_p4_decay() {
 
     // Transform the inbound message
     let message1 = &gs.data_transform.inbound_transform(m1).unwrap();
-    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).score, 0.0);
+    assert_eq!(gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score, 0.0);
 
     // message m1 gets rejected
     gs.report_message_validation_result(
@@ -1707,7 +1707,7 @@ fn test_scoring_p4_decay() {
     );
 
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score,
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score,
         -2.0 * 0.7
     );
 
@@ -1716,7 +1716,7 @@ fn test_scoring_p4_decay() {
 
     // the number of invalids gets decayed to 0.9 and then squared in the score
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score,
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score,
         0.9 * 0.9 * -2.0 * 0.7
     );
 }
@@ -1742,7 +1742,7 @@ fn test_scoring_p5() {
     gs.set_application_score(&peers[0], 1.1);
 
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score,
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score,
         1.1 * 2.0
     );
 }
@@ -1786,7 +1786,7 @@ fn test_scoring_p6() {
 
     // no penalties yet
     for peer in peers.iter().chain(others.iter()) {
-        assert_eq!(gs.as_peer_score_mut().score_report(peer).score, 0.0);
+        assert_eq!(gs.as_peer_score_mut().score_report(peer).unwrap().score, 0.0);
     }
 
     // add additional connection for 3 others with addr
@@ -1806,10 +1806,10 @@ fn test_scoring_p6() {
 
     // penalties apply squared
     for peer in peers.iter().chain(others.iter().take(3)) {
-        assert_eq!(gs.as_peer_score_mut().score_report(peer).score, 9.0 * -2.0);
+        assert_eq!(gs.as_peer_score_mut().score_report(peer).unwrap().score, 9.0 * -2.0);
     }
     // fourth other peer still no penalty
-    assert_eq!(gs.as_peer_score_mut().score_report(&others[3]).score, 0.0);
+    assert_eq!(gs.as_peer_score_mut().score_report(&others[3]).unwrap().score, 0.0);
 
     // add additional connection for 3 of the peers to addr2
     for peer in peers.iter().take(3) {
@@ -1829,17 +1829,17 @@ fn test_scoring_p6() {
     // double penalties for the first three of each
     for peer in peers.iter().take(3).chain(others.iter().take(3)) {
         assert_eq!(
-            gs.as_peer_score_mut().score_report(peer).score,
+            gs.as_peer_score_mut().score_report(peer).unwrap().score,
             (9.0 + 4.0) * -2.0
         );
     }
 
     // single penalties for the rest
     for peer in peers.iter().skip(3) {
-        assert_eq!(gs.as_peer_score_mut().score_report(peer).score, 9.0 * -2.0);
+        assert_eq!(gs.as_peer_score_mut().score_report(peer).unwrap().score, 9.0 * -2.0);
     }
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&others[3]).score,
+        gs.as_peer_score_mut().score_report(&others[3]).unwrap().score,
         4.0 * -2.0
     );
 
@@ -1860,17 +1860,17 @@ fn test_scoring_p6() {
     // double penalties for the first three of each
     for peer in peers.iter().take(3).chain(others.iter().take(3)) {
         assert_eq!(
-            gs.as_peer_score_mut().score_report(peer).score,
+            gs.as_peer_score_mut().score_report(peer).unwrap().score,
             (9.0 + 4.0) * -2.0
         );
     }
 
     // single penalties for the rest
     for peer in peers.iter().skip(3) {
-        assert_eq!(gs.as_peer_score_mut().score_report(peer).score, 9.0 * -2.0);
+        assert_eq!(gs.as_peer_score_mut().score_report(peer).unwrap().score, 9.0 * -2.0);
     }
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&others[3]).score,
+        gs.as_peer_score_mut().score_report(&others[3]).unwrap().score,
         4.0 * -2.0
     );
 }
@@ -1916,7 +1916,7 @@ fn test_scoring_p7_grafts_before_backoff() {
 
     // double behaviour penalty for first peer (squared)
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score,
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score,
         4.0 * -2.0
     );
 
@@ -1928,7 +1928,7 @@ fn test_scoring_p7_grafts_before_backoff() {
 
     // single behaviour penalty for second peer
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[1]).score,
+        gs.as_peer_score_mut().score_report(&peers[1]).unwrap().score,
         1.0 * -2.0
     );
 
@@ -1936,11 +1936,11 @@ fn test_scoring_p7_grafts_before_backoff() {
     gs.as_peer_score_mut().refresh_scores();
 
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[0]).score,
+        gs.as_peer_score_mut().score_report(&peers[0]).unwrap().score,
         4.0 * 0.9 * 0.9 * -2.0
     );
     assert_eq!(
-        gs.as_peer_score_mut().score_report(&peers[1]).score,
+        gs.as_peer_score_mut().score_report(&peers[1]).unwrap().score,
         1.0 * 0.9 * 0.9 * -2.0
     );
 }
@@ -2062,7 +2062,7 @@ fn test_subscribe_and_graft_with_negative_score() {
     // add penalty to peer p2
     gs1.as_peer_score_mut().add_penalty(&p2, 1);
 
-    let original_score = gs1.as_peer_score_mut().score_report(&p2).score;
+    let original_score = gs1.as_peer_score_mut().score_report(&p2).unwrap().score;
 
     // subscribe to topic in gs2
     gs2.subscribe(&topic).unwrap();
@@ -2103,7 +2103,7 @@ fn test_subscribe_and_graft_with_negative_score() {
     forward_messages_to_p1(&mut gs1, p1, p2, connection_id, queues);
 
     // nobody got penalized
-    assert!(gs1.as_peer_score_mut().score_report(&p2).score >= original_score);
+    assert!(gs1.as_peer_score_mut().score_report(&p2).unwrap().score >= original_score);
 }
 
 // Tests for PeerScoreParameters / peer_score_params().
@@ -2122,7 +2122,7 @@ fn test_peer_score_params_disabled() {
 }
 
 /// `peer_score_params` returns `Some` for a known peer when scoring is enabled,
-/// and the `final_score` field matches `peer_score`.
+/// and the `score` field matches `peer_score`.
 #[test]
 fn test_peer_score_params_consistency_with_peer_score() {
     let (gs, peers, _, _) = DefaultBehaviourTestBuilder::default()
@@ -2145,12 +2145,12 @@ fn test_peer_score_params_consistency_with_peer_score() {
         .expect("scoring enabled; peer should have a score");
 
     assert_eq!(
-        params.final_score, score,
-        "final_score in PeerScoreParameters must equal peer_score()"
+        params.score, score,
+        "score in PeerScoreParameters must equal peer_score()"
     );
 }
 
-/// Applying a behavioural penalty is reflected in `p7` and `final_score`.
+/// Applying a behavioural penalty is reflected in `p7` and `score`.
 #[test]
 fn test_peer_score_params_p7_reflects_penalty() {
     let score_params = PeerScoreParams::default();
@@ -2188,8 +2188,8 @@ fn test_peer_score_params_p7_reflects_penalty() {
         after.p7
     );
     assert_eq!(
-        after.final_score,
+        after.score,
         gs.peer_score(&peer).unwrap(),
-        "final_score must stay consistent with peer_score() after penalty"
+        "score must stay consistent with peer_score() after penalty"
     );
 }

--- a/protocols/gossipsub/src/peer_score.rs
+++ b/protocols/gossipsub/src/peer_score.rs
@@ -291,7 +291,7 @@ impl PeerScore {
             return report;
         };
 
-        // topic scores - accumulate weighted contributions per P, including topic weight.
+        // topic scores
         for (topic, topic_stats) in peer_stats.topics.iter() {
             // topic parameters
             if let Some(topic_params) = self.params.topics.get(topic) {

--- a/protocols/gossipsub/src/peer_score.rs
+++ b/protocols/gossipsub/src/peer_score.rs
@@ -63,7 +63,9 @@ impl PeerScoreState {
     ) -> (bool, f64) {
         match self {
             PeerScoreState::Active(active) => {
-                let score = active.score_report(peer_id).score;
+                let score = active
+                    .score_report(peer_id)
+                    .map_or(0.0, |r| r.score);
                 (score < threshold(&active.thresholds), score)
             }
             PeerScoreState::Disabled => (false, 0.0),
@@ -86,7 +88,7 @@ pub(crate) struct PeerScoreReport {
 /// Each field corresponds to a weighted score contribution as defined in the
 /// [gossipsub v1.1 peer scoring spec]. All values are pre-weighted (i.e. already
 /// multiplied by the relevant weight and, for topic parameters, the topic weight).
-/// `final_score` equals the sum of all components after the topic score cap is applied.
+/// `score` equals the sum of all components after the topic score cap is applied.
 ///
 /// Obtain this via [`Behaviour::peer_score_params`].
 ///
@@ -304,11 +306,9 @@ impl PeerScore {
 
     /// Returns the score report for a peer, with applied penalties.
     /// This is called from the heartbeat
-    pub(crate) fn score_report(&self, peer_id: &PeerId) -> PeerScoreReport {
+    pub(crate) fn score_report(&self, peer_id: &PeerId) -> Option<PeerScoreReport> {
         let mut report = PeerScoreReport::default();
-        let Some(peer_stats) = self.peer_stats.get(peer_id) else {
-            return report;
-        };
+        let peer_stats = self.peer_stats.get(peer_id)?;
 
         // topic scores
         for (topic, topic_stats) in peer_stats.topics.iter() {
@@ -461,9 +461,9 @@ impl PeerScore {
             + report.params.p7
             + report.params.slow_peer_penalty;
 
-        report.params.final_score = report.score;
+        report.params.score = report.score;
 
-        report
+        Some(report)
     }
 
     pub(crate) fn add_penalty(&mut self, peer_id: &PeerId, count: usize) {
@@ -621,7 +621,7 @@ impl PeerScore {
     /// non-positive.
     pub(crate) fn remove_peer(&mut self, peer_id: &PeerId) {
         // we only retain non-positive scores of peers
-        if self.score_report(peer_id).score > 0f64 {
+        if self.score_report(peer_id).map_or(0.0, |r| r.score) > 0f64 {
             if let hash_map::Entry::Occupied(entry) = self.peer_stats.entry(*peer_id) {
                 Self::remove_ips_for_peer(entry.get(), &mut self.peer_ips, peer_id);
                 entry.remove();

--- a/protocols/gossipsub/src/peer_score.rs
+++ b/protocols/gossipsub/src/peer_score.rs
@@ -81,20 +81,39 @@ pub(crate) struct PeerScoreReport {
     pub(crate) penalties: Vec<crate::metrics::Penalty>,
 }
 
-#[derive(Copy, Clone, Default)]
+/// A breakdown of the individual score components for a single peer.
+///
+/// Each field corresponds to a weighted score contribution as defined in the
+/// [gossipsub v1.1 peer scoring spec]. All values are pre-weighted (i.e. already
+/// multiplied by the relevant weight and, for topic parameters, the topic weight).
+/// `final_score` equals the sum of all components after the topic score cap is applied.
+///
+/// Obtain this via [`Behaviour::peer_score_params`].
+///
+/// [gossipsub v1.1 peer scoring spec]: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#the-score-function
+#[derive(Copy, Clone, Default, Debug)]
 pub struct PeerScoreParameters {
+    /// The final aggregate score. Equal to the sum of all other fields after
+    /// the topic score cap is applied.
     pub final_score: f64,
-    // weighted contributions per the spec.
-    // https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#the-score-function
+    /// P1: time in mesh contribution (summed across topics).
     pub p1: f64,
+    /// P2: first message deliveries contribution (summed across topics).
     pub p2: f64,
+    /// P3: mesh message delivery deficit penalty (summed across topics, negative).
     pub p3: f64,
+    /// P3b: mesh failure penalty (summed across topics, negative).
     pub p3b: f64,
+    /// P4: invalid message delivery penalty (summed across topics, negative).
     pub p4: f64,
+    /// P5: application-specific score contribution.
     pub p5: f64,
+    /// P6: IP collocation factor penalty (negative).
     pub p6: f64,
+    /// P7: behavioural pattern penalty (negative).
     pub p7: f64,
-    // not part of the spec, but useful.
+    /// Slow peer penalty. Not part of the spec, but applied when a peer is
+    /// consistently slow to acknowledge messages.
     pub slow_peer_penalty: f64,
 }
 

--- a/protocols/gossipsub/src/peer_score.rs
+++ b/protocols/gossipsub/src/peer_score.rs
@@ -95,7 +95,7 @@ pub(crate) struct PeerScoreReport {
 pub struct PeerScoreParameters {
     /// The final aggregate score. Equal to the sum of all other fields after
     /// the topic score cap is applied.
-    pub final_score: f64,
+    pub score: f64,
     /// P1: time in mesh contribution (summed across topics).
     pub p1: f64,
     /// P2: first message deliveries contribution (summed across topics).

--- a/protocols/gossipsub/src/peer_score/tests.rs
+++ b/protocols/gossipsub/src/peer_score/tests.rs
@@ -95,7 +95,7 @@ fn test_score_time_in_mesh() {
     // Peer score should start at 0
     peer_score.add_peer(peer_id);
 
-    let score = peer_score.score_report(&peer_id).score;
+    let score = peer_score.score_report(&peer_id).unwrap().score;
     assert!(
         score == 0.0,
         "expected score to start at zero. Score found: {score}"
@@ -107,7 +107,7 @@ fn test_score_time_in_mesh() {
     std::thread::sleep(elapsed);
     peer_score.refresh_scores();
 
-    let score = peer_score.score_report(&peer_id).score;
+    let score = peer_score.score_report(&peer_id).unwrap().score;
     let expected = topic_params.topic_weight
         * topic_params.time_in_mesh_weight
         * (elapsed.as_millis() / topic_params.time_in_mesh_quantum.as_millis()) as f64;
@@ -140,7 +140,7 @@ fn test_score_time_in_mesh_cap() {
     // Peer score should start at 0
     peer_score.add_peer(peer_id);
 
-    let score = peer_score.score_report(&peer_id).score;
+    let score = peer_score.score_report(&peer_id).unwrap().score;
     assert!(
         score == 0.0,
         "expected score to start at zero. Score found: {score}"
@@ -152,7 +152,7 @@ fn test_score_time_in_mesh_cap() {
     std::thread::sleep(elapsed);
     peer_score.refresh_scores();
 
-    let score = peer_score.score_report(&peer_id).score;
+    let score = peer_score.score_report(&peer_id).unwrap().score;
     let expected = topic_params.topic_weight
         * topic_params.time_in_mesh_weight
         * topic_params.time_in_mesh_cap;
@@ -201,7 +201,7 @@ fn test_score_first_message_deliveries() {
 
     peer_score.refresh_scores();
 
-    let score = peer_score.score_report(&peer_id).score;
+    let score = peer_score.score_report(&peer_id).unwrap().score;
     let expected =
         topic_params.topic_weight * topic_params.first_message_deliveries_weight * messages as f64;
     assert!(score == expected, "The score: {score} should be {expected}");
@@ -241,7 +241,7 @@ fn test_score_first_message_deliveries_cap() {
     }
 
     peer_score.refresh_scores();
-    let score = peer_score.score_report(&peer_id).score;
+    let score = peer_score.score_report(&peer_id).unwrap().score;
     let expected = topic_params.topic_weight
         * topic_params.first_message_deliveries_weight
         * topic_params.first_message_deliveries_cap;
@@ -279,7 +279,7 @@ fn test_score_first_message_deliveries_decay() {
     }
 
     peer_score.refresh_scores();
-    let score = peer_score.score_report(&peer_id).score;
+    let score = peer_score.score_report(&peer_id).unwrap().score;
     let mut expected = topic_params.topic_weight
         * topic_params.first_message_deliveries_weight
         * topic_params.first_message_deliveries_decay
@@ -292,7 +292,7 @@ fn test_score_first_message_deliveries_decay() {
         peer_score.refresh_scores();
         expected *= topic_params.first_message_deliveries_decay;
     }
-    let score = peer_score.score_report(&peer_id).score;
+    let score = peer_score.score_report(&peer_id).unwrap().score;
     assert!(score == expected, "The score: {score} should be {expected}");
 }
 
@@ -339,7 +339,7 @@ fn test_score_mesh_message_deliveries() {
     // assert that nobody has been penalized yet for not delivering messages before activation time
     peer_score.refresh_scores();
     for peer_id in &peers {
-        let score = peer_score.score_report(peer_id).score;
+        let score = peer_score.score_report(peer_id).unwrap().score;
         assert!(
             score >= 0.0,
             "expected no mesh delivery penalty before activation time, got score {score}"
@@ -369,9 +369,9 @@ fn test_score_mesh_message_deliveries() {
     }
 
     peer_score.refresh_scores();
-    let score_a = peer_score.score_report(&peer_id_a).score;
-    let score_b = peer_score.score_report(&peer_id_b).score;
-    let score_c = peer_score.score_report(&peer_id_c).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
+    let score_b = peer_score.score_report(&peer_id_b).unwrap().score;
+    let score_c = peer_score.score_report(&peer_id_c).unwrap().score;
 
     assert!(
         score_a >= 0.0,
@@ -432,7 +432,7 @@ fn test_score_mesh_message_deliveries_decay() {
     // we should have a positive score, since we delivered more messages than the threshold
     peer_score.refresh_scores();
 
-    let score_a = peer_score.score_report(&peer_id_a).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
     assert!(
         score_a >= 0.0,
         "expected non-negative score for Peer A, got score {score_a}"
@@ -444,7 +444,7 @@ fn test_score_mesh_message_deliveries_decay() {
         decayed_delivery_count *= topic_params.mesh_message_deliveries_decay;
     }
 
-    let score_a = peer_score.score_report(&peer_id_a).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
     // the penalty is the difference between the threshold and the (decayed)
     // mesh deliveries, squared.
     let deficit = topic_params.mesh_message_deliveries_threshold - decayed_delivery_count;
@@ -507,8 +507,8 @@ fn test_score_mesh_failure_penalty() {
 
     // peers A and B should both have zero scores, since the failure penalty hasn't been applied yet
     peer_score.refresh_scores();
-    let score_a = peer_score.score_report(&peer_id_a).score;
-    let score_b = peer_score.score_report(&peer_id_b).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
+    let score_b = peer_score.score_report(&peer_id_b).unwrap().score;
     assert!(
         score_a >= 0.0,
         "expected non-negative score for Peer A, got score {score_a}"
@@ -521,7 +521,7 @@ fn test_score_mesh_failure_penalty() {
     // prune peer B to apply the penalty
     peer_score.prune(&peer_id_b, topic.hash());
     peer_score.refresh_scores();
-    let score_a = peer_score.score_report(&peer_id_a).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
 
     assert_eq!(score_a, 0.0, "expected Peer A to have a 0");
 
@@ -532,7 +532,7 @@ fn test_score_mesh_failure_penalty() {
         * topic_params.mesh_message_deliveries_threshold;
     let expected = topic_params.topic_weight * topic_params.mesh_failure_penalty_weight * penalty;
 
-    let score_b = peer_score.score_report(&peer_id_b).score;
+    let score_b = peer_score.score_report(&peer_id_b).unwrap().score;
 
     assert_eq!(score_b, expected, "Peer B should have expected score",);
 }
@@ -575,7 +575,7 @@ fn test_score_invalid_message_deliveries() {
     }
 
     peer_score.refresh_scores();
-    let score_a = peer_score.score_report(&peer_id_a).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
 
     let expected = topic_params.topic_weight
         * topic_params.invalid_message_deliveries_weight
@@ -628,7 +628,7 @@ fn test_score_invalid_message_deliveris_decay() {
     let mut expected =
         topic_params.topic_weight * topic_params.invalid_message_deliveries_weight * decay * decay;
 
-    let score_a = peer_score.score_report(&peer_id_a).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
     assert_eq!(score_a, expected, "Peer has unexpected score");
 
     // refresh scores a few times to apply decay
@@ -638,7 +638,7 @@ fn test_score_invalid_message_deliveris_decay() {
             * topic_params.invalid_message_deliveries_decay;
     }
 
-    let score_a = peer_score.score_report(&peer_id_a).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
     assert_eq!(score_a, expected, "Peer has unexpected score");
 }
 
@@ -683,8 +683,8 @@ fn test_score_reject_message_deliveries() {
     peer_score.reject_message(&peer_id_a, &id, &msg.topic, RejectReason::ValidationIgnored);
 
     peer_score.refresh_scores();
-    let score_a = peer_score.score_report(&peer_id_a).score;
-    let score_b = peer_score.score_report(&peer_id_b).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
+    let score_b = peer_score.score_report(&peer_id_b).unwrap().score;
 
     assert_eq!(score_a, 0.0, "Should have no effect on the score");
     assert_eq!(score_b, 0.0, "Should have no effect on the score");
@@ -698,8 +698,8 @@ fn test_score_reject_message_deliveries() {
     peer_score.duplicated_message(&peer_id_b, &id, &msg.topic);
 
     peer_score.refresh_scores();
-    let score_a = peer_score.score_report(&peer_id_a).score;
-    let score_b = peer_score.score_report(&peer_id_b).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
+    let score_b = peer_score.score_report(&peer_id_b).unwrap().score;
 
     assert_eq!(score_a, 0.0, "Should have no effect on the score");
     assert_eq!(score_b, 0.0, "Should have no effect on the score");
@@ -716,8 +716,8 @@ fn test_score_reject_message_deliveries() {
     peer_score.duplicated_message(&peer_id_b, &id, &msg.topic);
 
     peer_score.refresh_scores();
-    let score_a = peer_score.score_report(&peer_id_a).score;
-    let score_b = peer_score.score_report(&peer_id_b).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
+    let score_b = peer_score.score_report(&peer_id_b).unwrap().score;
 
     assert_eq!(score_a, 0.0, "Should have no effect on the score");
     assert_eq!(score_b, 0.0, "Should have no effect on the score");
@@ -733,8 +733,8 @@ fn test_score_reject_message_deliveries() {
     peer_score.duplicated_message(&peer_id_b, &id, &msg.topic);
 
     peer_score.refresh_scores();
-    let score_a = peer_score.score_report(&peer_id_a).score;
-    let score_b = peer_score.score_report(&peer_id_b).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
+    let score_b = peer_score.score_report(&peer_id_b).unwrap().score;
 
     assert_eq!(score_a, -1.0, "Score should be effected");
     assert_eq!(score_b, -1.0, "Score should be effected");
@@ -750,8 +750,8 @@ fn test_score_reject_message_deliveries() {
     peer_score.reject_message(&peer_id_a, &id, &msg.topic, RejectReason::ValidationFailed);
 
     peer_score.refresh_scores();
-    let score_a = peer_score.score_report(&peer_id_a).score;
-    let score_b = peer_score.score_report(&peer_id_b).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
+    let score_b = peer_score.score_report(&peer_id_b).unwrap().score;
 
     assert_eq!(score_a, -4.0, "Score should be effected");
     assert_eq!(score_b, -4.0, "Score should be effected");
@@ -792,7 +792,7 @@ fn test_application_score() {
         let app_score_value = i as f64;
         peer_score.set_application_score(&peer_id_a, app_score_value);
         peer_score.refresh_scores();
-        let score_a = peer_score.score_report(&peer_id_a).score;
+        let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
         let expected = (i as f64) * app_specific_weight;
         assert_eq!(score_a, expected, "Peer has unexpected score");
     }
@@ -844,10 +844,10 @@ fn test_score_ip_colocation() {
     peer_score.add_ip(&peer_id_d, "2.3.4.5".parse().unwrap());
 
     peer_score.refresh_scores();
-    let score_a = peer_score.score_report(&peer_id_a).score;
-    let score_b = peer_score.score_report(&peer_id_b).score;
-    let score_c = peer_score.score_report(&peer_id_c).score;
-    let score_d = peer_score.score_report(&peer_id_d).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
+    let score_b = peer_score.score_report(&peer_id_b).unwrap().score;
+    let score_c = peer_score.score_report(&peer_id_c).unwrap().score;
+    let score_d = peer_score.score_report(&peer_id_d).unwrap().score;
 
     assert_eq!(score_a, 0.0, "Peer A should be unaffected");
 
@@ -894,25 +894,31 @@ fn test_score_behaviour_penalty() {
     // add a penalty to a non-existent peer.
     peer_score.add_penalty(&peer_id_a, 1);
 
-    let score_a = peer_score.score_report(&peer_id_a).score;
-    assert_eq!(score_a, 0.0, "Peer A should be unaffected");
+    assert!(
+        peer_score.score_report(&peer_id_a).is_none(),
+        "Non-existent peer should return None"
+    );
 
     // add the peer and test penalties
     peer_score.add_peer(peer_id_a);
-    assert_eq!(score_a, 0.0, "Peer A should be unaffected");
+    assert_eq!(
+        peer_score.score_report(&peer_id_a).unwrap().score,
+        0.0,
+        "Peer A should be unaffected"
+    );
 
     peer_score.add_penalty(&peer_id_a, 1);
 
-    let score_a = peer_score.score_report(&peer_id_a).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
     assert_eq!(score_a, -1.0, "Peer A should have been penalized");
 
     peer_score.add_penalty(&peer_id_a, 1);
-    let score_a = peer_score.score_report(&peer_id_a).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
     assert_eq!(score_a, -4.0, "Peer A should have been penalized");
 
     peer_score.refresh_scores();
 
-    let score_a = peer_score.score_report(&peer_id_a).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
     assert_eq!(score_a, -3.9204, "Peer A should have been penalized");
 }
 
@@ -950,7 +956,7 @@ fn test_score_retention() {
 
     // score should equal -1000 (app specific score)
     peer_score.refresh_scores();
-    let score_a = peer_score.score_report(&peer_id_a).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
     assert_eq!(
         score_a, app_score_value,
         "Score should be the application specific score"
@@ -960,18 +966,17 @@ fn test_score_retention() {
     peer_score.remove_peer(&peer_id_a);
     std::thread::sleep(retain_score / 2);
     peer_score.refresh_scores();
-    let score_a = peer_score.score_report(&peer_id_a).score;
+    let score_a = peer_score.score_report(&peer_id_a).unwrap().score;
     assert_eq!(
         score_a, app_score_value,
         "Score should be the application specific score"
     );
 
-    // wait remaining time (plus a little slop) and the score should reset to zero
+    // wait remaining time (plus a little slop) and the peer should be fully removed
     std::thread::sleep(retain_score / 2 + Duration::from_millis(50));
     peer_score.refresh_scores();
-    let score_a = peer_score.score_report(&peer_id_a).score;
-    assert_eq!(
-        score_a, 0.0,
-        "Score should be the application specific score"
+    assert!(
+        peer_score.score_report(&peer_id_a).is_none(),
+        "Peer should be removed after retention period expires"
     );
 }


### PR DESCRIPTION
## Description

Addresses https://github.com/libp2p/rust-libp2p/issues/6058

Add `PeerScoreParameters` struct and `Behaviour::peer_score_params()` to expose
a granular breakdown of the peer score function defined in the
[gossipsub v1.1 spec](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#the-score-function):

- `p1` – time in mesh (summed across topics, pre-weighted)
- `p2` – first message deliveries
- `p3` – mesh message delivery deficit penalty
- `p3b` – mesh failure penalty
- `p4` – invalid message delivery penalty
- `p5` – application-specific score
- `p6` – IP collocation factor penalty
- `p7` – behavioural pattern penalty
- `slow_peer_penalty` – slow peer weight (not in spec, but applied)
- `final_score` – aggregate after topic score cap; equals `peer_score()`

This enables external tooling and operators to inspect which scoring
components are driving a peer's score, rather than only seeing the total.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates