### PR TITLE
fix(examples): handle stdin EOF gracefully in chat example

### DIFF
--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -103,11 +103,22 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Kick it off
     loop {
         select! {
-            Ok(Some(line)) = stdin.next_line() => {
-                if let Err(e) = swarm
-                    .behaviour_mut().gossipsub
-                    .publish(topic.clone(), line.as_bytes()) {
-                    println!("Publish error: {e:?}");
+            line_result = stdin.next_line() => {
+                match line_result {
+                    Ok(Some(line)) => {
+                        if let Err(e) = swarm
+                            .behaviour_mut().gossipsub
+                            .publish(topic.clone(), line.as_bytes()) {
+                            println!("Publish error: {e:?}");
+                        }
+                    }
+                    Ok(None) => {
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        println!("Stdin error: {e}");
+                        return Err(e.into());
+                    }
                 }
             }
             event = swarm.select_next_some() => match event {


### PR DESCRIPTION

## Description

Fix panic in chat example when stdin reaches EOF or encounters an error.

Previously, the `tokio::select!` macro used pattern matching (`Ok(Some(line))`) which would panic if `stdin.next_line()` returned `Ok(None)` (EOF) or `Err(_)`. This made the example crash when stdin was closed, making it unsuitable for use in scripts or automated scenarios.

The fix explicitly handles all possible outcomes of `stdin.next_line()`:
- `Ok(Some(line))` - process the line as before
- `Ok(None)` - gracefully exit when EOF is reached
- `Err(e)` - return the error instead of panicking

This ensures the example can be safely used in pipelines and automated environments.

