### PR TITLE
feat(webrtc-utils): add Fingerprint::from_sdp_format

### DIFF
--- a/misc/webrtc-utils/CHANGELOG.md
+++ b/misc/webrtc-utils/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.5.0
 
+- Add `Fingerprint::from_sdp_format`, the inverse of `Fingerprint::to_sdp_format`.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+
 - Revert migration to `quick-protobuf`, migrate back to `prost`.
   See [PR 6363](https://github.com/libp2p/rust-libp2p/pull/6363).
 

--- a/misc/webrtc-utils/CHANGELOG.md
+++ b/misc/webrtc-utils/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.5.0
 
 - Add `Fingerprint::from_sdp_format`, the inverse of `Fingerprint::to_sdp_format`.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+  See [PR 6571](https://github.com/libp2p/rust-libp2p/pull/6571).
 
 - Revert migration to `quick-protobuf`, migrate back to `prost`.
   See [PR 6363](https://github.com/libp2p/rust-libp2p/pull/6363).

--- a/misc/webrtc-utils/src/fingerprint.rs
+++ b/misc/webrtc-utils/src/fingerprint.rs
@@ -69,6 +69,19 @@ impl Fingerprint {
         self.0.map(|byte| format!("{byte:02X}")).join(":")
     }
 
+    /// Parses a fingerprint from the format described in
+    /// <https://www.rfc-editor.org/rfc/rfc4572#section-5>: 32 hex-encoded bytes, optionally
+    /// separated by colons (`:`). Case-insensitive.
+    ///
+    /// This is the inverse of [`Fingerprint::to_sdp_format`]. Returns `None` if the input is
+    /// not a well-formed SHA-256 fingerprint.
+    pub fn from_sdp_format(sdp: &str) -> Option<Self> {
+        let mut digest = [0u8; 32];
+        hex::decode_to_slice(sdp.replace(':', ""), &mut digest).ok()?;
+
+        Some(Self(digest))
+    }
+
     /// Returns the algorithm used (e.g. "sha-256").
     /// See <https://datatracker.ietf.org/doc/html/rfc8122#section-5>
     pub fn algorithm(&self) -> String {
@@ -101,10 +114,51 @@ mod tests {
 
     #[test]
     fn from_sdp() {
-        let mut bytes = [0; 32];
-        bytes.copy_from_slice(&hex::decode(SDP_FORMAT.replace(':', "")).unwrap());
+        let fp = Fingerprint::from_sdp_format(SDP_FORMAT).unwrap();
 
-        let fp = Fingerprint::raw(bytes);
         assert_eq!(fp, Fingerprint::raw(REGULAR_FORMAT));
+    }
+
+    #[test]
+    fn sdp_format_round_trips() {
+        let fp = Fingerprint::raw(REGULAR_FORMAT);
+
+        assert_eq!(Fingerprint::from_sdp_format(&fp.to_sdp_format()), Some(fp));
+    }
+
+    /// Colons are separators, and hex is case-insensitive; neither carries meaning.
+    #[test]
+    fn from_sdp_accepts_lowercase_and_missing_colons() {
+        let expected = Fingerprint::raw(REGULAR_FORMAT);
+
+        for accepted in [
+            SDP_FORMAT.to_lowercase(),
+            SDP_FORMAT.replace(':', ""),
+            SDP_FORMAT.replace(':', "").to_lowercase(),
+        ] {
+            assert_eq!(Fingerprint::from_sdp_format(&accepted), Some(expected));
+        }
+    }
+
+    /// A truncated or malformed fingerprint must not yield a partial one: a wrong fingerprint
+    /// silently fails the DTLS handshake much later, which is far harder to diagnose.
+    #[test]
+    fn from_sdp_rejects_malformed_input() {
+        for rejected in [
+            "",
+            "not hex at all",
+            // One byte short.
+            &SDP_FORMAT[..SDP_FORMAT.len() - 3],
+            // One byte too many.
+            &format!("{SDP_FORMAT}:AB"),
+            // Odd number of nibbles.
+            &SDP_FORMAT[..SDP_FORMAT.len() - 1],
+        ] {
+            assert_eq!(
+                Fingerprint::from_sdp_format(rejected),
+                None,
+                "should have rejected {rejected:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Description

`Fingerprint` can be rendered into the [RFC 4572 §5][rfc] SDP format via `to_sdp_format`, but
there is no way back. Anyone who needs to read a fingerprint *out* of an SDP has to hand-roll the
hex/colon decoding — an out-of-tree transport parsing `localDescription`, or a test asserting
against a rendered description.

This adds the inverse:

```rust
pub fn from_sdp_format(sdp: &str) -> Option<Self>
```

Colons are separators and hex is case-insensitive, so both are accepted on the way in
(`AB:CD:…`, `abcd…`, and every mix round-trip to the same fingerprint). Malformed input yields
`None` rather than a truncated fingerprint — a wrong fingerprint surfaces as a DTLS handshake that
fails much later, which is considerably harder to diagnose than a parse failure at the source.

The existing `from_sdp` test decoded the constant by hand with `hex::decode` and compared the
result to itself, so it exercised no library code at all. It now goes through the new method, and
three more tests cover the round trip, the accepted spellings, and the rejected ones.

[rfc]: https://www.rfc-editor.org/rfc/rfc4572#section-5

## AI Assistance Disclosure

**Tools used** _(required — write `none` if no AI was used)_: Claude Code

**Attestation** _(required)_:

- [x] I have read every line of this diff, understand what it does, and can explain it in review.

## Notes & open questions

This came out of building a WebRTC-Direct transport outside the tree: the browser side has to read
the DTLS fingerprint back out of `RTCPeerConnection.localDescription`, so I ended up writing this
parser by hand. It seemed to belong next to `to_sdp_format` rather than in my crate.

`hex` is already a dependency of `libp2p-webrtc-utils` (used by `Fingerprint`'s `Debug` impl), so
this adds nothing to the dependency tree.

The changelog entry has a placeholder PR number; happy to push the real one once this is assigned.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates