### PR TITLE
docs: add Kinetic to Notable Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,4 +108,4 @@ used by [Polkadot](https://www.parity.io/technologies/polkadot/).
 - [Taple](https://github.com/opencanarias/taple-core) - Sustainable DLT for asset and process traceability by [OpenCanarias](https://www.opencanarias.com/en/).
 - [Ceylon](https://github.com/ceylonai/ceylon) - A Multi-Agent System (MAS) Development Framework.
 - [Fungi](https://github.com/enbop/fungi) - A platform built for seamless multi-device integration.
-- [Kinetic](https://github.com/saifmukhtar/kinetic) - Stateless, Sybil-resistant naming system with permanent identities using vdf and drand.
+- [Kinetic](https://github.com/saifmukhtar/kinetic) - Stateless, Sybil-resistant naming system with permanent identities using VDFs and drand.

--- a/README.md
+++ b/README.md
@@ -108,3 +108,4 @@ used by [Polkadot](https://www.parity.io/technologies/polkadot/).
 - [Taple](https://github.com/opencanarias/taple-core) - Sustainable DLT for asset and process traceability by [OpenCanarias](https://www.opencanarias.com/en/).
 - [Ceylon](https://github.com/ceylonai/ceylon) - A Multi-Agent System (MAS) Development Framework.
 - [Fungi](https://github.com/enbop/fungi) - A platform built for seamless multi-device integration.
+- [Kinetic](https://github.com/saifmukhtar/kinetic) - Stateless, Sybil-resistant naming system with permanent identities using vdf and drand.


### PR DESCRIPTION
## Description

Add Kinetic to Notable Users list.

Kinetic is a stateless, Sybil-resistant naming system with permanent identities using VDFs and drand. It builds on libp2p's Kademlia DHT and Gossipsub for decentralized name resolution and service discovery.

## AI Assistance Disclosure

**Tools used**: ChatGPT

**Attestation**:
- [x] I have read every line of this diff, understand what it does, and can explain it in review.

## Notes & open questions

This is a simple README addition. No code changes.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates