### PR TITLE
fix(webtransport-websys): Allow `poll_flush` after `poll_close`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-webtransport-websys"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "futures",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ libp2p-webrtc-utils = { version = "0.4.0", path = "misc/webrtc-utils" }
 libp2p-webrtc-websys = { version = "0.4.0", path = "transports/webrtc-websys" }
 libp2p-websocket = { version = "0.45.2", path = "transports/websocket" }
 libp2p-websocket-websys = { version = "0.5.0", path = "transports/websocket-websys" }
-libp2p-webtransport-websys = { version = "0.5.1", path = "transports/webtransport-websys" }
+libp2p-webtransport-websys = { version = "0.5.2", path = "transports/webtransport-websys" }
 libp2p-yamux = { version = "0.47.0", path = "muxers/yamux" }
 
 # External dependencies

--- a/transports/webtransport-websys/CHANGELOG.md
+++ b/transports/webtransport-websys/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.2
+
+- Remove `poll_flush called after poll_close` assertion.
+  See [PR 6193](https://github.com/libp2p/rust-libp2p/pull/6193).
+
 ## 0.5.1
 
 - Remove `once_cell` dependency.

--- a/transports/webtransport-websys/Cargo.toml
+++ b/transports/webtransport-websys/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-webtransport-websys"
 edition.workspace = true
 rust-version = { workspace = true }
 description = "WebTransport for libp2p under WASM environment"
-version = "0.5.1"
+version = "0.5.2"
 authors = [
     "Yiannis Marangos <yiannis@eiger.co>",
     "oblique <psyberbits@gmail.com>",

--- a/transports/webtransport-websys/src/stream.rs
+++ b/transports/webtransport-websys/src/stream.rs
@@ -153,10 +153,6 @@ impl StreamInner {
             // messages were flushed.
             self.poll_writer_ready(cx)
         } else {
-            debug_assert!(
-                false,
-                "libp2p_webtransport_websys::Stream: poll_flush called after poll_close"
-            );
             Poll::Ready(Ok(()))
         }
     }


### PR DESCRIPTION
## Description

This removes a `debug_assert` from `poll_flush` because it can be valid for the user to recheck the flush state. In that case the operation should be noop.

A real life code that triggers this assertition is [this](https://github.com/libp2p/rust-asynchronous-codec/blob/c818a83906891caf8aadcae8f899727c2c8393a8/src/framed_write.rs#L263-L266).

Fixes https://github.com/libp2p/rust-libp2p/issues/5618

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
