### PR TITLE
fix(floodsub): remove rand 0.7 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,17 +1149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cuckoofilter"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b810a8449931679f64cd7eef1bbd0fa315801b6d5d9cdc1ace2804d6529eee18"
-dependencies = [
- "byteorder",
- "fnv",
- "rand 0.7.3",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1841,17 +1830,6 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -3084,9 +3062,9 @@ version = "0.48.0"
 dependencies = [
  "asynchronous-codec",
  "bytes",
- "cuckoofilter",
  "fnv",
  "futures",
+ "hashlink",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
@@ -5139,19 +5117,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
@@ -5184,16 +5149,6 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
@@ -5210,15 +5165,6 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -5244,15 +5190,6 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
 
 [[package]]
 name = "rayon"
@@ -7092,12 +7029,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/protocols/floodsub/CHANGELOG.md
+++ b/protocols/floodsub/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.48.0
 
+- Replace the duplicate-message cuckoo filter with a bounded cache, removing the `rand` 0.7.3 dependency.
+  See [issue 6419](https://github.com/libp2p/rust-libp2p/issues/6419).
+
 - Raise MSRV to 1.88.0.
   See [PR 6273](https://github.com/libp2p/rust-libp2p/pull/6273).
 

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 asynchronous-codec = { workspace = true }
-cuckoofilter = "0.5.0"
-fnv = "1.0"
 bytes.workspace = true
+fnv = "1.0"
 futures = { workspace = true }
+hashlink = { workspace = true }
 libp2p-core = { workspace = true }
 libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true }

--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -30,7 +30,7 @@ use std::{
 
 use bytes::Bytes;
 use fnv::FnvHashSet;
-use hashlink::LinkedHashSet;
+use hashlink::LruCache;
 use libp2p_core::{Endpoint, Multiaddr, transport::PortUse};
 use libp2p_identity::PeerId;
 use libp2p_swarm::{
@@ -54,8 +54,7 @@ use crate::{
 const RECEIVED_CACHE_CAPACITY: usize = 1 << 16;
 
 struct ReceivedCache {
-    message_hashes: LinkedHashSet<u64>,
-    capacity: usize,
+    message_hashes: LruCache<u64, ()>,
 }
 
 impl ReceivedCache {
@@ -67,8 +66,7 @@ impl ReceivedCache {
         debug_assert!(capacity > 0);
 
         Self {
-            message_hashes: LinkedHashSet::new(),
-            capacity,
+            message_hashes: LruCache::new(capacity),
         }
     }
 
@@ -77,12 +75,7 @@ impl ReceivedCache {
         let mut hasher = DefaultHasher::new();
         value.hash(&mut hasher);
 
-        let is_new = self.message_hashes.insert(hasher.finish());
-        if self.message_hashes.len() > self.capacity {
-            self.message_hashes.pop_front();
-        }
-
-        is_new
+        self.message_hashes.insert(hasher.finish(), ()).is_none()
     }
 }
 

--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -50,8 +50,8 @@ use crate::{
     topic::Topic,
 };
 
-// Match the approximate maximum entry count of the previous cuckoo filter.
-const RECEIVED_CACHE_CAPACITY: usize = 1 << 20;
+// Keep the memory footprint close to the previous 1 MiB cuckoo filter.
+const RECEIVED_CACHE_CAPACITY: usize = 1 << 16;
 
 struct ReceivedCache {
     message_hashes: LinkedHashSet<u64>,

--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -19,11 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use std::{
-    collections::{
-        VecDeque,
-        hash_map::{DefaultHasher, HashMap},
-    },
-    hash::{Hash, Hasher},
+    collections::{HashMap, VecDeque},
     iter,
     task::{Context, Poll},
 };
@@ -50,34 +46,8 @@ use crate::{
     topic::Topic,
 };
 
-// Keep the memory footprint close to the previous 1 MiB cuckoo filter.
+// Limit the number of received messages retained for deduplication.
 const RECEIVED_CACHE_CAPACITY: usize = 1 << 16;
-
-struct ReceivedCache {
-    message_hashes: LruCache<u64, ()>,
-}
-
-impl ReceivedCache {
-    fn new() -> Self {
-        Self::with_capacity(RECEIVED_CACHE_CAPACITY)
-    }
-
-    fn with_capacity(capacity: usize) -> Self {
-        debug_assert!(capacity > 0);
-
-        Self {
-            message_hashes: LruCache::new(capacity),
-        }
-    }
-
-    /// Returns `true` if the value was not present in the cache.
-    fn insert<T: Hash>(&mut self, value: &T) -> bool {
-        let mut hasher = DefaultHasher::new();
-        value.hash(&mut hasher);
-
-        self.message_hashes.insert(hasher.finish(), ()).is_none()
-    }
-}
 
 #[deprecated = "Use `Behaviour` instead."]
 pub type Floodsub = Behaviour;
@@ -101,9 +71,9 @@ pub struct Behaviour {
     // erroneously.
     subscribed_topics: SmallVec<[Topic; 16]>,
 
-    // We keep track of the messages we received (in the format `hash(source ID, seq_no)`) so that
-    // we don't dispatch the same message twice if we receive it twice on the network.
-    received: ReceivedCache,
+    // We keep track of the messages we received so that we don't dispatch the same message twice
+    // if we receive it twice on the network.
+    received: LruCache<FloodsubMessage, ()>,
 }
 
 impl Behaviour {
@@ -120,7 +90,7 @@ impl Behaviour {
             target_peers: FnvHashSet::default(),
             connected_peers: HashMap::new(),
             subscribed_topics: SmallVec::new(),
-            received: ReceivedCache::new(),
+            received: LruCache::new(RECEIVED_CACHE_CAPACITY),
         }
     }
 
@@ -265,7 +235,7 @@ impl Behaviour {
             .iter()
             .any(|t| message.topics.iter().any(|u| t == u));
         if self_subscribed {
-            self.received.insert(&message);
+            self.received.insert(message.clone(), ());
             if self.config.subscribe_local_messages {
                 self.events
                     .push_back(ToSwarm::GenerateEvent(Event::Message(message.clone())));
@@ -444,7 +414,7 @@ impl NetworkBehaviour for Behaviour {
 
         for message in event.messages {
             // Use `self.received` to skip the messages that we have already received in the past.
-            if !self.received.insert(&message) {
+            if self.received.insert(message.clone(), ()).is_some() {
                 continue;
             }
 
@@ -569,23 +539,4 @@ pub enum Event {
         /// The topic it has subscribed from.
         topic: Topic,
     },
-}
-
-#[cfg(test)]
-mod tests {
-    use super::ReceivedCache;
-
-    #[test]
-    fn received_cache_evicts_least_recently_seen_hash() {
-        let mut cache = ReceivedCache::with_capacity(2);
-
-        assert!(cache.insert(&1));
-        assert!(cache.insert(&2));
-        assert!(!cache.insert(&1));
-
-        assert!(cache.insert(&3));
-        assert_eq!(cache.message_hashes.len(), 2);
-        assert!(!cache.insert(&1));
-        assert!(cache.insert(&2));
-    }
 }

--- a/protocols/floodsub/src/layer.rs
+++ b/protocols/floodsub/src/layer.rs
@@ -23,13 +23,14 @@ use std::{
         VecDeque,
         hash_map::{DefaultHasher, HashMap},
     },
+    hash::{Hash, Hasher},
     iter,
     task::{Context, Poll},
 };
 
 use bytes::Bytes;
-use cuckoofilter::{CuckooError, CuckooFilter};
 use fnv::FnvHashSet;
+use hashlink::LinkedHashSet;
 use libp2p_core::{Endpoint, Multiaddr, transport::PortUse};
 use libp2p_identity::PeerId;
 use libp2p_swarm::{
@@ -48,6 +49,42 @@ use crate::{
     },
     topic::Topic,
 };
+
+// Match the approximate maximum entry count of the previous cuckoo filter.
+const RECEIVED_CACHE_CAPACITY: usize = 1 << 20;
+
+struct ReceivedCache {
+    message_hashes: LinkedHashSet<u64>,
+    capacity: usize,
+}
+
+impl ReceivedCache {
+    fn new() -> Self {
+        Self::with_capacity(RECEIVED_CACHE_CAPACITY)
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        debug_assert!(capacity > 0);
+
+        Self {
+            message_hashes: LinkedHashSet::new(),
+            capacity,
+        }
+    }
+
+    /// Returns `true` if the value was not present in the cache.
+    fn insert<T: Hash>(&mut self, value: &T) -> bool {
+        let mut hasher = DefaultHasher::new();
+        value.hash(&mut hasher);
+
+        let is_new = self.message_hashes.insert(hasher.finish());
+        if self.message_hashes.len() > self.capacity {
+            self.message_hashes.pop_front();
+        }
+
+        is_new
+    }
+}
 
 #[deprecated = "Use `Behaviour` instead."]
 pub type Floodsub = Behaviour;
@@ -73,7 +110,7 @@ pub struct Behaviour {
 
     // We keep track of the messages we received (in the format `hash(source ID, seq_no)`) so that
     // we don't dispatch the same message twice if we receive it twice on the network.
-    received: CuckooFilter<DefaultHasher>,
+    received: ReceivedCache,
 }
 
 impl Behaviour {
@@ -90,7 +127,7 @@ impl Behaviour {
             target_peers: FnvHashSet::default(),
             connected_peers: HashMap::new(),
             subscribed_topics: SmallVec::new(),
-            received: CuckooFilter::new(),
+            received: ReceivedCache::new(),
         }
     }
 
@@ -235,13 +272,7 @@ impl Behaviour {
             .iter()
             .any(|t| message.topics.iter().any(|u| t == u));
         if self_subscribed {
-            if let Err(e @ CuckooError::NotEnoughSpace) = self.received.add(&message) {
-                tracing::warn!(
-                    "Message was added to 'received' Cuckoofilter but some \
-                     other message was removed as a consequence: {}",
-                    e,
-                );
-            }
+            self.received.insert(&message);
             if self.config.subscribe_local_messages {
                 self.events
                     .push_back(ToSwarm::GenerateEvent(Event::Message(message.clone())));
@@ -420,18 +451,8 @@ impl NetworkBehaviour for Behaviour {
 
         for message in event.messages {
             // Use `self.received` to skip the messages that we have already received in the past.
-            // Note that this can result in false positives.
-            match self.received.test_and_add(&message) {
-                Ok(true) => {}         // Message  was added.
-                Ok(false) => continue, // Message already existed.
-                Err(e @ CuckooError::NotEnoughSpace) => {
-                    // Message added, but some other removed.
-                    tracing::warn!(
-                        "Message was added to 'received' Cuckoofilter but some \
-                         other message was removed as a consequence: {}",
-                        e,
-                    );
-                }
+            if !self.received.insert(&message) {
+                continue;
             }
 
             // Add the message to be dispatched to the user.
@@ -555,4 +576,23 @@ pub enum Event {
         /// The topic it has subscribed from.
         topic: Topic,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReceivedCache;
+
+    #[test]
+    fn received_cache_evicts_least_recently_seen_hash() {
+        let mut cache = ReceivedCache::with_capacity(2);
+
+        assert!(cache.insert(&1));
+        assert!(cache.insert(&2));
+        assert!(!cache.insert(&1));
+
+        assert!(cache.insert(&3));
+        assert_eq!(cache.message_hashes.len(), 2);
+        assert!(!cache.insert(&1));
+        assert!(cache.insert(&2));
+    }
 }


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

Replace floodsub's cuckoo filter with a bounded cache of 64-bit message hashes.

The new cache preserves the previous approximate limit of 2^20 entries, refreshes the eviction order when a duplicate is observed, and evicts the least recently seen hash when full. This keeps duplicate suppression bounded without retaining complete messages.

Removing `cuckoofilter` also removes its transitive dependency on `rand` 0.7.3, which is flagged by RUSTSEC-2026-0097. There are no public API changes.

Fixes #6419.


## AI Assistance Disclosure

<!--
We ask every contributor to disclose AI assistance. This is not a filter — AI-assisted PRs
are accepted. We just need to know what was used and you need to vouch for what you submit.
We also ask contributors to be considerate of reviewer's time. Please keep AI-generated text brief and to the point.

Please do not delete this section.
-->

**Tools used** _(required — write `none` if no AI was used)_:  none 

**Attestation** _(required)_:

- [x] I have read every line of this diff, understand what it does, and can explain it in review.

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates
