### PR TITLE
chore: address cargo-semver-checks run time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,12 +307,7 @@ jobs:
         with:
           shared-key: semver
       - uses: obi1kenobi/cargo-semver-checks-action@v2
-      - name: Run semver checks on published crates only
-        run: |
-          PACKAGES=$(echo '${{ needs.gather_published_crates.outputs.members }}' \
-            | jq -r '.[] | "--package " + .' \
-            | tr '\n' ' ')
-          cargo semver-checks $PACKAGES
+      - run: cargo semver-checks
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,7 @@ jobs:
           wasm-pack build --target web --out-dir static
 
   semver:
+    needs: [gather_published_crates]
     runs-on: ubuntu-latest
     env:
       # Unset the global `RUSTFLAGS` env to allow warnings.
@@ -303,8 +304,16 @@ jobs:
       RUSTFLAGS: ''
     steps:
       - uses: actions/checkout@v5
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          shared-key: semver
       - uses: obi1kenobi/cargo-semver-checks-action@v2
-      - run: cargo semver-checks
+      - name: Run semver checks on published crates only
+        run: |
+          PACKAGES=$(echo '${{ needs.gather_published_crates.outputs.members }}' \
+            | jq -r '.[] | "--package " + .' \
+            | tr '\n' ' ')
+          cargo semver-checks $PACKAGES
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,6 @@ jobs:
           wasm-pack build --target web --out-dir static
 
   semver:
-    needs: [gather_published_crates]
     runs-on: ubuntu-latest
     env:
       # Unset the global `RUSTFLAGS` env to allow warnings.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,6 @@ jobs:
         with:
           shared-key: semver
       - uses: obi1kenobi/cargo-semver-checks-action@v2
-      - run: cargo semver-checks
 
   rustfmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This PR improves the `semver-checks` CI job by introducing caching to speed up executions and removing the explicit `cargo semver-checks` invocation, as it is already handled by the action by default.

The initial run with a cold cache is expected to take approximately 23 minutes, which is unchanged from the current execution time as the cache is being populated,  subsequent runs with a warm cache are expected to complete in approximately 3–6 minutes which reduces the job execution time by approximately 74–87% for cached runs.
