### PR TITLE
fix(identity): make quick-protobuf dep optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -6612,7 +6612,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ libp2p-dns = { version = "0.44.0", path = "transports/dns" }
 libp2p-floodsub = { version = "0.47.0", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.50.0", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.47.0", path = "protocols/identify" }
-libp2p-identity = { version = "0.2.12" }
+libp2p-identity = { version = "0.2.13" }
 libp2p-kad = { version = "0.49.0", path = "protocols/kad" }
 libp2p-mdns = { version = "0.48.0", path = "protocols/mdns" }
 libp2p-memory-connection-limits = { version = "0.5.0", path = "misc/memory-connection-limits" }

--- a/identity/CHANGELOG.md
+++ b/identity/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.2.12
 
+- Turn the `quick-protobuf` dependency optional to only the features which require it.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX)
+
+## 0.2.12
+
 - Avoid depending on the `rand_core` feature in `ed25519-dalek` crate.
   See [PR 6070](https://github.com/libp2p/rust-libp2p/pull/6070)
 

--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-identity"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2021" # MUST NOT inherit from workspace because we don't want to publish breaking changes to `libp2p-identity`.
 description = "Data structures and algorithms for identifying peers in libp2p."
 rust-version = "1.73.0" # MUST NOT inherit from workspace because we don't want to publish breaking changes to `libp2p-identity`.
@@ -20,7 +20,7 @@ k256 = { version = "0.13.4", optional = true, features = ["ecdsa", "arithmetic"]
 tracing = { workspace = true }
 multihash = { version = "0.19.1", optional = true }
 p256 = { version = "0.13", default-features = false, features = ["ecdsa", "std", "pem"], optional = true }
-quick-protobuf = "0.8.1"
+quick-protobuf = { version = "0.8.1", optional = true }
 rand = { version = "0.8", optional = true }
 sec1 = { version = "0.7", default-features = false, optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
@@ -32,10 +32,10 @@ zeroize = { version = "1.8", optional = true }
 ring = { workspace = true, features = ["alloc", "std"], optional = true }
 
 [features]
-secp256k1 = ["dep:k256", "dep:asn1_der", "dep:sha2", "dep:hkdf", "dep:zeroize"]
-ecdsa = ["dep:p256", "dep:zeroize", "dep:sec1", "dep:sha2", "dep:hkdf"]
-rsa = ["dep:ring", "dep:asn1_der", "dep:rand", "dep:zeroize"]
-ed25519 = ["dep:ed25519-dalek", "dep:zeroize", "dep:sha2", "dep:hkdf"]
+secp256k1 = ["dep:k256", "dep:asn1_der", "dep:sha2", "dep:hkdf", "dep:zeroize", "dep:quick-protobuf"]
+ecdsa = ["dep:p256", "dep:zeroize", "dep:sec1", "dep:sha2", "dep:hkdf", "dep:quick-protobuf"]
+rsa = ["dep:ring", "dep:asn1_der", "dep:rand", "dep:zeroize", "dep:quick-protobuf"]
+ed25519 = ["dep:ed25519-dalek", "dep:zeroize", "dep:sha2", "dep:hkdf", "dep:quick-protobuf"]
 peerid = ["dep:multihash", "dep:bs58", "dep:thiserror", "dep:sha2", "dep:hkdf"]
 rand = ["dep:rand"]
 


### PR DESCRIPTION
## Description

it's not required for the `peerid` feature