### PR TITLE
chore: Add edition to rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,5 @@
+edition = "2024"
+
 # Imports
 reorder_imports = true
 imports_granularity = "Crate"


### PR DESCRIPTION
## Description

Add edition to rustfmt.toml in order to respect edition-specific formatting when `rustfmt` is invoked manually instead of via `cargo fmt`.

## Notes & open questions

None.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
