### PR TITLE
refactor(gossipsub): do early return in for an empty input

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -19,12 +19,15 @@
 
 - Fix incorrect default values in ConfigBuilder
   See [PR 6113](https://github.com/libp2p/rust-libp2p/pull/6113)
-  
+
 - Remove duplicated config `set_topic_max_transmit_size` method, prefer `max_transmit_size_for_topic`.
   See [PR 6173](https://github.com/libp2p/rust-libp2p/pull/6173).
 
 - Switch the internal `async-channel` used to dispatch messages from `NetworkBehaviour` to the `ConnectionHandler`
   with an internal priority queue. See [PR 6175](https://github.com/libp2p/rust-libp2p/pull/6175)
+
+- gossipsub: do early return in for an empty input
+  See [PR 6208](https://github.com/libp2p/rust-libp2p/pull/6208).
 
 ## 0.49.2
 

--- a/protocols/gossipsub/src/queue.rs
+++ b/protocols/gossipsub/src/queue.rs
@@ -81,6 +81,10 @@ impl Queue {
     /// Remove pending low priority Publish and Forward messages.
     /// Returns the number of messages removed.
     pub(crate) fn remove_data_messages(&mut self, message_ids: &[MessageId]) -> usize {
+        if message_ids.is_empty() {
+            return 0;
+        }
+
         let mut count = 0;
         self.non_priority.retain(|message| match message {
             RpcOut::Publish { message_id, .. } | RpcOut::Forward { message_id, .. } => {


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

Adds a fast path in `remove_data_messages` to avoid unnecessary work when the caller provides an empty `message_ids` slice.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
