### PR TITLE
fix(relay): don't panic on circuit request without a matching reservation

### DIFF
--- a/protocols/relay/CHANGELOG.md
+++ b/protocols/relay/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 0.22.0
 
+- Don't panic when the destination peer has connections to the relay that carry no reservation.
+  The relay picked an arbitrary connection out of a `HashMap` and asserted that it held the
+  reservation, crashing the whole relay as soon as the (randomly ordered) iterator yielded any
+  of the others. It now looks for the connection that actually holds the reservation and falls
+  back to denying the request with `NO_RESERVATION`.
+  See [PR 6570](https://github.com/libp2p/rust-libp2p/pull/6570).
+
 - Use `futures-timer` instead of tokio's timer for stream timeouts so the bounded `Delay` works on
   `wasm32`; tokio's timer has no driver in the browser and panics at runtime.
   See [PR 6488](https://github.com/libp2p/rust-libp2p/pull/6488).

--- a/protocols/relay/src/behaviour.rs
+++ b/protocols/relay/src/behaviour.rs
@@ -711,13 +711,11 @@ impl NetworkBehaviour for Behaviour {
                             status: proto::Status::ResourceLimitExceeded,
                         }),
                     }
-                } else if let Some((dst_conn, status)) = self
+                } else if let Some((dst_conn, _)) = self
                     .connections
                     .get(&inbound_circuit_req.dst())
-                    .and_then(|cs| cs.iter().next())
+                    .and_then(|cs| cs.iter().find(|(_, status)| status.is_active()))
                 {
-                    assert_eq!(*status, Reservation::Active);
-
                     // Accept circuit request if reservation present.
                     let circuit_id = self.circuits.insert(Circuit {
                         status: CircuitStatus::Accepting,

--- a/protocols/relay/tests/lib.rs
+++ b/protocols/relay/tests/lib.rs
@@ -35,7 +35,10 @@ use libp2p_identity::PeerId;
 use libp2p_ping as ping;
 use libp2p_plaintext as plaintext;
 use libp2p_relay as relay;
-use libp2p_swarm::{Config, DialError, NetworkBehaviour, Swarm, SwarmEvent, dial_opts::DialOpts};
+use libp2p_swarm::{
+    Config, DialError, NetworkBehaviour, Swarm, SwarmEvent,
+    dial_opts::{DialOpts, PeerCondition},
+};
 use libp2p_swarm_test::SwarmExt;
 use tracing_subscriber::EnvFilter;
 
@@ -289,6 +292,85 @@ async fn connect() {
         false, // No renewal.
     )
     .await;
+
+    let mut src = build_client();
+    let src_peer_id = *src.local_peer_id();
+
+    src.dial(dst_addr).unwrap();
+
+    futures::future::join(
+        connection_established_to(&mut src, relay_peer_id, dst_peer_id),
+        connection_established_to(&mut dst, relay_peer_id, src_peer_id),
+    )
+    .await;
+}
+
+/// A destination peer may hold several connections to the relay while only one of them
+/// carries the reservation: a reconnect leaves the old connection around for a while, and
+/// nothing stops a peer from dialing the relay again for other reasons.
+///
+/// The relay used to pick an arbitrary connection out of a  and assert that it was
+/// the reserved one, which panicked the whole relay task as soon as the (randomly ordered)
+/// iterator yielded any of the others.
+#[tokio::test]
+async fn connect_with_extra_non_reserved_connections_to_relay() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .try_init();
+
+    let relay_addr = Multiaddr::empty().with(Protocol::Memory(rand::random::<u64>()));
+    let mut relay = build_relay();
+    let relay_peer_id = *relay.local_peer_id();
+
+    relay.listen_on(relay_addr.clone()).unwrap();
+    relay.add_external_address(relay_addr.clone());
+    tokio::spawn(async move {
+        relay.collect::<Vec<_>>().await;
+    });
+
+    let mut dst = build_client();
+    let dst_peer_id = *dst.local_peer_id();
+    let dst_addr = relay_addr
+        .clone()
+        .with(Protocol::P2p(relay_peer_id))
+        .with(Protocol::P2pCircuit)
+        .with(Protocol::P2p(dst_peer_id));
+
+    dst.listen_on(dst_addr.clone()).unwrap();
+
+    assert!(wait_for_dial(&mut dst, relay_peer_id).await);
+
+    wait_for_reservation(
+        &mut dst,
+        dst_addr.clone(),
+        relay_peer_id,
+        false, // No renewal.
+    )
+    .await;
+
+    // Open additional connections to the relay that do *not* carry a reservation. Several of
+    // them, so the test does not depend on which one the relay happens to look at first.
+    const EXTRA_CONNECTIONS: usize = 5;
+    for _ in 0..EXTRA_CONNECTIONS {
+        dst.dial(
+            DialOpts::peer_id(relay_peer_id)
+                .condition(PeerCondition::Always)
+                .addresses(vec![relay_addr.clone()])
+                .build(),
+        )
+        .unwrap();
+    }
+
+    let mut established = 0;
+    while established < EXTRA_CONNECTIONS {
+        match dst.select_next_some().await {
+            SwarmEvent::ConnectionEstablished { peer_id, .. } if peer_id == relay_peer_id => {
+                established += 1;
+            }
+            SwarmEvent::Dialing { .. } | SwarmEvent::Behaviour(ClientEvent::Ping(_)) => {}
+            e => panic!("{e:?}"),
+        }
+    }
 
     let mut src = build_client();
     let src_peer_id = *src.local_peer_id();


### PR DESCRIPTION
## Description

The relay server picked an arbitrary connection to the destination peer out of a `HashMap` and
asserted that it held the reservation:

```rust
.and_then(|cs| cs.iter().next())
{
    assert_eq!(*status, Reservation::Active);
```

Connections are inserted as `Reservation::None` on `ConnectionEstablished` and only flipped to
`Active` once a reservation is accepted. So as soon as the destination has any extra connection
open — a lingering one from a reconnect, for instance — the randomly ordered iterator can yield
it and the assertion takes down the whole relay task. It is reachable remotely: the source peer
only has to send a circuit request at that moment.

This looks for the connection that actually holds the reservation instead. Requests with none
fall through to the existing `NO_RESERVATION` branch. It also fixes the quieter half: even when
the assertion happened to pass, the circuit could be routed over a connection that did not hold
the reservation.

`Reservation::is_active()` already existed but was not used at this call site.

Fixes https://github.com/libp2p/rust-libp2p/issues/6569.

## AI Assistance Disclosure

**Tools used** _(required — write `none` if no AI was used)_: Claude Code

**Attestation** _(required)_:

- [x] I have read every line of this diff, understand what it does, and can explain it in review.

## Notes & open questions

The crash came from my own production relay (log in the linked issue). The new test reproduces it:
the destination opens five extra connections to the relay after reserving, then a source peer dials
the circuit. It fails on `master` with the same assertion at `behaviour.rs:719` and passes with the
fix.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates