### PR TITLE
chore(gossipsub): expose partial message opts on Subscribed event

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 0.50.0
+- Expose `supports_partial` and `requests_partial` flags on `Event::Subscribed` when the `partial_messages` feature is enabled.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+
 - Send all topic subscriptions in a single hello RPC when connecting to a new peer, aligning with the GossipSub spec and other implementations (Go, Nim, JS).
   See [PR 6385](https://github.com/libp2p/rust-libp2p/pull/6385).
 - Raise MSRV to 1.88.0.

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.50.0
 - Expose `supports_partial` and `requests_partial` flags on `Event::Subscribed` when the `partial_messages` feature is enabled.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+  See [PR 6439](https://github.com/libp2p/rust-libp2p/pull/6439).
 
 - Send all topic subscriptions in a single hello RPC when connecting to a new peer, aligning with the GossipSub spec and other implementations (Go, Nim, JS).
   See [PR 6385](https://github.com/libp2p/rust-libp2p/pull/6385).

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,7 +1,4 @@
 ## 0.50.0
-- Expose `supports_partial` and `requests_partial` flags on `Event::Subscribed` when the `partial_messages` feature is enabled.
-  See [PR 6439](https://github.com/libp2p/rust-libp2p/pull/6439).
-
 - Send all topic subscriptions in a single hello RPC when connecting to a new peer, aligning with the GossipSub spec and other implementations (Go, Nim, JS).
   See [PR 6385](https://github.com/libp2p/rust-libp2p/pull/6385).
 - Raise MSRV to 1.88.0.

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -172,6 +172,12 @@ pub enum Event {
         peer_id: PeerId,
         /// The topic it has subscribed to.
         topic: TopicHash,
+        /// Whether the remote peer indicated it supports partial messages on this topic.
+        #[cfg(feature = "partial_messages")]
+        supports_partial: bool,
+        /// Whether the remote peer indicated it requests partial messages on this topic.
+        #[cfg(feature = "partial_messages")]
+        requests_partial: bool,
     },
     /// A remote unsubscribed from a topic.
     Unsubscribed {
@@ -2205,6 +2211,10 @@ where
                     application_event.push(ToSwarm::GenerateEvent(Event::Subscribed {
                         peer_id: *propagation_source,
                         topic: topic_hash.clone(),
+                        #[cfg(feature = "partial_messages")]
+                        supports_partial: subscription.options.supports_partial,
+                        #[cfg(feature = "partial_messages")]
+                        requests_partial: subscription.options.requests_partial,
                     }));
                 }
                 SubscriptionAction::Unsubscribe => {


### PR DESCRIPTION
## Description
When the `partial_messages` feature is enabled, `Event::Subscribed` now carries `supports_partial` and `requests_partial` flags from the remote peer's `SubscriptionOpts`, so applications can react to a peer's partial message capabilities at subscription time.

## AI Assistance Disclosure

<!--
We ask every contributor to disclose AI assistance. This is not a filter — AI-assisted PRs
are accepted. We just need to know what was used and you need to vouch for what you submit.
We also ask contributors to be considerate of reviewer's time. Please keep AI-generated text brief and to the point.

Please do not delete this section.
-->

**Tools used** _(required — write `none` if no AI was used)_: Claude Code

**Attestation** _(required)_: 

- [x] I have read every line of this diff, understand what it does, and can explain it in review.

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

Potentially we could also embed a `SubscriptionOpts`, but I think I prefer it this way because `SubscriptionOpts` feels internal.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
