### PR TITLE
feat(gossipsub): default MaxCountSubscriptionFilter with 100 topics

### DIFF
--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -2,7 +2,7 @@
 - Change default `TopicSubscriptionFilter` from `AllowAllSubscriptionFilter` to `MaxCountSubscriptionFilter<AllowAllSubscriptionFilter>`
   with default limits of `100` for both `max_subscribed_topics` and `max_subscriptions_per_request`,
   providing built-in protection against excessive subscription requests.
-  See [PR 6503](https://github.com/libp2p/rust-libp2p/pull/6503).
+  See [PR 6527](https://github.com/libp2p/rust-libp2p/pull/6527).
 
 - Account for forwarded messages in `topic_mesg_sent_*` metrics.
   See [PR 6502](https://github.com/libp2p/rust-libp2p/pull/6502)

--- a/protocols/gossipsub/CHANGELOG.md
+++ b/protocols/gossipsub/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 0.50.0
+- Change default `TopicSubscriptionFilter` from `AllowAllSubscriptionFilter` to `MaxCountSubscriptionFilter<AllowAllSubscriptionFilter>`
+  with default limits of `100` for both `max_subscribed_topics` and `max_subscriptions_per_request`,
+  providing built-in protection against excessive subscription requests.
+  See [PR 6503](https://github.com/libp2p/rust-libp2p/pull/6503).
+
 - Account for forwarded messages in `topic_mesg_sent_*` metrics.
   See [PR 6502](https://github.com/libp2p/rust-libp2p/pull/6502)
 

--- a/protocols/gossipsub/src/behaviour.rs
+++ b/protocols/gossipsub/src/behaviour.rs
@@ -57,7 +57,8 @@ use web_time::{Instant, SystemTime};
 #[cfg(feature = "metrics")]
 use crate::metrics::{Churn, Config as MetricsConfig, Inclusion, Metrics, Penalty};
 use crate::{
-    FailedMessages, PublishError, SubscriptionError, TopicScoreParams, ValidationError,
+    FailedMessages, MaxCountSubscriptionFilter, PublishError, SubscriptionError, TopicScoreParams,
+    ValidationError,
     backoff::BackoffStorage,
     config::{Config, ValidationMode},
     gossip_promises::GossipPromises,
@@ -292,7 +293,10 @@ impl From<MessageAuthenticity> for PublishConfig {
 ///
 /// The TopicSubscriptionFilter allows applications to implement specific filters on topics to
 /// prevent unwanted messages being propagated and evaluated.
-pub struct Behaviour<D = IdentityTransform, F = AllowAllSubscriptionFilter> {
+pub struct Behaviour<
+    D = IdentityTransform,
+    F = MaxCountSubscriptionFilter<AllowAllSubscriptionFilter>,
+> {
     /// Configuration providing gossipsub performance parameters.
     config: Config,
 

--- a/protocols/gossipsub/src/behaviour/tests/mod.rs
+++ b/protocols/gossipsub/src/behaviour/tests/mod.rs
@@ -59,7 +59,7 @@ use crate::{
 
 /// Convenience alias for [`BehaviourTestBuilder`] with default transform and subscription filter.
 pub(super) type DefaultBehaviourTestBuilder =
-    BehaviourTestBuilder<IdentityTransform, AllowAllSubscriptionFilter>;
+    BehaviourTestBuilder<IdentityTransform, MaxCountSubscriptionFilter<AllowAllSubscriptionFilter>>;
 
 /// A builder for creating test gossipsub networks with configurable peers and topics.
 ///

--- a/protocols/gossipsub/src/subscription_filter.rs
+++ b/protocols/gossipsub/src/subscription_filter.rs
@@ -105,6 +105,7 @@ impl TopicSubscriptionFilter for WhitelistSubscriptionFilter {
 }
 
 /// Adds a max count to a given subscription filter
+#[derive(Debug, Clone)]
 pub struct MaxCountSubscriptionFilter<T: TopicSubscriptionFilter> {
     pub filter: T,
     pub max_subscribed_topics: usize,
@@ -155,6 +156,19 @@ impl<T: TopicSubscriptionFilter> TopicSubscriptionFilter for MaxCountSubscriptio
         }
 
         Ok(result)
+    }
+}
+
+impl<T> Default for MaxCountSubscriptionFilter<T>
+where
+    T: TopicSubscriptionFilter + Default,
+{
+    fn default() -> Self {
+        Self {
+            filter: Default::default(),
+            max_subscribed_topics: 100,
+            max_subscriptions_per_request: 100,
+        }
     }
 }
 


### PR DESCRIPTION
Change the default `TopicSubscriptionFilter` from `AllowAllSubscriptionFilter` to `MaxCountSubscriptionFilter<AllowAllSubscriptionFilter>`, adding a `Default` impl with limits of 100 for both `max_subscribed_topics` and `max_subscriptions_per_request`.

