### PR TITLE
fix(gossipsub): Don't forward full messages to peers requesting partials

### DIFF
--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -2991,6 +2991,11 @@ where
                     continue;
                 }
 
+                #[cfg(feature = "partial_messages")]
+                if self.partial_messages_extension.requests_partial(peer_id, topic) {
+                    continue;
+                }
+
                 tracing::debug!(%peer_id, message_id=%msg_id, "Sending message to peer");
 
                 self.send_message(

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -2992,7 +2992,10 @@ where
                 }
 
                 #[cfg(feature = "partial_messages")]
-                if self.partial_messages_extension.requests_partial(peer_id, topic) {
+                if self
+                    .partial_messages_extension
+                    .requests_partial(peer_id, topic)
+                {
                     continue;
                 }
 


### PR DESCRIPTION
## Description

The forwarding code path did not check for partial messages, causing us to send full messages to our mesh peers when receiving a full message from a peer not supporting partials. 


## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
