### PR TITLE
docs(websocket): clarify Config vs framed::Config in doc comments

### DIFF
--- a/transports/websocket/src/lib.rs
+++ b/transports/websocket/src/lib.rs
@@ -44,7 +44,13 @@ use libp2p_core::{
 };
 use rw_stream_sink::RwStreamSink;
 
-/// A Websocket transport.
+/// A Websocket transport whose output implements [`AsyncRead`] and [`AsyncWrite`].
+///
+/// This is a convenience wrapper around [`framed::Config`] that converts the
+/// [`Stream`](futures::Stream)/[`Sink`](futures::Sink) of frame payloads into a byte stream.
+/// For most use cases, this is the transport you want.
+///
+/// If you need direct access to individual Websocket frames, use [`framed::Config`] instead.
 ///
 /// DO NOT wrap this transport with a DNS transport if you want Secure Websockets to work.
 ///


### PR DESCRIPTION
Resolves #5976. 


## Description

Clarifies the doc comments on `crate::Config` in the websocket transport to explain its relationship with `framed::Config`

## Notes & open questions

- Updated the doc comment on `Config` in `transports/websocket/src/lib.rs` to explain:
  - It wraps `framed::Config` and converts the `Stream`/`Sink` of frame payloads into an `AsyncRead`/`AsyncWrite` byte stream
  - This is the transport most users want
  - Users who need direct frame access should use `framed::Config` instead
- This mirrors the existing cross-reference from `framed::Config` → `crate::Config` (line 54 of `framed.rs`)

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
