### PR TITLE
chore(deps): update overall deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,15 +53,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloca"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "asn1_der"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
+checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
 
 [[package]]
 name = "async-channel"
@@ -310,7 +301,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -368,13 +359,13 @@ dependencies = [
  "cfg-if",
  "clap",
  "libp2p",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
+ "opentelemetry 0.32.0",
+ "opentelemetry-otlp 0.32.0",
+ "opentelemetry_sdk 0.32.1",
  "rand 0.8.6",
  "tokio",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.33.0",
  "tracing-subscriber",
 ]
 
@@ -572,7 +563,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower 0.5.2",
- "tower-http 0.6.10",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
  "tracing-wasm",
@@ -795,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -817,14 +808,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -998,7 +989,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot 0.5.0",
+ "criterion-plot",
  "futures",
  "is-terminal",
  "itertools 0.10.5",
@@ -1017,31 +1008,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
-dependencies = [
- "alloca",
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot 0.8.2",
- "itertools 0.13.0",
- "num-traits",
- "oorandom",
- "page_size",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
 name = "criterion-plot"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,16 +1015,6 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
-dependencies = [
- "cast",
- "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1380,7 +1336,7 @@ dependencies = [
  "p384",
  "pem",
  "portable-atomic",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_core 0.6.4",
  "rcgen",
  "ring",
@@ -1388,7 +1344,7 @@ dependencies = [
  "rustls",
  "sec1",
  "sha1",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "webrtc-util",
@@ -1441,7 +1397,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1550,7 +1506,7 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.2",
  "libm",
- "rand 0.9.4",
+ "rand 0.9.5",
  "siphasher",
 ]
 
@@ -1682,9 +1638,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1707,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1717,27 +1673,26 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -1751,9 +1706,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1773,15 +1728,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-timer"
@@ -1795,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1807,7 +1762,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -2020,9 +1974,9 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -2032,12 +1986,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
@@ -2062,12 +2010,6 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
-
-[[package]]
-name = "hex-literal"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hex_fmt"
@@ -2338,7 +2280,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.9",
+ "socket2 0.6.5",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -2597,7 +2539,7 @@ dependencies = [
  "futures",
  "log",
  "portable-atomic",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rtcp",
  "rtp",
  "thiserror 1.0.69",
@@ -2625,7 +2567,7 @@ dependencies = [
  "mime_guess",
  "rand 0.8.6",
  "redis",
- "reqwest 0.12.24",
+ "reqwest 0.12.28",
  "rust-embed",
  "serde",
  "serde_json",
@@ -2853,7 +2795,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -2907,9 +2849,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -3137,7 +3079,7 @@ dependencies = [
  "rand 0.8.6",
  "regex",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.11.0",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3172,9 +3114,9 @@ version = "0.2.14"
 dependencies = [
  "asn1_der",
  "bs58",
- "criterion 0.8.2",
+ "criterion",
  "ed25519-dalek",
- "hex-literal 1.1.0",
+ "hex-literal",
  "hkdf",
  "k256",
  "multihash",
@@ -3187,7 +3129,7 @@ dependencies = [
  "sec1",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tracing",
  "zeroize",
@@ -3216,7 +3158,7 @@ dependencies = [
  "quickcheck-ext",
  "rand 0.8.6",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -3286,7 +3228,7 @@ version = "0.44.0"
 dependencies = [
  "asynchronous-codec",
  "bytes",
- "criterion 0.5.1",
+ "criterion",
  "futures",
  "libp2p-core",
  "libp2p-identity",
@@ -3573,7 +3515,7 @@ dependencies = [
 name = "libp2p-swarm"
 version = "0.48.0"
 dependencies = [
- "criterion 0.5.1",
+ "criterion",
  "either",
  "fnv",
  "futures",
@@ -3607,7 +3549,7 @@ version = "0.36.0"
 dependencies = [
  "heck",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3647,7 +3589,7 @@ version = "0.7.0"
 dependencies = [
  "futures",
  "futures-rustls",
- "hex-literal 0.4.1",
+ "hex-literal",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
@@ -3720,7 +3662,7 @@ dependencies = [
  "bytes",
  "futures",
  "hex",
- "hex-literal 0.4.1",
+ "hex-literal",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-noise",
@@ -3728,7 +3670,7 @@ dependencies = [
  "prost-codec",
  "rand 0.8.6",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tinytemplate",
  "tracing",
 ]
@@ -4023,13 +3965,13 @@ dependencies = [
  "axum",
  "futures",
  "libp2p",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
+ "opentelemetry 0.27.1",
+ "opentelemetry-otlp 0.27.0",
+ "opentelemetry_sdk 0.27.1",
  "prometheus-client",
  "tokio",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.28.0",
  "tracing-subscriber",
 ]
 
@@ -4218,17 +4160,17 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe 0.1.6",
+ "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 2.11.1",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -4382,16 +4324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
-]
-
-[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4452,9 +4384,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -4477,21 +4409,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -4514,6 +4440,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry 0.32.0",
+ "reqwest 0.13.1",
+]
+
+[[package]]
 name = "opentelemetry-otlp"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4522,9 +4475,9 @@ dependencies = [
  "async-trait",
  "futures-core",
  "http",
- "opentelemetry",
- "opentelemetry-proto",
- "opentelemetry_sdk",
+ "opentelemetry 0.27.1",
+ "opentelemetry-proto 0.27.0",
+ "opentelemetry_sdk 0.27.1",
  "prost 0.13.5",
  "thiserror 1.0.69",
  "tokio",
@@ -4533,15 +4486,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry 0.32.0",
+ "opentelemetry-http",
+ "opentelemetry-proto 0.32.0",
+ "opentelemetry_sdk 0.32.1",
+ "prost 0.14.4",
+ "reqwest 0.13.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
 dependencies = [
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.27.1",
+ "opentelemetry_sdk 0.27.1",
  "prost 0.13.5",
  "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry 0.32.0",
+ "opentelemetry_sdk 0.32.1",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -4555,7 +4535,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "glob",
- "opentelemetry",
+ "opentelemetry 0.27.1",
  "percent-encoding",
  "rand 0.8.6",
  "serde_json",
@@ -4563,6 +4543,24 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.32.0",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.5",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -4580,7 +4578,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4592,17 +4590,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "page_size"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
-dependencies = [
- "libc",
- "winapi",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4736,9 +4724,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -4838,9 +4826,9 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
 dependencies = [
  "either",
  "ipnet",
@@ -5077,7 +5065,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.9",
+ "socket2 0.6.5",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5095,7 +5083,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.9.5",
  "ring",
  "rustc-hash",
  "rustls",
@@ -5177,9 +5165,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -5304,9 +5292,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
+checksum = "9e23805debcc4435229c51187c0023a4d04499d354c101490e60744c087e973a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5414,9 +5402,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
@@ -5460,6 +5448,7 @@ checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -5623,7 +5612,7 @@ dependencies = [
  "bytes",
  "memchr",
  "portable-atomic",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "thiserror 1.0.69",
  "webrtc-util",
@@ -5737,10 +5726,10 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -5768,7 +5757,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -5834,11 +5823,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5859,7 +5848,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22c3b0257608d7de4de4c4ea650ccc2e6e3e45e3cd80039fcdee768bcb449253"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.9.5",
  "substring",
  "thiserror 1.0.69",
  "url",
@@ -5877,19 +5866,6 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
 ]
 
 [[package]]
@@ -5938,9 +5914,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -5948,22 +5924,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6035,9 +6011,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -6057,9 +6033,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -6116,9 +6092,9 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -6173,7 +6149,7 @@ dependencies = [
  "rand_core 0.6.4",
  "ring",
  "rustc_version",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle",
 ]
 
@@ -6265,15 +6241,15 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "stun"
-version = "0.17.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0fd33c04d4617df42c9c84c698511c59f59869629fb7a193067eec41bce347"
+checksum = "a2dcb5e8f583b58364b1e030f040660f092b0823dac8a7cb6ee71c965be67497"
 dependencies = [
  "base64",
  "crc",
  "lazy_static",
  "md-5",
- "rand 0.9.4",
+ "rand 0.9.5",
  "ring",
  "subtle",
  "thiserror 1.0.69",
@@ -6310,9 +6286,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6592,9 +6568,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -6640,9 +6616,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -6812,6 +6788,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "http",
+ "percent-encoding",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6875,8 +6866,24 @@ checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.27.1",
+ "opentelemetry_sdk 0.27.1",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry 0.32.0",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -6922,9 +6929,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.116"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+checksum = "06649c6f63d86604ba0c8950d5a1829fc9a17afd70fc6629f481d75b6a624c78"
 dependencies = [
  "glob",
  "serde",
@@ -6947,7 +6954,7 @@ dependencies = [
  "log",
  "md-5",
  "portable-atomic",
- "rand 0.9.4",
+ "rand 0.9.5",
  "ring",
  "stun",
  "thiserror 1.0.69",
@@ -7350,18 +7357,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webrtc"
-version = "0.17.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba06986c4fcfbbb4b490abe4b88887b0ac9de0d3eb0aae36f3254e38d6ecdd1"
+checksum = "26beccdc865a8f932cd5138cfcdea3d071423bbaae0123e0333cccd7d6c4c0eb"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -7373,7 +7380,7 @@ dependencies = [
  "log",
  "pem",
  "portable-atomic",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rcgen",
  "regex",
  "ring",
@@ -7382,7 +7389,7 @@ dependencies = [
  "sdp",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smol_str",
  "stun",
  "thiserror 1.0.69",
@@ -7426,7 +7433,7 @@ dependencies = [
  "crc",
  "log",
  "portable-atomic",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "serde_json",
  "stun",
@@ -7461,7 +7468,7 @@ checksum = "a9a28290bd0cdda196f8bf5c6f7dddaef18cc913ee0702cd1ea237bad203e337"
 dependencies = [
  "byteorder",
  "bytes",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rtp",
  "thiserror 1.0.69",
 ]
@@ -7478,7 +7485,7 @@ dependencies = [
  "crc",
  "log",
  "portable-atomic",
- "rand 0.9.4",
+ "rand 0.9.5",
  "thiserror 1.0.69",
  "tokio",
  "webrtc-util",
@@ -7521,7 +7528,7 @@ dependencies = [
  "log",
  "nix 0.26.4",
  "portable-atomic",
- "rand 0.9.4",
+ "rand 0.9.5",
  "thiserror 1.0.69",
  "tokio",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,43 +119,43 @@ libp2p-webtransport-websys = { version = "0.6.0", path = "transports/webtranspor
 libp2p-yamux = { version = "0.48.0", path = "muxers/yamux" }
 
 # External dependencies
-asynchronous-codec = { version = "0.7.0" }
-axum = { version = "0.7.9" }
-criterion = { version = "0.5.1" }
-bytes = "1.11.1"
+asynchronous-codec = { version = "0.7" }
+axum = { version = "0.7" }
+criterion = { version = "0.5" }
+bytes = "1.12"
 env_logger = "0.11"
-futures = "0.3.30"
+futures = "0.3"
 futures-bounded = { version = "0.3", features = ["futures-timer"] }
-futures-rustls = { version = "0.26.0", default-features = false }
+futures-rustls = { version = "0.26", default-features = false }
 futures-timer = "3.0"
 hex-literal = "0.4"
 getrandom = { version = "0.2", features = ["js"] }
-hashlink = "0.11.0"
-hickory-proto = { version = "0.26.1", default-features = false }
-hickory-resolver = { version = "0.26.1", default-features = false }
-if-watch = "3.2.2"
-multiaddr = "0.18.1"
-multihash = "0.19.5"
+hashlink = "0.11"
+hickory-proto = { version = "0.26", default-features = false }
+hickory-resolver = { version = "0.26", default-features = false }
+if-watch = "3.2"
+multiaddr = "0.18"
+multihash = "0.19"
 multistream-select = { version = "0.14.0", path = "misc/multistream-select" }
 prometheus-client = "0.24"
 prost-codec = { version = "0.4.0", path = "misc/prost-codec" }
 prost = "0.14"
 quickcheck = { package = "quickcheck-ext", path = "misc/quickcheck-ext" }
-rand = "0.8.0"
+rand = "0.8"
 rcgen = "0.13"
-ring = "0.17.12"
+ring = "0.17"
 rw-stream-sink = { version = "0.5.0", path = "misc/rw-stream-sink" }
 thiserror = "2"
-tokio = { version = "1.52", default-features = false }
-tracing = "0.1.44"
-tracing-subscriber = "0.3.23"
-unsigned-varint = { version = "0.8.0" }
+tokio = { version = "1.53", default-features = false }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+unsigned-varint = { version = "0.8" }
 # Pinned to avoid wasm-bindgen >=0.2.109 which breaks gloo-timers 0.2.6 (used by futures-timer for wasm).
 # wasm-bindgen-futures pins wasm-bindgen exactly, so capping it caps wasm-bindgen.
 # Versions 0.4.59-0.4.61 are unusable because they pin yanked js-sys releases (0.3.86-0.3.88).
 # TODO: remove when futures-timer is updated.
 wasm-bindgen-futures = "=0.4.58"
-web-time = "1.1.0"
+web-time = "1.1"
 
 [patch.crates-io]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,9 +20,9 @@ libp2p-identity = { workspace = true, features = ["peerid", "ed25519"] }
 multiaddr = { workspace = true }
 multihash = { workspace = true }
 multistream-select = { workspace = true }
-parking_lot = "0.12.5"
+parking_lot = "0.12"
 prost = { workspace = true }
-pin-project = "1.1.13"
+pin-project = "1.1"
 rand = { workspace = true }
 rw-stream-sink = { workspace = true }
 thiserror = { workspace = true }

--- a/examples/autonat/Cargo.toml
+++ b/examples/autonat/Cargo.toml
@@ -10,7 +10,7 @@ release = false
 
 [dependencies]
 tokio = { workspace = true, features = ["full"] }
-clap = { version = "4.6.1", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 futures = { workspace = true }
 libp2p = { path = "../../libp2p", features = ["tokio", "tcp", "noise", "yamux", "autonat", "identify", "macros"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/examples/autonatv2/Cargo.toml
+++ b/examples/autonatv2/Cargo.toml
@@ -16,16 +16,16 @@ name = "autonatv2_server"
 
 [dependencies]
 libp2p = { workspace = true, features = ["macros", "tokio", "tcp", "noise", "yamux", "autonat", "identify", "dns", "quic"] }
-clap = { version = "4.6.1", features = ["derive"] }
-tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread"] }
-tracing = "0.1.44"
+clap = { version = "4.6", features = ["derive"] }
+tokio = { version = "1.53", features = ["macros", "rt-multi-thread"] }
+tracing = "0.1"
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 rand = { workspace = true }
-opentelemetry = { version = "0.27.0", optional = true }
-opentelemetry_sdk = { version = "0.27.0", optional = true, features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.27.0", optional = true }
-tracing-opentelemetry = { version = "0.28.0", optional = true }
-cfg-if = "1.0.4"
+opentelemetry = { version = "0.32", optional = true }
+opentelemetry_sdk = { version = "0.32", optional = true, features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.32", optional = true }
+tracing-opentelemetry = { version = "0.33", optional = true }
+cfg-if = "1.0"
 
 [features]
 jaeger = ["opentelemetry", "opentelemetry_sdk", "opentelemetry-otlp", "tracing-opentelemetry"]

--- a/examples/browser-webrtc/Cargo.toml
+++ b/examples/browser-webrtc/Cargo.toml
@@ -16,7 +16,7 @@ release = false
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow = "1.0.102"
+anyhow = "1.0"
 futures = { workspace = true }
 rand = { workspace = true }
 tracing = { workspace = true }
@@ -26,19 +26,19 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 axum = { workspace = true }
 libp2p = { path = "../../libp2p", features = [ "ed25519", "macros", "ping", "tokio"] }
 libp2p-webrtc = { workspace = true, features = ["tokio"] }
-rust-embed = { version = "8.11.0", features = ["include-exclude", "interpolate-folder-path"] }
+rust-embed = { version = "8.12", features = ["include-exclude", "interpolate-folder-path"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "signal"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors"] }
-mime_guess = "2.0.4"
+tower-http = { version = "0.7", features = ["cors"] }
+mime_guess = "2.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3.69"
+js-sys = "0.3"
 libp2p = { path = "../../libp2p", features = [ "ed25519", "macros", "ping"] }
 libp2p-webrtc-websys = { workspace = true }
-tracing-wasm = "0.2.1"
-wasm-bindgen = "0.2.90"
+tracing-wasm = "0.2"
+wasm-bindgen = "0.2"
 wasm-bindgen-futures = { workspace = true}
 web-sys = { version = "0.3", features = ['Document', 'Element', 'HtmlElement', 'Node', 'Response', 'Window'] }
 

--- a/examples/dcutr/Cargo.toml
+++ b/examples/dcutr/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 release = false
 
 [dependencies]
-clap = { version = "4.6.1", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 futures = { workspace = true }
 futures-timer = { workspace = true }
 libp2p = { path = "../../libp2p", features = [ "dns", "dcutr", "identify", "macros", "noise", "ping", "quic", "relay", "rendezvous", "tcp", "tokio", "yamux"] }

--- a/examples/file-sharing/Cargo.toml
+++ b/examples/file-sharing/Cargo.toml
@@ -11,7 +11,7 @@ release = false
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 tokio = { workspace = true, features = ["full"] }
-clap = { version = "4.6.1", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 futures = { workspace = true }
 libp2p = { path = "../../libp2p", features = [ "tokio", "cbor", "dns", "kad", "noise", "macros", "request-response", "tcp", "websocket", "yamux"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/examples/identify/Cargo.toml
+++ b/examples/identify/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 release = false
 
 [dependencies]
-tokio = { version = "1.52.3", features = ["full"] }
+tokio = { version = "1.53", features = ["full"] }
 futures = { workspace = true }
 libp2p = { path = "../../libp2p", features = ["identify", "noise", "tcp", "tokio", "yamux"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/examples/ipfs-kad/Cargo.toml
+++ b/examples/ipfs-kad/Cargo.toml
@@ -10,9 +10,9 @@ release = false
 
 [dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
-clap = { version = "4.6.1", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 futures = { workspace = true }
-anyhow = "1.0.102"
+anyhow = "1.0"
 libp2p = { path = "../../libp2p", features = [ "tokio", "dns", "kad", "noise", "tcp", "yamux", "rsa"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 

--- a/examples/metrics/Cargo.toml
+++ b/examples/metrics/Cargo.toml
@@ -12,13 +12,13 @@ release = false
 futures = { workspace = true }
 axum = { workspace = true }
 libp2p = { path = "../../libp2p", features = ["tokio", "metrics", "ping", "noise", "identify", "tcp", "yamux", "macros"] }
-opentelemetry = { version = "0.27.0", features = ["metrics"] }
-opentelemetry-otlp = { version = "0.27.0", features = ["metrics"] }
-opentelemetry_sdk = { version = "0.27.0", features = ["rt-tokio", "metrics"] }
+opentelemetry = { version = "0.27", features = ["metrics"] }
+opentelemetry-otlp = { version = "0.27", features = ["metrics"] }
+opentelemetry_sdk = { version = "0.27", features = ["rt-tokio", "metrics"] }
 prometheus-client = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
-tracing-opentelemetry = "0.28.0"
+tracing-opentelemetry = "0.28"
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [lints]

--- a/examples/relay-server/Cargo.toml
+++ b/examples/relay-server/Cargo.toml
@@ -9,8 +9,8 @@ license = "MIT"
 release = false
 
 [dependencies]
-clap = { version = "4.6.1", features = ["derive"] }
-tokio = { version = "1.52.3", features = ["full"] }
+clap = { version = "4.6", features = ["derive"] }
+tokio = { version = "1.53", features = ["full"] }
 futures = { workspace = true }
 libp2p = { path = "../../libp2p", features = ["tokio", "noise", "macros", "ping", "tcp", "identify", "yamux", "relay", "quic"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/hole-punching-tests/Cargo.toml
+++ b/hole-punching-tests/Cargo.toml
@@ -11,8 +11,8 @@ env_logger = { workspace = true }
 futures = { workspace = true }
 libp2p = { path = "../libp2p", features = ["tokio", "dcutr", "identify", "macros", "noise", "ping", "relay", "tcp", "yamux", "quic"] }
 tracing = { workspace = true }
-redis = { version = "0.24.0", default-features = false, features = ["tokio-comp"] }
+redis = { version = "0.24", default-features = false, features = ["tokio-comp"] }
 tokio = { workspace = true, features = ["full"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.150"
-either = "1.16.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+either = "1.16"

--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -3,7 +3,7 @@ name = "libp2p-identity"
 version = "0.2.14"
 edition = "2021" # MUST NOT inherit from workspace because we don't want to publish breaking changes to `libp2p-identity`.
 description = "Data structures and algorithms for identifying peers in libp2p."
-rust-version = "1.73.0" # MUST NOT inherit from workspace because we don't want to publish breaking changes to `libp2p-identity`.
+rust-version = "1.73" # MUST NOT inherit from workspace because we don't want to publish breaking changes to `libp2p-identity`.
 license = "MIT"
 repository = "https://github.com/libp2p/rust-libp2p"
 keywords = ["peer-to-peer", "libp2p", "networking", "cryptography"]
@@ -12,19 +12,19 @@ categories = ["cryptography"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-asn1_der = { version = "0.7.6", optional = true }
-bs58 = { version = "0.5.1", optional = true }
-ed25519-dalek = { version = "2.2", optional = true }
-hkdf = { version = "0.12.4", optional = true }
-k256 = { version = "0.13.4", optional = true, features = ["ecdsa", "arithmetic"] }
+asn1_der = { version = "0.7", optional = true }
+bs58 = { version = "0.5", optional = true }
+ed25519-dalek = { version = "2.1", optional = true }
+hkdf = { version = "0.12", optional = true }
+k256 = { version = "0.13", optional = true, features = ["ecdsa", "arithmetic"] }
 tracing = { workspace = true }
-multihash = { version = "0.19.5", optional = true }
+multihash = { version = "0.19", optional = true }
 p256 = { version = "0.13", default-features = false, features = ["ecdsa", "std", "pem"], optional = true }
 prost = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 sec1 = { version = "0.7", default-features = false, optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
-sha2 = { version = "0.10.8", optional = true }
+sha2 = { version = "0.10", optional = true }
 thiserror = { workspace = true, optional = true }
 zeroize = { version = "1.8", optional = true }
 
@@ -43,8 +43,8 @@ rand = ["dep:rand"]
 quickcheck = { workspace = true }
 serde_json = "1.0"
 rmp-serde = "1.3"
-criterion = "0.8"
-hex-literal = "1.1.0"
+criterion = "0.5"
+hex-literal = "0.4"
 
 [[bench]]
 name = "peer_id"

--- a/interop-tests/Cargo.toml
+++ b/interop-tests/Cargo.toml
@@ -27,7 +27,7 @@ libp2p-noise = { workspace = true }
 libp2p-tls = { workspace = true }
 libp2p-webrtc = { workspace = true, features = ["tokio"] }
 mime_guess = "2.0"
-redis = { version = "0.24.0", default-features = false, features = [
+redis = { version = "0.24", default-features = false, features = [
     "tokio-comp",
 ] }
 rust-embed = "8.11"
@@ -44,10 +44,10 @@ libp2p-mplex = { path = "../muxers/mplex" }
 libp2p-webrtc-websys = { workspace = true }
 wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = { workspace = true}
-wasm-logger = { version = "0.2.0" }
+wasm-logger = { version = "0.2" }
 web-time = { workspace = true }
 reqwest = { version = "0.12", features = ["json"] }
-console_error_panic_hook = { version = "0.1.7" }
+console_error_panic_hook = { version = "0.1" }
 futures-timer = { workspace = true }
 
 [lints]

--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -90,7 +90,7 @@ yamux = ["dep:libp2p-yamux"]
 upnp = ["dep:libp2p-upnp"]
 [dependencies]
 bytes.workspace = true
-either = "1.9.0"
+either = "1.16"
 futures = { workspace = true }
 # TODO feature flag?
 rw-stream-sink = { workspace = true }
@@ -115,7 +115,7 @@ libp2p-request-response = { workspace = true, optional = true }
 libp2p-swarm = { workspace = true }
 libp2p-yamux = { workspace = true, optional = true }
 multiaddr = { workspace = true }
-pin-project = "1.0.0"
+pin-project = "1.1"
 thiserror = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/misc/gen-proto/Cargo.toml
+++ b/misc/gen-proto/Cargo.toml
@@ -7,4 +7,4 @@ license = "MIT"
 
 [dependencies]
 prost-build = "0.14"
-protox = "0.9.1"
+protox = "0.9"

--- a/misc/keygen/Cargo.toml
+++ b/misc/keygen/Cargo.toml
@@ -13,11 +13,11 @@ publish = false
 release = false
 
 [dependencies]
-clap = { version = "4.6.1", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 zeroize = "1"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.150"
-base64 = "0.22.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+base64 = "0.22"
 libp2p-identity = { workspace = true }
 
 [lints]

--- a/misc/metrics/Cargo.toml
+++ b/misc/metrics/Cargo.toml
@@ -30,7 +30,7 @@ libp2p-kad = { workspace = true, optional = true }
 libp2p-ping = { workspace = true, optional = true }
 libp2p-relay = { workspace = true, optional = true }
 libp2p-swarm = { workspace = true }
-pin-project = "1.1.13"
+pin-project = "1.1"
 prometheus-client = { workspace = true }
 
 [dev-dependencies]

--- a/misc/multistream-select/Cargo.toml
+++ b/misc/multistream-select/Cargo.toml
@@ -14,12 +14,12 @@ categories = ["network-programming", "asynchronous"]
 bytes.workspace = true
 futures = { workspace = true }
 tracing = { workspace = true }
-pin-project = "1.1.13"
-smallvec = "1.15.1"
+pin-project = "1.1"
+smallvec = "1.15"
 unsigned-varint = { workspace = true }
 
 [dev-dependencies]
-futures_ringbuf = "0.4.0"
+futures_ringbuf = "0.4"
 quickcheck = { workspace = true }
 rw-stream-sink = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/misc/peer-store/Cargo.toml
+++ b/misc/peer-store/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 libp2p-identity = { workspace = true, features = ["rand", "serde"] }
 libp2p = { workspace = true, features = ["macros", "identify"] }
 libp2p-swarm-test = { path = "../../swarm-test", features = ["tokio"] }
-serde_json = { version = "1.0.150" }
+serde_json = { version = "1.0" }
 
 [lints]
 workspace = true

--- a/misc/rw-stream-sink/Cargo.toml
+++ b/misc/rw-stream-sink/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = { workspace = true }
-pin-project = "1.1.13"
+pin-project = "1.1"
 static_assertions = "1"
 
 [dev-dependencies]

--- a/misc/server/Cargo.toml
+++ b/misc/server/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [dependencies]
 base64 = "0.22"
-clap = { version = "4.6.1", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 futures = { workspace = true }
 axum = { workspace = true }
 libp2p = { workspace = true, features = [

--- a/misc/webrtc-utils/Cargo.toml
+++ b/misc/webrtc-utils/Cargo.toml
@@ -22,7 +22,7 @@ prost = { workspace = true }
 prost-codec = { workspace = true }
 rand = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
-sha2 = "0.10.8"
+sha2 = "0.10"
 tinytemplate = "1.2"
 tracing = { workspace = true }
 

--- a/muxers/mplex/Cargo.toml
+++ b/muxers/mplex/Cargo.toml
@@ -19,7 +19,7 @@ libp2p-identity = { workspace = true }
 nohash-hasher = "0.2"
 parking_lot = "0.12"
 rand = { workspace = true }
-smallvec = "1.15.1"
+smallvec = "1.15"
 tracing = { workspace = true }
 unsigned-varint = { workspace = true, features = ["asynchronous_codec"] }
 

--- a/muxers/test-harness/Cargo.toml
+++ b/muxers/test-harness/Cargo.toml
@@ -14,7 +14,7 @@ release = false
 libp2p-core = { workspace = true }
 futures = { workspace = true }
 futures-timer = { workspace = true }
-futures_ringbuf = "0.4.0"
+futures_ringbuf = "0.4"
 tracing = { workspace = true }
 
 [lints]

--- a/protocols/autonat/Cargo.toml
+++ b/protocols/autonat/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 asynchronous-codec = { workspace = true }
-either = { version = "1.16.0", optional = true }
+either = { version = "1.16", optional = true }
 futures = { workspace = true }
 futures-bounded = { workspace = true, optional = true }
 futures-timer = { workspace = true }

--- a/protocols/dcutr/Cargo.toml
+++ b/protocols/dcutr/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 asynchronous-codec = { workspace = true }
-either = "1.16.0"
+either = "1.16"
 futures = { workspace = true }
 futures-timer = { workspace = true }
 web-time = { workspace = true }

--- a/protocols/floodsub/Cargo.toml
+++ b/protocols/floodsub/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 asynchronous-codec = { workspace = true }
-cuckoofilter = "0.5.0"
+cuckoofilter = "0.5"
 fnv = "1.0"
 bytes.workspace = true
 futures = { workspace = true }
@@ -22,7 +22,7 @@ libp2p-identity = { workspace = true }
 prost = { workspace = true }
 prost-codec = { workspace = true }
 rand = { workspace = true }
-smallvec = "1.15.1"
+smallvec = "1.15"
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -15,17 +15,17 @@ metrics = ["prometheus-client"]
 partial-messages = []
 
 [dependencies]
-async-channel = "2.5.0"
+async-channel = "2.5"
 asynchronous-codec = { workspace = true }
-base64 = "0.22.1"
-byteorder = "1.5.0"
+base64 = "0.22"
+byteorder = "1.5"
 bytes.workspace = true
 either = "1.16"
-fnv = "1.0.7"
+fnv = "1.0"
 futures = { workspace = true }
 futures-timer = { workspace = true }
 hashlink = { workspace = true }
-hex_fmt = "0.3.0"
+hex_fmt = "0.3"
 web-time = { workspace = true }
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true, features = ["rand"] }
@@ -33,9 +33,9 @@ libp2p-swarm = { workspace = true }
 prost = { workspace = true }
 prost-codec = { workspace = true }
 rand = { workspace = true }
-regex = "1.12.3"
+regex = "1.13"
 serde = { version = "1", optional = true, features = ["derive"] }
-sha2 = "0.10.8"
+sha2 = "0.11"
 tracing = { workspace = true }
 
 # Metrics dependencies

--- a/protocols/identify/Cargo.toml
+++ b/protocols/identify/Cargo.toml
@@ -20,10 +20,10 @@ libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true }
 prost-codec = { workspace = true }
 prost = { workspace = true }
-smallvec = "1.15.1"
+smallvec = "1.15"
 thiserror = { workspace = true }
 tracing = { workspace = true }
-either = "1.16.0"
+either = "1.16"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/protocols/kad/Cargo.toml
+++ b/protocols/kad/Cargo.toml
@@ -23,8 +23,8 @@ prost = { workspace = true }
 prost-codec = { workspace = true }
 libp2p-identity = { workspace = true, features = ["rand"] }
 rand = { workspace = true }
-sha2 = "0.10.8"
-smallvec = "1.15.1"
+sha2 = "0.10"
+smallvec = "1.15"
 uint = "0.10"
 futures-timer = { workspace = true }
 web-time = { workspace = true }

--- a/protocols/mdns/Cargo.toml
+++ b/protocols/mdns/Cargo.toml
@@ -17,8 +17,8 @@ libp2p-core = { workspace = true }
 libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true }
 rand = { workspace = true }
-smallvec = "1.15.1"
-socket2 = { version = "0.6.4", features = ["all"] }
+smallvec = "1.15"
+socket2 = { version = "0.6", features = ["all"] }
 tokio = { workspace = true, default-features = false, features = ["net", "time"], optional = true }
 tracing = { workspace = true }
 hickory-proto = { workspace = true, features = ["mdns"] }

--- a/protocols/perf/Cargo.toml
+++ b/protocols/perf/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 anyhow = "1"
-clap = { version = "4.6.1", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 futures = { workspace = true }
 futures-bounded = { workspace = true }
 futures-timer = { workspace = true }

--- a/protocols/relay/Cargo.toml
+++ b/protocols/relay/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 asynchronous-codec = { workspace = true }
 bytes.workspace = true
-either = "1.16.0"
+either = "1.16"
 futures = { workspace = true }
 futures-timer = { workspace = true }
 futures-bounded = { workspace = true }

--- a/protocols/rendezvous/Cargo.toml
+++ b/protocols/rendezvous/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 asynchronous-codec = { workspace = true }
-bimap = "0.6.3"
+bimap = "0.6"
 futures = { workspace = true, features = ["std"] }
 futures-timer = { workspace = true }
 hashlink = { workspace = true }

--- a/protocols/request-response/Cargo.toml
+++ b/protocols/request-response/Cargo.toml
@@ -18,8 +18,8 @@ libp2p-swarm = { workspace = true }
 libp2p-identity = { workspace = true }
 rand = { workspace = true }
 serde = { version = "1.0", optional = true }
-serde_json = { version = "1.0.150", optional = true }
-smallvec = "1.15.1"
+serde_json = { version = "1.0", optional = true }
+smallvec = "1.15"
 tracing = { workspace = true }
 futures-bounded = { workspace = true }
 
@@ -28,11 +28,11 @@ json = ["dep:serde", "dep:serde_json", "libp2p-swarm/macros"]
 cbor = ["dep:serde", "dep:cbor4ii", "libp2p-swarm/macros"]
 
 [dev-dependencies]
-anyhow = "1.0.102"
+anyhow = "1.0"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 rand = { workspace = true }
 libp2p-swarm-test = { path = "../../swarm-test" }
-futures_ringbuf = "0.4.0"
+futures_ringbuf = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 

--- a/protocols/stream/src/shared.rs
+++ b/protocols/stream/src/shared.rs
@@ -112,7 +112,7 @@ impl Shared {
             return;
         };
 
-        while let Ok(Some(new_stream)) = receiver.try_next() {
+        while let Ok(new_stream) = receiver.try_recv() {
             let _ = new_stream
                 .sender
                 .send(Err(crate::OpenStreamError::Io(io::Error::new(

--- a/protocols/upnp/Cargo.toml
+++ b/protocols/upnp/Cargo.toml
@@ -13,7 +13,7 @@ publish = true
 [dependencies]
 futures = { workspace = true }
 futures-timer = { workspace = true }
-igd-next = "0.17.1"
+igd-next = "0.17"
 libp2p-core = { workspace = true }
 libp2p-swarm = { workspace = true }
 tokio = { workspace = true, default-features = false, features = ["rt"], optional = true }

--- a/swarm-derive/Cargo.toml
+++ b/swarm-derive/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 [dependencies]
 heck = "0.5"
 quote = "1.0"
-syn = { version = "2.0.117", default-features = false, features = ["clone-impls", "derive", "parsing", "printing", "proc-macro"] }
+syn = { version = "3.0", default-features = false, features = ["clone-impls", "derive", "parsing", "printing", "proc-macro"] }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/swarm-test/Cargo.toml
+++ b/swarm-test/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1.89"
+async-trait = "0.1"
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true, features = ["rand"] }
 libp2p-plaintext = { workspace = true }

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["peer-to-peer", "libp2p", "networking"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-either = "1.16.0"
+either = "1.16"
 fnv = "1.0"
 futures = { workspace = true }
 futures-timer = { workspace = true }
@@ -22,7 +22,7 @@ libp2p-identity = { workspace = true }
 libp2p-swarm-derive = { workspace = true, optional = true }
 multistream-select = { workspace = true }
 rand = { workspace = true }
-smallvec = "1.15.1"
+smallvec = "1.15"
 tracing = { workspace = true }
 
 [target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "unknown")))'.dependencies]
@@ -37,7 +37,7 @@ macros = ["dep:libp2p-swarm-derive"]
 tokio = ["dep:tokio"]
 
 [dev-dependencies]
-either = "1.16.0"
+either = "1.16"
 futures = { workspace = true }
 libp2p-identify = { path = "../protocols/identify" } # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
 libp2p-identity = { workspace = true, features = ["ed25519"] }
@@ -49,7 +49,7 @@ libp2p-swarm-test = { path = "../swarm-test", features = ["tokio"] } # Using `pa
 libp2p-yamux = { path = "../muxers/yamux" } # Using `path` here because this is a cyclic dev-dependency which otherwise breaks releasing.
 quickcheck = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio"] }
-trybuild = "1.0.116"
+trybuild = "1.0"
 tokio = { workspace = true, features = ["time", "rt", "macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 

--- a/transports/dns/Cargo.toml
+++ b/transports/dns/Cargo.toml
@@ -14,9 +14,9 @@ categories = ["network-programming", "asynchronous"]
 futures = { workspace = true }
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true }
-parking_lot = "0.12.5"
+parking_lot = "0.12"
 hickory-resolver = { workspace = true, features = ["system-config"] }
-smallvec = "1.15.1"
+smallvec = "1.15"
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/transports/noise/Cargo.toml
+++ b/transports/noise/Cargo.toml
@@ -25,13 +25,13 @@ x25519-dalek = "2"
 zeroize = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-snow = { version = "0.9.6", features = ["ring-resolver"], default-features = false }
+snow = { version = "0.9", features = ["ring-resolver"], default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-snow = { version = "0.9.5", features = ["default-resolver"], default-features = false }
+snow = { version = "0.9", features = ["default-resolver"], default-features = false }
 
 [dev-dependencies]
-futures_ringbuf = "0.4.0"
+futures_ringbuf = "0.4"
 quickcheck = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 libp2p-identity = { workspace = true, features = ["rand"] }

--- a/transports/plaintext/Cargo.toml
+++ b/transports/plaintext/Cargo.toml
@@ -23,7 +23,7 @@ prost-codec = { workspace = true }
 [dev-dependencies]
 libp2p-identity = { workspace = true, features = ["ed25519", "rand"] }
 quickcheck = { workspace = true }
-futures_ringbuf = "0.4.0"
+futures_ringbuf = "0.4"
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.

--- a/transports/pnet/Cargo.toml
+++ b/transports/pnet/Cargo.toml
@@ -16,7 +16,7 @@ salsa20 = "0.10"
 sha3 = "0.10"
 tracing = { workspace = true }
 rand = { workspace = true }
-pin-project = "1.1.13"
+pin-project = "1.1"
 
 [dev-dependencies]
 libp2p-core = { workspace = true }

--- a/transports/quic/Cargo.toml
+++ b/transports/quic/Cargo.toml
@@ -15,14 +15,14 @@ if-watch = { workspace = true }
 libp2p-core = { workspace = true }
 libp2p-tls = { workspace = true }
 libp2p-identity = { workspace = true }
-quinn = { version = "0.11.9", default-features = false, features = ["rustls", "futures-io"] }
+quinn = { version = "0.11", default-features = false, features = ["rustls", "futures-io"] }
 quinn-proto = { version = "0.11" }
 rand = { workspace = true }
-rustls = { version = "0.23.40", default-features = false }
+rustls = { version = "0.23", default-features = false }
 thiserror = { workspace = true }
 tokio = { workspace = true, default-features = false, features = ["net", "rt", "time"], optional = true }
 tracing = { workspace = true }
-socket2 = "0.6.4"
+socket2 = "0.6"
 ring = { workspace = true }
 
 [features]

--- a/transports/tcp/Cargo.toml
+++ b/transports/tcp/Cargo.toml
@@ -14,9 +14,9 @@ categories = ["network-programming", "asynchronous"]
 futures = { workspace = true }
 futures-timer = { workspace = true }
 if-watch = { workspace = true }
-libc = "0.2.186"
+libc = "0.2"
 libp2p-core = { workspace = true }
-socket2 = { version = "0.6.4", features = ["all"] }
+socket2 = { version = "0.6", features = ["all"] }
 tokio = { workspace = true, default-features = false, features = ["net"], optional = true }
 tracing = { workspace = true }
 

--- a/transports/tls/Cargo.toml
+++ b/transports/tls/Cargo.toml
@@ -22,7 +22,7 @@ yasna = "0.6"
 
 # Exposed dependencies. Breaking changes to these are breaking changes to us.
 [dependencies.rustls]
-version = "0.23.40"
+version = "0.23"
 default-features = false
 features = ["ring", "std"] # Must enable this to allow for custom verification code.
 

--- a/transports/webrtc-websys/Cargo.toml
+++ b/transports/webrtc-websys/Cargo.toml
@@ -14,17 +14,17 @@ publish = true
 [dependencies]
 bytes.workspace = true
 futures = { workspace = true }
-hex = "0.4.3"
+hex = "0.4"
 js-sys = { version = "0.3" }
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true }
 libp2p-webrtc-utils = { workspace = true }
-send_wrapper = { version = "0.6.0", features = ["futures"] }
+send_wrapper = { version = "0.6", features = ["futures"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-wasm-bindgen = { version = "0.2.90" }
+wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = { workspace = true}
-web-sys = { version = "0.3.70", features = ["Document", "Location", "MessageEvent", "Navigator", "RtcCertificate", "RtcConfiguration", "RtcDataChannel", "RtcDataChannelEvent", "RtcDataChannelInit", "RtcDataChannelState", "RtcDataChannelType", "RtcPeerConnection", "RtcSdpType", "RtcSessionDescription", "RtcSessionDescriptionInit", "Window"] }
+web-sys = { version = "0.3", features = ["Document", "Location", "MessageEvent", "Navigator", "RtcCertificate", "RtcConfiguration", "RtcDataChannel", "RtcDataChannelEvent", "RtcDataChannelInit", "RtcDataChannelState", "RtcDataChannelType", "RtcPeerConnection", "RtcSdpType", "RtcSessionDescription", "RtcSessionDescriptionInit", "Window"] }
 
 [target.'cfg(target_family="wasm")'.dependencies]
 getrandom = { workspace = true}

--- a/transports/webrtc/Cargo.toml
+++ b/transports/webrtc/Cargo.toml
@@ -23,12 +23,12 @@ libp2p-webrtc-utils = { workspace = true }
 multihash = { workspace = true }
 rand = { workspace = true }
 rcgen = { workspace = true }
-stun = "0.17.0"
+stun = "0.17"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["net"], optional = true }
 tokio-util = { version = "0.7", features = ["compat"], optional = true }
 tracing = { workspace = true }
-webrtc = { version = "0.17.0", optional = true }
+webrtc = { version = "0.17", optional = true }
 
 [features]
 tokio = ["dep:tokio", "dep:tokio-util", "dep:webrtc", "if-watch/tokio"]
@@ -37,7 +37,7 @@ pem = ["webrtc?/pem"]
 [dev-dependencies]
 libp2p-identity = { workspace = true, features = ["rand"] }
 tokio = { workspace = true, features = ["full"] }
-quickcheck = "1.1.0"
+quickcheck = "1.1"
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 

--- a/transports/websocket-websys/Cargo.toml
+++ b/transports/websocket-websys/Cargo.toml
@@ -13,13 +13,13 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 bytes.workspace = true
 futures = { workspace = true }
-js-sys = "0.3.69"
+js-sys = "0.3"
 libp2p-core = { workspace = true }
 tracing = { workspace = true }
-send_wrapper = "0.6.0"
+send_wrapper = "0.6"
 thiserror = { workspace = true }
-wasm-bindgen = "0.2.90"
-web-sys = { version = "0.3.69", features = ["BinaryType", "CloseEvent", "MessageEvent", "WebSocket", "Window", "WorkerGlobalScope"] }
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = ["BinaryType", "CloseEvent", "MessageEvent", "WebSocket", "Window", "WorkerGlobalScope"] }
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/transports/websocket/Cargo.toml
+++ b/transports/websocket/Cargo.toml
@@ -12,18 +12,18 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures-rustls = { workspace = true, features = ["ring"] }
-either = "1.16.0"
+either = "1.16"
 futures = { workspace = true }
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true }
-parking_lot = "0.12.5"
-pin-project-lite = "0.2.17"
+parking_lot = "0.12"
+pin-project-lite = "0.2"
 rw-stream-sink = { workspace = true }
-soketto = "0.8.0"
+soketto = "0.8"
 tracing = { workspace = true }
 thiserror = { workspace = true }
 url = "2.5"
-webpki-roots = "0.26"
+webpki-roots = "1.0"
 
 [dev-dependencies]
 libp2p-tcp = { workspace = true, features = ["tokio"] }

--- a/transports/webtransport-websys/Cargo.toml
+++ b/transports/webtransport-websys/Cargo.toml
@@ -15,18 +15,18 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = { workspace = true }
-js-sys = "0.3.70"
+js-sys = "0.3"
 libp2p-core = { workspace = true }
 libp2p-identity = { workspace = true }
 libp2p-noise = { workspace = true }
 multiaddr = { workspace = true }
 multihash = { workspace = true }
-send_wrapper = { version = "0.6.0", features = ["futures"] }
+send_wrapper = { version = "0.6", features = ["futures"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-wasm-bindgen = "0.2.93"
+wasm-bindgen = "0.2"
 wasm-bindgen-futures = { workspace = true }
-web-sys = { version = "0.3.70", features = [
+web-sys = { version = "0.3", features = [
     "ReadableStreamDefaultReader",
     "WebTransport",
     "WebTransportBidirectionalStream",
@@ -38,7 +38,7 @@ web-sys = { version = "0.3.70", features = [
 ] }
 
 [dev-dependencies]
-multibase = "0.9.2"
+multibase = "0.9"
 
 # Passing arguments to the docsrs builder in order to properly document cfg's.
 # More information: https://docs.rs/about/builds#cross-compiling

--- a/wasm-tests/webtransport-tests/Cargo.toml
+++ b/wasm-tests/webtransport-tests/Cargo.toml
@@ -17,10 +17,10 @@ libp2p-noise = { workspace = true }
 libp2p-webtransport-websys = { workspace = true }
 multiaddr = { workspace = true }
 multihash = { workspace = true }
-wasm-bindgen = "0.2.93"
+wasm-bindgen = "0.2"
 wasm-bindgen-futures = { workspace = true }
-wasm-bindgen-test = "0.3.50"
-web-sys = { version = "0.3.70", features = ["Response", "Window"] }
+wasm-bindgen-test = "0.3"
+web-sys = { version = "0.3", features = ["Response", "Window"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
And strip patch version specifiers from all external dependency entries across the workspace.
With Cargo.lock versioned, the lockfile provides reproducible builds regardless
of how loosely deps are specified. Patch-level pinning in Cargo.toml is therefore
redundant: it adds dependabot churn without meaningful protection against
semver breakage.