### PR TITLE
feat(gossipsub): unify control-message limits

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Optimize IDONTWANT sending by avoiding broadcasts for already-seen messages and deduplicating recipient peers.
   See [PR 6356](https://github.com/libp2p/rust-libp2p/pull/6356)
 
+- Unify gossipsub control-message limits under max_control_messages (replacing per-type control ID caps),
+  and truncate control vectors immediately after RPC decode.
+  rename `max_ihave_messages` to `max_ihave_messages_heartbeat`.
+  See PR XXXX (https://github.com/libp2p/rust-libp2p/pull/XXXX)
+
 - Rename metric `topic_msg_sent_bytes` to `topic_msg_last_sent_bytes` for accuracy.
   See [PR 6283](https://github.com/libp2p/rust-libp2p/pull/6283)
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Unify gossipsub control-message limits under max_control_messages (replacing per-type control ID caps),
   and truncate control vectors immediately after RPC decode.
   rename `max_ihave_messages` to `max_ihave_messages_heartbeat`.
-  See PR 6409 (https://github.com/libp2p/rust-libp2p/pull/6409)
+  See [PR 6409](https://github.com/libp2p/rust-libp2p/pull/6409)
 
 - Rename metric `topic_msg_sent_bytes` to `topic_msg_last_sent_bytes` for accuracy.
   See [PR 6283](https://github.com/libp2p/rust-libp2p/pull/6283)

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Unify gossipsub control-message limits under max_control_messages (replacing per-type control ID caps),
   and truncate control vectors immediately after RPC decode.
   rename `max_ihave_messages` to `max_ihave_messages_heartbeat`.
-  See PR XXXX (https://github.com/libp2p/rust-libp2p/pull/XXXX)
+  See PR 6409 (https://github.com/libp2p/rust-libp2p/pull/6409)
 
 - Rename metric `topic_msg_sent_bytes` to `topic_msg_last_sent_bytes` for accuracy.
   See [PR 6283](https://github.com/libp2p/rust-libp2p/pull/6283)

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1341,7 +1341,7 @@ where
         // IHAVE flood protection
         let peer_have = self.count_received_ihave.entry(*peer_id).or_insert(0);
         *peer_have += 1;
-        if *peer_have > self.config.max_ihave_messages() {
+        if *peer_have > self.config.max_ihave_messages_heartbeat() {
             tracing::debug!(
                 peer=%peer_id,
                 "IHAVE: peer has advertised too many times ({}) within this heartbeat \
@@ -1352,7 +1352,7 @@ where
         }
 
         if let Some(iasked) = self.count_sent_iwant.get(peer_id)
-            && *iasked >= self.config.max_ihave_length()
+            && *iasked >= self.config.max_control_messages()
         {
             tracing::debug!(
                 peer=%peer_id,
@@ -1411,8 +1411,8 @@ where
         if !iwant_ids.is_empty() {
             let iasked = self.count_sent_iwant.entry(*peer_id).or_insert(0);
             let mut iask = iwant_ids.len();
-            if *iasked + iask > self.config.max_ihave_length() {
-                iask = self.config.max_ihave_length().saturating_sub(*iasked);
+            if *iasked + iask > self.config.max_control_messages() {
+                iask = self.config.max_control_messages().saturating_sub(*iasked);
             }
 
             // Send the list of IWANT control messages
@@ -2793,7 +2793,7 @@ where
             }
 
             // if we are emitting more than GossipSubMaxIHaveLength message_ids, truncate the list
-            if message_ids.len() > self.config.max_ihave_length() {
+            if message_ids.len() > self.config.max_control_messages() {
                 // we do the truncation (with shuffling) per peer below
                 tracing::debug!(
                     "too many messages for gossip; will truncate IHAVE list ({} messages)",
@@ -2835,12 +2835,12 @@ where
             for peer_id in to_msg_peers {
                 let mut peer_message_ids = message_ids.clone();
 
-                if peer_message_ids.len() > self.config.max_ihave_length() {
+                if peer_message_ids.len() > self.config.max_control_messages() {
                     // We do this per peer so that we emit a different set for each peer.
                     // we have enough redundancy in the system that this will significantly increase
                     // the message coverage when we do truncate.
-                    peer_message_ids.partial_shuffle(&mut rng, self.config.max_ihave_length());
-                    peer_message_ids.truncate(self.config.max_ihave_length());
+                    peer_message_ids.partial_shuffle(&mut rng, self.config.max_control_messages());
+                    peer_message_ids.truncate(self.config.max_control_messages());
                 }
 
                 // send an IHAVE message
@@ -3592,19 +3592,7 @@ where
                 }
 
                 // Handle messages
-                for (count, raw_message) in rpc.messages.into_iter().enumerate() {
-                    // Only process the amount of messages the configuration allows.
-                    if self
-                        .config
-                        .max_messages_per_rpc()
-                        .is_some_and(|max_msg| count >= max_msg)
-                    {
-                        tracing::warn!(
-                            "Received more messages than permitted. Ignoring further messages. Processed: {}",
-                            count
-                        );
-                        break;
-                    }
+                for raw_message in rpc.messages {
                     self.handle_received_message(raw_message, &propagation_source);
                 }
 
@@ -3614,20 +3602,7 @@ where
                 let mut ihave_msgs = vec![];
                 let mut graft_msgs = vec![];
                 let mut prune_msgs = vec![];
-                for (count, control_msg) in rpc.control_msgs.into_iter().enumerate() {
-                    // Only process the amount of messages the configuration allows.
-                    if self
-                        .config
-                        .max_messages_per_rpc()
-                        .is_some_and(|max_msg| count >= max_msg)
-                    {
-                        tracing::warn!(
-                            "Received more control messages than permitted. Ignoring further messages. Processed: {}",
-                            count
-                        );
-                        break;
-                    }
-
+                for control_msg in rpc.control_msgs {
                     match control_msg {
                         ControlAction::IHave(IHave {
                             topic_hash,

--- a/protocols/gossipsub/src/behaviour/tests/gossip.rs
+++ b/protocols/gossipsub/src/behaviour/tests/gossip.rs
@@ -452,7 +452,7 @@ fn test_ignore_too_many_iwants_from_same_peer_for_same_message() {
 #[test]
 fn test_ignore_too_many_ihaves() {
     let config = ConfigBuilder::default()
-        .max_ihave_messages(10)
+        .max_ihave_messages_heartbeat(10)
         .build()
         .unwrap();
     // build gossipsub with full mesh
@@ -529,8 +529,8 @@ fn test_ignore_too_many_ihaves() {
 #[test]
 fn test_ignore_too_many_messages_in_ihave() {
     let config = ConfigBuilder::default()
-        .max_ihave_messages(10)
-        .max_ihave_length(10)
+        .max_ihave_messages_heartbeat(10)
+        .max_control_messages(10)
         .build()
         .unwrap();
     // build gossipsub with full mesh
@@ -610,8 +610,8 @@ fn test_ignore_too_many_messages_in_ihave() {
 #[test]
 fn test_limit_number_of_message_ids_inside_ihave() {
     let config = ConfigBuilder::default()
-        .max_ihave_messages(10)
-        .max_ihave_length(100)
+        .max_ihave_messages_heartbeat(10)
+        .max_control_messages(100)
         .build()
         .unwrap();
     // build gossipsub with full mesh

--- a/protocols/gossipsub/src/behaviour/tests/topic_config.rs
+++ b/protocols/gossipsub/src/behaviour/tests/topic_config.rs
@@ -669,6 +669,8 @@ fn test_validation_error_message_size_too_large_topic_specific() {
         Config::default_max_transmit_size() * 2,
         ValidationMode::None,
         max_transmit_size_map,
+        5000,
+        5000,
     );
     let mut buf = BytesMut::new();
     let rpc = proto::RPC {
@@ -776,6 +778,8 @@ fn test_validation_message_size_within_topic_specific() {
         Config::default_max_transmit_size() * 2,
         ValidationMode::None,
         max_transmit_size_map,
+        5000,
+        5000,
     );
     let mut buf = BytesMut::new();
     let rpc = proto::RPC {

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -123,11 +123,11 @@ pub struct Config {
     opportunistic_graft_ticks: u64,
     opportunistic_graft_peers: usize,
     gossip_retransimission: u32,
-    max_messages_per_rpc: Option<usize>,
-    max_ihave_length: usize,
     #[cfg(feature = "partial_messages")]
     max_metadata_length: usize,
-    max_ihave_messages: usize,
+    max_publish_messages: usize,
+    max_control_messages: usize,
+    max_ihave_messages_heartbeat: usize,
     iwant_followup_time: Duration,
     connection_handler_queue_len: usize,
     connection_handler_publish_duration: Duration,
@@ -412,21 +412,6 @@ impl Config {
         self.opportunistic_graft_peers
     }
 
-    /// The maximum number of messages we will process in a given RPC. If this is unset, there is
-    /// no limit. The default is None.
-    pub fn max_messages_per_rpc(&self) -> Option<usize> {
-        self.max_messages_per_rpc
-    }
-
-    /// The maximum number of messages to include in an IHAVE message.
-    /// Also controls the maximum number of IHAVE ids we will accept and request with IWANT from a
-    /// peer within a heartbeat, to protect from IHAVE floods. You should adjust this value from the
-    /// default if your system is pushing more than 5000 messages in GossipSubHistoryGossip
-    /// heartbeats; with the defaults this is 1666 messages/s. The default is 5000.
-    pub fn max_ihave_length(&self) -> usize {
-        self.max_ihave_length
-    }
-
     /// The maximum number of metadata messages to send per peer during heartbeat gossip.
     /// The default is 1000.
     #[cfg(feature = "partial_messages")]
@@ -434,10 +419,15 @@ impl Config {
         self.max_metadata_length
     }
 
-    /// GossipSubMaxIHaveMessages is the maximum number of IHAVE messages to accept from a peer
-    /// within a heartbeat.
-    pub fn max_ihave_messages(&self) -> usize {
-        self.max_ihave_messages
+    /// The maximum number of publish messages we will process in a given RPC. The default is 5000.
+    pub fn max_publish_messages(&self) -> usize {
+        self.max_publish_messages
+    }
+
+    /// The maximum number of control messages by type we will process in a given RPC. The default
+    /// is 5000.
+    pub fn max_control_messages(&self) -> usize {
+        self.max_control_messages
     }
 
     /// Time to wait for a message requested through IWANT following an IHAVE advertisement.
@@ -484,6 +474,12 @@ impl Config {
     /// By default it is false.
     pub fn idontwant_on_publish(&self) -> bool {
         self.idontwant_on_publish
+    }
+
+    /// GossipSubMaxIHaveMessages is the maximum number of IHAVE messages to accept from a peer
+    /// within a heartbeat.
+    pub fn max_ihave_messages_heartbeat(&self) -> usize {
+        self.max_ihave_messages_heartbeat
     }
 }
 
@@ -545,11 +541,11 @@ impl Default for ConfigBuilder {
                 opportunistic_graft_ticks: 60,
                 opportunistic_graft_peers: 2,
                 gossip_retransimission: 3,
-                max_messages_per_rpc: None,
-                max_ihave_length: 5000,
                 #[cfg(feature = "partial_messages")]
                 max_metadata_length: 1000,
-                max_ihave_messages: 10,
+                max_publish_messages: 5000,
+                max_control_messages: 5000,
+                max_ihave_messages_heartbeat: 10,
                 iwant_followup_time: Duration::from_secs(3),
                 connection_handler_queue_len: 5000,
                 connection_handler_publish_duration: Duration::from_secs(5),
@@ -966,20 +962,10 @@ impl ConfigBuilder {
         self
     }
 
-    /// The maximum number of messages we will process in a given RPC. If this is unset, there is
-    /// no limit. The default is None.
-    pub fn max_messages_per_rpc(&mut self, max: Option<usize>) -> &mut Self {
-        self.config.max_messages_per_rpc = max;
-        self
-    }
-
-    /// The maximum number of messages to include in an IHAVE message.
-    /// Also controls the maximum number of IHAVE ids we will accept and request with IWANT from a
-    /// peer within a heartbeat, to protect from IHAVE floods. You should adjust this value from the
-    /// default if your system is pushing more than 5000 messages in GossipSubHistoryGossip
-    /// heartbeats; with the defaults this is 1666 messages/s. The default is 5000.
-    pub fn max_ihave_length(&mut self, max_ihave_length: usize) -> &mut Self {
-        self.config.max_ihave_length = max_ihave_length;
+    /// The maximum number of publish messages we will process in a single RPC. The default is 5000.
+    pub fn max_publish_messages(&mut self, max: usize) -> &mut Self {
+        self.config.max_publish_messages = max;
+        self.config.protocol.max_publish_messages = max;
         self
     }
 
@@ -993,8 +979,8 @@ impl ConfigBuilder {
 
     /// GossipSubMaxIHaveMessages is the maximum number of IHAVE messages to accept from a peer
     /// within a heartbeat.
-    pub fn max_ihave_messages(&mut self, max_ihave_messages: usize) -> &mut Self {
-        self.config.max_ihave_messages = max_ihave_messages;
+    pub fn max_ihave_messages_heartbeat(&mut self, max_ihave_messages: usize) -> &mut Self {
+        self.config.max_ihave_messages_heartbeat = max_ihave_messages;
         self
     }
 
@@ -1065,6 +1051,14 @@ impl ConfigBuilder {
     /// By default it is false.
     pub fn idontwant_on_publish(&mut self, idontwant_on_publish: bool) -> &mut Self {
         self.config.idontwant_on_publish = idontwant_on_publish;
+        self
+    }
+
+    /// The maximum number of control messages by type we will process in a single RPC. The default
+    /// is 5000.
+    pub fn max_control_messages(&mut self, size: usize) -> &mut Self {
+        self.config.max_control_messages = size;
+        self.config.protocol.max_control_messages = size;
         self
     }
 
@@ -1176,9 +1170,12 @@ impl std::fmt::Debug for Config {
         );
         let _ = builder.field("opportunistic_graft_ticks", &self.opportunistic_graft_ticks);
         let _ = builder.field("opportunistic_graft_peers", &self.opportunistic_graft_peers);
-        let _ = builder.field("max_messages_per_rpc", &self.max_messages_per_rpc);
-        let _ = builder.field("max_ihave_length", &self.max_ihave_length);
-        let _ = builder.field("max_ihave_messages", &self.max_ihave_messages);
+        let _ = builder.field("max_messages_per_rpc", &self.max_publish_messages);
+        let _ = builder.field("max_control_messages", &self.max_control_messages);
+        let _ = builder.field(
+            "max_ihave_messages_heartbeat",
+            &self.max_ihave_messages_heartbeat,
+        );
         let _ = builder.field("iwant_followup_time", &self.iwant_followup_time);
         let _ = builder.field(
             "idontwant_message_size_threshold",

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -79,6 +79,10 @@ pub struct ProtocolConfig {
     pub(crate) default_max_transmit_size: usize,
     /// The max transmit sizes for a topic.
     pub(crate) max_transmit_sizes: HashMap<TopicHash, usize>,
+    /// The max number of publish messages to decode in a single RPC.
+    pub(crate) max_publish_messages: usize,
+    /// The max number of control messages per type to decode in a single RPC.
+    pub(crate) max_control_messages: usize,
 }
 
 impl Default for ProtocolConfig {
@@ -93,6 +97,8 @@ impl Default for ProtocolConfig {
             ],
             default_max_transmit_size: 65536,
             max_transmit_sizes: HashMap::new(),
+            max_publish_messages: 500,
+            max_control_messages: 500,
         }
     }
 }
@@ -147,6 +153,8 @@ where
                     self.default_max_transmit_size,
                     self.validation_mode,
                     self.max_transmit_sizes,
+                    self.max_publish_messages,
+                    self.max_control_messages,
                 ),
             ),
             protocol_id.kind,
@@ -170,6 +178,8 @@ where
                     self.default_max_transmit_size,
                     self.validation_mode,
                     self.max_transmit_sizes,
+                    self.max_publish_messages,
+                    self.max_control_messages,
                 ),
             ),
             protocol_id.kind,
@@ -186,6 +196,10 @@ pub struct GossipsubCodec {
     codec: quick_protobuf_codec::Codec<proto::RPC>,
     /// Maximum transmit sizes per topic, with a default if not specified.
     max_transmit_sizes: HashMap<TopicHash, usize>,
+    /// The max number of publish messages to decode in a single RPC.
+    max_publish_messages: usize,
+    /// The max number of control messages per type to decode in a single RPC.
+    max_control_messages: usize,
 }
 
 impl GossipsubCodec {
@@ -193,12 +207,16 @@ impl GossipsubCodec {
         max_length: usize,
         validation_mode: ValidationMode,
         max_transmit_sizes: HashMap<TopicHash, usize>,
+        max_publish_messages: usize,
+        max_control_messages: usize,
     ) -> GossipsubCodec {
         let codec = quick_protobuf_codec::Codec::new(max_length);
         GossipsubCodec {
             validation_mode,
             codec,
             max_transmit_sizes,
+            max_publish_messages,
+            max_control_messages,
         }
     }
 
@@ -273,14 +291,44 @@ impl Encoder for GossipsubCodec {
     }
 }
 
+// Truncate oversized RPC messages and emit a single warning with dropped count.
+fn truncate_excess<T>(items: &mut Vec<T>, max: usize, kind: &str) {
+    let original = items.len();
+    if original > max {
+        tracing::debug!(
+            kind = kind,
+            received = original,
+            kept = max,
+            dropped = original - max,
+            "Received more gossipsub entries than permitted; truncating"
+        );
+        items.truncate(max);
+    }
+}
+
 impl Decoder for GossipsubCodec {
     type Item = HandlerEvent;
     type Error = quick_protobuf_codec::Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        let Some(rpc) = self.codec.decode(src)? else {
+        let Some(mut rpc) = self.codec.decode(src)? else {
             return Ok(None);
         };
+
+        // Limit messages
+        truncate_excess(&mut rpc.publish, self.max_publish_messages, "publish");
+
+        let mut control = rpc.control.take().unwrap_or_default();
+        truncate_excess(&mut control.ihave, self.max_control_messages, "IHAVE");
+        truncate_excess(&mut control.iwant, self.max_control_messages, "IWANT");
+        truncate_excess(&mut control.graft, self.max_control_messages, "GRAFT");
+        truncate_excess(&mut control.prune, self.max_control_messages, "PRUNE");
+        truncate_excess(
+            &mut control.idontwant,
+            self.max_control_messages,
+            "IDONTWANT",
+        );
+
         // Store valid messages.
         let mut messages = Vec::with_capacity(rpc.publish.len());
         // Store any invalid messages.
@@ -484,99 +532,91 @@ impl Decoder for GossipsubCodec {
 
         let mut control_msgs = Vec::new();
 
-        if let Some(rpc_control) = rpc.control {
-            // Collect the gossipsub control messages
-            let ihave_msgs: Vec<ControlAction> = rpc_control
-                .ihave
-                .into_iter()
-                .map(|ihave| {
-                    ControlAction::IHave(IHave {
-                        topic_hash: TopicHash::from_raw(ihave.topic_id.unwrap_or_default()),
-                        message_ids: ihave
-                            .message_ids
-                            .into_iter()
-                            .map(MessageId::from)
-                            .collect::<Vec<_>>(),
-                    })
+        // Collect the gossipsub control messages
+        let ihave_msgs: Vec<ControlAction> = control
+            .ihave
+            .into_iter()
+            .map(|ihave| {
+                ControlAction::IHave(IHave {
+                    topic_hash: TopicHash::from_raw(ihave.topic_id.unwrap_or_default()),
+                    message_ids: ihave
+                        .message_ids
+                        .into_iter()
+                        .map(MessageId::from)
+                        .collect::<Vec<_>>(),
                 })
-                .collect();
+            })
+            .collect();
+        control_msgs.extend(ihave_msgs);
 
-            let iwant_msgs: Vec<ControlAction> = rpc_control
-                .iwant
-                .into_iter()
-                .map(|iwant| {
-                    ControlAction::IWant(IWant {
-                        message_ids: iwant
-                            .message_ids
-                            .into_iter()
-                            .map(MessageId::from)
-                            .collect::<Vec<_>>(),
-                    })
+        let iwant_msgs: Vec<ControlAction> = control
+            .iwant
+            .into_iter()
+            .map(|iwant| {
+                ControlAction::IWant(IWant {
+                    message_ids: iwant
+                        .message_ids
+                        .into_iter()
+                        .map(MessageId::from)
+                        .collect::<Vec<_>>(),
                 })
-                .collect();
+            })
+            .collect();
+        control_msgs.extend(iwant_msgs);
 
-            let graft_msgs: Vec<ControlAction> = rpc_control
-                .graft
-                .into_iter()
-                .map(|graft| {
-                    ControlAction::Graft(Graft {
-                        topic_hash: TopicHash::from_raw(graft.topic_id.unwrap_or_default()),
-                    })
+        let graft_msgs: Vec<ControlAction> = control
+            .graft
+            .into_iter()
+            .map(|graft| {
+                ControlAction::Graft(Graft {
+                    topic_hash: TopicHash::from_raw(graft.topic_id.unwrap_or_default()),
                 })
-                .collect();
+            })
+            .collect();
+        control_msgs.extend(graft_msgs);
 
-            let mut prune_msgs = Vec::new();
-
-            for prune in rpc_control.prune {
-                // filter out invalid peers
-                let peers = prune
-                    .peers
-                    .into_iter()
-                    .filter_map(|info| {
-                        info.peer_id
-                            .as_ref()
-                            .and_then(|id| PeerId::from_bytes(id).ok())
-                            .map(|peer_id|
+        let mut prune_messages = Vec::new();
+        for prune in control.prune {
+            // filter out invalid peers
+            let peers = prune
+                .peers
+                .into_iter()
+                .filter_map(|info| {
+                    info.peer_id
+                        .as_ref()
+                        .and_then(|id| PeerId::from_bytes(id).ok())
+                        .map(|peer_id|
                                     //TODO signedPeerRecord, see https://github.com/libp2p/specs/pull/217
                                     PeerInfo {
                                         peer_id: Some(peer_id),
                                     })
-                    })
-                    .collect::<Vec<PeerInfo>>();
-
-                let topic_hash = TopicHash::from_raw(prune.topic_id.unwrap_or_default());
-                prune_msgs.push(ControlAction::Prune(Prune {
-                    topic_hash,
-                    peers,
-                    backoff: prune.backoff,
-                }));
-            }
-
-            let idontwant_msgs: Vec<ControlAction> = rpc_control
-                .idontwant
-                .into_iter()
-                .map(|idontwant| {
-                    ControlAction::IDontWant(IDontWant {
-                        message_ids: idontwant
-                            .message_ids
-                            .into_iter()
-                            .map(MessageId::from)
-                            .collect::<Vec<_>>(),
-                    })
                 })
                 .collect();
-
-            let extensions_msg = rpc_control.extensions.map(|extensions| Extensions {
-                partial_messages: extensions.partialMessages,
-            });
-
-            control_msgs.extend(ihave_msgs);
-            control_msgs.extend(iwant_msgs);
-            control_msgs.extend(graft_msgs);
-            control_msgs.extend(prune_msgs);
-            control_msgs.extend(idontwant_msgs);
-            control_msgs.push(ControlAction::Extensions(extensions_msg));
+            let topic_hash = TopicHash::from_raw(prune.topic_id.unwrap_or_default());
+            prune_messages.push(ControlAction::Prune(Prune {
+                topic_hash,
+                peers,
+                backoff: prune.backoff,
+            }));
         }
+        control_msgs.extend(prune_messages);
+
+        let mut idontwant_messages = Vec::new();
+        for idontwant in control.idontwant {
+            idontwant_messages.push(ControlAction::IDontWant(IDontWant {
+                message_ids: idontwant
+                    .message_ids
+                    .into_iter()
+                    .map(MessageId::from)
+                    .collect::<Vec<_>>(),
+            }));
+        }
+        control_msgs.extend(idontwant_messages);
+
+        let extensions_msg = control.extensions.map(|extensions| Extensions {
+            partial_messages: extensions.partialMessages,
+        });
+        control_msgs.push(ControlAction::Extensions(extensions_msg));
 
         #[cfg(feature = "partial_messages")]
         let partial_message = rpc.partial.and_then(|partial_proto| {
@@ -704,8 +744,13 @@ mod tests {
                 message_id: MessageId(vec![0, 0]),
             };
 
-            let mut codec =
-                GossipsubCodec::new(u32::MAX as usize, ValidationMode::Strict, HashMap::new());
+            let mut codec = GossipsubCodec::new(
+                u32::MAX as usize,
+                ValidationMode::Strict,
+                HashMap::new(),
+                5000,
+                1000,
+            );
             let mut buf = BytesMut::new();
             codec.encode(rpc.into_protobuf(), &mut buf).unwrap();
             let decoded_rpc = codec.decode(&mut buf).unwrap().unwrap();


### PR DESCRIPTION
## Description
This PR consolidates gossipsub control-message limiting under a single `max_control_messages` bound, replacing per-type controls (`max_iwant_length`, `max_ihave_length`, and `max_idontwant_messages`).

This PR also renames `max_ihave_messages` to `max_ihave_messages_heartbeat` to make its heartbeat-scoped semantics explicit.

Finally, this PR normalizes control handling in the codec path by truncating capped control vectors immediately after RPC decode and converting them through a unified flow.