### PR TITLE
chore: bump versions for #6138

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2563,7 +2563,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dcutr"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "criterion",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ libp2p-allow-block-list = { version = "0.6.0", path = "misc/allow-block-list" }
 libp2p-autonat = { version = "0.15.0", path = "protocols/autonat" }
 libp2p-connection-limits = { version = "0.6.0", path = "misc/connection-limits" }
 libp2p-core = { version = "0.43.2", path = "core" }
-libp2p-dcutr = { version = "0.14.0", path = "protocols/dcutr" }
+libp2p-dcutr = { version = "0.14.1", path = "protocols/dcutr" }
 libp2p-dns = { version = "0.44.0", path = "transports/dns" }
 libp2p-floodsub = { version = "0.47.0", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.50.0", path = "protocols/gossipsub" }
@@ -102,7 +102,7 @@ libp2p-rendezvous = { version = "0.17.0", path = "protocols/rendezvous" }
 libp2p-request-response = { version = "0.29.0", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.7", path = "misc/server" }
 libp2p-stream = { version = "0.4.0-alpha", path = "protocols/stream" }
-libp2p-swarm = { version = "0.47.0", path = "swarm" }
+libp2p-swarm = { version = "0.47.1", path = "swarm" }
 libp2p-swarm-derive = { version = "=0.35.1", path = "swarm-derive" } # `libp2p-swarm-derive` may not be compatible with different `libp2p-swarm` non-breaking releases. E.g. `libp2p-swarm` might introduce a new enum variant `FromSwarm` (which is `#[non-exhaustive]`) in a non-breaking release. Older versions of `libp2p-swarm-derive` would not forward this enum variant within the `NetworkBehaviour` hierarchy. Thus the version pinning is required.
 libp2p-swarm-test = { version = "0.6.0", path = "swarm-test" }
 libp2p-tcp = { version = "0.44.1", path = "transports/tcp" }

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.1
+
+<!-- Remove lru dependency -->
+
 ## 0.14.0
 
 <!-- Update to libp2p-swarm v0.47.0 -->

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.14.1
 
-<!-- Remove lru dependency -->
+- Replace `lru::LruCache` with `hashlink::LruCache`.
+  See [PR #6138](https://github.com/libp2p/rust-libp2p/pull/6138)
 
 ## 0.14.0
 

--- a/protocols/dcutr/Cargo.toml
+++ b/protocols/dcutr/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-dcutr"
 edition.workspace = true
 rust-version = { workspace = true }
 description = "Direct connection upgrade through relay"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Max Inden <mail@max-inden.de>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.47.1
 
-<!-- Remove lru dependency -->
+- Replace `lru::LruCache` with `hashlink::LruCache`.
+  See [PR #6138](https://github.com/libp2p/rust-libp2p/pull/6138)
 
 ## 0.47.0
 

--- a/swarm/CHANGELOG.md
+++ b/swarm/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.47.1
+
+<!-- Remove lru dependency -->
+
 ## 0.47.0
 
 - Remove `async-std` support.

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-swarm"
 edition.workspace = true
 rust-version = { workspace = true }
 description = "The libp2p swarm"
-version = "0.47.0"
+version = "0.47.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"


### PR DESCRIPTION
## Description

Version bump for `libp2p-swarm` and `libp2p-dcutr` so we can cut patch releases. See https://github.com/libp2p/rust-libp2p/pull/6138#issuecomment-3746931640.

cc @jxs

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
