### PR TITLE
fix(gossipsub): Do not handle IHAVE for peers supporting partials

### DIFF
--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1376,6 +1376,20 @@ where
                 continue;
             }
 
+            // We should not handle IHAVEs from peers that support partials on topics where we
+            // request partial messages.
+            #[cfg(feature = "partial_messages")]
+            if self
+                .partial_messages_extension
+                .opts(&topic)
+                .is_some_and(|opts| opts.requests_partial)
+                && self
+                    .partial_messages_extension
+                    .supports_partial(peer_id, &topic)
+            {
+                continue;
+            }
+
             for id in ids.into_iter().filter(|id| {
                 if self.duplicate_cache.contains(id) {
                     return false;


### PR DESCRIPTION
## Description

If we request partials for a topic, any peer supporting partial messages for that topic should not send us IHAVEs.

To safeguard, do not send IWANTs for any peers that IHAVE anyway.


## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
