### PR TITLE
feat(relay): remove deprecated error events in favor of warn! logs

### DIFF
--- a/misc/metrics/src/relay.rs
+++ b/misc/metrics/src/relay.rs
@@ -51,16 +51,11 @@ struct EventLabels {
 #[derive(Debug, Clone, Hash, PartialEq, Eq, EncodeLabelValue)]
 enum EventType {
     ReservationReqAccepted,
-    ReservationReqAcceptFailed,
     ReservationReqDenied,
-    ReservationReqDenyFailed,
     ReservationClosed,
     ReservationTimedOut,
     CircuitReqDenied,
-    CircuitReqDenyFailed,
-    CircuitReqOutboundConnectFailed,
     CircuitReqAccepted,
-    CircuitReqAcceptFailed,
     CircuitClosed,
 }
 
@@ -68,27 +63,11 @@ impl From<&libp2p_relay::Event> for EventType {
     fn from(event: &libp2p_relay::Event) -> Self {
         match event {
             libp2p_relay::Event::ReservationReqAccepted { .. } => EventType::ReservationReqAccepted,
-            #[allow(deprecated)]
-            libp2p_relay::Event::ReservationReqAcceptFailed { .. } => {
-                EventType::ReservationReqAcceptFailed
-            }
             libp2p_relay::Event::ReservationReqDenied { .. } => EventType::ReservationReqDenied,
-            #[allow(deprecated)]
-            libp2p_relay::Event::ReservationReqDenyFailed { .. } => {
-                EventType::ReservationReqDenyFailed
-            }
             libp2p_relay::Event::ReservationClosed { .. } => EventType::ReservationClosed,
             libp2p_relay::Event::ReservationTimedOut { .. } => EventType::ReservationTimedOut,
             libp2p_relay::Event::CircuitReqDenied { .. } => EventType::CircuitReqDenied,
-            #[allow(deprecated)]
-            libp2p_relay::Event::CircuitReqOutboundConnectFailed { .. } => {
-                EventType::CircuitReqOutboundConnectFailed
-            }
-            #[allow(deprecated)]
-            libp2p_relay::Event::CircuitReqDenyFailed { .. } => EventType::CircuitReqDenyFailed,
             libp2p_relay::Event::CircuitReqAccepted { .. } => EventType::CircuitReqAccepted,
-            #[allow(deprecated)]
-            libp2p_relay::Event::CircuitReqAcceptFailed { .. } => EventType::CircuitReqAcceptFailed,
             libp2p_relay::Event::CircuitClosed { .. } => EventType::CircuitClosed,
         }
     }


### PR DESCRIPTION
## Description

Resolves #4757

This PR removes the deprecated relay server events and replaces them with `tracing::warn!` logs:
- `ReservationReqAcceptFailed`
- `ReservationReqDenyFailed`
- `CircuitReqDenyFailed`
- `CircuitReqAcceptFailed`
- `CircuitReqOutboundConnectFailed`

## Changes

- Removed deprecated `Event` variants from `relay::Event`
- Replaced event emissions with structured `tracing::warn!` logs including peer IDs and error details
- Updated `libp2p-metrics` to remove corresponding event type tracking
