### PR TITLE
fix(prost-codec): checked addition in Codec::decode

### DIFF
--- a/misc/prost-codec/src/lib.rs
+++ b/misc/prost-codec/src/lib.rs
@@ -81,7 +81,10 @@ where
         let varint_length = src.len() - remaining.len();
 
         // Ensure we can read an entire message.
-        if src.len() < (message_length + varint_length) {
+        if message_length
+            .checked_add(varint_length)
+            .is_none_or(|total_length| src.len() < total_length)
+        {
             return Ok(None);
         }
 


### PR DESCRIPTION
## Description

If the length of the varint at the beginning of a decoded value plus the payload length reported within it overflows, we can cheat the test for the remaining buffer length, and the `src.split_to(message_length)` call will then cause a panic as `message_length` is a very large value.

## AI Assistance Disclosure

<!--
We ask every contributor to disclose AI assistance. This is not a filter — AI-assisted PRs
are accepted. We just need to know what was used and you need to vouch for what you submit.
We also ask contributors to be considerate of reviewer's time. Please keep AI-generated text brief and to the point.

Please do not delete this section.
-->

**Tools used** _(required — write `none` if no AI was used)_: none

**Attestation** _(required)_:

- [x] I have read every line of this diff, understand what it does, and can explain it in review.

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->
As this is in an unreleased version of prost-codec, there is no CVE publication.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
