### PR TITLE
fix: Use futures-timer instead of tokio's timer for stream timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1648,8 +1648,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b604752cefc5aa3ab98992a107a8bd99465d2825c1584e0b60cb6957b21e19d7"
 dependencies = [
+ "futures-timer",
  "futures-util",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ criterion = { version = "0.5.1" }
 bytes = "1.11.1"
 env_logger = "0.11"
 futures = "0.3.30"
-futures-bounded = { version = "0.3", features = ["tokio"] }
+futures-bounded = { version = "0.3", features = ["futures-timer"] }
 futures-rustls = { version = "0.26.0", default-features = false }
 futures-timer = "3.0"
 hex-literal = "0.4"

--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Use `futures-timer` instead of tokio's timer for stream timeouts so the bounded `Delay` works on
   `wasm32`; tokio's timer has no driver in the browser and panics at runtime.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+  See [PR 6488](https://github.com/libp2p/rust-libp2p/pull/6488).
 
 - refactor: `Codec` no longer requires `#[async_trait]`
   See [PR 6292](https://github.com/libp2p/rust-libp2p/pull/6292)

--- a/protocols/autonat/CHANGELOG.md
+++ b/protocols/autonat/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.16.0
 
+- Use `futures-timer` instead of tokio's timer for stream timeouts so the bounded `Delay` works on
+  `wasm32`; tokio's timer has no driver in the browser and panics at runtime.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+
 - refactor: `Codec` no longer requires `#[async_trait]`
   See [PR 6292](https://github.com/libp2p/rust-libp2p/pull/6292)
 

--- a/protocols/autonat/src/v2/client/handler/dial_back.rs
+++ b/protocols/autonat/src/v2/client/handler/dial_back.rs
@@ -22,7 +22,7 @@ pub struct Handler {
 impl Handler {
     pub(crate) fn new() -> Self {
         Self {
-            inbound: StreamSet::new(|| futures_bounded::Delay::tokio(Duration::from_secs(5)), 2),
+            inbound: StreamSet::new(|| futures_bounded::Delay::futures_timer(Duration::from_secs(5)), 2),
         }
     }
 }

--- a/protocols/autonat/src/v2/client/handler/dial_back.rs
+++ b/protocols/autonat/src/v2/client/handler/dial_back.rs
@@ -22,7 +22,10 @@ pub struct Handler {
 impl Handler {
     pub(crate) fn new() -> Self {
         Self {
-            inbound: StreamSet::new(|| futures_bounded::Delay::futures_timer(Duration::from_secs(5)), 2),
+            inbound: StreamSet::new(
+                || futures_bounded::Delay::futures_timer(Duration::from_secs(5)),
+                2,
+            ),
         }
     }
 }

--- a/protocols/autonat/src/v2/client/handler/dial_request.rs
+++ b/protocols/autonat/src/v2/client/handler/dial_request.rs
@@ -92,7 +92,7 @@ impl Handler {
         Self {
             queued_events: VecDeque::new(),
             outbound: FuturesMap::new(
-                || futures_bounded::Delay::tokio(Duration::from_secs(10)),
+                || futures_bounded::Delay::futures_timer(Duration::from_secs(10)),
                 10,
             ),
             queued_streams: VecDeque::default(),

--- a/protocols/autonat/src/v2/server/handler/dial_back.rs
+++ b/protocols/autonat/src/v2/server/handler/dial_back.rs
@@ -33,7 +33,7 @@ impl Handler {
         Self {
             pending_nonce: Some(cmd),
             requested_substream_nonce: None,
-            outbound: FuturesSet::new(|| futures_bounded::Delay::tokio(Duration::from_secs(10)), 5),
+            outbound: FuturesSet::new(|| futures_bounded::Delay::futures_timer(Duration::from_secs(10)), 5),
         }
     }
 }

--- a/protocols/autonat/src/v2/server/handler/dial_back.rs
+++ b/protocols/autonat/src/v2/server/handler/dial_back.rs
@@ -33,7 +33,10 @@ impl Handler {
         Self {
             pending_nonce: Some(cmd),
             requested_substream_nonce: None,
-            outbound: FuturesSet::new(|| futures_bounded::Delay::futures_timer(Duration::from_secs(10)), 5),
+            outbound: FuturesSet::new(
+                || futures_bounded::Delay::futures_timer(Duration::from_secs(10)),
+                5,
+            ),
         }
     }
 }

--- a/protocols/autonat/src/v2/server/handler/dial_request.rs
+++ b/protocols/autonat/src/v2/server/handler/dial_request.rs
@@ -65,7 +65,7 @@ where
             dial_back_cmd_sender,
             dial_back_cmd_receiver,
             inbound: FuturesSet::new(
-                || futures_bounded::Delay::tokio(Duration::from_secs(10)),
+                || futures_bounded::Delay::futures_timer(Duration::from_secs(10)),
                 10,
             ),
             rng,

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.15.0
 
+- Use `futures-timer` instead of tokio's timer for stream timeouts so the bounded `Delay` works on
+  `wasm32`; tokio's timer has no driver in the browser and panics at runtime.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+
 - Raise MSRV to 1.88.0.
   See [PR 6273](https://github.com/libp2p/rust-libp2p/pull/6273).
 

--- a/protocols/dcutr/CHANGELOG.md
+++ b/protocols/dcutr/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Use `futures-timer` instead of tokio's timer for stream timeouts so the bounded `Delay` works on
   `wasm32`; tokio's timer has no driver in the browser and panics at runtime.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+  See [PR 6488](https://github.com/libp2p/rust-libp2p/pull/6488).
 
 - Raise MSRV to 1.88.0.
   See [PR 6273](https://github.com/libp2p/rust-libp2p/pull/6273).

--- a/protocols/dcutr/src/handler/relayed.rs
+++ b/protocols/dcutr/src/handler/relayed.rs
@@ -88,11 +88,11 @@ impl Handler {
             endpoint,
             queued_events: Default::default(),
             inbound_stream: futures_bounded::FuturesSet::new(
-                || futures_bounded::Delay::tokio(Duration::from_secs(10)),
+                || futures_bounded::Delay::futures_timer(Duration::from_secs(10)),
                 1,
             ),
             outbound_stream: futures_bounded::FuturesSet::new(
-                || futures_bounded::Delay::tokio(Duration::from_secs(10)),
+                || futures_bounded::Delay::futures_timer(Duration::from_secs(10)),
                 1,
             ),
             holepunch_candidates,

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Use `futures-timer` instead of tokio's timer for stream timeouts so the bounded `Delay` works on
   `wasm32`; tokio's timer has no driver in the browser and panics at runtime.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+  See [PR 6488](https://github.com/libp2p/rust-libp2p/pull/6488).
 
 - Raise MSRV to 1.88.0.
   See [PR 6273](https://github.com/libp2p/rust-libp2p/pull/6273).

--- a/protocols/identify/CHANGELOG.md
+++ b/protocols/identify/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.48.0
 
+- Use `futures-timer` instead of tokio's timer for stream timeouts so the bounded `Delay` works on
+  `wasm32`; tokio's timer has no driver in the browser and panics at runtime.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+
 - Raise MSRV to 1.88.0.
   See [PR 6273](https://github.com/libp2p/rust-libp2p/pull/6273).
 

--- a/protocols/identify/src/handler.rs
+++ b/protocols/identify/src/handler.rs
@@ -139,7 +139,7 @@ impl Handler {
             remote_peer_id,
             events: SmallVec::new(),
             active_streams: futures_bounded::FuturesSet::new(
-                move || futures_bounded::Delay::tokio(STREAM_TIMEOUT),
+                move || futures_bounded::Delay::futures_timer(STREAM_TIMEOUT),
                 MAX_CONCURRENT_STREAMS_PER_CONNECTION,
             ),
             trigger_next_identify: Delay::new(Duration::ZERO),

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.49.0
 
+- Use `futures-timer` instead of tokio's timer for stream timeouts so the bounded `Delay` works on
+  `wasm32`; tokio's timer has no driver in the browser and panics at runtime.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+
 - Raise MSRV to 1.88.0.
   See [PR 6273](https://github.com/libp2p/rust-libp2p/pull/6273).
 

--- a/protocols/kad/CHANGELOG.md
+++ b/protocols/kad/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Use `futures-timer` instead of tokio's timer for stream timeouts so the bounded `Delay` works on
   `wasm32`; tokio's timer has no driver in the browser and panics at runtime.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+  See [PR 6488](https://github.com/libp2p/rust-libp2p/pull/6488).
 
 - Raise MSRV to 1.88.0.
   See [PR 6273](https://github.com/libp2p/rust-libp2p/pull/6273).

--- a/protocols/kad/src/handler.rs
+++ b/protocols/kad/src/handler.rs
@@ -463,7 +463,7 @@ impl Handler {
             next_connec_unique_id: UniqueConnecId(0),
             inbound_substreams: Default::default(),
             outbound_substreams: futures_bounded::FuturesTupleSet::new(
-                move || futures_bounded::Delay::tokio(substreams_timeout),
+                move || futures_bounded::Delay::futures_timer(substreams_timeout),
                 MAX_NUM_STREAMS,
             ),
             pending_streams: Default::default(),

--- a/protocols/perf/CHANGELOG.md
+++ b/protocols/perf/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.4.0
 
+- Use `futures-timer` instead of tokio's timer for stream timeouts so the bounded `Delay` works on
+  `wasm32`; tokio's timer has no driver in the browser and panics at runtime.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+
 - Raise MSRV to 1.88.0.
   See [PR 6273](https://github.com/libp2p/rust-libp2p/pull/6273).
 - Add ConnectionError to FromSwarm::ConnectionClosed.

--- a/protocols/perf/CHANGELOG.md
+++ b/protocols/perf/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Use `futures-timer` instead of tokio's timer for stream timeouts so the bounded `Delay` works on
   `wasm32`; tokio's timer has no driver in the browser and panics at runtime.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+  See [PR 6488](https://github.com/libp2p/rust-libp2p/pull/6488).
 
 - Raise MSRV to 1.88.0.
   See [PR 6273](https://github.com/libp2p/rust-libp2p/pull/6273).

--- a/protocols/perf/src/server/handler.rs
+++ b/protocols/perf/src/server/handler.rs
@@ -49,7 +49,7 @@ impl Handler {
     pub fn new() -> Self {
         Self {
             inbound: futures_bounded::FuturesSet::new(
-                move || futures_bounded::Delay::tokio(crate::RUN_TIMEOUT),
+                move || futures_bounded::Delay::futures_timer(crate::RUN_TIMEOUT),
                 crate::MAX_PARALLEL_RUNS_PER_CONNECTION,
             ),
         }

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.22.0
 
+- Use `futures-timer` instead of tokio's timer for stream timeouts so the bounded `Delay` works on
+  `wasm32`; tokio's timer has no driver in the browser and panics at runtime.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+
 - Raise MSRV to 1.88.0.
   See [PR 6273](https://github.com/libp2p/rust-libp2p/pull/6273).
 

--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Use `futures-timer` instead of tokio's timer for stream timeouts so the bounded `Delay` works on
   `wasm32`; tokio's timer has no driver in the browser and panics at runtime.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+  See [PR 6488](https://github.com/libp2p/rust-libp2p/pull/6488).
 
 - Raise MSRV to 1.88.0.
   See [PR 6273](https://github.com/libp2p/rust-libp2p/pull/6273).

--- a/protocols/relay/src/behaviour/handler.rs
+++ b/protocols/relay/src/behaviour/handler.rs
@@ -403,11 +403,11 @@ impl Handler {
     pub fn new(config: Config, endpoint: ConnectedPoint, status: behaviour::Status) -> Handler {
         Handler {
             inbound_workers: futures_bounded::FuturesSet::new(
-                move || futures_bounded::Delay::tokio(STREAM_TIMEOUT),
+                move || futures_bounded::Delay::futures_timer(STREAM_TIMEOUT),
                 MAX_CONCURRENT_STREAMS_PER_CONNECTION,
             ),
             outbound_workers: futures_bounded::FuturesMap::new(
-                move || futures_bounded::Delay::tokio(STREAM_TIMEOUT),
+                move || futures_bounded::Delay::futures_timer(STREAM_TIMEOUT),
                 MAX_CONCURRENT_STREAMS_PER_CONNECTION,
             ),
             endpoint,

--- a/protocols/relay/src/priv_client/handler.rs
+++ b/protocols/relay/src/priv_client/handler.rs
@@ -142,19 +142,19 @@ impl Handler {
             queued_events: Default::default(),
             pending_streams: Default::default(),
             inflight_reserve_requests: futures_bounded::FuturesTupleSet::new(
-                move || futures_bounded::Delay::tokio(STREAM_TIMEOUT),
+                move || futures_bounded::Delay::futures_timer(STREAM_TIMEOUT),
                 MAX_CONCURRENT_STREAMS_PER_CONNECTION,
             ),
             inflight_inbound_circuit_requests: futures_bounded::FuturesSet::new(
-                move || futures_bounded::Delay::tokio(STREAM_TIMEOUT),
+                move || futures_bounded::Delay::futures_timer(STREAM_TIMEOUT),
                 MAX_CONCURRENT_STREAMS_PER_CONNECTION,
             ),
             inflight_outbound_connect_requests: futures_bounded::FuturesTupleSet::new(
-                move || futures_bounded::Delay::tokio(STREAM_TIMEOUT),
+                move || futures_bounded::Delay::futures_timer(STREAM_TIMEOUT),
                 MAX_CONCURRENT_STREAMS_PER_CONNECTION,
             ),
             inflight_outbound_circuit_deny_requests: futures_bounded::FuturesSet::new(
-                move || futures_bounded::Delay::tokio(DENYING_CIRCUIT_TIMEOUT),
+                move || futures_bounded::Delay::futures_timer(DENYING_CIRCUIT_TIMEOUT),
                 MAX_NUMBER_DENYING_CIRCUIT,
             ),
             reservation: Reservation::None,

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Use `futures-timer` instead of tokio's timer for stream timeouts so the bounded `Delay` works on
   `wasm32`; tokio's timer has no driver in the browser and panics at runtime.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+  See [PR 6488](https://github.com/libp2p/rust-libp2p/pull/6488).
 
 - refactor: `Codec` no longer requires `#[async_trait]`
   See [PR 6292](https://github.com/libp2p/rust-libp2p/pull/6292)

--- a/protocols/request-response/CHANGELOG.md
+++ b/protocols/request-response/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.30.0
 
+- Use `futures-timer` instead of tokio's timer for stream timeouts so the bounded `Delay` works on
+  `wasm32`; tokio's timer has no driver in the browser and panics at runtime.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+
 - refactor: `Codec` no longer requires `#[async_trait]`
   See [PR 6292](https://github.com/libp2p/rust-libp2p/pull/6292)
 

--- a/protocols/request-response/src/handler.rs
+++ b/protocols/request-response/src/handler.rs
@@ -111,7 +111,7 @@ where
             pending_events: VecDeque::new(),
             inbound_request_id,
             worker_streams: futures_bounded::FuturesMap::new(
-                move || futures_bounded::Delay::tokio(substream_timeout),
+                move || futures_bounded::Delay::futures_timer(substream_timeout),
                 max_concurrent_streams,
             ),
         }


### PR DESCRIPTION
## Description

`futures_bounded::Delay::tokio` compiles on `wasm32-unknown-unknown` (tokio's `time` feature builds there) but panics at runtime: in the browser, futures are driven by `wasm-bindgen-futures` rather than a tokio runtime, so there is no tokio timer driver and `tokio::time::sleep` panics the first time it is polled. tokio's timer fundamentally cannot run on that target.

Switch the workspace `futures-bounded` dependency to the `futures-timer` feature and replace every `Delay::tokio(..)` with `Delay::futures_timer(..)` across autonat, dcutr, identify, kad, perf, relay and request-response. `futures-timer` works on both native and wasm — it already backs the project's wasm timers via `gloo-timers` (see the `wasm-bindgen-futures` pin in the root `Cargo.toml`).

## AI Assistance Disclosure

**Tools used** _(required — write `none` if no AI was used)_: _e.g. none / Claude Code / Copilot / Cursor / ChatGPT_

Claude Code w/ Opus 4.8 1M context

**Attestation** _(required)_:

- [X] I have read every line of this diff, understand what it does, and can explain it in review.

Description section was written by Claude, the rest of the PR description by me.

## Notes & open questions

This removes Tokio timer integration even on native builds. I believe that would primarily be used in tests, but none seem to depend on it.

## Change checklist

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works (tests were crashing on WASM)
- [X] A changelog entry has been made in the appropriate crates - guess I need to force-push or add another commit once I know the PR number?
