### PR TITLE
fix: chat example to establish connections

### DIFF
--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -112,9 +112,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
             event = swarm.select_next_some() => match event {
                 SwarmEvent::Behaviour(MyBehaviourEvent::Mdns(mdns::Event::Discovered(list))) => {
-                    for (peer_id, _multiaddr) in list {
+                    for (peer_id, multiaddr) in list {
                         println!("mDNS discovered a new peer: {peer_id}");
                         swarm.behaviour_mut().gossipsub.add_explicit_peer(&peer_id);
+                        if let Err(e) = swarm.dial(multiaddr) {
+                            println!("Dial error: {e:?}");
+                        }
                     }
                 },
                 SwarmEvent::Behaviour(MyBehaviourEvent::Mdns(mdns::Event::Expired(list))) => {
@@ -133,6 +136,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     ),
                 SwarmEvent::NewListenAddr { address, .. } => {
                     println!("Local node is listening on {address}");
+                }
+                SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                    println!("Connected to peer: {peer_id}");
                 }
                 _ => {}
             }


### PR DESCRIPTION
## Description

Fix chat example to establish connections when peers are discovered via mDNS.

Previously, the chat example would discover peers through mDNS but fail to publish messages with a NoPeersSubscribedToTopic error. This occurred because add_explicit_peer only informs gossipsub about the peer's existence but doesn't establish an actual connection.

This fix adds a swarm.dial() call when peers are discovered via mDNS to establish the connection, and adds a ConnectionEstablished event handler to provide feedback when peers are ready to exchange messages.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
