### PR TITLE
chore(gossipsub): Explicitly track partial support for unsubbed topics

### DIFF
--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -548,32 +548,6 @@ where
     /// Returns [`Ok(true)`](Ok) if the subscription worked.
     /// Returns [`Ok(false)`](Ok) if we were already subscribed.
     pub fn subscribe<H: Hasher>(&mut self, topic: &Topic<H>) -> Result<bool, SubscriptionError> {
-        self.subscribe_inner(topic, false, false)
-    }
-
-    /// Subscribe to a topic with partial options.
-    ///
-    /// Returns [`Ok(true)`](Ok) if the subscription worked.
-    /// Returns [`Ok(false)`](Ok) if we were already subscribed.
-    #[cfg(feature = "partial_messages")]
-    pub fn subscribe_partial<H: Hasher>(
-        &mut self,
-        topic: &Topic<H>,
-        requests_partial: bool,
-    ) -> Result<bool, SubscriptionError> {
-        self.subscribe_inner(topic, true, requests_partial)
-    }
-
-    /// Subscribe to a topic.
-    ///
-    /// Returns [`Ok(true)`](Ok) if the subscription worked.
-    /// Returns [`Ok(false)`](Ok) if we were already subscribed.
-    fn subscribe_inner<H: Hasher>(
-        &mut self,
-        topic: &Topic<H>,
-        supports_partial: bool,
-        requests_partial: bool,
-    ) -> Result<bool, SubscriptionError> {
         let topic_hash = topic.hash();
         if !self.subscription_filter.can_subscribe(&topic_hash) {
             return Err(SubscriptionError::NotAllowed);
@@ -583,6 +557,14 @@ where
             tracing::debug!(%topic, "Topic is already in the mesh");
             return Ok(false);
         }
+
+        #[cfg(not(feature = "partial_messages"))]
+        let (requests_partial, supports_partial) = (false, false);
+        #[cfg(feature = "partial_messages")]
+        let SubscriptionOpts {
+            requests_partial,
+            supports_partial,
+        } = self.partial_messages_extension.opts(&topic_hash);
 
         // send subscription request to all peers
         for peer_id in self.connected_peers.keys().copied().collect::<Vec<_>>() {
@@ -599,10 +581,6 @@ where
         // call JOIN(topic)
         // this will add new peers to the mesh for the topic
         self.join(&topic_hash);
-
-        #[cfg(feature = "partial_messages")]
-        self.partial_messages_extension
-            .subscribe(topic_hash, supports_partial, requests_partial);
 
         tracing::debug!(%topic, "Subscribed to topic");
         Ok(true)
@@ -630,10 +608,6 @@ where
         // call LEAVE(topic)
         // this will remove the topic from the mesh
         self.leave(&topic_hash);
-
-        #[cfg(feature = "partial_messages")]
-        self.partial_messages_extension
-            .unsubscribe(&topic_hash.clone());
 
         tracing::debug!(topic=%topic_hash, "Unsubscribed from topic");
         true
@@ -694,7 +668,7 @@ where
         let candidates = if self
             .partial_messages_extension
             .opts(&topic_hash)
-            .is_some_and(|opts| opts.supports_partial)
+            .supports_partial
         {
             candidates
                 .filter(|peer_id| {
@@ -867,6 +841,18 @@ where
             }
         }
         recipients
+    }
+
+    #[cfg(feature = "partial_messages")]
+    /// Enable partial messages for a topic. This must be called while not subscribed to the topic.
+    /// Partials can be enabled only once per topic.
+    pub fn enable_partials_for_topic(&mut self, topic_hash: TopicHash, requests_partials: bool) {
+        if self.mesh.contains_key(&topic_hash) {
+            tracing::warn!(topic=%topic_hash, "Tried to enable partials while subscribed");
+            return;
+        }
+        self.partial_messages_extension
+            .enable_partials_for_topic(topic_hash, requests_partials);
     }
 
     #[cfg(feature = "partial_messages")]
@@ -1390,7 +1376,7 @@ where
             if self
                 .partial_messages_extension
                 .opts(&topic)
-                .is_some_and(|opts| opts.requests_partial)
+                .requests_partial
                 && self
                     .partial_messages_extension
                     .supports_partial(peer_id, &topic)
@@ -3238,24 +3224,15 @@ where
             .mesh
             .keys()
             .cloned()
-            .filter_map(|topic_hash| {
+            .map(|topic_hash| {
                 #[cfg(not(feature = "partial_messages"))]
                 let (requests_partial, supports_partial) = (false, false);
                 #[cfg(feature = "partial_messages")]
                 let (requests_partial, supports_partial) = {
-                    let Some(SubscriptionOpts {
-                        requests_partial,
-                        supports_partial,
-                    }) = self.partial_messages_extension.opts(&topic_hash)
-                    else {
-                        tracing::error!(
-                            "Partial subscription options should exist for subscribed topic"
-                        );
-                        return None;
-                    };
-                    (requests_partial, supports_partial)
+                    let opts = self.partial_messages_extension.opts(&topic_hash);
+                    (opts.requests_partial, opts.supports_partial)
                 };
-                Some((topic_hash, requests_partial, supports_partial))
+                (topic_hash, requests_partial, supports_partial)
             })
             .collect();
 

--- a/protocols/gossipsub/src/behaviour/tests/mod.rs
+++ b/protocols/gossipsub/src/behaviour/tests/mod.rs
@@ -136,12 +136,9 @@ where
         for t in self.topics {
             let topic = Topic::new(t);
             #[cfg(feature = "partial_messages")]
-            if self.requests_partial {
-                gs.subscribe_partial(&topic, self.requests_partial).unwrap();
-            } else {
-                gs.subscribe(&topic).unwrap();
+            if self.supports_partial || self.requests_partial {
+                gs.enable_partials_for_topic(topic.hash().clone(), self.requests_partial);
             }
-            #[cfg(not(feature = "partial_messages"))]
             gs.subscribe(&topic).unwrap();
             topic_hashes.push(topic.hash().clone());
         }

--- a/protocols/gossipsub/src/behaviour/tests/partial.rs
+++ b/protocols/gossipsub/src/behaviour/tests/partial.rs
@@ -219,9 +219,9 @@ fn test_full_data_provider_to_requester() {
 
     let mut state1 = State::default();
     let mut state2 = State::default();
-    // Both subscribe to the topic with partial support
-    state1.subscribe(topic_hash.clone(), true, true);
-    state2.subscribe(topic_hash.clone(), true, true);
+    // Both enable partial support for the topic.
+    state1.enable_partials_for_topic(topic_hash.clone(), true);
+    state2.enable_partials_for_topic(topic_hash.clone(), true);
 
     // Set up peer subscriptions (each knows about the other)
     state1.peer_subscribed(
@@ -351,8 +351,8 @@ fn test_overlap_exchange() {
     let peer2 = PeerId::random();
     let mut state1 = State::default();
     let mut state2 = State::default();
-    state1.subscribe(topic_hash.clone(), true, true);
-    state2.subscribe(topic_hash.clone(), true, true);
+    state1.enable_partials_for_topic(topic_hash.clone(), true);
+    state2.enable_partials_for_topic(topic_hash.clone(), true);
     state1.peer_subscribed(
         &peer2,
         topic_hash.clone(),
@@ -484,8 +484,8 @@ fn test_symmetric_half_exchange() {
     let peer2 = PeerId::random();
     let mut state1 = State::default();
     let mut state2 = State::default();
-    state1.subscribe(topic_hash.clone(), true, true);
-    state2.subscribe(topic_hash.clone(), true, true);
+    state1.enable_partials_for_topic(topic_hash.clone(), true);
+    state2.enable_partials_for_topic(topic_hash.clone(), true);
     state1.peer_subscribed(
         &peer2,
         topic_hash.clone(),
@@ -623,8 +623,8 @@ fn test_no_redundant_transfer() {
     let peer2 = PeerId::random();
     let mut state1 = State::default();
     let mut state2 = State::default();
-    state1.subscribe(topic_hash.clone(), true, true);
-    state2.subscribe(topic_hash.clone(), true, true);
+    state1.enable_partials_for_topic(topic_hash.clone(), true);
+    state2.enable_partials_for_topic(topic_hash.clone(), true);
     state1.peer_subscribed(
         &peer2,
         topic_hash.clone(),
@@ -707,7 +707,7 @@ fn test_heartbeat_ttl_expiry() {
     let peer2 = PeerId::random();
     let peer3 = PeerId::random();
     let mut state1 = State::default();
-    state1.subscribe(topic_hash.clone(), true, true);
+    state1.enable_partials_for_topic(topic_hash.clone(), true);
     state1.peer_subscribed(
         &peer2,
         topic_hash.clone(),
@@ -778,7 +778,7 @@ fn test_peer_disconnect_cleanup() {
     let group_id: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
     let peer2 = PeerId::random();
     let mut state1 = State::default();
-    state1.subscribe(topic_hash.clone(), true, true);
+    state1.enable_partials_for_topic(topic_hash.clone(), true);
     state1.peer_subscribed(
         &peer2,
         topic_hash.clone(),
@@ -858,82 +858,6 @@ fn test_peer_disconnect_cleanup() {
 }
 
 /// Verifies that:
-/// - When we unsubscribe from a topic, our local partial message state is cleaned up.
-/// - Before unsubscribe, a peer metadata update triggers a `Publish` response when local partial
-///   cache exists.
-/// - After re-subscribing, receiving the same metadata-only update is treated as fresh
-///   (`EmitEvent`) because local partial cache was removed.
-#[test]
-fn test_unsubscribe_cleanup() {
-    let topic_hash = TopicHash::from_raw("test-topic");
-    let group_id: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
-    let peer2 = PeerId::random();
-    let peer3 = PeerId::random();
-    let mut state1 = State::default();
-    state1.subscribe(topic_hash.clone(), true, true);
-    state1.peer_subscribed(
-        &peer2,
-        topic_hash.clone(),
-        SubscriptionOpts {
-            requests_partial: true,
-            supports_partial: true,
-        },
-    );
-    state1.peer_subscribed(
-        &peer3,
-        topic_hash.clone(),
-        SubscriptionOpts {
-            requests_partial: true,
-            supports_partial: true,
-        },
-    );
-    // Publish to a different peer to populate local cache without syncing peer2 state.
-    let mut message = Bitmap::new(group_id);
-    message.fill_parts(0b11111111);
-    let _actions = state1
-        .handle_publish(topic_hash.clone(), message, HashSet::from([peer3]))
-        .expect("Publish should succeed");
-
-    // Receive from peer2 - should return Publish (we have cached local partial and no
-    // tracked knowledge that peer2 already has this data)
-    let peer2_partial = PartialMessage {
-        group_id: group_id.to_vec(),
-        topic_hash: topic_hash.clone(),
-        body: None,
-        metadata: Some(vec![0b00000000]), // peer2 has nothing
-    };
-    let received_actions = state1.handle_received(peer2, peer2_partial.clone());
-    assert!(
-        received_actions
-            .iter()
-            .any(|a| matches!(a, ReceivedAction::Publish(_))),
-        "Before unsubscribe: should return Publish since we have cached local partial"
-    );
-    // Unsubscribe from the topic
-    state1.unsubscribe(&topic_hash);
-    // Re-subscribe to the topic
-    state1.subscribe(topic_hash.clone(), true, true);
-    state1.peer_subscribed(
-        &peer2,
-        topic_hash.clone(),
-        SubscriptionOpts {
-            requests_partial: true,
-            supports_partial: true,
-        },
-    );
-    // Receive the same partial again from peer2
-    // Since our local cache was cleaned up, should return EmitEvent (no local partial)
-    let received_actions_after = state1.handle_received(peer2, peer2_partial.clone());
-    assert_eq!(received_actions_after.len(), 1);
-    assert!(
-        received_actions_after
-            .iter()
-            .any(|a| matches!(a, ReceivedAction::EmitEvent { .. })),
-        "After unsubscribe: should return EmitEvent since local partial cache was cleaned up"
-    );
-}
-
-/// Verifies that:
 /// - When a peer unsubscribes from a topic, their partial message state for that topic is cleaned
 ///   up.
 /// - After the peer re-subscribes, we treat them as fresh (no knowledge of what they have).
@@ -943,7 +867,7 @@ fn test_peer_unsubscribed_cleanup() {
     let group_id: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
     let peer2 = PeerId::random();
     let mut state1 = State::default();
-    state1.subscribe(topic_hash.clone(), true, true);
+    state1.enable_partials_for_topic(topic_hash.clone(), true);
     state1.peer_subscribed(
         &peer2,
         topic_hash.clone(),
@@ -1012,9 +936,9 @@ fn test_peer_unsubscribed_preserves_other_topics() {
     let group_id: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
     let peer2 = PeerId::random();
     let mut state1 = State::default();
-    // Subscribe to both topics
-    state1.subscribe(topic1.clone(), true, true);
-    state1.subscribe(topic2.clone(), true, true);
+    // Enable partial support for both topics.
+    state1.enable_partials_for_topic(topic1.clone(), true);
+    state1.enable_partials_for_topic(topic2.clone(), true);
     // Peer2 subscribes to both topics
     state1.peer_subscribed(
         &peer2,
@@ -1111,7 +1035,7 @@ fn test_subscription_options_tracking() {
     let peer2 = PeerId::random();
     let peer3 = PeerId::random();
     let mut state1 = State::default();
-    state1.subscribe(topic_hash.clone(), true, true);
+    state1.enable_partials_for_topic(topic_hash.clone(), true);
     // Peer1: requests and supports partial
     state1.peer_subscribed(
         &peer1,
@@ -1198,7 +1122,7 @@ fn test_handle_received_penalizes_invalid_action_from_metadata() {
     let group_id: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
     let peer = PeerId::random();
     let mut state = State::default();
-    state.subscribe(topic_hash.clone(), true, true);
+    state.enable_partials_for_topic(topic_hash.clone(), true);
     state.peer_subscribed(
         &peer,
         topic_hash.clone(),
@@ -1242,7 +1166,7 @@ fn test_metadata_only_update_unchanged_returns_empty() {
     let group_id: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
     let peer = PeerId::random();
     let mut state = State::default();
-    state.subscribe(topic_hash.clone(), true, true);
+    state.enable_partials_for_topic(topic_hash.clone(), true);
     state.peer_subscribed(
         &peer,
         topic_hash.clone(),
@@ -1291,7 +1215,7 @@ fn test_handle_publish_skips_redundant_update_after_receiving_data() {
     let peer_a = PeerId::random();
     let peer_b = PeerId::random();
     let mut state_a = State::default();
-    state_a.subscribe(topic_hash.clone(), true, true);
+    state_a.enable_partials_for_topic(topic_hash.clone(), true);
     state_a.peer_subscribed(
         &peer_b,
         topic_hash.clone(),
@@ -1404,7 +1328,7 @@ fn test_heartbeat_excludes_mesh_and_fanout_peers() {
     let published_peer = PeerId::random();
     let mut state = State::default();
 
-    state.subscribe(topic_hash.clone(), true, true);
+    state.enable_partials_for_topic(topic_hash.clone(), true);
 
     for peer in &[mesh_peer, fanout_peer, gossip_peer, published_peer] {
         state.peer_subscribed(
@@ -1486,7 +1410,7 @@ fn test_heartbeat_requests_partial_false_gets_metadata_only() {
     let metadata_only_peer = PeerId::random();
     let cache_peer = PeerId::random();
     let mut state = State::default();
-    state.subscribe(topic_hash.clone(), true, true);
+    state.enable_partials_for_topic(topic_hash.clone(), true);
     // Peer that requests partial data.
     state.peer_subscribed(
         &requests_peer,
@@ -1575,7 +1499,7 @@ fn test_heartbeat_max_metadata_length() {
     let gossip_peer = PeerId::random();
     let cache_peer = PeerId::random(); // Used to cache the messages
     let mut state = State::default();
-    state.subscribe(topic_hash.clone(), true, true);
+    state.enable_partials_for_topic(topic_hash.clone(), true);
 
     for peer in [&gossip_peer, &cache_peer] {
         state.peer_subscribed(

--- a/protocols/gossipsub/src/extensions/partial_messages.rs
+++ b/protocols/gossipsub/src/extensions/partial_messages.rs
@@ -114,36 +114,29 @@ pub struct PartialAction {
 /// Partial message state for sent and received messages.
 #[derive(Default)]
 pub(crate) struct State {
-    /// Our subscription options per topic and respective cached partial messages we are
-    /// publishing.
-    pub(crate) subscriptions: HashMap<TopicHash, LocalSubscription>,
+    /// Whether we request per topic and the respective cached partial messages we are
+    /// publishing. Only present if partial message support is enabled for that topic.
+    pub(crate) topics: HashMap<TopicHash, LocalTopic>,
     /// Per-peer partial state
     pub(crate) peer_subscriptions: HashMap<TopicHash, HashMap<PeerId, RemoteSubscription>>,
 }
 
 impl State {
-    /// Called by the [`Behaviour`](crate::Behaviour) when we subscribed to the topic.
-    pub(crate) fn subscribe(
+    /// Called by the [`Behaviour`](crate::Behaviour) when partial messages are enabled.
+    /// Will do nothing if previously called for a topic.
+    pub(crate) fn enable_partials_for_topic(
         &mut self,
         topic_hash: TopicHash,
-        supports_partial: bool,
         requests_partial: bool,
     ) {
-        self.subscriptions.insert(
-            topic_hash,
-            LocalSubscription {
-                options: SubscriptionOpts {
-                    requests_partial,
-                    supports_partial,
-                },
-                partial_messages: Default::default(),
-            },
-        );
-    }
-
-    /// Called by the [`Behaviour`](crate::Behaviour) when we unsubscribed from the topic.
-    pub(crate) fn unsubscribe(&mut self, topic_hash: &TopicHash) {
-        self.subscriptions.remove(&topic_hash.clone());
+        if self.topics.contains_key(&topic_hash) {
+            tracing::warn!(topic=%topic_hash, "Tried to enable partials while already enabled");
+            return;
+        }
+        self.topics.insert(topic_hash, LocalTopic {
+            requests_partials: requests_partial,
+            partial_messages: Default::default(),
+        });
     }
 
     /// Called by the [`Behaviour`](crate::Behaviour) when a peer has disconnected.
@@ -203,8 +196,8 @@ impl State {
             }
         }
 
-        for subscription in self.subscriptions.values_mut() {
-            subscription.partial_messages.retain(|_, partial| {
+        for local_topic in self.topics.values_mut() {
+            local_topic.partial_messages.retain(|_, partial| {
                 partial.ttl -= 1;
                 partial.ttl != 0
             });
@@ -212,12 +205,7 @@ impl State {
 
         // Emit gossip.
         let mut actions = vec![];
-        let all_topics: HashSet<_> = mesh.keys().chain(fanout.keys()).collect();
-        for topic_hash in all_topics {
-            let Some(subscription) = self.subscriptions.get(topic_hash) else {
-                continue;
-            };
-
+        for (topic_hash, local_topic) in self.topics.iter() {
             let Some(subscription_peers) = self.peer_subscriptions.get_mut(topic_hash) else {
                 tracing::trace!("Skipping sending partials on topic, no peer subscriptions for it");
                 continue;
@@ -246,7 +234,7 @@ impl State {
 
             for (peer_id, remote_subscription) in to_msg_peers {
                 let mut num_messages = 0;
-                for (group_id, local_partial) in subscription.partial_messages.iter() {
+                for (group_id, local_partial) in local_topic.partial_messages.iter() {
                     if num_messages == max_metadata_length {
                         break;
                     }
@@ -301,6 +289,13 @@ impl State {
         peer_id: PeerId,
         message: PartialMessage,
     ) -> Vec<ReceivedAction> {
+        let Some(local_topic) = self.topics.get(&message.topic_hash) else {
+            // We do not support partial messages for this topic.
+            tracing::debug!(peer = %peer_id, group_id = ?message.group_id, topic = ?message.topic_hash,
+                "Received partial message for unsupported topic");
+            return vec![];
+        };
+
         // If we don't have any peer yet subscribed to this topic, insert it.
         // We might have received a message from a peer not subscribed to a topic.
         let topic = self
@@ -360,11 +355,7 @@ impl State {
 
         // Check if we already have this partial,
         // if not, just return it to the application layer.
-        let Some(local_partial) = self
-            .subscriptions
-            .get_mut(&message.topic_hash)
-            .and_then(|t| t.partial_messages.get(&message.group_id))
-        else {
+        let Some(local_partial) = local_topic.partial_messages.get(&message.group_id) else {
             return vec![ReceivedAction::EmitEvent {
                 topic_hash: message.topic_hash,
                 peer_id,
@@ -458,10 +449,17 @@ impl State {
     }
 
     /// Get our partial opts for a topic (used by Behaviour when sending Subscribe)
-    pub(crate) fn opts(&self, topic: &TopicHash) -> Option<SubscriptionOpts> {
-        self.subscriptions
-            .get(topic)
-            .map(|subscription| subscription.options)
+    pub(crate) fn opts(&self, topic: &TopicHash) -> SubscriptionOpts {
+        match self.topics.get(topic) {
+            None => SubscriptionOpts {
+                requests_partial: false,
+                supports_partial: false,
+            },
+            Some(local_topic) => SubscriptionOpts {
+                requests_partial: local_topic.requests_partials,
+                supports_partial: true,
+            },
+        }
     }
 
     /// Check if the peer has sent us message on the provided topic and group_id.
@@ -486,6 +484,12 @@ impl State {
         partial_message: P,
         recipients: HashSet<PeerId>,
     ) -> Result<Vec<PublishAction>, PublishError> {
+        let Some(topic_partials) = self.topics.get_mut(&topic_hash) else {
+            return Err(PublishError::Partial(
+                PartialError::PartialNotSupportedForTopic,
+            ));
+        };
+
         if recipients.is_empty() {
             tracing::debug!(topic = %topic_hash, "Recipient list for publishing partial message is empty");
             return Err(PublishError::NoPeersSubscribedToTopic);
@@ -524,7 +528,6 @@ impl State {
         }
 
         // Cache the sent partial
-        let topic_partials = self.subscriptions.entry(topic_hash).or_default();
         topic_partials.partial_messages.insert(
             partial_message.group_id(),
             LocalPartial {
@@ -697,12 +700,12 @@ impl AsRef<[u8]> for PeerMetadata {
     }
 }
 
-/// Local per-topic subscription state.
+/// Local per-topic state.
 /// Holds the subscription configuration and a cache of sent partial messages.
 #[derive(Default)]
-pub(crate) struct LocalSubscription {
-    /// Subscription options, None if we have not subscribe to the topic.
-    options: SubscriptionOpts,
+pub(crate) struct LocalTopic {
+    /// Whether we should actively request partial messages from the peer on subscription.
+    requests_partials: bool,
     /// Partial messages we have sent us on the topic subscription.
     partial_messages: HashMap<Vec<u8>, LocalPartial>,
 }
@@ -775,6 +778,10 @@ pub enum PartialError {
 
     /// Application-specific validation failed.
     ValidationFailed,
+
+    /// Local node does not allow partial messages for this topic.
+    /// Should send full messages instead or activate partial messages for this topic.
+    PartialNotSupportedForTopic,
 }
 
 impl std::error::Error for PartialError {}
@@ -806,6 +813,12 @@ impl std::fmt::Display for PartialError {
             }
             Self::ValidationFailed => {
                 write!(f, "Validation failed")
+            }
+            PartialError::PartialNotSupportedForTopic => {
+                write!(
+                    f,
+                    "Local node does not allow partial messages for this topic."
+                )
             }
         }
     }

--- a/protocols/gossipsub/src/extensions/partial_messages.rs
+++ b/protocols/gossipsub/src/extensions/partial_messages.rs
@@ -133,10 +133,13 @@ impl State {
             tracing::warn!(topic=%topic_hash, "Tried to enable partials while already enabled");
             return;
         }
-        self.topics.insert(topic_hash, LocalTopic {
-            requests_partials: requests_partial,
-            partial_messages: Default::default(),
-        });
+        self.topics.insert(
+            topic_hash,
+            LocalTopic {
+                requests_partials: requests_partial,
+                partial_messages: Default::default(),
+            },
+        );
     }
 
     /// Called by the [`Behaviour`](crate::Behaviour) when a peer has disconnected.


### PR DESCRIPTION
## Description

The internal state no longer tracks sent partial messages only for subscribed topics, but for all topics for which the user enabled partial messages.

This fixes issues such as 
- sending both full and partial messages to a peer when publishing to a non-subscribed topic
- forwarding partials to the application and creating local state when a partial is received for an unsupported topic.

## Notes & open questions

- Open for naming suggestions
- Should we support disabling partial support again?

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
