### PR TITLE
chore(gossipsub): check if message size exceeds max_message_size 

### DIFF
--- a/protocols/gossipsub/src/protocol.rs
+++ b/protocols/gossipsub/src/protocol.rs
@@ -192,6 +192,8 @@ where
 // Gossip codec for the framing
 
 pub struct GossipsubCodec {
+    /// The global max transmit size.
+    global_max_transmit_size: usize,
     /// Determines the level of validation performed on incoming messages.
     validation_mode: ValidationMode,
     /// The codec to handle common encoding/decoding of protobuf messages
@@ -207,14 +209,15 @@ pub struct GossipsubCodec {
 
 impl GossipsubCodec {
     pub fn new(
-        max_length: usize,
+        global_max_transmit_size: usize,
         validation_mode: ValidationMode,
         max_transmit_sizes: HashMap<TopicHash, usize>,
         max_publish_messages: usize,
         max_control_message_size: usize,
     ) -> GossipsubCodec {
-        let codec = prost_codec::Codec::new(max_length);
+        let codec = prost_codec::Codec::new(global_max_transmit_size);
         GossipsubCodec {
+            global_max_transmit_size,
             validation_mode,
             codec,
             max_transmit_sizes,
@@ -291,9 +294,18 @@ impl Encoder for GossipsubCodec {
 /// Validate RPC limits by parsing the wire format without allocating.
 fn validate_rpc_limits(
     mut buf: &[u8],
+    max_message_size: usize,
     max_publish_messages: usize,
     max_control_message_size: usize,
 ) -> io::Result<bool> {
+    let message_length = buf.len();
+    if message_length > max_message_size {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("message with {message_length}b exceeds maximum of {max_message_size}b",),
+        ));
+    }
+
     // Consume length prefix and get message bytes from length-prefixed buffer for validation
     if !consume_message_prefix(&mut buf)? {
         return Ok(false);
@@ -342,6 +354,7 @@ impl Decoder for GossipsubCodec {
         // Pre-validate: discard if limits exceeded
         if !validate_rpc_limits(
             src.as_ref(),
+            self.global_max_transmit_size,
             self.max_publish_messages,
             self.max_control_message_size,
         )? {


### PR DESCRIPTION
Adds a length check at the start of `validate_rpc_limits` to reject RPC messages whose raw size exceeds 
`default_max_transmit_size`. This was missed in #6468 when the `max_message_size` parameter was added, and without it, oversized messages would proceed past validation only to be caught later, wasting processing.