### PR TITLE
chore(*): fix clippy 1.95.0-beta.3 lints

### DIFF
--- a/misc/peer-store/src/memory_store.rs
+++ b/misc/peer-store/src/memory_store.rs
@@ -220,11 +220,11 @@ impl<T> Store for MemoryStore<T> {
                 };
 
                 match info.error {
-                    DialError::WrongPeerId { obtained, address } => {
+                    DialError::WrongPeerId { obtained, address }
+                        if self.remove_address_inner(&peer, address, false) =>
+                    {
                         // The stored peer id is incorrect, remove incorrect and add correct one.
-                        if self.remove_address_inner(&peer, address, false) {
-                            self.add_address_inner(obtained, address, false);
-                        }
+                        self.add_address_inner(obtained, address, false);
                     }
                     DialError::Transport(errors) => {
                         for (addr, _) in errors {

--- a/protocols/autonat/src/v2/client/handler/dial_back.rs
+++ b/protocols/autonat/src/v2/client/handler/dial_back.rs
@@ -73,7 +73,7 @@ impl ConnectionHandler for Handler {
                 protocol, ..
             }) =>
             {
-                #[expect(clippy::collapsible_match)]
+                #[allow(clippy::collapsible_match)]
                 if self.inbound.try_push(perform_dial_back(protocol)).is_err() {
                     tracing::warn!("Dial back request dropped, too many requests in flight");
                 }

--- a/protocols/autonat/src/v2/client/handler/dial_back.rs
+++ b/protocols/autonat/src/v2/client/handler/dial_back.rs
@@ -71,7 +71,9 @@ impl ConnectionHandler for Handler {
         match event {
             ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
                 protocol, ..
-            }) => {
+            }) =>
+            {
+                #[expect(clippy::collapsible_match)]
                 if self.inbound.try_push(perform_dial_back(protocol)).is_err() {
                     tracing::warn!("Dial back request dropped, too many requests in flight");
                 }

--- a/protocols/autonat/src/v2/client/handler/dial_request.rs
+++ b/protocols/autonat/src/v2/client/handler/dial_request.rs
@@ -188,7 +188,7 @@ impl ConnectionHandler for Handler {
                 }
             },
             ConnectionEvent::RemoteProtocolsChange(ProtocolsChange::Added(mut added)) => {
-                #[expect(clippy::collapsible_match)]
+                #[allow(clippy::collapsible_match)]
                 if added.any(|p| p.as_ref() == DIAL_REQUEST_PROTOCOL) {
                     self.queued_events
                         .push_back(ConnectionHandlerEvent::NotifyBehaviour(

--- a/protocols/autonat/src/v2/client/handler/dial_request.rs
+++ b/protocols/autonat/src/v2/client/handler/dial_request.rs
@@ -188,6 +188,7 @@ impl ConnectionHandler for Handler {
                 }
             },
             ConnectionEvent::RemoteProtocolsChange(ProtocolsChange::Added(mut added)) => {
+                #[expect(clippy::collapsible_match)]
                 if added.any(|p| p.as_ref() == DIAL_REQUEST_PROTOCOL) {
                     self.queued_events
                         .push_back(ConnectionHandlerEvent::NotifyBehaviour(

--- a/protocols/autonat/src/v2/server/handler/dial_request.rs
+++ b/protocols/autonat/src/v2/server/handler/dial_request.rs
@@ -121,6 +121,7 @@ where
             ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
                 protocol, ..
             }) => {
+                #[expect(clippy::collapsible_match)]
                 if self
                     .inbound
                     .try_push(handle_request(

--- a/protocols/autonat/src/v2/server/handler/dial_request.rs
+++ b/protocols/autonat/src/v2/server/handler/dial_request.rs
@@ -121,7 +121,7 @@ where
             ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
                 protocol, ..
             }) => {
-                #[expect(clippy::collapsible_match)]
+                #[allow(clippy::collapsible_match)]
                 if self
                     .inbound
                     .try_push(handle_request(

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -3544,14 +3544,12 @@ fn validate_config(
                 return Err("Published messages contain an author but incoming messages with an author will be rejected. Consider adjusting the validation or privacy settings in the config");
             }
         }
-        ValidationMode::Strict => {
-            if !authenticity.is_signing() {
-                return Err(
+        ValidationMode::Strict if !authenticity.is_signing() => {
+            return Err(
                     "Messages will be
                 published unsigned and incoming unsigned messages will be rejected. Consider adjusting
                 the validation or privacy settings in the config"
                 );
-            }
         }
         _ => {}
     }

--- a/protocols/gossipsub/src/behaviour/tests/scoring.rs
+++ b/protocols/gossipsub/src/behaviour/tests/scoring.rs
@@ -293,13 +293,9 @@ fn test_do_not_gossip_to_peers_below_gossip_threshold() {
         RpcOut::IHave(IHave {
             topic_hash,
             message_ids,
-        }) => {
-            if topic_hash == &topics[0] && message_ids.iter().any(|id| id == &msg_id) {
-                assert_eq!(peer, &p2);
-                true
-            } else {
-                false
-            }
+        }) if topic_hash == &topics[0] && message_ids.iter().any(|id| id == &msg_id) => {
+            assert_eq!(peer, &p2);
+            true
         }
         _ => false,
     });
@@ -455,13 +451,9 @@ fn test_ihave_msg_from_peer_below_gossip_threshold_gets_ignored() {
 
     // check that we sent exactly one IWANT request to p2
     let (control_msgs, _) = count_control_msgs(queues, |peer, c| match c {
-        RpcOut::IWant(IWant { message_ids }) => {
-            if message_ids.iter().any(|m| m == &msg_id) {
-                assert_eq!(peer, &p2);
-                true
-            } else {
-                false
-            }
+        RpcOut::IWant(IWant { message_ids }) if message_ids.iter().any(|m| m == &msg_id) => {
+            assert_eq!(peer, &p2);
+            true
         }
         _ => false,
     });

--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -274,6 +274,7 @@ impl EnabledHandler {
                                 ref mut timeout,
                                 ..
                             } => {
+                                #[expect(clippy::collapsible_match)]
                                 if Pin::new(timeout).poll(cx).is_ready() {
                                     // Inform the behaviour and end the poll.
                                     self.outbound_substream =

--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -274,7 +274,7 @@ impl EnabledHandler {
                                 ref mut timeout,
                                 ..
                             } => {
-                                #[expect(clippy::collapsible_match)]
+                                #[allow(clippy::collapsible_match)]
                                 if Pin::new(timeout).poll(cx).is_ready() {
                                     // Inform the behaviour and end the poll.
                                     self.outbound_substream =

--- a/protocols/gossipsub/src/queue.rs
+++ b/protocols/gossipsub/src/queue.rs
@@ -87,13 +87,11 @@ impl Queue {
 
         let mut count = 0;
         self.non_priority.retain(|message| match message {
-            RpcOut::Publish { message_id, .. } | RpcOut::Forward { message_id, .. } => {
-                if message_ids.contains(message_id) {
-                    count += 1;
-                    false
-                } else {
-                    true
-                }
+            RpcOut::Publish { message_id, .. } | RpcOut::Forward { message_id, .. }
+                if message_ids.contains(message_id) =>
+            {
+                count += 1;
+                false
             }
             _ => true,
         });

--- a/protocols/identify/src/behaviour.rs
+++ b/protocols/identify/src/behaviour.rs
@@ -33,10 +33,11 @@ use libp2p_core::{
 };
 use libp2p_identity::{Keypair, PeerId, PublicKey};
 use libp2p_swarm::{
+    _address_translation,
     behaviour::{ConnectionClosed, ConnectionEstablished, DialFailure, FromSwarm},
     ConnectionDenied, ConnectionId, DialError, ExternalAddresses, ListenAddresses,
     NetworkBehaviour, NotifyHandler, PeerAddresses, StreamUpgradeError, THandler, THandlerInEvent,
-    THandlerOutEvent, ToSwarm, _address_translation,
+    THandlerOutEvent, ToSwarm,
 };
 
 use crate::{

--- a/protocols/kad/src/query/peers/closest.rs
+++ b/protocols/kad/src/query/peers/closest.rs
@@ -394,8 +394,8 @@ impl ClosestPeersIter {
     /// Consumes the iterator, returning the closest peers.
     pub fn into_result(self) -> impl Iterator<Item = PeerId> {
         self.closest_peers
-            .into_iter()
-            .filter_map(|(_, peer)| {
+            .into_values()
+            .filter_map(|peer| {
                 if let PeerState::Succeeded = peer.state {
                     Some(peer.key.into_preimage())
                 } else {

--- a/protocols/kad/src/query/peers/closest/disjoint.rs
+++ b/protocols/kad/src/query/peers/closest/disjoint.rs
@@ -723,8 +723,7 @@ mod tests {
                 .clone()
                 .into_iter()
                 .map(|(peer_id, key)| {
-                    peer_ids
-                        .sort_unstable_by(|(_, a), (_, b)| key.distance(a).cmp(&key.distance(b)));
+                    peer_ids.sort_unstable_by_key(|(_, a)| key.distance(a));
 
                     assert_eq!(peer_id, peer_ids[0].0);
 
@@ -794,7 +793,7 @@ mod tests {
     impl Peer {
         fn get_closest_peers(&mut self, target: &KeyBytes) -> Vec<PeerId> {
             self.known_peers
-                .sort_unstable_by(|(_, a), (_, b)| target.distance(a).cmp(&target.distance(b)));
+                .sort_unstable_by_key(|(_, a)| target.distance(a));
 
             self.known_peers
                 .iter()

--- a/protocols/mdns/tests/use-tokio.rs
+++ b/protocols/mdns/tests/use-tokio.rs
@@ -67,15 +67,15 @@ async fn test_expired_tokio() {
 
     loop {
         match futures::future::select(a.next_behaviour_event(), b.next_behaviour_event()).await {
-            Either::Left((Event::Expired(peers), _)) => {
-                if peers.into_iter().any(|(p, _)| p == b_peer_id) {
-                    return;
-                }
+            Either::Left((Event::Expired(ref peers), _))
+                if peers.iter().any(|(p, _)| p == &b_peer_id) =>
+            {
+                return;
             }
-            Either::Right((Event::Expired(peers), _)) => {
-                if peers.into_iter().any(|(p, _)| p == a_peer_id) {
-                    return;
-                }
+            Either::Right((Event::Expired(ref peers), _))
+                if peers.iter().any(|(p, _)| p == &a_peer_id) =>
+            {
+                return;
             }
             _ => {}
         }
@@ -94,15 +94,15 @@ async fn run_discovery_test(config: Config) {
 
     while !discovered_a && !discovered_b {
         match futures::future::select(a.next_behaviour_event(), b.next_behaviour_event()).await {
-            Either::Left((Event::Discovered(peers), _)) => {
-                if peers.into_iter().any(|(p, _)| p == b_peer_id) {
-                    discovered_b = true;
-                }
+            Either::Left((Event::Discovered(ref peers), _))
+                if peers.iter().any(|(p, _)| p == &b_peer_id) =>
+            {
+                discovered_b = true;
             }
-            Either::Right((Event::Discovered(peers), _)) => {
-                if peers.into_iter().any(|(p, _)| p == a_peer_id) {
-                    discovered_a = true;
-                }
+            Either::Right((Event::Discovered(ref peers), _))
+                if peers.iter().any(|(p, _)| p == &a_peer_id) =>
+            {
+                discovered_a = true;
             }
             _ => {}
         }

--- a/protocols/perf/src/client/behaviour.rs
+++ b/protocols/perf/src/client/behaviour.rs
@@ -114,12 +114,10 @@ impl NetworkBehaviour for Behaviour {
                 peer_id,
                 connection_id: _,
                 endpoint: _,
-                remaining_established,
+                remaining_established: 0,
                 ..
             }) => {
-                if remaining_established == 0 {
-                    assert!(self.connected.remove(&peer_id));
-                }
+                assert!(self.connected.remove(&peer_id));
             }
             _ => {}
         }

--- a/protocols/perf/src/server/handler.rs
+++ b/protocols/perf/src/server/handler.rs
@@ -87,6 +87,7 @@ impl ConnectionHandler for Handler {
                 protocol,
                 info: _,
             }) => {
+                #[expect(clippy::collapsible_match)]
                 if self
                     .inbound
                     .try_push(crate::protocol::receive_send(protocol).boxed())

--- a/protocols/perf/src/server/handler.rs
+++ b/protocols/perf/src/server/handler.rs
@@ -87,7 +87,7 @@ impl ConnectionHandler for Handler {
                 protocol,
                 info: _,
             }) => {
-                #[expect(clippy::collapsible_match)]
+                #[allow(clippy::collapsible_match)]
                 if self
                     .inbound
                     .try_push(crate::protocol::receive_send(protocol).boxed())

--- a/protocols/relay/src/priv_client/handler.rs
+++ b/protocols/relay/src/priv_client/handler.rs
@@ -431,6 +431,7 @@ impl ConnectionHandler for Handler {
                 protocol: stream,
                 ..
             }) => {
+                #[expect(clippy::collapsible_match)]
                 if self
                     .inflight_inbound_circuit_requests
                     .try_push(inbound_stop::handle_open_circuit(stream))

--- a/protocols/relay/src/priv_client/handler.rs
+++ b/protocols/relay/src/priv_client/handler.rs
@@ -431,7 +431,7 @@ impl ConnectionHandler for Handler {
                 protocol: stream,
                 ..
             }) => {
-                #[expect(clippy::collapsible_match)]
+                #[allow(clippy::collapsible_match)]
                 if self
                     .inflight_inbound_circuit_requests
                     .try_push(inbound_stop::handle_open_circuit(stream))


### PR DESCRIPTION
## Description

Fix format and clippy lints. 

`expect` false positive `clippy::collapsible_match` for some branches where collapsing the if branch into the match statement is not possible. 

See rust-lang/rust-clippy#16705.

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
