### PR TITLE
fix: support hickory 0.26 APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -517,7 +517,7 @@ dependencies = [
  "libp2p-webrtc",
  "libp2p-webrtc-websys",
  "mime_guess",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rust-embed",
  "tokio",
  "tokio-util",
@@ -1753,7 +1753,7 @@ dependencies = [
  "idna",
  "ipnet",
  "jni",
- "rand 0.10.0",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -1773,7 +1773,7 @@ dependencies = [
  "jni",
  "once_cell",
  "prefix-trie",
- "rand 0.10.0",
+ "rand 0.10.1",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1798,7 +1798,7 @@ dependencies = [
  "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "resolv-conf",
  "smallvec",
  "system-configuration 0.7.0",
@@ -2214,7 +2214,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.9.0",
+ "rand 0.9.3",
  "tokio",
  "url",
  "xmltree",
@@ -2262,7 +2262,7 @@ dependencies = [
  "bytes",
  "log",
  "portable-atomic",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rtcp",
  "rtp",
  "thiserror 1.0.69",
@@ -2288,7 +2288,7 @@ dependencies = [
  "libp2p-webrtc",
  "libp2p-webrtc-websys",
  "mime_guess",
- "rand 0.8.5",
+ "rand 0.8.6",
  "redis",
  "reqwest",
  "rust-embed",
@@ -2615,7 +2615,7 @@ dependencies = [
  "libp2p-swarm-test",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "thiserror 2.0.18",
  "tokio",
@@ -2636,7 +2636,7 @@ dependencies = [
  "libp2p-swarm-derive",
  "libp2p-swarm-test",
  "quickcheck-ext",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
 ]
 
@@ -2657,7 +2657,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rw-stream-sink",
  "thiserror 2.0.18",
  "tokio",
@@ -2723,7 +2723,7 @@ dependencies = [
  "libp2p-swarm",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "thiserror 2.0.18",
  "tracing",
@@ -2753,7 +2753,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "quickcheck-ext",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "serde",
  "sha2",
@@ -2800,7 +2800,7 @@ dependencies = [
  "p256",
  "quick-protobuf",
  "quickcheck-ext",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ring",
  "rmp-serde",
  "sec1",
@@ -2833,7 +2833,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "quickcheck-ext",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "sha2",
  "smallvec",
@@ -2856,7 +2856,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "libp2p-swarm-test",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "socket2 0.6.3",
  "tokio",
@@ -2915,7 +2915,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "quickcheck-ext",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "tokio",
  "tracing",
@@ -2948,7 +2948,7 @@ dependencies = [
  "multihash",
  "quick-protobuf",
  "quickcheck-ext",
- "rand 0.8.5",
+ "rand 0.8.6",
  "snow",
  "static_assertions",
  "thiserror 2.0.18",
@@ -3009,7 +3009,7 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-swarm-test",
  "quickcheck-ext",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
  "tracing",
  "web-time",
@@ -3046,7 +3046,7 @@ dependencies = [
  "libp2p-yamux",
  "pin-project",
  "quickcheck-ext",
- "rand 0.8.5",
+ "rand 0.8.6",
  "salsa20",
  "sha3",
  "tokio",
@@ -3069,7 +3069,7 @@ dependencies = [
  "libp2p-yamux",
  "quickcheck",
  "quinn",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ring",
  "rustls",
  "socket2 0.6.3",
@@ -3099,7 +3099,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "quickcheck-ext",
- "rand 0.8.5",
+ "rand 0.8.6",
  "static_assertions",
  "thiserror 2.0.18",
  "tokio",
@@ -3124,7 +3124,7 @@ dependencies = [
  "libp2p-swarm-test",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3145,7 +3145,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "libp2p-swarm-test",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "smallvec",
@@ -3181,7 +3181,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "libp2p-swarm-test",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3209,7 +3209,7 @@ dependencies = [
  "libp2p-yamux",
  "multistream-select",
  "quickcheck-ext",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "tokio",
  "tracing",
@@ -3319,7 +3319,7 @@ dependencies = [
  "libp2p-webrtc-utils",
  "multihash",
  "quickcheck",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rcgen",
  "stun",
  "thiserror 2.0.18",
@@ -3344,7 +3344,7 @@ dependencies = [
  "libp2p-noise",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "sha2",
  "tinytemplate",
@@ -3688,7 +3688,7 @@ checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
  "arbitrary",
  "quickcheck",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "unsigned-varint",
 ]
@@ -4027,7 +4027,7 @@ dependencies = [
  "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -4395,7 +4395,7 @@ checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
 dependencies = [
  "env_logger",
  "log",
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -4436,7 +4436,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.2",
  "lru-slab",
- "rand 0.9.0",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4498,9 +4498,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4509,20 +4509,19 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy",
 ]
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
@@ -4870,7 +4869,7 @@ dependencies = [
  "bytes",
  "memchr",
  "portable-atomic",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "thiserror 1.0.69",
  "webrtc-util",
@@ -5064,7 +5063,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02a526161f474ae94b966ba622379d939a8fe46c930eebbadb73e339622599d5"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
  "substring",
  "thiserror 1.0.69",
  "url",
@@ -5377,7 +5376,7 @@ dependencies = [
  "futures",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha1",
 ]
 
@@ -5411,7 +5410,7 @@ dependencies = [
  "futures",
  "libp2p",
  "libp2p-stream",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5464,7 +5463,7 @@ dependencies = [
  "crc",
  "lazy_static",
  "md-5",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ring",
  "subtle",
  "thiserror 1.0.69",
@@ -5584,7 +5583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -5905,7 +5904,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -6109,7 +6108,7 @@ dependencies = [
  "log",
  "md-5",
  "portable-atomic",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ring",
  "stun",
  "thiserror 1.0.69",
@@ -6507,7 +6506,7 @@ dependencies = [
  "log",
  "pem",
  "portable-atomic",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rcgen",
  "regex",
  "ring",
@@ -6572,7 +6571,7 @@ dependencies = [
  "p384",
  "pem",
  "portable-atomic",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "rcgen",
  "ring",
@@ -6600,7 +6599,7 @@ dependencies = [
  "crc",
  "log",
  "portable-atomic",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "stun",
@@ -6635,7 +6634,7 @@ checksum = "e153be16b8650021ad3e9e49ab6e5fa9fb7f6d1c23c213fd8bbd1a1135a4c704"
 dependencies = [
  "byteorder",
  "bytes",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rtp",
  "thiserror 1.0.69",
 ]
@@ -6652,7 +6651,7 @@ dependencies = [
  "crc",
  "log",
  "portable-atomic",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 1.0.69",
  "tokio",
  "webrtc-util",
@@ -6696,7 +6695,7 @@ dependencies = [
  "log",
  "nix 0.26.4",
  "portable-atomic",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 1.0.69",
  "tokio",
  "winapi",
@@ -7438,7 +7437,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "static_assertions",
 ]
 
@@ -7453,7 +7452,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "static_assertions",
  "web-time",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4978,18 +4978,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -636,7 +636,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -646,7 +657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -817,6 +828,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,7 +985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -1204,18 +1224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1730,24 +1738,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.0",
- "ring",
- "socket2 0.5.9",
+ "jni",
+ "rand 0.10.0",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -1756,21 +1762,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.0",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.0",
+ "rand 0.10.0",
  "resolv-conf",
  "smallvec",
+ "system-configuration 0.7.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2314,6 +2345,9 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -2391,6 +2425,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,7 +2503,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -3647,6 +3730,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "netlink-packet-core"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4153,7 +4242,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4165,7 +4254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4198,6 +4287,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -4434,6 +4534,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
+ "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
@@ -5129,7 +5230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5140,7 +5241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5196,6 +5297,22 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5583,7 +5583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,8 +126,8 @@ futures-rustls = { version = "0.26.0", default-features = false }
 futures-timer = { version = "3" }
 getrandom = { version = "0.2", features = ["js"] }
 hashlink = "0.11.0"
-hickory-proto = { version = "0.25.2", default-features = false }
-hickory-resolver = { version = "0.25.2", default-features = false }
+hickory-proto = { version = "0.26.1", default-features = false }
+hickory-resolver = { version = "0.26.1", default-features = false }
 if-watch = "3.2.2"
 multiaddr = "0.18.1"
 multihash = "0.19.4"

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,10 @@ yanked = "warn"
 # output a note when they are encountered.
 ignore = [
     "RUSTSEC-2024-0436",
+    # No safe upgrade is available; this is pulled in through webrtc-dtls.
+    "RUSTSEC-2025-0141",
+    # rand 0.7 remains through cuckoofilter; patched rand lines stay updated in Cargo.lock.
+    "RUSTSEC-2026-0097",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,7 @@ yanked = "warn"
 ignore = [
     "RUSTSEC-2024-0436",
     # No safe upgrade is available; this is pulled in through webrtc-dtls.
+    # Tracked in #6240.
     "RUSTSEC-2025-0141",
     # rand 0.8/0.9/0.10 are updated to patched releases in Cargo.lock.
     # rand 0.7.3 remains through cuckoofilter -> libp2p-floodsub, and

--- a/deny.toml
+++ b/deny.toml
@@ -16,7 +16,9 @@ ignore = [
     "RUSTSEC-2024-0436",
     # No safe upgrade is available; this is pulled in through webrtc-dtls.
     "RUSTSEC-2025-0141",
-    # rand 0.7 remains through cuckoofilter; patched rand lines stay updated in Cargo.lock.
+    # rand 0.8/0.9/0.10 are updated to patched releases in Cargo.lock.
+    # rand 0.7.3 remains through cuckoofilter -> libp2p-floodsub, and
+    # RustSec does not list a patched 0.7.x release. Tracked in #6419.
     "RUSTSEC-2026-0097",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score

--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.57.0
 
+- Add `SwarmBuilder::try_with_dns_config` for fallible custom DNS resolver construction.
+  See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
+
 - Remove `wasm-bindgen` feature and make `wasm` support implicit.
   See [PR 6102](https://github.com/libp2p/rust-libp2p/pull/6102)
 - Raise MSRV to 1.88.0.

--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -1,7 +1,15 @@
 ## 0.57.0
 
-- Change `SwarmBuilder::with_dns_config` to return `Result<_, libp2p_dns::ResolveError>`
-  instead of panicking when Hickory rejects resolver construction.
+- Change `SwarmBuilder::with_dns_config` on the DNS, QUIC, and other-transport
+  builder phases to return `Result<_, libp2p_dns::ResolveError>` instead of
+  panicking when Hickory rejects resolver construction.
+  See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
+
+- Update the re-exported `libp2p::dns` API for `hickory-resolver` 0.26:
+  `libp2p::dns::tokio::Transport::custom` now returns `Result`,
+  `libp2p::dns::ResolveError` is Hickory's `NetError`,
+  `libp2p::dns::ResolveErrorKind` is no longer re-exported, and hidden public
+  `Resolver` lookup methods now return Hickory's generic `Lookup`.
   See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
 
 - Remove `wasm-bindgen` feature and make `wasm` support implicit.

--- a/libp2p/CHANGELOG.md
+++ b/libp2p/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.57.0
 
-- Add `SwarmBuilder::try_with_dns_config` for fallible custom DNS resolver construction.
+- Change `SwarmBuilder::with_dns_config` to return `Result<_, libp2p_dns::ResolveError>`
+  instead of panicking when Hickory rejects resolver construction.
   See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
 
 - Remove `wasm-bindgen` feature and make `wasm` support implicit.

--- a/libp2p/src/builder.rs
+++ b/libp2p/src/builder.rs
@@ -287,10 +287,11 @@ mod tests {
                 libp2p_yamux::Config::default,
             )
             .unwrap()
-            .with_dns_config(
+            .try_with_dns_config(
                 libp2p_dns::ResolverConfig::default(),
                 libp2p_dns::ResolverOpts::default(),
             )
+            .unwrap()
             .with_behaviour(|_| libp2p_swarm::dummy::Behaviour)
             .unwrap()
             .build();

--- a/libp2p/src/builder.rs
+++ b/libp2p/src/builder.rs
@@ -287,7 +287,7 @@ mod tests {
                 libp2p_yamux::Config::default,
             )
             .unwrap()
-            .try_with_dns_config(
+            .with_dns_config(
                 libp2p_dns::ResolverConfig::default(),
                 libp2p_dns::ResolverOpts::default(),
             )
@@ -307,6 +307,7 @@ mod tests {
                 libp2p_dns::ResolverConfig::default(),
                 libp2p_dns::ResolverOpts::default(),
             )
+            .unwrap()
             .with_behaviour(|_| libp2p_swarm::dummy::Behaviour)
             .unwrap()
             .build();
@@ -335,6 +336,7 @@ mod tests {
                 libp2p_dns::ResolverConfig::default(),
                 libp2p_dns::ResolverOpts::default(),
             )
+            .unwrap()
             .with_behaviour(|_| libp2p_swarm::dummy::Behaviour)
             .unwrap()
             .build();

--- a/libp2p/src/builder/phase/dns.rs
+++ b/libp2p/src/builder/phase/dns.rs
@@ -32,22 +32,9 @@ impl<T: AuthenticatedMultiplexedTransport> SwarmBuilder<super::provider::Tokio, 
 impl<T: AuthenticatedMultiplexedTransport> SwarmBuilder<super::provider::Tokio, DnsPhase<T>> {
     /// Builds the DNS transport with a custom resolver configuration.
     ///
-    /// Panics if the underlying Hickory resolver cannot be constructed. Use
-    /// [`Self::try_with_dns_config`] to handle this case.
+    /// Returns an error if the underlying Hickory resolver cannot be
+    /// constructed.
     pub fn with_dns_config(
-        self,
-        cfg: libp2p_dns::ResolverConfig,
-        opts: libp2p_dns::ResolverOpts,
-    ) -> SwarmBuilder<super::provider::Tokio, WebsocketPhase<impl AuthenticatedMultiplexedTransport>>
-    {
-        self.try_with_dns_config(cfg, opts)
-            .expect("hickory resolver construction to be valid")
-    }
-
-    /// Builds the DNS transport with a custom resolver configuration.
-    ///
-    /// Returns an error if the underlying Hickory resolver cannot be constructed.
-    pub fn try_with_dns_config(
         self,
         cfg: libp2p_dns::ResolverConfig,
         opts: libp2p_dns::ResolverOpts,
@@ -62,11 +49,7 @@ impl<T: AuthenticatedMultiplexedTransport> SwarmBuilder<super::provider::Tokio, 
             keypair: self.keypair,
             phantom: PhantomData,
             phase: WebsocketPhase {
-                transport: libp2p_dns::tokio::Transport::try_custom(
-                    self.phase.transport,
-                    cfg,
-                    opts,
-                )?,
+                transport: libp2p_dns::tokio::Transport::custom(self.phase.transport, cfg, opts)?,
             },
         })
     }

--- a/libp2p/src/builder/phase/dns.rs
+++ b/libp2p/src/builder/phase/dns.rs
@@ -30,19 +30,45 @@ impl<T: AuthenticatedMultiplexedTransport> SwarmBuilder<super::provider::Tokio, 
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "tokio", feature = "dns"))]
 impl<T: AuthenticatedMultiplexedTransport> SwarmBuilder<super::provider::Tokio, DnsPhase<T>> {
+    /// Builds the DNS transport with a custom resolver configuration.
+    ///
+    /// Panics if the underlying Hickory resolver cannot be constructed. Use
+    /// [`Self::try_with_dns_config`] to handle this case.
     pub fn with_dns_config(
         self,
         cfg: libp2p_dns::ResolverConfig,
         opts: libp2p_dns::ResolverOpts,
     ) -> SwarmBuilder<super::provider::Tokio, WebsocketPhase<impl AuthenticatedMultiplexedTransport>>
     {
-        SwarmBuilder {
+        self.try_with_dns_config(cfg, opts)
+            .expect("hickory resolver construction to be valid")
+    }
+
+    /// Builds the DNS transport with a custom resolver configuration.
+    ///
+    /// Returns an error if the underlying Hickory resolver cannot be constructed.
+    pub fn try_with_dns_config(
+        self,
+        cfg: libp2p_dns::ResolverConfig,
+        opts: libp2p_dns::ResolverOpts,
+    ) -> Result<
+        SwarmBuilder<
+            super::provider::Tokio,
+            WebsocketPhase<impl AuthenticatedMultiplexedTransport>,
+        >,
+        libp2p_dns::ResolveError,
+    > {
+        Ok(SwarmBuilder {
             keypair: self.keypair,
             phantom: PhantomData,
             phase: WebsocketPhase {
-                transport: libp2p_dns::tokio::Transport::custom(self.phase.transport, cfg, opts),
+                transport: libp2p_dns::tokio::Transport::try_custom(
+                    self.phase.transport,
+                    cfg,
+                    opts,
+                )?,
             },
-        }
+        })
     }
 }
 

--- a/libp2p/src/builder/phase/other_transport.rs
+++ b/libp2p/src/builder/phase/other_transport.rs
@@ -95,6 +95,22 @@ impl<T: AuthenticatedMultiplexedTransport>
         self.without_any_other_transports()
             .with_dns_config(cfg, opts)
     }
+
+    /// See [`SwarmBuilder::try_with_dns_config`].
+    pub fn try_with_dns_config(
+        self,
+        cfg: libp2p_dns::ResolverConfig,
+        opts: libp2p_dns::ResolverOpts,
+    ) -> Result<
+        SwarmBuilder<
+            super::provider::Tokio,
+            WebsocketPhase<impl AuthenticatedMultiplexedTransport>,
+        >,
+        libp2p_dns::ResolveError,
+    > {
+        self.without_any_other_transports()
+            .try_with_dns_config(cfg, opts)
+    }
 }
 #[cfg(feature = "relay")]
 impl<T: AuthenticatedMultiplexedTransport, Provider>

--- a/libp2p/src/builder/phase/other_transport.rs
+++ b/libp2p/src/builder/phase/other_transport.rs
@@ -90,17 +90,6 @@ impl<T: AuthenticatedMultiplexedTransport>
         self,
         cfg: libp2p_dns::ResolverConfig,
         opts: libp2p_dns::ResolverOpts,
-    ) -> SwarmBuilder<super::provider::Tokio, WebsocketPhase<impl AuthenticatedMultiplexedTransport>>
-    {
-        self.without_any_other_transports()
-            .with_dns_config(cfg, opts)
-    }
-
-    /// See [`SwarmBuilder::try_with_dns_config`].
-    pub fn try_with_dns_config(
-        self,
-        cfg: libp2p_dns::ResolverConfig,
-        opts: libp2p_dns::ResolverOpts,
     ) -> Result<
         SwarmBuilder<
             super::provider::Tokio,
@@ -109,7 +98,7 @@ impl<T: AuthenticatedMultiplexedTransport>
         libp2p_dns::ResolveError,
     > {
         self.without_any_other_transports()
-            .try_with_dns_config(cfg, opts)
+            .with_dns_config(cfg, opts)
     }
 }
 #[cfg(feature = "relay")]

--- a/libp2p/src/builder/phase/quic.rs
+++ b/libp2p/src/builder/phase/quic.rs
@@ -177,6 +177,23 @@ impl<T: AuthenticatedMultiplexedTransport> SwarmBuilder<super::provider::Tokio, 
             .without_any_other_transports()
             .with_dns_config(cfg, opts)
     }
+
+    /// See [`SwarmBuilder::try_with_dns_config`].
+    pub fn try_with_dns_config(
+        self,
+        cfg: libp2p_dns::ResolverConfig,
+        opts: libp2p_dns::ResolverOpts,
+    ) -> Result<
+        SwarmBuilder<
+            super::provider::Tokio,
+            WebsocketPhase<impl AuthenticatedMultiplexedTransport>,
+        >,
+        libp2p_dns::ResolveError,
+    > {
+        self.without_quic()
+            .without_any_other_transports()
+            .try_with_dns_config(cfg, opts)
+    }
 }
 
 macro_rules! impl_quic_phase_with_websocket {

--- a/libp2p/src/builder/phase/quic.rs
+++ b/libp2p/src/builder/phase/quic.rs
@@ -171,18 +171,6 @@ impl<T: AuthenticatedMultiplexedTransport> SwarmBuilder<super::provider::Tokio, 
         self,
         cfg: libp2p_dns::ResolverConfig,
         opts: libp2p_dns::ResolverOpts,
-    ) -> SwarmBuilder<super::provider::Tokio, WebsocketPhase<impl AuthenticatedMultiplexedTransport>>
-    {
-        self.without_quic()
-            .without_any_other_transports()
-            .with_dns_config(cfg, opts)
-    }
-
-    /// See [`SwarmBuilder::try_with_dns_config`].
-    pub fn try_with_dns_config(
-        self,
-        cfg: libp2p_dns::ResolverConfig,
-        opts: libp2p_dns::ResolverOpts,
     ) -> Result<
         SwarmBuilder<
             super::provider::Tokio,
@@ -192,7 +180,7 @@ impl<T: AuthenticatedMultiplexedTransport> SwarmBuilder<super::provider::Tokio, 
     > {
         self.without_quic()
             .without_any_other_transports()
-            .try_with_dns_config(cfg, opts)
+            .with_dns_config(cfg, opts)
     }
 }
 

--- a/protocols/mdns/CHANGELOG.md
+++ b/protocols/mdns/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.49.0
 
+- Update packet parsing internals to support `hickory-proto` 0.26.
+  See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
+
 - Raise MSRV to 1.88.0.
   See [PR 6273](https://github.com/libp2p/rust-libp2p/pull/6273).
 

--- a/protocols/mdns/src/behaviour/iface/query.rs
+++ b/protocols/mdns/src/behaviour/iface/query.rs
@@ -54,23 +54,23 @@ impl MdnsPacket {
     ) -> Result<Option<MdnsPacket>, hickory_proto::ProtoError> {
         let packet = Message::from_vec(buf)?;
 
-        if packet.query().is_none() {
+        if packet.queries.is_empty() {
             return Ok(Some(MdnsPacket::Response(MdnsResponse::new(&packet, from))));
         }
 
         if packet
-            .queries()
+            .queries
             .iter()
             .any(|q| q.name().to_utf8() == SERVICE_NAME_FQDN)
         {
             return Ok(Some(MdnsPacket::Query(MdnsQuery {
                 from,
-                query_id: packet.header().id(),
+                query_id: packet.id,
             })));
         }
 
         if packet
-            .queries()
+            .queries
             .iter()
             .any(|q| q.name().to_utf8() == META_QUERY_SERVICE_FQDN)
         {
@@ -78,7 +78,7 @@ impl MdnsPacket {
             // one with SERVICE_NAME and one with META_QUERY_SERVICE?
             return Ok(Some(MdnsPacket::ServiceDiscovery(MdnsServiceDiscovery {
                 from,
-                query_id: packet.header().id(),
+                query_id: packet.id,
             })));
         }
 
@@ -154,18 +154,18 @@ impl MdnsResponse {
     /// Creates a new `MdnsResponse` based on the provided `Packet`.
     pub(crate) fn new(packet: &Message, from: SocketAddr) -> MdnsResponse {
         let peers = packet
-            .answers()
+            .answers
             .iter()
             .filter_map(|record| {
-                if record.name().to_string() != SERVICE_NAME_FQDN {
+                if record.name.to_string() != SERVICE_NAME_FQDN {
                     return None;
                 }
 
-                let RData::PTR(record_value) = record.data() else {
+                let RData::PTR(record_value) = &record.data else {
                     return None;
                 };
 
-                MdnsPeer::new(packet, record_value, record.ttl())
+                MdnsPeer::new(packet, record_value, record.ttl)
             })
             .collect();
 
@@ -236,20 +236,20 @@ impl MdnsPeer {
     pub(crate) fn new(packet: &Message, record_value: &Name, ttl: u32) -> Option<MdnsPeer> {
         let mut my_peer_id: Option<PeerId> = None;
         let addrs = packet
-            .additionals()
+            .additionals
             .iter()
             .filter_map(|add_record| {
-                if add_record.name() != record_value {
+                if &add_record.name != record_value {
                     return None;
                 }
 
-                if let RData::TXT(txt) = add_record.data() {
+                if let RData::TXT(txt) = &add_record.data {
                     Some(txt)
                 } else {
                     None
                 }
             })
-            .flat_map(|txt| txt.iter())
+            .flat_map(|txt| txt.txt_data.iter())
             .filter_map(|txt| {
                 // TODO: wrong, txt can be multiple character strings
                 let addr = dns::decode_character_string(txt).ok()?;
@@ -335,13 +335,13 @@ mod tests {
         for bytes in packets {
             let packet = Message::from_vec(&bytes).expect("unable to parse packet");
             let record_value = packet
-                .answers()
+                .answers
                 .iter()
                 .filter_map(|record| {
-                    if record.name().to_utf8() != SERVICE_NAME_FQDN {
+                    if record.name.to_utf8() != SERVICE_NAME_FQDN {
                         return None;
                     }
-                    let RData::PTR(record_value) = record.data() else {
+                    let RData::PTR(record_value) = &record.data else {
                         return None;
                     };
                     Some(record_value)

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -20,8 +20,8 @@
 
 ### Fixed
 
-- Return a DNS resolve error instead of panicking if a generic `Dns` lookup
-  succeeds with no returned IP addresses.
+- Return a DNS resolve error instead of panicking if `Dns`, `Dns4`, or `Dns6`
+  lookups succeed with no matching records.
   See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
 
 ### Changed

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -14,9 +14,8 @@
   helper methods like `ResolveError::is_no_records_found()`.
   See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
 
-### Added
-
-- Add `tokio::Transport::try_custom` for fallible custom resolver construction.
+- Change `tokio::Transport::custom` to return `Result<_, ResolveError>`
+  instead of panicking when Hickory rejects resolver construction.
   See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
 
 ### Fixed

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -9,6 +9,10 @@
   returned `RData` values by record type.
   See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
 
+- Return a DNS resolve error instead of panicking if a generic `Dns` lookup
+  succeeds with no returned IP addresses.
+  See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
+
 - Update DNS transport internals to support `hickory-resolver` 0.26.
   See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
 

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 0.45.0
 
-- Add `tokio::Transport::try_custom` for fallible custom resolver construction.
-  See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
+### Breaking
 
 - Change the hidden public `Resolver` trait's `ipv4_lookup`, `ipv6_lookup`,
   and `txt_lookup` methods to return Hickory's generic `Lookup` type. Custom
@@ -9,9 +8,18 @@
   returned `RData` values by record type.
   See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
 
+### Added
+
+- Add `tokio::Transport::try_custom` for fallible custom resolver construction.
+  See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
+
+### Fixed
+
 - Return a DNS resolve error instead of panicking if a generic `Dns` lookup
   succeeds with no returned IP addresses.
   See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
+
+### Changed
 
 - Update DNS transport internals to support `hickory-resolver` 0.26.
   See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -8,6 +8,12 @@
   returned `RData` values by record type.
   See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
 
+- Replace the re-exported `ResolveError` type with Hickory's `NetError` and
+  remove the `ResolveErrorKind` re-export. Code matching `ResolveErrorKind`
+  should match Hickory's `NetError` / `DnsError` variants directly, or use
+  helper methods like `ResolveError::is_no_records_found()`.
+  See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
+
 ### Added
 
 - Add `tokio::Transport::try_custom` for fallible custom resolver construction.

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.45.0
 
+- Add `tokio::Transport::try_custom` for fallible custom resolver construction.
+  See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
+
 - Update DNS transport internals to support `hickory-resolver` 0.26.
   See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
 

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.45.0
 
+- Update DNS transport internals to support `hickory-resolver` 0.26.
+  See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
+
 - refactor: `Resolver` no longer requires `#[async_trait]`
   See [PR 6292](https://github.com/libp2p/rust-libp2p/pull/6292)
 

--- a/transports/dns/CHANGELOG.md
+++ b/transports/dns/CHANGELOG.md
@@ -3,6 +3,12 @@
 - Add `tokio::Transport::try_custom` for fallible custom resolver construction.
   See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
 
+- Change the hidden public `Resolver` trait's `ipv4_lookup`, `ipv6_lookup`,
+  and `txt_lookup` methods to return Hickory's generic `Lookup` type. Custom
+  resolver implementations must update their method signatures and filter
+  returned `RData` values by record type.
+  See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
+
 - Update DNS transport internals to support `hickory-resolver` 0.26.
   See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
 

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -437,7 +437,7 @@ fn resolve<'a, E: 'a + Send, R: Resolver>(
                     let mut ips = ips.iter();
                     let one = ips
                         .next()
-                        .expect("If there are no results, `Err(NoRecordsFound)` is expected.");
+                        .ok_or_else(|| Error::ResolveError("No Matching Records Found".into()))?;
                     if let Some(two) = ips.next() {
                         Ok(Resolved::Many(
                             iter::once(one)
@@ -766,6 +766,64 @@ mod tests {
         }
 
         test_tokio(CustomTransport, run);
+    }
+
+    #[test]
+    fn dns_empty_lookup_ip_returns_resolve_error() {
+        use hickory_resolver::{
+            lookup::Lookup,
+            lookup_ip::LookupIp,
+            proto::{
+                op::Query,
+                rr::{Name, RecordType},
+            },
+        };
+
+        #[derive(Clone)]
+        struct EmptyLookupResolver;
+
+        fn empty_lookup(name: String, record_type: RecordType) -> Lookup {
+            let query = Query::query(
+                Name::from_ascii(name).expect("test domain name should be valid"),
+                record_type,
+            );
+            Lookup::new_with_max_ttl(query, std::iter::empty())
+        }
+
+        impl Resolver for EmptyLookupResolver {
+            async fn lookup_ip(&self, name: String) -> Result<LookupIp, ResolveError> {
+                Ok(empty_lookup(name, RecordType::A).into())
+            }
+
+            async fn ipv4_lookup(&self, name: String) -> Result<Lookup, ResolveError> {
+                Ok(empty_lookup(name, RecordType::A))
+            }
+
+            async fn ipv6_lookup(&self, name: String) -> Result<Lookup, ResolveError> {
+                Ok(empty_lookup(name, RecordType::AAAA))
+            }
+
+            async fn txt_lookup(&self, name: String) -> Result<Lookup, ResolveError> {
+                Ok(empty_lookup(name, RecordType::TXT))
+            }
+        }
+
+        let rt = ::tokio::runtime::Builder::new_current_thread()
+            .enable_io()
+            .enable_time()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            let resolver = EmptyLookupResolver;
+            let proto = Protocol::Dns("example.com".into());
+
+            match resolve::<std::io::Error, _>(&proto, &resolver).await {
+                Err(Error::ResolveError(_)) => {}
+                Err(e) => panic!("Unexpected error: {e:?}"),
+                Ok(_) => panic!("Unexpected success."),
+            }
+        });
     }
 
     #[test]

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -69,8 +69,8 @@ pub mod tokio {
     impl<T> Transport<T> {
         /// Creates a new [`Transport`] from the OS's DNS configuration and defaults.
         pub fn system(inner: T) -> Result<Transport<T>, std::io::Error> {
-            let (cfg, opts) = system_conf::read_system_conf().map_err(crate::invalid_data)?;
-            Self::try_custom(inner, cfg, opts).map_err(crate::invalid_data)
+            let (cfg, opts) = system_conf::read_system_conf().map_err(crate::system_conf_error)?;
+            Self::try_custom(inner, cfg, opts).map_err(crate::resolver_error_to_io)
         }
 
         /// Creates a [`Transport`] with a custom resolver configuration
@@ -572,6 +572,34 @@ fn invalid_data(e: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> io::E
     io::Error::new(io::ErrorKind::InvalidData, e)
 }
 
+#[cfg(all(
+    feature = "tokio",
+    unix,
+    not(any(target_os = "android", target_vendor = "apple"))
+))]
+fn system_conf_error(e: ResolveError) -> io::Error {
+    resolver_error_to_io(e)
+}
+
+#[cfg(all(
+    feature = "tokio",
+    not(all(unix, not(any(target_os = "android", target_vendor = "apple"))))
+))]
+fn system_conf_error(e: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> io::Error {
+    io::Error::other(e)
+}
+
+#[cfg(feature = "tokio")]
+fn resolver_error_to_io(e: ResolveError) -> io::Error {
+    let kind = match &e {
+        hickory_resolver::net::NetError::Io(source) => source.kind(),
+        hickory_resolver::net::NetError::Timeout => io::ErrorKind::TimedOut,
+        _ => io::ErrorKind::Other,
+    };
+
+    io::Error::new(kind, e)
+}
+
 #[doc(hidden)]
 pub trait Resolver {
     fn lookup_ip(
@@ -782,6 +810,16 @@ mod tests {
         }
 
         test_tokio(CustomTransport, run);
+    }
+
+    #[test]
+    fn resolver_error_to_io_preserves_io_kind_and_source() {
+        let error = resolver_error_to_io(ResolveError::from(std::io::Error::from(
+            std::io::ErrorKind::PermissionDenied,
+        )));
+
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(error.get_ref().is_some());
     }
 
     #[test]

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -30,17 +30,18 @@
 //! a DNS, replacing them with the resolved protocols (typically TCP/IP).
 //!
 //! The [`tokio::Transport`] is enabled by default under the `tokio` feature.
-//! Tokio users can furthermore opt-in to the `tokio-dns-over-rustls` and
-//! `tokio-dns-over-https-rustls` features.
-//! For more information about these features, please refer to the documentation
-//! of [trust-dns-resolver].
+//! Additional resolver transports are controlled by `hickory-resolver`
+//! features.
+//! For more information about these features, please refer to the
+//! [hickory-resolver] documentation.
 //! Alternative runtimes or resolvers can be used though a manual implementation of [`Resolver`].
 //!
-//! On Unix systems, if no custom configuration is given, [trust-dns-resolver]
+//! On Unix systems, if no custom configuration is given, [hickory-resolver]
 //! will try to parse the `/etc/resolv.conf` file. This approach comes with a
 //! few caveats to be aware of:
-//!   1) This fails (panics even!) if `/etc/resolv.conf` does not exist. This is the case on all
-//!      versions of Android.
+//!   1) This fails if `/etc/resolv.conf` does not exist. This is the case on
+//!      all versions of Android. [`tokio::Transport::system`] returns that
+//!      failure as an [`std::io::Error`].
 //!   2) DNS configuration is only evaluated during startup. Runtime changes are thus ignored.
 //!   3) DNS resolution is obviously done in process and consequently not using any system APIs
 //!      (like libc's `gethostbyname`). Again this is problematic on platforms like Android, where
@@ -51,7 +52,7 @@
 //! platform specific APIs to extract the host's DNS configuration (if possible)
 //! and provide a custom [`ResolverConfig`].
 //!
-//! [trust-dns-resolver]: https://docs.rs/trust-dns-resolver/latest/trust_dns_resolver/#dns-over-tls-and-dns-over-https
+//! [hickory-resolver]: https://docs.rs/hickory-resolver
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
@@ -343,6 +344,8 @@ where
             if !dial_errors.is_empty() {
                 Err(Error::Dial(dial_errors))
             } else {
+                // No single DNS query owns this error: all lookups succeeded, but none produced
+                // a protocol compatible with the dialed address.
                 Err(Error::ResolveError(no_records_found(Query::default())))
             }
         }

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -70,26 +70,15 @@ pub mod tokio {
         /// Creates a new [`Transport`] from the OS's DNS configuration and defaults.
         pub fn system(inner: T) -> Result<Transport<T>, std::io::Error> {
             let (cfg, opts) = system_conf::read_system_conf().map_err(crate::system_conf_error)?;
-            Self::try_custom(inner, cfg, opts).map_err(crate::resolver_error_to_io)
+            Self::custom(inner, cfg, opts).map_err(crate::resolver_error_to_io)
         }
 
         /// Creates a [`Transport`] with a custom resolver configuration
         /// and options.
         ///
-        /// Panics if the underlying Hickory resolver cannot be constructed. Use
-        /// [`Self::try_custom`] to handle this case.
+        /// Returns an error if the underlying Hickory resolver cannot be
+        /// constructed.
         pub fn custom(
-            inner: T,
-            cfg: hickory_resolver::config::ResolverConfig,
-            opts: hickory_resolver::config::ResolverOpts,
-        ) -> Transport<T> {
-            Self::try_custom(inner, cfg, opts).expect("hickory resolver construction to be valid")
-        }
-
-        /// Creates a [`Transport`] with a custom resolver configuration
-        /// and options, returning an error if the underlying Hickory resolver
-        /// cannot be constructed.
-        pub fn try_custom(
             inner: T,
             cfg: hickory_resolver::config::ResolverConfig,
             opts: hickory_resolver::config::ResolverOpts,
@@ -657,7 +646,7 @@ mod tests {
     ) {
         let config = ResolverConfig::udp_and_tcp(&hickory_resolver::config::QUAD9);
         let opts = ResolverOpts::default();
-        let transport = tokio::Transport::try_custom(transport, config, opts).unwrap();
+        let transport = tokio::Transport::custom(transport, config, opts).unwrap();
         let rt = ::tokio::runtime::Builder::new_current_thread()
             .enable_io()
             .enable_time()

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -85,7 +85,12 @@ pub mod tokio {
                 resolver: TokioResolver::builder_with_config(cfg, TokioRuntimeProvider::default())
                     .with_options(opts)
                     .build()
-                    .expect("resolver configuration to be valid"),
+                    // With libp2p-dns' Hickory features (`system-config` and `tokio`),
+                    // `build` does not validate the caller-provided config or options.
+                    // It only returns an error for Hickory feature combinations that construct
+                    // TLS config, which this crate does not enable. Exposing the `Result` is
+                    // tracked in libp2p/rust-libp2p#6420 for the next breaking release.
+                    .expect("hickory resolver construction to be infallible"),
             }
         }
     }

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -70,28 +70,36 @@ pub mod tokio {
         /// Creates a new [`Transport`] from the OS's DNS configuration and defaults.
         pub fn system(inner: T) -> Result<Transport<T>, std::io::Error> {
             let (cfg, opts) = system_conf::read_system_conf().map_err(crate::invalid_data)?;
-            Ok(Self::custom(inner, cfg, opts))
+            Self::try_custom(inner, cfg, opts).map_err(crate::invalid_data)
         }
 
         /// Creates a [`Transport`] with a custom resolver configuration
         /// and options.
+        ///
+        /// Panics if the underlying Hickory resolver cannot be constructed. Use
+        /// [`Self::try_custom`] to handle this case.
         pub fn custom(
             inner: T,
             cfg: hickory_resolver::config::ResolverConfig,
             opts: hickory_resolver::config::ResolverOpts,
         ) -> Transport<T> {
-            Transport {
+            Self::try_custom(inner, cfg, opts).expect("hickory resolver construction to be valid")
+        }
+
+        /// Creates a [`Transport`] with a custom resolver configuration
+        /// and options, returning an error if the underlying Hickory resolver
+        /// cannot be constructed.
+        pub fn try_custom(
+            inner: T,
+            cfg: hickory_resolver::config::ResolverConfig,
+            opts: hickory_resolver::config::ResolverOpts,
+        ) -> Result<Transport<T>, crate::ResolveError> {
+            Ok(Transport {
                 inner: Arc::new(Mutex::new(inner)),
                 resolver: TokioResolver::builder_with_config(cfg, TokioRuntimeProvider::default())
                     .with_options(opts)
-                    .build()
-                    // With libp2p-dns' Hickory features (`system-config` and `tokio`),
-                    // `build` does not validate the caller-provided config or options.
-                    // It only returns an error for Hickory feature combinations that construct
-                    // TLS config, which this crate does not enable. Exposing the `Result` is
-                    // tracked in libp2p/rust-libp2p#6420 for the next breaking release.
-                    .expect("hickory resolver construction to be infallible"),
-            }
+                    .build()?,
+            })
         }
     }
 }
@@ -605,7 +613,7 @@ mod tests {
     ) {
         let config = ResolverConfig::udp_and_tcp(&hickory_resolver::config::QUAD9);
         let opts = ResolverOpts::default();
-        let transport = tokio::Transport::custom(transport, config, opts);
+        let transport = tokio::Transport::try_custom(transport, config, opts).unwrap();
         let rt = ::tokio::runtime::Builder::new_current_thread()
             .enable_io()
             .enable_time()

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -39,9 +39,8 @@
 //! On Unix systems, if no custom configuration is given, [hickory-resolver]
 //! will try to parse the `/etc/resolv.conf` file. This approach comes with a
 //! few caveats to be aware of:
-//!   1) This fails if `/etc/resolv.conf` does not exist. This is the case on
-//!      all versions of Android. [`tokio::Transport::system`] returns that
-//!      failure as an [`std::io::Error`].
+//!   1) This fails if `/etc/resolv.conf` does not exist. This is the case on all versions of
+//!      Android. [`tokio::Transport::system`] returns that failure as an [`std::io::Error`].
 //!   2) DNS configuration is only evaluated during startup. Runtime changes are thus ignored.
 //!   3) DNS resolution is obviously done in process and consequently not using any system APIs
 //!      (like libc's `gethostbyname`). Again this is problematic on platforms like Android, where

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -506,16 +506,16 @@ fn resolve<'a, E: 'a + Send, R: Resolver>(
                     Ok(lookup) => {
                         let mut addrs = Vec::new();
                         for record in lookup.answers() {
-                            if let RData::TXT(txt) = &record.data {
-                                if let Some(chars) = txt.txt_data.first() {
-                                    match parse_dnsaddr_txt(chars) {
-                                        Err(e) => {
-                                            // Skip over seemingly invalid entries.
-                                            tracing::debug!("Invalid TXT record: {:?}", e);
-                                        }
-                                        Ok(a) => {
-                                            addrs.push(a);
-                                        }
+                            if let RData::TXT(txt) = &record.data
+                                && let Some(chars) = txt.txt_data.first()
+                            {
+                                match parse_dnsaddr_txt(chars) {
+                                    Err(e) => {
+                                        // Skip over seemingly invalid entries.
+                                        tracing::debug!("Invalid TXT record: {:?}", e);
+                                    }
+                                    Ok(a) => {
+                                        addrs.push(a);
                                     }
                                 }
                             }

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -59,7 +59,7 @@
 pub mod tokio {
     use std::sync::Arc;
 
-    use hickory_resolver::{TokioResolver, name_server::TokioConnectionProvider, system_conf};
+    use hickory_resolver::{TokioResolver, net::runtime::TokioRuntimeProvider, system_conf};
     use parking_lot::Mutex;
 
     /// A `Transport` wrapper for performing DNS lookups when dialing `Multiaddr`esses
@@ -69,7 +69,7 @@ pub mod tokio {
     impl<T> Transport<T> {
         /// Creates a new [`Transport`] from the OS's DNS configuration and defaults.
         pub fn system(inner: T) -> Result<Transport<T>, std::io::Error> {
-            let (cfg, opts) = system_conf::read_system_conf()?;
+            let (cfg, opts) = system_conf::read_system_conf().map_err(crate::invalid_data)?;
             Ok(Self::custom(inner, cfg, opts))
         }
 
@@ -82,12 +82,10 @@ pub mod tokio {
         ) -> Transport<T> {
             Transport {
                 inner: Arc::new(Mutex::new(inner)),
-                resolver: TokioResolver::builder_with_config(
-                    cfg,
-                    TokioConnectionProvider::default(),
-                )
-                .with_options(opts)
-                .build(),
+                resolver: TokioResolver::builder_with_config(cfg, TokioRuntimeProvider::default())
+                    .with_options(opts)
+                    .build()
+                    .expect("resolver configuration to be valid"),
             }
         }
     }
@@ -104,14 +102,10 @@ use std::{
 };
 
 use futures::{future::BoxFuture, prelude::*};
+use hickory_resolver::{ConnectionProvider, lookup::Lookup, lookup_ip::LookupIp, proto::rr::RData};
 pub use hickory_resolver::{
-    ResolveError, ResolveErrorKind,
     config::{ResolverConfig, ResolverOpts},
-};
-use hickory_resolver::{
-    lookup::{Ipv4Lookup, Ipv6Lookup, TxtLookup},
-    lookup_ip::LookupIp,
-    name_server::ConnectionProvider,
+    net::NetError as ResolveError,
 };
 use libp2p_core::{
     multiaddr::{Multiaddr, Protocol},
@@ -334,9 +328,7 @@ where
             if !dial_errors.is_empty() {
                 Err(Error::Dial(dial_errors))
             } else {
-                Err(Error::ResolveError(
-                    ResolveErrorKind::Message("No Matching Records Found").into(),
-                ))
+                Err(Error::ResolveError("No Matching Records Found".into()))
             }
         }
         .boxed()
@@ -429,7 +421,7 @@ fn resolve<'a, E: 'a + Send, R: Resolver>(
             .lookup_ip(name.clone().into_owned())
             .map(move |res| match res {
                 Ok(ips) => {
-                    let mut ips = ips.into_iter();
+                    let mut ips = ips.iter();
                     let one = ips
                         .next()
                         .expect("If there are no results, `Err(NoRecordsFound)` is expected.");
@@ -451,22 +443,27 @@ fn resolve<'a, E: 'a + Send, R: Resolver>(
         Protocol::Dns4(name) => resolver
             .ipv4_lookup(name.clone().into_owned())
             .map(move |res| match res {
-                Ok(ips) => {
-                    let mut ips = ips.into_iter();
+                Ok(lookup) => {
+                    let mut ips = lookup.answers().iter().filter_map(|record| {
+                        if let RData::A(ip) = &record.data {
+                            Some(Ipv4Addr::from(*ip))
+                        } else {
+                            None
+                        }
+                    });
                     let one = ips
                         .next()
-                        .expect("If there are no results, `Err(NoRecordsFound)` is expected.");
+                        .ok_or_else(|| Error::ResolveError("No Matching Records Found".into()))?;
                     if let Some(two) = ips.next() {
                         Ok(Resolved::Many(
                             iter::once(one)
                                 .chain(iter::once(two))
                                 .chain(ips)
-                                .map(Ipv4Addr::from)
                                 .map(Protocol::from)
                                 .collect(),
                         ))
                     } else {
-                        Ok(Resolved::One(Protocol::from(Ipv4Addr::from(one))))
+                        Ok(Resolved::One(Protocol::from(one)))
                     }
                 }
                 Err(e) => Err(Error::ResolveError(e)),
@@ -475,22 +472,27 @@ fn resolve<'a, E: 'a + Send, R: Resolver>(
         Protocol::Dns6(name) => resolver
             .ipv6_lookup(name.clone().into_owned())
             .map(move |res| match res {
-                Ok(ips) => {
-                    let mut ips = ips.into_iter();
+                Ok(lookup) => {
+                    let mut ips = lookup.answers().iter().filter_map(|record| {
+                        if let RData::AAAA(ip) = &record.data {
+                            Some(Ipv6Addr::from(*ip))
+                        } else {
+                            None
+                        }
+                    });
                     let one = ips
                         .next()
-                        .expect("If there are no results, `Err(NoRecordsFound)` is expected.");
+                        .ok_or_else(|| Error::ResolveError("No Matching Records Found".into()))?;
                     if let Some(two) = ips.next() {
                         Ok(Resolved::Many(
                             iter::once(one)
                                 .chain(iter::once(two))
                                 .chain(ips)
-                                .map(Ipv6Addr::from)
                                 .map(Protocol::from)
                                 .collect(),
                         ))
                     } else {
-                        Ok(Resolved::One(Protocol::from(Ipv6Addr::from(one))))
+                        Ok(Resolved::One(Protocol::from(one)))
                     }
                 }
                 Err(e) => Err(Error::ResolveError(e)),
@@ -501,17 +503,19 @@ fn resolve<'a, E: 'a + Send, R: Resolver>(
             resolver
                 .txt_lookup(name)
                 .map(move |res| match res {
-                    Ok(txts) => {
+                    Ok(lookup) => {
                         let mut addrs = Vec::new();
-                        for txt in txts {
-                            if let Some(chars) = txt.txt_data().first() {
-                                match parse_dnsaddr_txt(chars) {
-                                    Err(e) => {
-                                        // Skip over seemingly invalid entries.
-                                        tracing::debug!("Invalid TXT record: {:?}", e);
-                                    }
-                                    Ok(a) => {
-                                        addrs.push(a);
+                        for record in lookup.answers() {
+                            if let RData::TXT(txt) = &record.data {
+                                if let Some(chars) = txt.txt_data.first() {
+                                    match parse_dnsaddr_txt(chars) {
+                                        Err(e) => {
+                                            // Skip over seemingly invalid entries.
+                                            tracing::debug!("Invalid TXT record: {:?}", e);
+                                        }
+                                        Ok(a) => {
+                                            addrs.push(a);
+                                        }
                                     }
                                 }
                             }
@@ -548,15 +552,13 @@ pub trait Resolver {
     fn ipv4_lookup(
         &self,
         name: String,
-    ) -> impl Future<Output = Result<Ipv4Lookup, ResolveError>> + Send;
+    ) -> impl Future<Output = Result<Lookup, ResolveError>> + Send;
     fn ipv6_lookup(
         &self,
         name: String,
-    ) -> impl Future<Output = Result<Ipv6Lookup, ResolveError>> + Send;
-    fn txt_lookup(
-        &self,
-        name: String,
-    ) -> impl Future<Output = Result<TxtLookup, ResolveError>> + Send;
+    ) -> impl Future<Output = Result<Lookup, ResolveError>> + Send;
+    fn txt_lookup(&self, name: String)
+    -> impl Future<Output = Result<Lookup, ResolveError>> + Send;
 }
 
 impl<C> Resolver for hickory_resolver::Resolver<C>
@@ -567,15 +569,15 @@ where
         self.lookup_ip(name).await
     }
 
-    async fn ipv4_lookup(&self, name: String) -> Result<Ipv4Lookup, ResolveError> {
+    async fn ipv4_lookup(&self, name: String) -> Result<Lookup, ResolveError> {
         self.ipv4_lookup(name).await
     }
 
-    async fn ipv6_lookup(&self, name: String) -> Result<Ipv6Lookup, ResolveError> {
+    async fn ipv6_lookup(&self, name: String) -> Result<Lookup, ResolveError> {
         self.ipv6_lookup(name).await
     }
 
-    async fn txt_lookup(&self, name: String) -> Result<TxtLookup, ResolveError> {
+    async fn txt_lookup(&self, name: String) -> Result<Lookup, ResolveError> {
         self.txt_lookup(name).await
     }
 }
@@ -583,7 +585,6 @@ where
 #[cfg(all(test, feature = "tokio"))]
 mod tests {
     use futures::future::BoxFuture;
-    use hickory_resolver::proto::{ProtoError, ProtoErrorKind};
     use libp2p_core::{
         Endpoint, Transport,
         multiaddr::{Multiaddr, Protocol},
@@ -597,7 +598,7 @@ mod tests {
         transport: T,
         test_fn: impl FnOnce(tokio::Transport<T>) -> F,
     ) {
-        let config = ResolverConfig::quad9();
+        let config = ResolverConfig::udp_and_tcp(&hickory_resolver::config::QUAD9);
         let opts = ResolverOpts::default();
         let transport = tokio::Transport::custom(transport, config, opts);
         let rt = ::tokio::runtime::Builder::new_current_thread()
@@ -739,14 +740,7 @@ mod tests {
                     );
 
                     match &dial_errs[0] {
-                        Error::ResolveError(e) => match e.kind() {
-                            ResolveErrorKind::Proto(ProtoError { kind, .. })
-                                if matches!(
-                                    kind.as_ref(),
-                                    ProtoErrorKind::NoRecordsFound { .. }
-                                ) => {}
-                            _ => panic!("Unexpected DNS error: {e:?}"),
-                        },
+                        Error::ResolveError(e) if e.is_no_records_found() => {}
                         other => {
                             panic!("Expected a single ResolveError(...) sub-error, got {other:?}")
                         }

--- a/transports/dns/src/lib.rs
+++ b/transports/dns/src/lib.rs
@@ -115,7 +115,16 @@ use std::{
 };
 
 use futures::{future::BoxFuture, prelude::*};
-use hickory_resolver::{ConnectionProvider, lookup::Lookup, lookup_ip::LookupIp, proto::rr::RData};
+use hickory_resolver::{
+    ConnectionProvider,
+    lookup::Lookup,
+    lookup_ip::LookupIp,
+    net::NoRecords,
+    proto::{
+        op::{Query, ResponseCode},
+        rr::RData,
+    },
+};
 pub use hickory_resolver::{
     config::{ResolverConfig, ResolverOpts},
     net::NetError as ResolveError,
@@ -144,6 +153,10 @@ const MAX_DNS_LOOKUPS: usize = 32;
 /// being dialed that are considered for further lookups as a
 /// result of a single `/dnsaddr` lookup.
 const MAX_TXT_RECORDS: usize = 16;
+
+fn no_records_found(query: Query) -> ResolveError {
+    NoRecords::new(query, ResponseCode::NoError).into()
+}
 
 /// A [`Transport`] for performing DNS lookups when dialing `Multiaddr`esses.
 /// You shouldn't need to use this type directly. Use [`tokio::Transport`] instead.
@@ -341,7 +354,7 @@ where
             if !dial_errors.is_empty() {
                 Err(Error::Dial(dial_errors))
             } else {
-                Err(Error::ResolveError("No Matching Records Found".into()))
+                Err(Error::ResolveError(no_records_found(Query::default())))
             }
         }
         .boxed()
@@ -434,10 +447,11 @@ fn resolve<'a, E: 'a + Send, R: Resolver>(
             .lookup_ip(name.clone().into_owned())
             .map(move |res| match res {
                 Ok(ips) => {
+                    let query = ips.query().clone();
                     let mut ips = ips.iter();
                     let one = ips
                         .next()
-                        .ok_or_else(|| Error::ResolveError("No Matching Records Found".into()))?;
+                        .ok_or_else(|| Error::ResolveError(no_records_found(query)))?;
                     if let Some(two) = ips.next() {
                         Ok(Resolved::Many(
                             iter::once(one)
@@ -457,6 +471,7 @@ fn resolve<'a, E: 'a + Send, R: Resolver>(
             .ipv4_lookup(name.clone().into_owned())
             .map(move |res| match res {
                 Ok(lookup) => {
+                    let query = lookup.query().clone();
                     let mut ips = lookup.answers().iter().filter_map(|record| {
                         if let RData::A(ip) = &record.data {
                             Some(Ipv4Addr::from(*ip))
@@ -466,7 +481,7 @@ fn resolve<'a, E: 'a + Send, R: Resolver>(
                     });
                     let one = ips
                         .next()
-                        .ok_or_else(|| Error::ResolveError("No Matching Records Found".into()))?;
+                        .ok_or_else(|| Error::ResolveError(no_records_found(query)))?;
                     if let Some(two) = ips.next() {
                         Ok(Resolved::Many(
                             iter::once(one)
@@ -486,6 +501,7 @@ fn resolve<'a, E: 'a + Send, R: Resolver>(
             .ipv6_lookup(name.clone().into_owned())
             .map(move |res| match res {
                 Ok(lookup) => {
+                    let query = lookup.query().clone();
                     let mut ips = lookup.answers().iter().filter_map(|record| {
                         if let RData::AAAA(ip) = &record.data {
                             Some(Ipv6Addr::from(*ip))
@@ -495,7 +511,7 @@ fn resolve<'a, E: 'a + Send, R: Resolver>(
                     });
                     let one = ips
                         .next()
-                        .ok_or_else(|| Error::ResolveError("No Matching Records Found".into()))?;
+                        .ok_or_else(|| Error::ResolveError(no_records_found(query)))?;
                     if let Some(two) = ips.next() {
                         Ok(Resolved::Many(
                             iter::once(one)
@@ -731,7 +747,7 @@ mod tests {
                 .unwrap()
                 .await
             {
-                Err(Error::ResolveError(_)) => {}
+                Err(Error::ResolveError(e)) if e.is_no_records_found() => {}
                 Err(e) => panic!("Unexpected error: {e:?}"),
                 Ok(_) => panic!("Unexpected success."),
             }
@@ -769,7 +785,7 @@ mod tests {
     }
 
     #[test]
-    fn dns_empty_lookup_ip_returns_resolve_error() {
+    fn empty_dns_lookups_return_no_records_error() {
         use hickory_resolver::{
             lookup::Lookup,
             lookup_ip::LookupIp,
@@ -815,13 +831,18 @@ mod tests {
             .unwrap();
 
         rt.block_on(async {
-            let resolver = EmptyLookupResolver;
-            let proto = Protocol::Dns("example.com".into());
+            for proto in [
+                Protocol::Dns("example.com".into()),
+                Protocol::Dns4("example.com".into()),
+                Protocol::Dns6("example.com".into()),
+            ] {
+                let resolver = EmptyLookupResolver;
 
-            match resolve::<std::io::Error, _>(&proto, &resolver).await {
-                Err(Error::ResolveError(_)) => {}
-                Err(e) => panic!("Unexpected error: {e:?}"),
-                Ok(_) => panic!("Unexpected success."),
+                match resolve::<std::io::Error, _>(&proto, &resolver).await {
+                    Err(Error::ResolveError(e)) if e.is_no_records_found() => {}
+                    Err(e) => panic!("Unexpected error: {e:?}"),
+                    Ok(_) => panic!("Unexpected success."),
+                }
             }
         });
     }

--- a/transports/tls/CHANGELOG.md
+++ b/transports/tls/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Raise MSRV to 1.88.0.
   See [PR 6273](https://github.com/libp2p/rust-libp2p/pull/6273).
 
+- Update `rustls-webpki` in the lockfile.
+  See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
+
 ## 0.6.3
 
 - Enable rustls TLS key logging via `SSLKEYLOGFILE`.

--- a/transports/tls/CHANGELOG.md
+++ b/transports/tls/CHANGELOG.md
@@ -3,7 +3,8 @@
 - Raise MSRV to 1.88.0.
   See [PR 6273](https://github.com/libp2p/rust-libp2p/pull/6273).
 
-- Update `rustls-webpki` in the lockfile.
+- Update `rustls-webpki` in the lockfile and use its contextual
+  signature-algorithm errors.
   See [PR 6418](https://github.com/libp2p/rust-libp2p/pull/6418).
 
 ## 0.6.3

--- a/transports/tls/src/certificate.rs
+++ b/transports/tls/src/certificate.rs
@@ -44,14 +44,41 @@ const P2P_SIGNING_PREFIX: [u8; 21] = *b"libp2p-tls-handshake:";
 // Similarly, hash functions with an output length less than 256 bits MUST NOT be used.
 static P2P_SIGNATURE_ALGORITHM: &rcgen::SignatureAlgorithm = &rcgen::PKCS_ECDSA_P256_SHA256;
 
-#[allow(deprecated)]
-fn unsupported_signature_algorithm() -> webpki::Error {
-    webpki::Error::UnsupportedSignatureAlgorithm
+fn supported_signature_algorithms() -> Vec<rustls::pki_types::AlgorithmIdentifier> {
+    use rustls::pki_types::alg_id;
+
+    vec![
+        alg_id::ECDSA_SHA256,
+        alg_id::ECDSA_SHA384,
+        alg_id::ED25519,
+        alg_id::RSA_PKCS1_SHA256,
+        alg_id::RSA_PKCS1_SHA384,
+        alg_id::RSA_PKCS1_SHA512,
+        alg_id::RSA_PSS_SHA256,
+        alg_id::RSA_PSS_SHA384,
+        alg_id::RSA_PSS_SHA512,
+    ]
 }
 
-#[allow(deprecated)]
-fn unsupported_signature_algorithm_for_public_key() -> webpki::Error {
-    webpki::Error::UnsupportedSignatureAlgorithmForPublicKey
+fn unsupported_signature_algorithm(signature_algorithm: &AlgorithmIdentifier<'_>) -> webpki::Error {
+    webpki::Error::UnsupportedSignatureAlgorithmContext(
+        webpki::UnsupportedSignatureAlgorithmContext {
+            signature_algorithm_id: signature_algorithm.algorithm.as_bytes().to_vec(),
+            supported_algorithms: supported_signature_algorithms(),
+        },
+    )
+}
+
+fn unsupported_signature_algorithm_for_public_key(
+    signature_algorithm: &AlgorithmIdentifier<'_>,
+    public_key_algorithm: &AlgorithmIdentifier<'_>,
+) -> webpki::Error {
+    webpki::Error::UnsupportedSignatureAlgorithmForPublicKeyContext(
+        webpki::UnsupportedSignatureAlgorithmForPublicKeyContext {
+            signature_algorithm_id: signature_algorithm.algorithm.as_bytes().to_vec(),
+            public_key_algorithm_id: public_key_algorithm.algorithm.as_bytes().to_vec(),
+        },
+    )
 }
 
 #[derive(Debug)]
@@ -315,9 +342,16 @@ impl P2pCertificate<'_> {
         use rustls::SignatureScheme::*;
 
         let current_signature_scheme = self.signature_scheme()?;
+        let spki = &self.certificate.tbs_certificate.subject_pki;
+        let signature_algorithm = &self.certificate.signature_algorithm;
+        let public_key_algorithm = &spki.algorithm;
+
         if signature_scheme != current_signature_scheme {
             // This certificate was signed with a different signature scheme
-            return Err(unsupported_signature_algorithm_for_public_key());
+            return Err(unsupported_signature_algorithm_for_public_key(
+                signature_algorithm,
+                public_key_algorithm,
+            ));
         }
 
         let verification_algorithm: &dyn signature::VerificationAlgorithm = match signature_scheme {
@@ -328,7 +362,7 @@ impl P2pCertificate<'_> {
             ECDSA_NISTP384_SHA384 => &signature::ECDSA_P384_SHA384_ASN1,
             ECDSA_NISTP521_SHA512 => {
                 // See https://github.com/briansmith/ring/issues/824
-                return Err(unsupported_signature_algorithm());
+                return Err(unsupported_signature_algorithm(signature_algorithm));
             }
             RSA_PSS_SHA256 => &signature::RSA_PSS_2048_8192_SHA256,
             RSA_PSS_SHA384 => &signature::RSA_PSS_2048_8192_SHA384,
@@ -336,16 +370,15 @@ impl P2pCertificate<'_> {
             ED25519 => &signature::ED25519,
             ED448 => {
                 // See https://github.com/briansmith/ring/issues/463
-                return Err(unsupported_signature_algorithm());
+                return Err(unsupported_signature_algorithm(signature_algorithm));
             }
             // Similarly, hash functions with an output length less than 256 bits
             // MUST NOT be used, due to the possibility of collision attacks.
             // In particular, MD5 and SHA1 MUST NOT be used.
-            RSA_PKCS1_SHA1 => return Err(unsupported_signature_algorithm()),
-            ECDSA_SHA1_Legacy => return Err(unsupported_signature_algorithm()),
-            _ => return Err(unsupported_signature_algorithm()),
+            RSA_PKCS1_SHA1 => return Err(unsupported_signature_algorithm(signature_algorithm)),
+            ECDSA_SHA1_Legacy => return Err(unsupported_signature_algorithm(signature_algorithm)),
+            _ => return Err(unsupported_signature_algorithm(signature_algorithm)),
         };
-        let spki = &self.certificate.tbs_certificate.subject_pki;
         let key = signature::UnparsedPublicKey::new(
             verification_algorithm,
             spki.subject_public_key.as_ref(),
@@ -456,7 +489,7 @@ impl P2pCertificate<'_> {
 
                 // Default hash algo is SHA-1, however:
                 // In particular, MD5 and SHA1 MUST NOT be used.
-                return Err(unsupported_signature_algorithm());
+                return Err(unsupported_signature_algorithm(signature_algorithm));
             }
         }
 
@@ -482,7 +515,7 @@ impl P2pCertificate<'_> {
             {
                 return Ok(ECDSA_NISTP521_SHA512);
             }
-            return Err(unsupported_signature_algorithm());
+            return Err(unsupported_signature_algorithm(signature_algorithm));
         }
 
         if signature_algorithm.algorithm == OID_SIG_ED25519 {
@@ -492,7 +525,7 @@ impl P2pCertificate<'_> {
             return Ok(ED448);
         }
 
-        Err(unsupported_signature_algorithm())
+        Err(unsupported_signature_algorithm(signature_algorithm))
     }
 }
 

--- a/transports/tls/src/certificate.rs
+++ b/transports/tls/src/certificate.rs
@@ -44,6 +44,16 @@ const P2P_SIGNING_PREFIX: [u8; 21] = *b"libp2p-tls-handshake:";
 // Similarly, hash functions with an output length less than 256 bits MUST NOT be used.
 static P2P_SIGNATURE_ALGORITHM: &rcgen::SignatureAlgorithm = &rcgen::PKCS_ECDSA_P256_SHA256;
 
+#[allow(deprecated)]
+fn unsupported_signature_algorithm() -> webpki::Error {
+    webpki::Error::UnsupportedSignatureAlgorithm
+}
+
+#[allow(deprecated)]
+fn unsupported_signature_algorithm_for_public_key() -> webpki::Error {
+    webpki::Error::UnsupportedSignatureAlgorithmForPublicKey
+}
+
 #[derive(Debug)]
 pub(crate) struct AlwaysResolvesCert(Arc<rustls::sign::CertifiedKey>);
 
@@ -307,7 +317,7 @@ impl P2pCertificate<'_> {
         let current_signature_scheme = self.signature_scheme()?;
         if signature_scheme != current_signature_scheme {
             // This certificate was signed with a different signature scheme
-            return Err(webpki::Error::UnsupportedSignatureAlgorithmForPublicKey);
+            return Err(unsupported_signature_algorithm_for_public_key());
         }
 
         let verification_algorithm: &dyn signature::VerificationAlgorithm = match signature_scheme {
@@ -318,7 +328,7 @@ impl P2pCertificate<'_> {
             ECDSA_NISTP384_SHA384 => &signature::ECDSA_P384_SHA384_ASN1,
             ECDSA_NISTP521_SHA512 => {
                 // See https://github.com/briansmith/ring/issues/824
-                return Err(webpki::Error::UnsupportedSignatureAlgorithm);
+                return Err(unsupported_signature_algorithm());
             }
             RSA_PSS_SHA256 => &signature::RSA_PSS_2048_8192_SHA256,
             RSA_PSS_SHA384 => &signature::RSA_PSS_2048_8192_SHA384,
@@ -326,14 +336,14 @@ impl P2pCertificate<'_> {
             ED25519 => &signature::ED25519,
             ED448 => {
                 // See https://github.com/briansmith/ring/issues/463
-                return Err(webpki::Error::UnsupportedSignatureAlgorithm);
+                return Err(unsupported_signature_algorithm());
             }
             // Similarly, hash functions with an output length less than 256 bits
             // MUST NOT be used, due to the possibility of collision attacks.
             // In particular, MD5 and SHA1 MUST NOT be used.
-            RSA_PKCS1_SHA1 => return Err(webpki::Error::UnsupportedSignatureAlgorithm),
-            ECDSA_SHA1_Legacy => return Err(webpki::Error::UnsupportedSignatureAlgorithm),
-            _ => return Err(webpki::Error::UnsupportedSignatureAlgorithm),
+            RSA_PKCS1_SHA1 => return Err(unsupported_signature_algorithm()),
+            ECDSA_SHA1_Legacy => return Err(unsupported_signature_algorithm()),
+            _ => return Err(unsupported_signature_algorithm()),
         };
         let spki = &self.certificate.tbs_certificate.subject_pki;
         let key = signature::UnparsedPublicKey::new(
@@ -446,7 +456,7 @@ impl P2pCertificate<'_> {
 
                 // Default hash algo is SHA-1, however:
                 // In particular, MD5 and SHA1 MUST NOT be used.
-                return Err(webpki::Error::UnsupportedSignatureAlgorithm);
+                return Err(unsupported_signature_algorithm());
             }
         }
 
@@ -472,7 +482,7 @@ impl P2pCertificate<'_> {
             {
                 return Ok(ECDSA_NISTP521_SHA512);
             }
-            return Err(webpki::Error::UnsupportedSignatureAlgorithm);
+            return Err(unsupported_signature_algorithm());
         }
 
         if signature_algorithm.algorithm == OID_SIG_ED25519 {
@@ -482,7 +492,7 @@ impl P2pCertificate<'_> {
             return Ok(ED448);
         }
 
-        Err(webpki::Error::UnsupportedSignatureAlgorithm)
+        Err(unsupported_signature_algorithm())
     }
 }
 

--- a/transports/tls/src/certificate.rs
+++ b/transports/tls/src/certificate.rs
@@ -26,8 +26,7 @@ use std::sync::Arc;
 
 use libp2p_identity as identity;
 use libp2p_identity::PeerId;
-use x509_parser::asn1_rs::ToDer;
-use x509_parser::{prelude::*, signature_algorithm::SignatureAlgorithm};
+use x509_parser::{asn1_rs::ToDer, prelude::*, signature_algorithm::SignatureAlgorithm};
 
 /// The libp2p Public Key Extension is a X.509 extension
 /// with the Object Identifier 1.3.6.1.4.1.53594.1.1,

--- a/transports/tls/src/certificate.rs
+++ b/transports/tls/src/certificate.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 
 use libp2p_identity as identity;
 use libp2p_identity::PeerId;
+use x509_parser::asn1_rs::ToDer;
 use x509_parser::{prelude::*, signature_algorithm::SignatureAlgorithm};
 
 /// The libp2p Public Key Extension is a X.509 extension
@@ -60,10 +61,30 @@ fn supported_signature_algorithms() -> Vec<rustls::pki_types::AlgorithmIdentifie
     ]
 }
 
+fn algorithm_identifier_value(
+    algorithm_identifier: &AlgorithmIdentifier<'_>,
+) -> Result<Vec<u8>, webpki::Error> {
+    let mut content = algorithm_identifier
+        .algorithm
+        .to_der_vec()
+        .map_err(|_| webpki::Error::BadDer)?;
+
+    if let Some(parameters) = &algorithm_identifier.parameters {
+        content.extend(parameters.to_der_vec().map_err(|_| webpki::Error::BadDer)?);
+    }
+
+    Ok(content)
+}
+
 fn unsupported_signature_algorithm(signature_algorithm: &AlgorithmIdentifier<'_>) -> webpki::Error {
+    let signature_algorithm_id = match algorithm_identifier_value(signature_algorithm) {
+        Ok(id) => id,
+        Err(err) => return err,
+    };
+
     webpki::Error::UnsupportedSignatureAlgorithmContext(
         webpki::UnsupportedSignatureAlgorithmContext {
-            signature_algorithm_id: signature_algorithm.algorithm.as_bytes().to_vec(),
+            signature_algorithm_id,
             supported_algorithms: supported_signature_algorithms(),
         },
     )
@@ -73,10 +94,19 @@ fn unsupported_signature_algorithm_for_public_key(
     signature_algorithm: &AlgorithmIdentifier<'_>,
     public_key_algorithm: &AlgorithmIdentifier<'_>,
 ) -> webpki::Error {
+    let signature_algorithm_id = match algorithm_identifier_value(signature_algorithm) {
+        Ok(id) => id,
+        Err(err) => return err,
+    };
+    let public_key_algorithm_id = match algorithm_identifier_value(public_key_algorithm) {
+        Ok(id) => id,
+        Err(err) => return err,
+    };
+
     webpki::Error::UnsupportedSignatureAlgorithmForPublicKeyContext(
         webpki::UnsupportedSignatureAlgorithmForPublicKeyContext {
-            signature_algorithm_id: signature_algorithm.algorithm.as_bytes().to_vec(),
-            public_key_algorithm_id: public_key_algorithm.algorithm.as_bytes().to_vec(),
+            signature_algorithm_id,
+            public_key_algorithm_id,
         },
     )
 }
@@ -532,8 +562,15 @@ impl P2pCertificate<'_> {
 #[cfg(test)]
 mod tests {
     use hex_literal::hex;
+    use x509_parser::asn1_rs::FromDer;
 
     use super::*;
+
+    fn parse_algorithm_identifier(der: &[u8]) -> AlgorithmIdentifier<'_> {
+        let (remaining, algorithm_identifier) = AlgorithmIdentifier::from_der(der).unwrap();
+        assert!(remaining.is_empty());
+        algorithm_identifier
+    }
 
     #[test]
     fn sanity_check() {
@@ -544,6 +581,54 @@ mod tests {
 
         assert!(parsed_cert.verify().is_ok());
         assert_eq!(keypair.public(), parsed_cert.extension.public_key);
+    }
+
+    #[test]
+    fn unsupported_signature_algorithm_error_uses_der_algorithm_identifier() {
+        let algorithm_identifier = parse_algorithm_identifier(&hex!("300a06082a8648ce3d040302"));
+
+        let err = unsupported_signature_algorithm(&algorithm_identifier);
+
+        match err {
+            webpki::Error::UnsupportedSignatureAlgorithmContext(context) => {
+                assert_eq!(
+                    context.signature_algorithm_id,
+                    rustls::pki_types::alg_id::ECDSA_SHA256.as_ref()
+                );
+                assert!(
+                    context
+                        .supported_algorithms
+                        .contains(&rustls::pki_types::alg_id::ECDSA_SHA256)
+                );
+            }
+            err => panic!("unexpected error: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn unsupported_public_key_error_uses_der_algorithm_identifiers() {
+        let signature_algorithm = parse_algorithm_identifier(&hex!("300a06082a8648ce3d040302"));
+        let public_key_algorithm =
+            parse_algorithm_identifier(&hex!("300d06092a864886f70d0101010500"));
+
+        let err = unsupported_signature_algorithm_for_public_key(
+            &signature_algorithm,
+            &public_key_algorithm,
+        );
+
+        match err {
+            webpki::Error::UnsupportedSignatureAlgorithmForPublicKeyContext(context) => {
+                assert_eq!(
+                    context.signature_algorithm_id,
+                    rustls::pki_types::alg_id::ECDSA_SHA256.as_ref()
+                );
+                assert_eq!(
+                    context.public_key_algorithm_id,
+                    rustls::pki_types::alg_id::RSA_ENCRYPTION.as_ref()
+                );
+            }
+            err => panic!("unexpected error: {err:?}"),
+        }
     }
 
     macro_rules! check_cert {


### PR DESCRIPTION
Finishes #6395. It keeps the Hickory 0.26 dependency bump and adds the source changes needed for the new resolver/proto APIs.

## Motivation
The Hickory 0.26 bump no longer compiles as-is. The main breakages are in libp2p-dns, where resolver error and lookup types changed, and in libp2p-mdns, where hickory-proto message and record access moved to public fields.

## Changes
- Update libp2p-dns to use `TokioRuntimeProvider`, `NetError`, and `Lookup` for A, AAAA, and TXT lookups.
- Call out that the hidden public `libp2p_dns::Resolver` trait now returns Hickory's generic `Lookup` from `ipv4_lookup`, `ipv6_lookup`, and `txt_lookup`; custom resolver implementors must update signatures and filter returned `RData` values by record type.
- Call out that `libp2p_dns::ResolveError` is now Hickory's `NetError` and that `ResolveErrorKind` is no longer re-exported.
- Return `ResolveError` instead of panicking if `Dns`, `Dns4`, or `Dns6` lookups succeed with no matching records.
- Build empty-lookup and no-matching-record errors with Hickory's `NoRecords` type so callers still get `is_no_records_found() == true`.
- Make custom DNS construction fallible: `libp2p_dns::tokio::Transport::custom` and `libp2p::SwarmBuilder::with_dns_config` now return `Result` instead of panicking if Hickory rejects resolver construction. Fixes #6420.
- Convert system DNS configuration and resolver-construction failures to `io::Error` without reusing the `dnsaddr` invalid-data helper.
- Update libp2p-mdns packet parsing to use Hickory 0.26 `Message` and `Record` public fields.
- Update the TLS certificate code to use `rustls-webpki`'s contextual signature-algorithm errors instead of deprecated error variants, preserving the encoded algorithm identifier value instead of only the raw OID bytes.
- Keep the remaining advisory ignores limited to the dependency paths that still exist.
- Keep `tempfile` on `getrandom 0.4.2` so this PR does not include an unrelated `getrandom` downgrade.

## Review notes
Start with `transports/dns/src/lib.rs`; that is where the resolver API changes, the empty `Dns` / `Dns4` / `Dns6` lookup handling, and the fallible custom constructor are handled.

Downstream code that matched `libp2p_dns::ResolveErrorKind` needs to move to Hickory's `NetError` / `DnsError` variants, or use helper methods such as `ResolveError::is_no_records_found()` when it only needs classification.

For mDNS, Hickory 0.25.2 `Message::query()` returned `self.queries.first()`, so the `packet.query().is_none()` to `packet.queries.is_empty()` replacement is equivalent. The remaining mDNS changes are direct public-field replacements for Hickory 0.26.

The Hickory 0.26 lockfile adds Android and Apple dependencies. Cargo.lock includes target-specific dependencies, so this does not mean they are built on every target: reverse-tree checks for `wasm32-unknown-unknown` and Linux do not include `jni`, `ndk-context`, or `system-configuration`, and the libp2p WASM check passes. Android builds do include `jni` through `hickory-proto`, `hickory-net`, and `hickory-resolver`; `jni` also brings in the `jni-macros` proc macro path, which is a real supply-chain surface increase for Android builds. Apple builds include `system-configuration 0.7.0` through `hickory-resolver`'s `system-config` feature. The resolver side follows from libp2p-dns enabling system resolver support; hickory-dns/hickory-dns#3636 tracks whether the Android `jni` deps in `hickory-proto` and `hickory-net` should be feature-gated.

The initial lockfile diff also appeared to move `tempfile` from `getrandom 0.4.2` to `getrandom 0.3.2`. A clean `tempfile` update did not require that downgrade, so this branch keeps the existing `getrandom 0.4.2` edge and leaves unrelated dependency versions alone.

Hickory 0.26 made resolver construction return `Result`. This branch now surfaces that through `tokio::Transport::custom` and `SwarmBuilder::with_dns_config` instead of keeping an `expect` inside libp2p. I checked hickory-resolver 0.26.1 while making this change: an empty nameserver list is not rejected during `build()` itself, but the upstream constructor is still fallible and libp2p should not turn that into a panic.

The `invalid_data` helper was already present for malformed `dnsaddr` TXT records. System DNS configuration errors now use a separate conversion path: on Unix, Hickory `NetError::Io` keeps the underlying `io::ErrorKind` such as `NotFound` or `PermissionDenied`; other Hickory errors are wrapped as `io::ErrorKind::Other` with the original error kept inside the `io::Error`.

`RUSTSEC-2025-0141` still needs an advisory ignore because `bincode 1.3.3` remains through `webrtc-dtls -> webrtc -> libp2p-webrtc`. Removing that path is tracked in #6240.

`RUSTSEC-2026-0097` still needs an advisory ignore because `rand 0.7.3` remains through `cuckoofilter -> libp2p-floodsub`. Removing that path is tracked in #6419.

## Verification
- DNS, mDNS, and TLS package tests pass.
- Top-level libp2p checks pass for the DNS/TCP/QUIC/TLS/metrics path used by the builder change.
- The builder test now exercises the successful `Result`-returning `with_dns_config` path.
- The TLS tests verify that unsupported-signature diagnostics include the same encoded algorithm identifier values expected by `rustls-webpki`.
- The DNS tests include regression coverage for empty `Dns`, `Dns4`, and `Dns6` lookups, and verify the no-matching `dnsaddr` path is still classified as no records found.
- The DNS tests verify that resolver IO errors preserve the original `io::ErrorKind` and keep the original error attached.
- Checked Hickory 0.25.2 source for the mDNS `query()` migration.
- Checked target-specific dependency graphs for the new Hickory Android and Apple dependencies.
- Checked the `tempfile` lockfile edge and confirmed the PR does not keep the unrelated `getrandom` downgrade.
- Rustdoc link checking passes for the affected public docs.
- Nightly formatting passes.

## Notes
This branch is based on the existing Dependabot PR #6395 and has been merged with upstream `master` through `a5c9962dd`.
