### PR TITLE
fix(noise): return immediately when reading into an empty buffer

### DIFF
--- a/transports/noise/src/io.rs
+++ b/transports/noise/src/io.rs
@@ -69,6 +69,10 @@ impl<T: AsyncRead + Unpin> AsyncRead for Output<T> {
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
         loop {
             let len = self.recv_buffer.len();
             let off = self.recv_offset;

--- a/transports/noise/tests/smoke.rs
+++ b/transports/noise/tests/smoke.rs
@@ -111,6 +111,33 @@ fn xx() {
         .quickcheck(prop as fn(Vec<Message>) -> bool)
 }
 
+#[test]
+fn read_into_empty_buffer_returns_immediately() {
+    let server_id = identity::Keypair::generate_ed25519();
+    let client_id = identity::Keypair::generate_ed25519();
+
+    let (client, server) = futures_ringbuf::Endpoint::pair(100, 100);
+
+    futures::executor::block_on(async move {
+        let ((_reported_client_id, mut server_session), (_reported_server_id, _client_session)) =
+            futures::future::try_join(
+                noise::Config::new(&server_id)
+                    .unwrap()
+                    .upgrade_inbound(server, ""),
+                noise::Config::new(&client_id)
+                    .unwrap()
+                    .upgrade_outbound(client, ""),
+            )
+            .await
+            .unwrap();
+
+        let mut buf = [];
+        let read = server_session.read(&mut buf).now_or_never();
+
+        assert!(matches!(read, Some(Ok(0))));
+    });
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct Message(Vec<u8>);
 


### PR DESCRIPTION
## Description

This updates `libp2p-noise`'s `AsyncRead` implementation to return `Poll::Ready(Ok(0))` immediately when `poll_read` is called with an empty destination buffer.

Previously, if no decrypted data was already buffered, reading into an empty buffer could still poll the underlying framed stream and return `Pending`. Returning immediately matches the expected `AsyncRead` behavior for zero-length reads and avoids unnecessary waiting.


## AI Assistance Disclosure

<!--
We ask every contributor to disclose AI assistance. This is not a filter — AI-assisted PRs
are accepted. We just need to know what was used and you need to vouch for what you submit.
We also ask contributors to be considerate of reviewer's time. Please keep AI-generated text brief and to the point.

Please do not delete this section.
-->

**Tools used** _(required — write `none` if no AI was used)_: _e.g. none / Claude Code / Copilot / Cursor / ChatGPT_

**Attestation** _(required)_:

- [ ] I have read every line of this diff, understand what it does, and can explain it in review.

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

This does not change the Noise protocol framing or any public API. 
It only handles the zero-length read case before polling the underlying stream.


## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
