### PR TITLE
fix(gossipsub): add missing message id truncation to protocol

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Unify gossipsub control-message limits under max_control_messages (replacing per-type control ID caps),
   and truncate control vectors immediately after RPC decode.
   rename `max_ihave_messages` to `max_ihave_messages_heartbeat`.
-  See [PR 6409](https://github.com/libp2p/rust-libp2p/pull/6409) and [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX)
+  See [PR 6409](https://github.com/libp2p/rust-libp2p/pull/6409) and [PR 6428](https://github.com/libp2p/rust-libp2p/pull/6428)
 
 - Rename metric `topic_msg_sent_bytes` to `topic_msg_last_sent_bytes` for accuracy.
   See [PR 6283](https://github.com/libp2p/rust-libp2p/pull/6283)

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.50.0
 - Send all topic subscriptions in a single hello RPC when connecting to a new peer, aligning with the GossipSub spec and other implementations (Go, Nim, JS).
   See [PR 6385](https://github.com/libp2p/rust-libp2p/pull/6385).
+
 - Raise MSRV to 1.88.0.
   See [PR 6273](https://github.com/libp2p/rust-libp2p/pull/6273).
 
@@ -10,7 +11,7 @@
 - Unify gossipsub control-message limits under max_control_messages (replacing per-type control ID caps),
   and truncate control vectors immediately after RPC decode.
   rename `max_ihave_messages` to `max_ihave_messages_heartbeat`.
-  See [PR 6409](https://github.com/libp2p/rust-libp2p/pull/6409)
+  See [PR 6409](https://github.com/libp2p/rust-libp2p/pull/6409) and [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX)
 
 - Rename metric `topic_msg_sent_bytes` to `topic_msg_last_sent_bytes` for accuracy.
   See [PR 6283](https://github.com/libp2p/rust-libp2p/pull/6283)

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Unify gossipsub control-message limits under max_control_messages (replacing per-type control ID caps),
   and truncate control vectors immediately after RPC decode.
   rename `max_ihave_messages` to `max_ihave_messages_heartbeat`.
+  Introduce `max_ids_per_control_message` to limit the number of message IDs per control message.
   See [PR 6409](https://github.com/libp2p/rust-libp2p/pull/6409) and [PR 6428](https://github.com/libp2p/rust-libp2p/pull/6428)
 
 - Rename metric `topic_msg_sent_bytes` to `topic_msg_last_sent_bytes` for accuracy.

--- a/protocols/gossipsub/src/behaviour/tests/topic_config.rs
+++ b/protocols/gossipsub/src/behaviour/tests/topic_config.rs
@@ -671,6 +671,7 @@ fn test_validation_error_message_size_too_large_topic_specific() {
         max_transmit_size_map,
         5000,
         5000,
+        5000,
     );
     let mut buf = BytesMut::new();
     let rpc = proto::RPC {
@@ -778,6 +779,7 @@ fn test_validation_message_size_within_topic_specific() {
         Config::default_max_transmit_size() * 2,
         ValidationMode::None,
         max_transmit_size_map,
+        5000,
         5000,
         5000,
     );

--- a/protocols/gossipsub/src/config.rs
+++ b/protocols/gossipsub/src/config.rs
@@ -127,6 +127,7 @@ pub struct Config {
     max_metadata_length: usize,
     max_publish_messages: usize,
     max_control_messages: usize,
+    max_ids_per_control_message: usize,
     max_ihave_messages_heartbeat: usize,
     iwant_followup_time: Duration,
     connection_handler_queue_len: usize,
@@ -430,6 +431,13 @@ impl Config {
         self.max_control_messages
     }
 
+    /// The maximum number of message ids per IHAVE/IWANT/IDONTWANT control message we will
+    /// process in a given RPC. Other control message types (GRAFT, PRUNE) are not affected by
+    /// this limit as they do not contain message IDs. The default is 5000.
+    pub fn max_ids_per_control_message(&self) -> usize {
+        self.max_ids_per_control_message
+    }
+
     /// Time to wait for a message requested through IWANT following an IHAVE advertisement.
     /// If the message is not received within this window, a broken promise is declared and
     /// the router may apply behavioural penalties. The default is 3 seconds.
@@ -545,6 +553,7 @@ impl Default for ConfigBuilder {
                 max_metadata_length: 1000,
                 max_publish_messages: 5000,
                 max_control_messages: 5000,
+                max_ids_per_control_message: 5000,
                 max_ihave_messages_heartbeat: 10,
                 iwant_followup_time: Duration::from_secs(3),
                 connection_handler_queue_len: 5000,
@@ -1062,6 +1071,15 @@ impl ConfigBuilder {
         self
     }
 
+    /// The maximum number of message ids per IHAVE/IWANT/IDONTWANT control message we will
+    /// process in a single RPC. Other control message types (GRAFT, PRUNE) are not affected by
+    /// this limit as they do not contain message IDs. The default is 5000.
+    pub fn max_ids_per_control_message(&mut self, size: usize) -> &mut Self {
+        self.config.max_ids_per_control_message = size;
+        self.config.protocol.max_ids_per_control_message = size;
+        self
+    }
+
     /// The topic configuration sets mesh parameter sizes for a given topic. Notes on default
     /// below.
     ///
@@ -1172,6 +1190,10 @@ impl std::fmt::Debug for Config {
         let _ = builder.field("opportunistic_graft_peers", &self.opportunistic_graft_peers);
         let _ = builder.field("max_messages_per_rpc", &self.max_publish_messages);
         let _ = builder.field("max_control_messages", &self.max_control_messages);
+        let _ = builder.field(
+            "max_ids_per_control_message",
+            &self.max_ids_per_control_message,
+        );
         let _ = builder.field(
             "max_ihave_messages_heartbeat",
             &self.max_ihave_messages_heartbeat,

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -542,6 +542,7 @@ impl Decoder for GossipsubCodec {
                     message_ids: ihave
                         .message_ids
                         .into_iter()
+                        .take(self.max_control_messages)
                         .map(MessageId::from)
                         .collect::<Vec<_>>(),
                 })
@@ -557,6 +558,7 @@ impl Decoder for GossipsubCodec {
                     message_ids: iwant
                         .message_ids
                         .into_iter()
+                        .take(self.max_control_messages)
                         .map(MessageId::from)
                         .collect::<Vec<_>>(),
                 })
@@ -607,6 +609,7 @@ impl Decoder for GossipsubCodec {
                 message_ids: idontwant
                     .message_ids
                     .into_iter()
+                    .take(self.max_control_messages)
                     .map(MessageId::from)
                     .collect::<Vec<_>>(),
             }));

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -83,6 +83,9 @@ pub struct ProtocolConfig {
     pub(crate) max_publish_messages: usize,
     /// The max number of control messages per type to decode in a single RPC.
     pub(crate) max_control_messages: usize,
+    /// The max number of message ids per IHAVE/IWANT/IDONTWANT control message to decode in a
+    /// single RPC.
+    pub(crate) max_ids_per_control_message: usize,
 }
 
 impl Default for ProtocolConfig {
@@ -99,6 +102,7 @@ impl Default for ProtocolConfig {
             max_transmit_sizes: HashMap::new(),
             max_publish_messages: 500,
             max_control_messages: 500,
+            max_ids_per_control_message: 5000,
         }
     }
 }
@@ -155,6 +159,7 @@ where
                     self.max_transmit_sizes,
                     self.max_publish_messages,
                     self.max_control_messages,
+                    self.max_ids_per_control_message,
                 ),
             ),
             protocol_id.kind,
@@ -180,6 +185,7 @@ where
                     self.max_transmit_sizes,
                     self.max_publish_messages,
                     self.max_control_messages,
+                    self.max_ids_per_control_message,
                 ),
             ),
             protocol_id.kind,
@@ -200,6 +206,9 @@ pub struct GossipsubCodec {
     max_publish_messages: usize,
     /// The max number of control messages per type to decode in a single RPC.
     max_control_messages: usize,
+    /// The max number of message ids per IHAVE/IWANT/IDONTWANT control message to decode in a
+    /// single RPC.
+    max_ids_per_control_message: usize,
 }
 
 impl GossipsubCodec {
@@ -209,6 +218,7 @@ impl GossipsubCodec {
         max_transmit_sizes: HashMap<TopicHash, usize>,
         max_publish_messages: usize,
         max_control_messages: usize,
+        max_ids_per_control_message: usize,
     ) -> GossipsubCodec {
         let codec = quick_protobuf_codec::Codec::new(max_length);
         GossipsubCodec {
@@ -217,6 +227,7 @@ impl GossipsubCodec {
             max_transmit_sizes,
             max_publish_messages,
             max_control_messages,
+            max_ids_per_control_message,
         }
     }
 
@@ -542,7 +553,7 @@ impl Decoder for GossipsubCodec {
                     message_ids: ihave
                         .message_ids
                         .into_iter()
-                        .take(self.max_control_messages)
+                        .take(self.max_ids_per_control_message)
                         .map(MessageId::from)
                         .collect::<Vec<_>>(),
                 })
@@ -558,7 +569,7 @@ impl Decoder for GossipsubCodec {
                     message_ids: iwant
                         .message_ids
                         .into_iter()
-                        .take(self.max_control_messages)
+                        .take(self.max_ids_per_control_message)
                         .map(MessageId::from)
                         .collect::<Vec<_>>(),
                 })
@@ -609,7 +620,7 @@ impl Decoder for GossipsubCodec {
                 message_ids: idontwant
                     .message_ids
                     .into_iter()
-                    .take(self.max_control_messages)
+                    .take(self.max_ids_per_control_message)
                     .map(MessageId::from)
                     .collect::<Vec<_>>(),
             }));

--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -764,6 +764,7 @@ mod tests {
                 HashMap::new(),
                 5000,
                 1000,
+                5000,
             );
             let mut buf = BytesMut::new();
             codec.encode(rpc.into_protobuf(), &mut buf).unwrap();


### PR DESCRIPTION
## Description
https://github.com/libp2p/rust-libp2p/pull/6409 missed the id truncation that existed before, this PR re-adds it 