### PR TITLE
chore(gossipsub): Send full messages if local doesn't support partial

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -28,10 +28,6 @@
 - Implement gossipsub 1.3 partial messages extension.
   See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX)
 
-- Fix full-message publishing to peers that request partial messages when the publisher does not
-  support partial messages.
-  See [PR 6410](https://github.com/libp2p/rust-libp2p/pull/6410)
-
 - Remove peer penalty for duplicate messages.
   See [PR 6112](https://github.com/libp2p/rust-libp2p/pull/6112)
 

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 - Fix full-message publishing to peers that request partial messages when the publisher does not
   support partial messages.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX)
+  See [PR 6410](https://github.com/libp2p/rust-libp2p/pull/6410)
 
 - Remove peer penalty for duplicate messages.
   See [PR 6112](https://github.com/libp2p/rust-libp2p/pull/6112)

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -28,6 +28,10 @@
 - Implement gossipsub 1.3 partial messages extension.
   See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX)
 
+- Fix full-message publishing to peers that request partial messages when the publisher does not
+  support partial messages.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX)
+
 - Remove peer penalty for duplicate messages.
   See [PR 6112](https://github.com/libp2p/rust-libp2p/pull/6112)
 

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -691,13 +691,21 @@ where
         let candidates = self.publish_peers(&topic_hash);
 
         #[cfg(feature = "partial_messages")]
-        let candidates = candidates
-            .filter(|peer_id| {
-                !self
-                    .partial_messages_extension
-                    .requests_partial(peer_id, &topic_hash)
-            })
-            .collect();
+        let candidates = if self
+            .partial_messages_extension
+            .opts(&topic_hash)
+            .is_some_and(|opts| opts.supports_partial)
+        {
+            candidates
+                .filter(|peer_id| {
+                    !self
+                        .partial_messages_extension
+                        .requests_partial(peer_id, &topic_hash)
+                })
+                .collect()
+        } else {
+            candidates.collect()
+        };
         #[cfg(not(feature = "partial_messages"))]
         let candidates = candidates.collect();
 

--- a/protocols/gossipsub/src/behaviour/tests/partial.rs
+++ b/protocols/gossipsub/src/behaviour/tests/partial.rs
@@ -1728,6 +1728,45 @@ fn test_partial_messages_two_node_exchange() {
     assert_eq!(recv_body.as_ref().unwrap()[0], 0b10101010);
 }
 
+/// Verifies that a peer subscribed without partial-message support still sends
+/// full publish messages to peers that request and support partial messages.
+#[test]
+fn test_full_publish_to_partial_peer_when_local_does_not_support_partial() {
+    let (mut gs, _, _, topics) = DefaultBehaviourTestBuilder::default()
+        .peer_no(0)
+        .topics(vec!["test-partial".into()])
+        .to_subscribe(true)
+        .create_network();
+
+    let topic_hash = topics[0].clone();
+    let (_peer, mut queue) = add_peer_with_addr_and_kind(
+        &mut gs,
+        slice::from_ref(&topic_hash),
+        false,
+        false,
+        Multiaddr::empty(),
+        Some(PeerKind::Gossipsubv1_3),
+        true, // requests_partial
+        true, // supports_partial
+    );
+
+    let publish_data = vec![1, 2, 3, 4];
+    gs.publish(topic_hash.clone(), publish_data.clone())
+        .expect("Full publish to partial peer should succeed");
+
+    let mut published = None;
+    while !queue.is_empty() {
+        if let Some(RpcOut::Publish { message, .. }) = queue.try_pop() {
+            published = Some(message);
+            break;
+        }
+    }
+
+    let published = published.expect("Partial peer should receive a full publish message");
+    assert_eq!(published.topic, topic_hash);
+    assert_eq!(published.data, publish_data);
+}
+
 /// Verifies that:
 /// - Partial messages are only sent to peers with `supports_partial: true`.
 /// - Peers with `supports_partial: false` are filtered out from `publish_partial`.


### PR DESCRIPTION
## Description

When using the partial message extension/feature.

If the local peer does not support partial messages it should always send full messages regardless if the remote peer supports partial messages or not.

cc @dknopik 

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation 
  - (not needed)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
