### PR TITLE
fix(libp2p-dcutr): Handle /p2p/PEER_ID multiaddrs

### DIFF
--- a/protocols/dcutr/src/behaviour.rs
+++ b/protocols/dcutr/src/behaviour.rs
@@ -273,6 +273,7 @@ impl NetworkBehaviour for Behaviour {
                 let opts = DialOpts::peer_id(event_source)
                     .addresses(remote_addrs)
                     .condition(dial_opts::PeerCondition::Always)
+                    .extend_addresses_through_behaviour()
                     .build();
 
                 let maybe_direct_connection_id = opts.connection_id();
@@ -305,6 +306,7 @@ impl NetworkBehaviour for Behaviour {
                 let opts = DialOpts::peer_id(event_source)
                     .condition(dial_opts::PeerCondition::Always)
                     .addresses(remote_addrs)
+                    .extend_addresses_through_behaviour()
                     .override_role()
                     .build();
 


### PR DESCRIPTION
## Description

Previously, we were seeing the majority of attempts at DCUTR in prod failing like this:

```
DEBUG Swarm::poll: libp2p_dcutr::behaviour: Attempting to hole-punch as dialer target=REDACTED_PEER_ID addresses=[/p2p/REDACTED_PEER_ID]
DEBUG Swarm::poll: libp2p_swarm: Connection attempt to peer failed with Transport([(/p2p/REDACTED_PEER_ID, MultiaddrNotSupported(/p2p/REDACTED_PEER_ID))]). peer=REDACTED_PEER_ID
DEBUG Redacted|DCUTR: DCUTR to "REDACTED_PEER_ID" result: Err(Error { inner: AttemptsExceeded(3) })
```

After making these changes and pushing an update that uses them, DCUTR works as expected.

## Notes & open questions

I'm unsure if you want me to write this fix in the changelog. If that's desired, let me know.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
