### PR TITLE
chore(gossipsub): manually impl Debug for PartialMessage

### DIFF
--- a/protocols/gossipsub/src/extensions/partial_messages.rs
+++ b/protocols/gossipsub/src/extensions/partial_messages.rs
@@ -672,10 +672,7 @@ impl Debug for PartialMessage {
         f.debug_struct("PartialMessage")
             .field("group_id", &self.group_id)
             .field("topic_hash", &self.topic_hash)
-            .field(
-                "body length",
-                &self.body.as_ref().map(|body| body.len()).unwrap_or(0),
-            )
+            .field("body length", &self.body.as_ref().map(|body| body.len()))
             .field("metadata", &self.metadata)
             .finish()
     }

--- a/protocols/gossipsub/src/extensions/partial_messages.rs
+++ b/protocols/gossipsub/src/extensions/partial_messages.rs
@@ -21,7 +21,7 @@
 use std::{
     cmp::max,
     collections::{BTreeSet, HashMap, HashSet},
-    fmt::Debug,
+    fmt::{self, Debug},
 };
 
 use libp2p_core::PeerId;
@@ -655,7 +655,7 @@ pub(crate) enum ReceivedAction {
 }
 
 /// A Partial message sent and received from remote peers.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PartialMessage {
     /// The group ID that identifies the complete logical message.
     pub group_id: Vec<u8>,
@@ -665,6 +665,20 @@ pub struct PartialMessage {
     pub body: Option<Vec<u8>>,
     /// The partial metadata we have and want.
     pub metadata: Option<Vec<u8>>,
+}
+
+impl Debug for PartialMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PartialMessage")
+            .field("group_id", &self.group_id)
+            .field("topic_hash", &self.topic_hash)
+            .field(
+                "body length",
+                &self.body.as_ref().map(|body| body.len()).unwrap_or(0),
+            )
+            .field("metadata", &self.metadata)
+            .finish()
+    }
 }
 
 /// Stored `Metadata` for a peer,


### PR DESCRIPTION
## Description

`PartialMessage` derived `Debug`, causing very long log lines as the whole body is printed. 

Manually impl Debug for PartialMessage so that for the body, only the length is printed, similar to RawMessage.

## Notes & open questions

I kept the print for groupid and metadata as they are expected to be rather short, but this is up for discussion. I'd be also open to hex encode them to reduce the log spam a bit.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
