### PR TITLE
docs: fix ProviderPhase documentation contradiction

### DIFF
--- a/libp2p/src/builder/phase/provider.rs
+++ b/libp2p/src/builder/phase/provider.rs
@@ -19,7 +19,8 @@ pub enum Tokio {}
 /// Represents the WasmBindgen environment for WebAssembly.
 pub enum WasmBindgen {}
 
-/// Represents a phase in the SwarmBuilder where a provider has been chosen but not yet specified.
+/// Represents a phase in the SwarmBuilder where the identity has been set, but the runtime provider
+/// is not yet specified.
 pub struct ProviderPhase {}
 
 impl SwarmBuilder<NoProviderSpecified, ProviderPhase> {


### PR DESCRIPTION
## Description

The documentation for ProviderPhase incorrectly stated that "a provider has been chosen but not yet specified", which contradicts the type signature SwarmBuilder<NoProviderSpecified, ProviderPhase>. 
Updated the docs to accurately reflect that the identity has been set, but the runtime provider selection is still pending.
