### PR TITLE
fix(gossipsub): Count forwarded messages in metrics

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 0.50.0
+- Account for forwarded messages in `topic_mesg_sent_*` metrics.
+  See [PR 6502](https://github.com/libp2p/rust-libp2p/pull/6502)
+
 - Simplify gossipsub control message validation by scanning protobuf bytes before decoding
   to validate cumulative control message size, rather than decoding then counting individual IDs
   to prevent memory amplification from decoding.

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -1501,7 +1501,7 @@ where
                     tracing::debug!(peer=%peer_id, "IWANT: Sending cached messages to peer");
                     self.send_message(
                         *peer_id,
-                        RpcOut::Forward {
+                        RpcOut::Publish {
                             message_id: id.clone(),
                             message: msg,
                             timeout: Delay::new(self.config.forward_queue_duration()),
@@ -3025,7 +3025,7 @@ where
 
                 self.send_message(
                     *peer_id,
-                    RpcOut::Forward {
+                    RpcOut::Publish {
                         message_id: msg_id.clone(),
                         message: message.clone(),
                         timeout: Delay::new(self.config.forward_queue_duration()),

--- a/protocols/gossipsub/src/behaviour/tests/explicit_peers.rs
+++ b/protocols/gossipsub/src/behaviour/tests/explicit_peers.rs
@@ -235,7 +235,7 @@ fn do_forward_messages_to_explicit_peers() {
     assert_eq!(
         queues.into_iter().fold(0, |mut fwds, (peer_id, mut queue)| {
             while !queue.is_empty() {
-                if matches!(queue.try_pop(), Some(RpcOut::Forward{message: m, ..}) if peer_id == peers[0] && m.data == message.data) {
+                if matches!(queue.try_pop(), Some(RpcOut::Publish{message: m, ..}) if peer_id == peers[0] && m.data == message.data) {
                     fwds +=1;
                 }
             }

--- a/protocols/gossipsub/src/behaviour/tests/gossip.rs
+++ b/protocols/gossipsub/src/behaviour/tests/gossip.rs
@@ -72,7 +72,7 @@ fn test_handle_iwant_msg_cached() {
         .into_values()
         .fold(vec![], |mut collected_messages, mut queue| {
             while !queue.is_empty() {
-                if let Some(RpcOut::Forward { message, .. }) = queue.try_pop() {
+                if let Some(RpcOut::Publish { message, .. }) = queue.try_pop() {
                     collected_messages.push(message)
                 }
             }
@@ -129,7 +129,7 @@ fn test_handle_iwant_msg_cached_shifted() {
             .into_iter()
             .map(|(peer_id, mut queue)| {
                 while !queue.is_empty() {
-                    if matches!(queue.try_pop(), Some(RpcOut::Forward{message, ..}) if
+                    if matches!(queue.try_pop(), Some(RpcOut::Publish{message, ..}) if
                         gs.config.message_id(
                             &gs.data_transform
                                 .inbound_transform(message.clone())
@@ -438,7 +438,7 @@ fn test_ignore_too_many_iwants_from_same_peer_for_same_message() {
     assert_eq!(
         queues.into_values().fold(0, |mut fwds, mut queue| {
             while !queue.is_empty() {
-                if let Some(RpcOut::Forward { .. }) = queue.try_pop() {
+                if let Some(RpcOut::Publish { .. }) = queue.try_pop() {
                     fwds += 1;
                 }
             }

--- a/protocols/gossipsub/src/behaviour/tests/idontwant.rs
+++ b/protocols/gossipsub/src/behaviour/tests/idontwant.rs
@@ -170,7 +170,7 @@ fn doesnt_forward_idontwant() {
             .into_iter()
             .fold(0, |mut fwds, (peer_id, mut queue)| {
                 while !queue.is_empty() {
-                    if let Some(RpcOut::Forward { .. }) = queue.try_pop() {
+                    if let Some(RpcOut::Publish { .. }) = queue.try_pop() {
                         assert_ne!(peer_id, peers[2]);
                         fwds += 1;
                     }

--- a/protocols/gossipsub/src/behaviour/tests/scoring.rs
+++ b/protocols/gossipsub/src/behaviour/tests/scoring.rs
@@ -367,7 +367,7 @@ fn test_iwant_msg_from_peer_below_gossip_threshold_gets_ignored() {
             .into_iter()
             .fold(vec![], |mut collected_messages, (peer_id, mut queue)| {
                 while !queue.is_empty() {
-                    if let Some(RpcOut::Forward { message, .. }) = queue.try_pop() {
+                    if let Some(RpcOut::Publish { message, .. }) = queue.try_pop() {
                         collected_messages.push((peer_id, message));
                     }
                 }

--- a/protocols/gossipsub/src/handler.rs
+++ b/protocols/gossipsub/src/handler.rs
@@ -263,28 +263,17 @@ impl EnabledHandler {
                     if let Poll::Ready(mut message) = Pin::new(&mut self.message_queue).poll_pop(cx)
                     {
                         tracing::debug!(peer=%self.peer_id, ?message, "Sending gossipsub message");
-                        match message {
-                            RpcOut::Publish {
-                                message: _,
-                                ref mut timeout,
-                                ..
-                            }
-                            | RpcOut::Forward {
-                                message: _,
-                                ref mut timeout,
-                                ..
-                            } => {
-                                #[allow(clippy::collapsible_match)]
-                                if Pin::new(timeout).poll(cx).is_ready() {
-                                    // Inform the behaviour and end the poll.
-                                    self.outbound_substream =
-                                        Some(OutboundSubstreamState::WaitingOutput(substream));
-                                    return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
-                                        HandlerEvent::MessageDropped(message),
-                                    ));
-                                }
-                            }
-                            _ => {} // All other messages are not time-bound.
+                        if let RpcOut::Publish {
+                            ref mut timeout, ..
+                        } = message
+                            && Pin::new(timeout).poll(cx).is_ready()
+                        {
+                            // Inform the behaviour and end the poll.
+                            self.outbound_substream =
+                                Some(OutboundSubstreamState::WaitingOutput(substream));
+                            return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
+                                HandlerEvent::MessageDropped(message),
+                            ));
                         }
                         self.outbound_substream = Some(OutboundSubstreamState::PendingSend(
                             substream,

--- a/protocols/gossipsub/src/queue.rs
+++ b/protocols/gossipsub/src/queue.rs
@@ -75,7 +75,6 @@ impl Queue {
                 self.control.try_push(message)
             }
             RpcOut::Publish { .. }
-            | RpcOut::Forward { .. }
             | RpcOut::IHave(_)
             | RpcOut::TestExtension
             | RpcOut::IWant(_) => self.non_priority.try_push(message),
@@ -93,9 +92,7 @@ impl Queue {
 
         let mut count = 0;
         self.non_priority.retain(|message| match message {
-            RpcOut::Publish { message_id, .. } | RpcOut::Forward { message_id, .. }
-                if message_ids.contains(message_id) =>
-            {
+            RpcOut::Publish { message_id, .. } if message_ids.contains(message_id) => {
                 count += 1;
                 false
             }

--- a/protocols/gossipsub/src/types.rs
+++ b/protocols/gossipsub/src/types.rs
@@ -336,15 +336,9 @@ pub struct Extensions {
 #[derive(Debug)]
 pub enum RpcOut {
     /// Publish a Gossipsub message on network.`timeout` limits the duration the message
-    /// can wait to be sent before it is abandoned.
+    /// can wait to be sent before it is abandoned. This can be both a message originating
+    /// from this node, or a forwarded message.
     Publish {
-        message_id: MessageId,
-        message: RawMessage,
-        timeout: Delay,
-    },
-    /// Forward a Gossipsub message on network. `timeout` limits the duration the message
-    /// can wait to be sent before it is abandoned.
-    Forward {
         message_id: MessageId,
         message: RawMessage,
         timeout: Delay,
@@ -407,12 +401,6 @@ impl From<RpcOut> for proto::Rpc {
             RpcOut::Publish { message, .. } => proto::Rpc {
                 subscriptions: Vec::new(),
                 publish: vec![message.into()],
-                control: None,
-                partial: None,
-            },
-            RpcOut::Forward { message, .. } => proto::Rpc {
-                publish: vec![message.into()],
-                subscriptions: Vec::new(),
                 control: None,
                 partial: None,
             },


### PR DESCRIPTION
## Description

Forwarded messages were not accounted in the `topic_msg_sent_*` metrics.

Furthermore, after this change, all code location matching on `RpcOut` handle `Publish` and `Forward` the same, so I unified them into `Publish`.

## AI Assistance Disclosure

<!--
We ask every contributor to disclose AI assistance. This is not a filter — AI-assisted PRs
are accepted. We just need to know what was used and you need to vouch for what you submit.
We also ask contributors to be considerate of reviewer's time. Please keep AI-generated text brief and to the point.

Please do not delete this section.
-->

**Tools used** _(required — write `none` if no AI was used)_: none

**Attestation** _(required)_:

- [x] I have read every line of this diff, understand what it does, and can explain it in review.

## Notes & open questions
N/A

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
