### PR TITLE
fix(AutoNAT V2): Client should reset address status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2476,7 +2476,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-autonat"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "asynchronous-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ edition = "2021"
 [workspace.dependencies]
 libp2p = { version = "0.56.1", path = "libp2p" }
 libp2p-allow-block-list = { version = "0.6.0", path = "misc/allow-block-list" }
-libp2p-autonat = { version = "0.15.0", path = "protocols/autonat" }
+libp2p-autonat = { version = "0.15.1", path = "protocols/autonat" }
 libp2p-connection-limits = { version = "0.6.0", path = "misc/connection-limits" }
 libp2p-core = { version = "0.43.1", path = "core" }
 libp2p-dcutr = { version = "0.14.0", path = "protocols/dcutr" }

--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.15.1
+
+- Fix issue where AutoNATv2 client was not resetting address status on `FromSwarm::ExternalAddrExpired` event.
+  See [PR ]().
+
 ## 0.15.0
 
 - Fix infinity loop on wrong `nonce` when performing `dial_back`.

--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.15.1
 
 - Fix issue where AutoNATv2 client was not resetting address status on `FromSwarm::ExternalAddrExpired` event.
-  See [PR ]().
+  See [PR 6207](https://github.com/libp2p/rust-libp2p/pull/6207).
 
 ## 0.15.0
 

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-autonat"
 edition.workspace = true
 rust-version = { workspace = true }
 description = "NAT and firewall detection for libp2p"
-version = "0.15.0"
+version = "0.15.1"
 authors = [
     "David Craven <david@craven.ch>",
     "Elena Frank <elena.frank@protonmail.com>",


### PR DESCRIPTION
## Description

This PR tries to deal with the issues of the AutoNAT v2 Client not resetting address candidates when those addresses are reported expired with swarm events.

Related to #6203.


## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
