### PR TITLE
perf: use IntoIter for pending_dials to remove trait object

### DIFF
--- a/swarm/src/connection/pool/concurrent_dial.rs
+++ b/swarm/src/connection/pool/concurrent_dial.rs
@@ -44,7 +44,7 @@ type Dial = BoxFuture<
 
 pub(crate) struct ConcurrentDial {
     dials: FuturesUnordered<Dial>,
-    pending_dials: Box<dyn Iterator<Item = Dial> + Send>,
+    pending_dials: std::vec::IntoIter<Dial>,
     errors: Vec<(Multiaddr, TransportError<std::io::Error>)>,
 }
 
@@ -65,7 +65,7 @@ impl ConcurrentDial {
         Self {
             dials,
             errors: Default::default(),
-            pending_dials: Box::new(pending_dials),
+            pending_dials,
         }
     }
 }


### PR DESCRIPTION
Replace the pending_dials field in ConcurrentDial from a boxed iterator (Box<dyn Iterator<Item=Dial> + Send>) to a concretestd::vec::IntoIter<Dial>. The constructor already receives a Vec<Dial> and immediately converts it via into_iter(), sokeeping a trait object added an avoidable heap allocation and dynamic dispatch on every next() call. Since ConcurrentDial is internal (pub(crate)), there are no API stability concerns, and call sites do not rely on heterogenous iterator types. This change preserves behavior and concurrency semantics while slightly reducing overhead and tightening types.