### PR TITLE
chore: updated rustwasm links to new org home

### DIFF
--- a/examples/browser-webrtc/README.md
+++ b/examples/browser-webrtc/README.md
@@ -1,11 +1,11 @@
 # Rust-libp2p Browser-Server WebRTC Example
 
 This example demonstrates how to use the `libp2p-webrtc-websys` transport library in a browser to ping the WebRTC Server.
-It uses [wasm-pack](https://rustwasm.github.io/docs/wasm-pack/) to build the project for use in the browser.
+It uses [wasm-pack](https://drager.github.io/wasm-pack/) to build the project for use in the browser.
 
 ## Running the example
 
-Ensure you have `wasm-pack` [installed](https://rustwasm.github.io/wasm-pack/).
+Ensure you have `wasm-pack` [installed](https://drager.github.io/wasm-pack/).
 
 1. Build the client library:
 ```shell

--- a/interop-tests/Dockerfile.chromium
+++ b/interop-tests/Dockerfile.chromium
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.5-labs
 FROM rust:1.83 as chef
 RUN rustup target add wasm32-unknown-unknown
-RUN wget -q -O- https://github.com/rustwasm/wasm-pack/releases/download/v0.12.1/wasm-pack-v0.12.1-x86_64-unknown-linux-musl.tar.gz | tar -zx -C /usr/local/bin --strip-components 1 --wildcards "wasm-pack-*/wasm-pack"
+RUN wget -q -O- https://github.com/drager/wasm-pack/releases/download/v0.12.1/wasm-pack-v0.12.1-x86_64-unknown-linux-musl.tar.gz | tar -zx -C /usr/local/bin --strip-components 1 --wildcards "wasm-pack-*/wasm-pack"
 RUN wget -q -O- https://github.com/WebAssembly/binaryen/releases/download/version_115/binaryen-version_115-x86_64-linux.tar.gz | tar -zx -C /usr/local/bin --strip-components 2 --wildcards "binaryen-version_*/bin/wasm-opt"
 RUN wget -q -O- https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.62/cargo-chef-x86_64-unknown-linux-gnu.tar.gz | tar -zx -C /usr/local/bin
 WORKDIR /app

--- a/transports/websocket-websys/src/lib.rs
+++ b/transports/websocket-websys/src/lib.rs
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-//! Libp2p websocket transports built on [web-sys](https://rustwasm.github.io/wasm-bindgen/web-sys/index.html).
+//! Libp2p websocket transports built on [web-sys](https://wasm-bindgen.github.io/wasm-bindgen/contributing/web-sys/index.html).
 
 #![allow(unexpected_cfgs)]
 

--- a/transports/webtransport-websys/src/lib.rs
+++ b/transports/webtransport-websys/src/lib.rs
@@ -1,4 +1,4 @@
-//! Libp2p WebTransport built on [web-sys](https://rustwasm.github.io/wasm-bindgen/web-sys/index.html)
+//! Libp2p WebTransport built on [web-sys](https://wasm-bindgen.github.io/wasm-bindgen/contributing/web-sys/index.html)
 
 #![allow(unexpected_cfgs)]
 


### PR DESCRIPTION
## Description
The rustwasm organization was archived this year. Projects have moved to new URLs to reflect that. This PR just updates those URLs.

See https://blog.rust-lang.org/inside-rust/2025/07/21/sunsetting-the-rustwasm-github-org/

## Notes & open questions

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
