### PR TITLE
fix(gossipsub): optimize IDONTWANT send

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 0.50.0
 
-
 - Optimize IDONTWANT sending by avoiding broadcasts for already-seen messages and deduplicating recipient peers.
   See PR 6356 (https://github.com/libp2p/rust-libp2p/pull/6356)
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.50.0
 
+- Optimize IDONTWANT sending by avoiding broadcasts for already-seen messages and deduplicating recipient peers.
+  See PR 6356 (https://github.com/libp2p/rust-libp2p/pull/6356)
+
 - Add extra metrics for bytes received and sent, filtered and unfiltered for each topic.
   See [PR 6192](https://github.com/libp2p/rust-libp2p/pull/6192)
 

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1761,7 +1761,9 @@ where
         let msg_id = self.config.message_id(&message);
 
         // Broadcast IDONTWANT messages
-        if raw_message.raw_protobuf_len() > self.config.idontwant_message_size_threshold() {
+        if raw_message.raw_protobuf_len() > self.config.idontwant_message_size_threshold()
+            && !self.duplicate_cache.contains(&msg_id)
+        {
             let recipient_peers = self
                 .mesh
                 .get(&message.topic)
@@ -1772,7 +1774,7 @@ where
                 .filter(|peer_id| {
                     peer_id != propagation_source && Some(peer_id) != message.source.as_ref()
                 })
-                .collect::<Vec<PeerId>>();
+                .collect::<HashSet<PeerId>>();
 
             for peer_id in recipient_peers {
                 self.send_message(


### PR DESCRIPTION
## Description

avoid sending redundant IDONTWANT messages by only sending IDONTWANT for first-seen large messages and deduplicating recipient peers with a HashSet.
