### PR TITLE
fix: downgrade rmp-serde 1.3.1 -> 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4652,7 +4652,7 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "1.3.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4654,8 +4654,9 @@ dependencies = [
 name = "rmp-serde"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
 dependencies = [
+ "byteorder",
  "rmp",
  "serde",
 ]


### PR DESCRIPTION
## Description

Revert #6330.
The rmp-serde bump includes a rust edition bump, so until #6273 is merged it breaks clippy.

## Notes & open questions

CI Error: https://github.com/libp2p/rust-libp2p/actions/runs/23186369514/job/67370783906?pr=6220

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
