### PR TITLE
feat(request_response, dns): remove `async_trait` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2497,7 +2497,6 @@ dependencies = [
 name = "libp2p-autonat"
 version = "0.15.0"
 dependencies = [
- "async-trait",
  "asynchronous-codec",
  "either",
  "futures",
@@ -2594,7 +2593,6 @@ dependencies = [
 name = "libp2p-dns"
 version = "0.44.0"
 dependencies = [
- "async-trait",
  "futures",
  "hickory-resolver",
  "libp2p-core",
@@ -3009,7 +3007,6 @@ dependencies = [
 name = "libp2p-rendezvous"
 version = "0.17.0"
 dependencies = [
- "async-trait",
  "asynchronous-codec",
  "bimap",
  "futures",
@@ -3034,7 +3031,6 @@ name = "libp2p-request-response"
 version = "0.29.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "cbor4ii",
  "futures",
  "futures-bounded",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-autonat"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "futures",
  "hickory-resolver",
@@ -3005,7 +3005,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-rendezvous"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "asynchronous-codec",
  "bimap",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "cbor4ii",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,11 +76,11 @@ edition = "2021"
 [workspace.dependencies]
 libp2p = { version = "0.56.1", path = "libp2p" }
 libp2p-allow-block-list = { version = "0.6.0", path = "misc/allow-block-list" }
-libp2p-autonat = { version = "0.15.0", path = "protocols/autonat" }
+libp2p-autonat = { version = "0.16.0", path = "protocols/autonat" }
 libp2p-connection-limits = { version = "0.6.0", path = "misc/connection-limits" }
 libp2p-core = { version = "0.43.2", path = "core" }
 libp2p-dcutr = { version = "0.14.1", path = "protocols/dcutr" }
-libp2p-dns = { version = "0.44.0", path = "transports/dns" }
+libp2p-dns = { version = "0.45.0", path = "transports/dns" }
 libp2p-floodsub = { version = "0.47.0", path = "protocols/floodsub" }
 libp2p-gossipsub = { version = "0.50.0", path = "protocols/gossipsub" }
 libp2p-identify = { version = "0.47.0", path = "protocols/identify" }
@@ -98,8 +98,8 @@ libp2p-plaintext = { version = "0.43.0", path = "transports/plaintext" }
 libp2p-pnet = { version = "0.26.0", path = "transports/pnet" }
 libp2p-quic = { version = "0.13.0", path = "transports/quic" }
 libp2p-relay = { version = "0.21.1", path = "protocols/relay" }
-libp2p-rendezvous = { version = "0.17.0", path = "protocols/rendezvous" }
-libp2p-request-response = { version = "0.29.0", path = "protocols/request-response" }
+libp2p-rendezvous = { version = "0.18.0", path = "protocols/rendezvous" }
+libp2p-request-response = { version = "0.30.0", path = "protocols/request-response" }
 libp2p-server = { version = "0.12.7", path = "misc/server" }
 libp2p-stream = { version = "0.4.0-alpha", path = "protocols/stream" }
 libp2p-swarm = { version = "0.47.1", path = "swarm" }

--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.16.0
+
+- refactor: `Codec` no longer requires `#[async_trait]`
+  See [PR 6292](https://github.com/libp2p/rust-libp2p/pull/6292)
+
 ## 0.15.0
 
 - Fix infinity loop on wrong `nonce` when performing `dial_back`.

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-autonat"
 edition.workspace = true
 rust-version = { workspace = true }
 description = "NAT and firewall detection for libp2p"
-version = "0.15.0"
+version = "0.16.0"
 authors = [
     "David Craven <david@craven.ch>",
     "Elena Frank <elena.frank@protonmail.com>",

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -16,7 +16,6 @@ categories = ["network-programming", "asynchronous"]
 
 
 [dependencies]
-async-trait = { version = "0.1", optional = true }
 asynchronous-codec = { workspace = true }
 either = { version = "1.9.0", optional = true }
 futures = { workspace = true }
@@ -43,7 +42,7 @@ libp2p-swarm = { workspace = true, features = ["macros"] }
 
 [features]
 default = ["v1", "v2"]
-v1 = ["dep:libp2p-request-response", "dep:web-time", "dep:async-trait"]
+v1 = ["dep:libp2p-request-response", "dep:web-time"]
 v2 = ["dep:either", "dep:futures-bounded", "dep:thiserror", "dep:rand_core"]
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.

--- a/protocols/autonat/src/v1/protocol.rs
+++ b/protocols/autonat/src/v1/protocol.rs
@@ -20,7 +20,6 @@
 
 use std::io;
 
-use async_trait::async_trait;
 use asynchronous_codec::{FramedRead, FramedWrite};
 use futures::{
     io::{AsyncRead, AsyncWrite},
@@ -39,7 +38,6 @@ pub const DEFAULT_PROTOCOL_NAME: StreamProtocol = StreamProtocol::new("/libp2p/a
 #[derive(Clone)]
 pub struct AutoNatCodec;
 
-#[async_trait]
 impl request_response::Codec for AutoNatCodec {
     type Protocol = StreamProtocol;
     type Request = DialRequest;

--- a/protocols/rendezvous/CHANGELOG.md
+++ b/protocols/rendezvous/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.18.0
+
+- refactor: `Codec` no longer requires `#[async_trait]`
+  See [PR 6292](https://github.com/libp2p/rust-libp2p/pull/6292)
+
 ## 0.17.0
 
 - Emit `ToSwarm::NewExternalAddrOfPeer` for newly discovered peers.

--- a/protocols/rendezvous/Cargo.toml
+++ b/protocols/rendezvous/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-rendezvous"
 edition.workspace = true
 rust-version = { workspace = true }
 description = "Rendezvous protocol for libp2p"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["The COMIT guys <hello@comit.network>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/rendezvous/Cargo.toml
+++ b/protocols/rendezvous/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 asynchronous-codec = { workspace = true }
-async-trait = "0.1"
 bimap = "0.6.3"
 futures = { workspace = true, features = ["std"] }
 futures-timer = "3.0.3"

--- a/protocols/rendezvous/src/codec.rs
+++ b/protocols/rendezvous/src/codec.rs
@@ -20,7 +20,6 @@
 
 use std::{fmt, io};
 
-use async_trait::async_trait;
 use asynchronous_codec::{BytesMut, Decoder, Encoder, FramedRead, FramedWrite};
 use futures::{AsyncRead, AsyncWrite, SinkExt, StreamExt};
 use libp2p_core::{peer_record, signed_envelope, PeerRecord, SignedEnvelope};
@@ -241,7 +240,6 @@ impl Decoder for Codec {
 #[derive(Clone, Default)]
 pub struct Codec {}
 
-#[async_trait]
 impl libp2p_request_response::Codec for Codec {
     type Protocol = StreamProtocol;
     type Request = Message;

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.30.0
+
+- refactor: `Codec` no longer requires `#[async_trait]`
+  See [PR 6292](https://github.com/libp2p/rust-libp2p/pull/6292)
+
 ## 0.29.0
 
 - fix: public cbor/json codec module

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-request-response"
 edition.workspace = true
 rust-version = { workspace = true }
 description = "Generic Request/Response Protocols"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-trait = "0.1"
 cbor4ii = { version = "0.3.2", features = ["serde1", "use_std"], optional = true }
 futures = { workspace = true }
 libp2p-core = { workspace = true }

--- a/protocols/request-response/src/cbor.rs
+++ b/protocols/request-response/src/cbor.rs
@@ -58,7 +58,6 @@ pub type Behaviour<Req, Resp> = crate::Behaviour<codec::Codec<Req, Resp>>;
 pub mod codec {
     use std::{collections::TryReserveError, convert::Infallible, io, marker::PhantomData};
 
-    use async_trait::async_trait;
     use cbor4ii::core::error::DecodeError;
     use futures::prelude::*;
     use libp2p_swarm::StreamProtocol;
@@ -106,7 +105,6 @@ pub mod codec {
         }
     }
 
-    #[async_trait]
     impl<Req, Resp> crate::Codec for Codec<Req, Resp>
     where
         Req: Send + Serialize + DeserializeOwned,

--- a/protocols/request-response/src/codec.rs
+++ b/protocols/request-response/src/codec.rs
@@ -20,13 +20,11 @@
 
 use std::io;
 
-use async_trait::async_trait;
 use futures::prelude::*;
 
 /// A `Codec` defines the request and response types
 /// for a request-response [`Behaviour`](crate::Behaviour) protocol or
 /// protocol family and how they are encoded / decoded on an I/O stream.
-#[async_trait]
 pub trait Codec {
     /// The type of protocol(s) or protocol versions being negotiated.
     type Protocol: AsRef<str> + Send + Clone;
@@ -37,43 +35,43 @@ pub trait Codec {
 
     /// Reads a request from the given I/O stream according to the
     /// negotiated protocol.
-    async fn read_request<T>(
+    fn read_request<T>(
         &mut self,
         protocol: &Self::Protocol,
         io: &mut T,
-    ) -> io::Result<Self::Request>
+    ) -> impl Future<Output = io::Result<Self::Request>> + Send
     where
         T: AsyncRead + Unpin + Send;
 
     /// Reads a response from the given I/O stream according to the
     /// negotiated protocol.
-    async fn read_response<T>(
+    fn read_response<T>(
         &mut self,
         protocol: &Self::Protocol,
         io: &mut T,
-    ) -> io::Result<Self::Response>
+    ) -> impl Future<Output = io::Result<Self::Response>> + Send
     where
         T: AsyncRead + Unpin + Send;
 
     /// Writes a request to the given I/O stream according to the
     /// negotiated protocol.
-    async fn write_request<T>(
+    fn write_request<T>(
         &mut self,
         protocol: &Self::Protocol,
         io: &mut T,
         req: Self::Request,
-    ) -> io::Result<()>
+    ) -> impl Future<Output = io::Result<()>> + Send
     where
         T: AsyncWrite + Unpin + Send;
 
     /// Writes a response to the given I/O stream according to the
     /// negotiated protocol.
-    async fn write_response<T>(
+    fn write_response<T>(
         &mut self,
         protocol: &Self::Protocol,
         io: &mut T,
         res: Self::Response,
-    ) -> io::Result<()>
+    ) -> impl Future<Output = io::Result<()>> + Send
     where
         T: AsyncWrite + Unpin + Send;
 }

--- a/protocols/request-response/src/json.rs
+++ b/protocols/request-response/src/json.rs
@@ -58,7 +58,6 @@ pub type Behaviour<Req, Resp> = crate::Behaviour<codec::Codec<Req, Resp>>;
 pub mod codec {
     use std::{io, marker::PhantomData};
 
-    use async_trait::async_trait;
     use futures::prelude::*;
     use libp2p_swarm::StreamProtocol;
     use serde::{de::DeserializeOwned, Serialize};
@@ -105,7 +104,6 @@ pub mod codec {
         }
     }
 
-    #[async_trait]
     impl<Req, Resp> crate::Codec for Codec<Req, Resp>
     where
         Req: Send + Serialize + DeserializeOwned,

--- a/protocols/request-response/tests/error_reporting.rs
+++ b/protocols/request-response/tests/error_reporting.rs
@@ -1,7 +1,6 @@
 use std::{io, iter, pin::pin, time::Duration};
 
 use anyhow::{bail, Result};
-use async_trait::async_trait;
 use futures::{future::pending, prelude::*};
 use libp2p_identity::PeerId;
 use libp2p_request_response as request_response;
@@ -416,7 +415,6 @@ impl TryFrom<u8> for Action {
     }
 }
 
-#[async_trait]
 impl Codec for TestCodec {
     type Protocol = StreamProtocol;
     type Request = Action;

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.45.0
+
+- refactor: `Resolver` no longer requires `#[async_trait]`
+  See [PR 6292](https://github.com/libp2p/rust-libp2p/pull/6292)
+
 ## 0.44.0
 
 - Removed `async_std` module [PR 5959](https://github.com/libp2p/rust-libp2p/pull/5959)

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-dns"
 edition.workspace = true
 rust-version = { workspace = true }
 description = "DNS transport implementation for libp2p"
-version = "0.44.0"
+version = "0.45.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-trait = "0.1.80"
 futures = { workspace = true }
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true }

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -103,7 +103,6 @@ use std::{
     task::{Context, Poll},
 };
 
-use async_trait::async_trait;
 use futures::{future::BoxFuture, prelude::*};
 pub use hickory_resolver::{
     config::{ResolverConfig, ResolverOpts},
@@ -540,16 +539,26 @@ fn invalid_data(e: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> io::E
     io::Error::new(io::ErrorKind::InvalidData, e)
 }
 
-#[async_trait::async_trait]
 #[doc(hidden)]
 pub trait Resolver {
-    async fn lookup_ip(&self, name: String) -> Result<LookupIp, ResolveError>;
-    async fn ipv4_lookup(&self, name: String) -> Result<Ipv4Lookup, ResolveError>;
-    async fn ipv6_lookup(&self, name: String) -> Result<Ipv6Lookup, ResolveError>;
-    async fn txt_lookup(&self, name: String) -> Result<TxtLookup, ResolveError>;
+    fn lookup_ip(
+        &self,
+        name: String,
+    ) -> impl Future<Output = Result<LookupIp, ResolveError>> + Send;
+    fn ipv4_lookup(
+        &self,
+        name: String,
+    ) -> impl Future<Output = Result<Ipv4Lookup, ResolveError>> + Send;
+    fn ipv6_lookup(
+        &self,
+        name: String,
+    ) -> impl Future<Output = Result<Ipv6Lookup, ResolveError>> + Send;
+    fn txt_lookup(
+        &self,
+        name: String,
+    ) -> impl Future<Output = Result<TxtLookup, ResolveError>> + Send;
 }
 
-#[async_trait]
 impl<C> Resolver for hickory_resolver::Resolver<C>
 where
     C: ConnectionProvider,


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

This PR refactors `request_response::Codec` to simplify its implementation and remove the need for `#[async_trait::async_trait]`.  It also refactors `libp2p-dns::Resolver` to not use `async_trait`

(async trait method has been stablized in [1.75.0](https://releases.rs/docs/1.75.0/#language) and MSRV of libp2p is 1.83.0)

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
