### PR TITLE
fix(stream): propagate backpressure

### DIFF
--- a/protocols/stream/src/behaviour.rs
+++ b/protocols/stream/src/behaviour.rs
@@ -32,7 +32,7 @@ impl Default for Behaviour {
 
 impl Behaviour {
     pub fn new() -> Self {
-        let (dial_sender, dial_receiver) = mpsc::channel(0);
+        let (dial_sender, dial_receiver) = mpsc::channel(32);
 
         Self {
             shared: Arc::new(Mutex::new(Shared::new(dial_sender))),

--- a/protocols/stream/src/behaviour.rs
+++ b/protocols/stream/src/behaviour.rs
@@ -21,7 +21,7 @@ use crate::{handler::Handler, shared::Shared, Control};
 /// A generic behaviour for stream-oriented protocols.
 pub struct Behaviour {
     shared: Arc<Mutex<Shared>>,
-    dial_receiver: mpsc::Receiver<PeerId>,
+    dial_receiver: mpsc::UnboundedReceiver<PeerId>,
 }
 
 impl Default for Behaviour {
@@ -32,7 +32,7 @@ impl Default for Behaviour {
 
 impl Behaviour {
     pub fn new() -> Self {
-        let (dial_sender, dial_receiver) = mpsc::channel(32);
+        let (dial_sender, dial_receiver) = mpsc::unbounded();
 
         Self {
             shared: Arc::new(Mutex::new(Shared::new(dial_sender))),

--- a/protocols/stream/src/behaviour.rs
+++ b/protocols/stream/src/behaviour.rs
@@ -21,7 +21,7 @@ use crate::{handler::Handler, shared::Shared, Control};
 /// A generic behaviour for stream-oriented protocols.
 pub struct Behaviour {
     shared: Arc<Mutex<Shared>>,
-    dial_receiver: mpsc::UnboundedReceiver<PeerId>,
+    dial_receiver: mpsc::Receiver<PeerId>,
 }
 
 impl Default for Behaviour {
@@ -32,7 +32,7 @@ impl Default for Behaviour {
 
 impl Behaviour {
     pub fn new() -> Self {
-        let (dial_sender, dial_receiver) = mpsc::unbounded();
+        let (dial_sender, dial_receiver) = mpsc::channel(32);
 
         Self {
             shared: Arc::new(Mutex::new(Shared::new(dial_sender))),

--- a/protocols/stream/src/control.rs
+++ b/protocols/stream/src/control.rs
@@ -8,7 +8,6 @@ use std::{
 
 use futures::{
     channel::{mpsc, oneshot},
-    SinkExt as _,
     StreamExt as _,
 };
 use libp2p_identity::PeerId;
@@ -49,14 +48,15 @@ impl Control {
     ) -> Result<Stream, OpenStreamError> {
         tracing::debug!(%peer, "Requesting new stream");
 
-        let mut new_stream_sender = Shared::lock(&self.shared).sender(peer);
-
         let (sender, receiver) = oneshot::channel();
 
-        new_stream_sender
-            .send(NewStream { protocol, sender })
-            .await
-            .map_err(|e| io::Error::new(io::ErrorKind::ConnectionReset, e))?;
+        Shared::send_new_stream(
+            &self.shared,
+            peer,
+            NewStream { protocol, sender },
+        )
+        .await
+        .map_err(OpenStreamError::Io)?;
 
         let stream = receiver
             .await

--- a/protocols/stream/src/shared.rs
+++ b/protocols/stream/src/shared.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, Mutex, MutexGuard},
 };
 
-use futures::channel::mpsc;
+use futures::{channel::mpsc, SinkExt as _};
 use libp2p_identity::PeerId;
 use libp2p_swarm::{ConnectionId, Stream, StreamProtocol};
 use rand::seq::IteratorRandom as _;
@@ -122,7 +122,7 @@ impl Shared {
         }
     }
 
-    pub(crate) fn sender(&mut self, peer: PeerId) -> (mpsc::Sender<NewStream>, Option<(PeerId, mpsc::Sender<PeerId>)>) {
+    fn prepare_sender(&mut self, peer: PeerId) -> SenderAction {
         let maybe_sender = self
             .connections
             .iter()
@@ -134,7 +134,9 @@ impl Shared {
             Some(sender) => {
                 tracing::debug!("Returning sender to existing connection");
 
-                (sender.clone(), None)
+                SenderAction::Connected {
+                    sender: sender.clone(),
+                }
             }
             None => {
                 tracing::debug!(%peer, "Not connected to peer, initiating dial");
@@ -144,8 +146,44 @@ impl Shared {
                     .entry(peer)
                     .or_insert_with(|| mpsc::channel(0));
 
-                // Return both the pending channel sender and the dial_sender for async use
-                (sender.clone(), Some((peer, self.dial_sender.clone())))
+                SenderAction::Dial {
+                    pending_sender: sender.clone(),
+                    dial_sender: self.dial_sender.clone(),
+                    peer_to_dial: peer,
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn send_new_stream(
+        shared: &Arc<Mutex<Shared>>,
+        peer: PeerId,
+        new_stream: NewStream,
+    ) -> io::Result<()> {
+        let action = {
+            let mut shared = Shared::lock(shared);
+            shared.prepare_sender(peer)
+        };
+
+        match action {
+            SenderAction::Connected { mut sender } => sender
+                .send(new_stream)
+                .await
+                .map_err(|e| io::Error::new(io::ErrorKind::ConnectionReset, e)),
+            SenderAction::Dial {
+                mut pending_sender,
+                mut dial_sender,
+                peer_to_dial,
+            } => {
+                dial_sender
+                    .send(peer_to_dial)
+                    .await
+                    .map_err(|e| io::Error::new(io::ErrorKind::ConnectionReset, e.clone()))?;
+
+                pending_sender
+                    .send(new_stream)
+                    .await
+                    .map_err(|e| io::Error::new(io::ErrorKind::ConnectionReset, e))
             }
         }
     }
@@ -169,4 +207,15 @@ impl Shared {
 
         receiver
     }
+}
+
+enum SenderAction {
+    Connected {
+        sender: mpsc::Sender<NewStream>,
+    },
+    Dial {
+        pending_sender: mpsc::Sender<NewStream>,
+        dial_sender: mpsc::Sender<PeerId>,
+        peer_to_dial: PeerId,
+    },
 }

--- a/protocols/stream/src/shared.rs
+++ b/protocols/stream/src/shared.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, Mutex, MutexGuard},
 };
 
-use futures::channel::mpsc;
+use futures::{channel::mpsc, SinkExt as _};
 use libp2p_identity::PeerId;
 use libp2p_swarm::{ConnectionId, Stream, StreamProtocol};
 use rand::seq::IteratorRandom as _;
@@ -29,7 +29,7 @@ pub(crate) struct Shared {
     ///
     /// We manage this through a channel to avoid locks as part of
     /// [`NetworkBehaviour::poll`](libp2p_swarm::NetworkBehaviour::poll).
-    dial_sender: mpsc::UnboundedSender<PeerId>,
+    dial_sender: mpsc::Sender<PeerId>,
 }
 
 impl Shared {
@@ -39,7 +39,7 @@ impl Shared {
 }
 
 impl Shared {
-    pub(crate) fn new(dial_sender: mpsc::UnboundedSender<PeerId>) -> Self {
+    pub(crate) fn new(dial_sender: mpsc::Sender<PeerId>) -> Self {
         Self {
             dial_sender,
             connections: Default::default(),
@@ -122,11 +122,7 @@ impl Shared {
         }
     }
 
-    /// Returns a sender for the given peer, initiating a dial if necessary.
-    ///
-    /// Uses an unbounded channel for dial requests to avoid holding the mutex
-    /// across await points while still tracking all dial attempts.
-    pub(crate) fn sender(&mut self, peer: PeerId) -> mpsc::Sender<NewStream> {
+    fn prepare_sender(&mut self, peer: PeerId) -> SenderAction {
         let maybe_sender = self
             .connections
             .iter()
@@ -137,7 +133,10 @@ impl Shared {
         match maybe_sender {
             Some(sender) => {
                 tracing::debug!("Returning sender to existing connection");
-                sender.clone()
+
+                SenderAction::Connected {
+                    sender: sender.clone(),
+                }
             }
             None => {
                 tracing::debug!(%peer, "Not connected to peer, initiating dial");
@@ -147,11 +146,44 @@ impl Shared {
                     .entry(peer)
                     .or_insert_with(|| mpsc::channel(0));
 
-                // Send dial request through unbounded channel
-                // This never blocks, never fails (unless disconnected), and properly tracks all dial attempts
-                let _ = self.dial_sender.unbounded_send(peer);
+                SenderAction::Dial {
+                    pending_sender: sender.clone(),
+                    dial_sender: self.dial_sender.clone(),
+                    peer_to_dial: peer,
+                }
+            }
+        }
+    }
 
-                sender.clone()
+    pub(crate) async fn send_new_stream(
+        shared: &Arc<Mutex<Shared>>,
+        peer: PeerId,
+        new_stream: NewStream,
+    ) -> io::Result<()> {
+        let action = {
+            let mut shared = Shared::lock(shared);
+            shared.prepare_sender(peer)
+        };
+
+        match action {
+            SenderAction::Connected { mut sender } => sender
+                .send(new_stream)
+                .await
+                .map_err(|e| io::Error::new(io::ErrorKind::ConnectionReset, e)),
+            SenderAction::Dial {
+                mut pending_sender,
+                mut dial_sender,
+                peer_to_dial,
+            } => {
+                dial_sender
+                    .send(peer_to_dial)
+                    .await
+                    .map_err(|e| io::Error::new(io::ErrorKind::ConnectionReset, e.clone()))?;
+
+                pending_sender
+                    .send(new_stream)
+                    .await
+                    .map_err(|e| io::Error::new(io::ErrorKind::ConnectionReset, e))
             }
         }
     }
@@ -175,4 +207,15 @@ impl Shared {
 
         receiver
     }
+}
+
+enum SenderAction {
+    Connected {
+        sender: mpsc::Sender<NewStream>,
+    },
+    Dial {
+        pending_sender: mpsc::Sender<NewStream>,
+        dial_sender: mpsc::Sender<PeerId>,
+        peer_to_dial: PeerId,
+    },
 }

--- a/protocols/stream/tests/lib.rs
+++ b/protocols/stream/tests/lib.rs
@@ -113,12 +113,9 @@ async fn backpressure_on_many_concurrent_dials() {
 
     // All tasks should complete (not hang indefinitely)
     for handle in handles {
-        tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            handle,
-        )
-        .await
-        .expect("Task should not hang - backpressure should work")
-        .expect("Task should complete successfully");
+        tokio::time::timeout(std::time::Duration::from_secs(5), handle)
+            .await
+            .expect("Task should not hang - backpressure should work")
+            .expect("Task should complete successfully");
     }
 }

--- a/protocols/stream/tests/lib.rs
+++ b/protocols/stream/tests/lib.rs
@@ -113,9 +113,12 @@ async fn backpressure_on_many_concurrent_dials() {
 
     // All tasks should complete (not hang indefinitely)
     for handle in handles {
-        tokio::time::timeout(std::time::Duration::from_secs(5), handle)
-            .await
-            .expect("Task should not hang - backpressure should work")
-            .expect("Task should complete successfully");
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            handle,
+        )
+        .await
+        .expect("Task should not hang - backpressure should work")
+        .expect("Task should complete successfully");
     }
 }


### PR DESCRIPTION
Fixes #6157

When opening hundreds of streams per second, dial requests were being silently dropped because `try_send()` would fail when the channel was full, causing `Control::open_stream()` to hang indefinitely.

This commit implements backpressure propagation as suggested by maintainers:

1. Increased dial_sender channel buffer from 0 (rendezvous) to 32 to handle burst traffic without blocking on every request.

2. Replaced `try_send()` with `send().await` in the dial path to propagate backpressure when >32 dial requests are pending, instead of silently dropping them.

3. Refactored `Shared::sender()` to return a cloned dial_sender, allowing the async send operation to happen outside the mutex lock to prevent deadlocks.

With these changes:
- Up to 32 concurrent dial requests queue immediately
- Additional requests block until space is available (backpressure)
- Errors are properly propagated instead of silent failures
- No more indefinite hangs on dropped dial requests