### PR TITLE
chore: update dependabot configuration for cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    versioning-strategy: "increase" # combination of increase with ignoring patch releases
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
     open-pull-requests-limit: 9999
     commit-message:
       prefix: "deps"


### PR DESCRIPTION
Set versioning strategy to increase and ignore patch updates for all dependencies.
