### PR TITLE
feat(webrtc-utils): move the offer SDP template alongside the answer

### DIFF
--- a/misc/webrtc-utils/CHANGELOG.md
+++ b/misc/webrtc-utils/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Add `sdp::offer`, mirroring the existing `sdp::answer`. The offer template moved here
   from `libp2p-webrtc`, where it was private.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+  See [PR 6572](https://github.com/libp2p/rust-libp2p/pull/6572).
 
 - Revert migration to `quick-protobuf`, migrate back to `prost`.
   See [PR 6363](https://github.com/libp2p/rust-libp2p/pull/6363).

--- a/misc/webrtc-utils/CHANGELOG.md
+++ b/misc/webrtc-utils/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.5.0
 
+- Add `sdp::offer`, mirroring the existing `sdp::answer`. The offer template moved here
+  from `libp2p-webrtc`, where it was private.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+
 - Revert migration to `quick-protobuf`, migrate back to `prost`.
   See [PR 6363](https://github.com/libp2p/rust-libp2p/pull/6363).
 

--- a/misc/webrtc-utils/src/sdp.rs
+++ b/misc/webrtc-utils/src/sdp.rs
@@ -26,6 +26,24 @@ use tinytemplate::TinyTemplate;
 
 use crate::fingerprint::Fingerprint;
 
+/// Renders the SDP offer, describing the client (the dialer).
+///
+/// The server does not verify the client's certificate -- the client's identity is established by
+/// the Noise handshake that runs afterwards -- so a server rendering this offer on the client's
+/// behalf passes [`Fingerprint::FF`] here.
+pub fn offer(addr: SocketAddr, client_fingerprint: Fingerprint, client_ufrag: &str) -> String {
+    let offer = render_description(
+        CLIENT_SESSION_DESCRIPTION,
+        addr,
+        client_fingerprint,
+        client_ufrag,
+    );
+
+    tracing::trace!(%offer, "Created SDP offer");
+
+    offer
+}
+
 pub fn answer(addr: SocketAddr, server_fingerprint: Fingerprint, client_ufrag: &str) -> String {
     let answer = render_description(
         SERVER_SESSION_DESCRIPTION,
@@ -38,6 +56,95 @@ pub fn answer(addr: SocketAddr, server_fingerprint: Fingerprint, client_ufrag: &
 
     answer
 }
+
+// An SDP message that constitutes the offer.
+//
+// Main RFC: <https://datatracker.ietf.org/doc/html/rfc8866>
+// `sctp-port` and `max-message-size` attrs RFC: <https://datatracker.ietf.org/doc/html/rfc8841>
+// `group` and `mid` attrs RFC: <https://datatracker.ietf.org/doc/html/rfc9143>
+// `ice-ufrag`, `ice-pwd` and `ice-options` attrs RFC: <https://datatracker.ietf.org/doc/html/rfc8839>
+// `setup` attr RFC: <https://datatracker.ietf.org/doc/html/rfc8122>
+//
+// Short description:
+//
+// v=<protocol-version> -> always 0
+// o=<username> <sess-id> <sess-version> <nettype> <addrtype> <unicast-address>
+//
+//     <username> identifies the creator of the SDP document. We are allowed to use dummy values
+//     (`-` and `0.0.0.0` as <addrtype>) to remain anonymous, which we do. Note that "IN" means
+//     "Internet".
+//
+// s=<session name>
+//
+//     We are allowed to pass a dummy `-`.
+//
+// c=<nettype> <addrtype> <connection-address>
+//
+//     Indicates the IP address of the remote.
+//     Note that "IN" means "Internet".
+//
+// t=<start-time> <stop-time>
+//
+//     Start and end of the validity of the session. `0 0` means that the session never expires.
+//
+// m=<media> <port> <proto> <fmt> ...
+//
+//     A `m=` line describes a request to establish a certain protocol. The protocol in this line
+//     (i.e. `TCP/DTLS/SCTP` or `UDP/DTLS/SCTP`) must always be the same as the one in the offer.
+//     We know that this is true because we tweak the offer to match the protocol. The `<fmt>`
+//     component must always be `webrtc-datachannel` for WebRTC.
+//     RFCs: 8839, 8866, 8841
+//
+// a=mid:<MID>
+//
+//     Media ID - uniquely identifies this media stream (RFC9143).
+//
+// a=ice-options:ice2
+//
+//     Indicates that we are complying with RFC8839 (as opposed to the legacy RFC5245).
+//
+// a=ice-ufrag:<ICE user>
+// a=ice-pwd:<ICE password>
+//
+//     ICE username and password, which are used for establishing and
+//     maintaining the ICE connection. (RFC8839)
+//     MUST match ones used by the answerer (server).
+//
+// a=fingerprint:sha-256 <fingerprint>
+//
+//     Fingerprint of the certificate that the remote will use during the TLS
+//     handshake. (RFC8122)
+//
+// a=setup:actpass
+//
+//     The endpoint that is the offerer MUST use the setup attribute value of setup:actpass and be
+//     prepared to receive a client_hello before it receives the answer.
+//
+// a=sctp-port:<value>
+//
+//     The SCTP port (RFC8841)
+//     Note it's different from the "m=" line port value, which indicates the port of the
+//     underlying transport-layer protocol (UDP or TCP).
+//
+// a=max-message-size:<value>
+//
+//     The maximum SCTP user message size (in bytes). (RFC8841)
+const CLIENT_SESSION_DESCRIPTION: &str = "v=0
+o=- 0 0 IN {ip_version} {target_ip}
+s=-
+c=IN {ip_version} {target_ip}
+t=0 0
+
+m=application {target_port} UDP/DTLS/SCTP webrtc-datachannel
+a=mid:0
+a=ice-options:ice2
+a=ice-ufrag:{ufrag}
+a=ice-pwd:{pwd}
+a=fingerprint:{fingerprint_algorithm} {fingerprint_value}
+a=setup:actpass
+a=sctp-port:5000
+a=max-message-size:16384
+";
 
 // See [`CLIENT_SESSION_DESCRIPTION`].
 //

--- a/transports/webrtc/CHANGELOG.md
+++ b/transports/webrtc/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.10.0-alpha
 
+- Move the offer SDP template into `libp2p-webrtc-utils` and render it through the new
+  `sdp::offer` there. No behaviour change.
+  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+
 - Update webrtc-rs to `v0.17` and fix libp2p noise data channel negotiation.
   See [PR 6429](https://github.com/libp2p/rust-libp2p/pull/6429)
 

--- a/transports/webrtc/CHANGELOG.md
+++ b/transports/webrtc/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Move the offer SDP template into `libp2p-webrtc-utils` and render it through the new
   `sdp::offer` there. No behaviour change.
-  See [PR XXXX](https://github.com/libp2p/rust-libp2p/pull/XXXX).
+  See [PR 6572](https://github.com/libp2p/rust-libp2p/pull/6572).
 
 - Update webrtc-rs to `v0.17` and fix libp2p noise data channel negotiation.
   See [PR 6429](https://github.com/libp2p/rust-libp2p/pull/6429)

--- a/transports/webrtc/src/tokio/sdp.rs
+++ b/transports/webrtc/src/tokio/sdp.rs
@@ -20,8 +20,8 @@
 
 use std::net::SocketAddr;
 
+use libp2p_webrtc_utils::Fingerprint;
 pub(crate) use libp2p_webrtc_utils::sdp::random_ufrag;
-use libp2p_webrtc_utils::{Fingerprint, sdp::render_description};
 use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
 
 /// Creates the SDP answer used by the client.
@@ -42,103 +42,10 @@ pub(crate) fn answer(
 ///
 /// Certificate verification is disabled which is why we hardcode a dummy fingerprint here.
 pub(crate) fn offer(addr: SocketAddr, client_ufrag: &str) -> RTCSessionDescription {
-    let offer = render_description(
-        CLIENT_SESSION_DESCRIPTION,
+    RTCSessionDescription::offer(libp2p_webrtc_utils::sdp::offer(
         addr,
         Fingerprint::FF,
         client_ufrag,
-    );
-
-    tracing::trace!(offer=%offer, "Created SDP offer");
-
-    RTCSessionDescription::offer(offer).unwrap()
+    ))
+    .unwrap()
 }
-
-// An SDP message that constitutes the offer.
-//
-// Main RFC: <https://datatracker.ietf.org/doc/html/rfc8866>
-// `sctp-port` and `max-message-size` attrs RFC: <https://datatracker.ietf.org/doc/html/rfc8841>
-// `group` and `mid` attrs RFC: <https://datatracker.ietf.org/doc/html/rfc9143>
-// `ice-ufrag`, `ice-pwd` and `ice-options` attrs RFC: <https://datatracker.ietf.org/doc/html/rfc8839>
-// `setup` attr RFC: <https://datatracker.ietf.org/doc/html/rfc8122>
-//
-// Short description:
-//
-// v=<protocol-version> -> always 0
-// o=<username> <sess-id> <sess-version> <nettype> <addrtype> <unicast-address>
-//
-//     <username> identifies the creator of the SDP document. We are allowed to use dummy values
-//     (`-` and `0.0.0.0` as <addrtype>) to remain anonymous, which we do. Note that "IN" means
-//     "Internet".
-//
-// s=<session name>
-//
-//     We are allowed to pass a dummy `-`.
-//
-// c=<nettype> <addrtype> <connection-address>
-//
-//     Indicates the IP address of the remote.
-//     Note that "IN" means "Internet".
-//
-// t=<start-time> <stop-time>
-//
-//     Start and end of the validity of the session. `0 0` means that the session never expires.
-//
-// m=<media> <port> <proto> <fmt> ...
-//
-//     A `m=` line describes a request to establish a certain protocol. The protocol in this line
-//     (i.e. `TCP/DTLS/SCTP` or `UDP/DTLS/SCTP`) must always be the same as the one in the offer.
-//     We know that this is true because we tweak the offer to match the protocol. The `<fmt>`
-//     component must always be `webrtc-datachannel` for WebRTC.
-//     RFCs: 8839, 8866, 8841
-//
-// a=mid:<MID>
-//
-//     Media ID - uniquely identifies this media stream (RFC9143).
-//
-// a=ice-options:ice2
-//
-//     Indicates that we are complying with RFC8839 (as opposed to the legacy RFC5245).
-//
-// a=ice-ufrag:<ICE user>
-// a=ice-pwd:<ICE password>
-//
-//     ICE username and password, which are used for establishing and
-//     maintaining the ICE connection. (RFC8839)
-//     MUST match ones used by the answerer (server).
-//
-// a=fingerprint:sha-256 <fingerprint>
-//
-//     Fingerprint of the certificate that the remote will use during the TLS
-//     handshake. (RFC8122)
-//
-// a=setup:actpass
-//
-//     The endpoint that is the offerer MUST use the setup attribute value of setup:actpass and be
-//     prepared to receive a client_hello before it receives the answer.
-//
-// a=sctp-port:<value>
-//
-//     The SCTP port (RFC8841)
-//     Note it's different from the "m=" line port value, which indicates the port of the
-//     underlying transport-layer protocol (UDP or TCP).
-//
-// a=max-message-size:<value>
-//
-//     The maximum SCTP user message size (in bytes). (RFC8841)
-const CLIENT_SESSION_DESCRIPTION: &str = "v=0
-o=- 0 0 IN {ip_version} {target_ip}
-s=-
-c=IN {ip_version} {target_ip}
-t=0 0
-
-m=application {target_port} UDP/DTLS/SCTP webrtc-datachannel
-a=mid:0
-a=ice-options:ice2
-a=ice-ufrag:{ufrag}
-a=ice-pwd:{pwd}
-a=fingerprint:{fingerprint_algorithm} {fingerprint_value}
-a=setup:actpass
-a=sctp-port:5000
-a=max-message-size:16384
-";


### PR DESCRIPTION
## Description

`libp2p-webrtc-utils` owns half of the SDP pair. `sdp::answer` and
`SERVER_SESSION_DESCRIPTION` live there; the offer template sits private in
`transports/webrtc/src/tokio/sdp.rs`. The split is visible in the source — the doc comment on
`SERVER_SESSION_DESCRIPTION` opens with:

```rust
// See [`CLIENT_SESSION_DESCRIPTION`].
```

pointing at a constant in a different crate, where the shared RFC annotations for both templates
actually live.

This moves `CLIENT_SESSION_DESCRIPTION` over with its annotations and adds `sdp::offer` mirroring
`sdp::answer`, so both descriptions of the libp2p WebRTC handshake sit in one place:

```rust
pub fn offer(addr: SocketAddr, client_fingerprint: Fingerprint, client_ufrag: &str) -> String
pub fn answer(addr: SocketAddr, server_fingerprint: Fingerprint, client_ufrag: &str) -> String
```

The offer takes the fingerprint as an argument rather than hardcoding `Fingerprint::FF`. That
keeps the two symmetric and leaves the "we don't verify the client's certificate, its identity
comes from the Noise handshake" decision at the call site, where the comment explaining it already
is. `libp2p-webrtc`'s `sdp::offer` becomes the same thin `RTCSessionDescription` wrapper its
`sdp::answer` already was.

No behaviour change — the rendered offer is byte-for-byte what it was.

## AI Assistance Disclosure

**Tools used** _(required — write `none` if no AI was used)_: Claude Code

**Attestation** _(required)_:

- [x] I have read every line of this diff, understand what it does, and can explain it in review.

## Notes & open questions

This came out of building a WebRTC-Direct transport outside the tree. `libp2p-webrtc-utils` is
otherwise exactly the crate you need for that — fingerprints, the Noise prologue, the stream
framing, the answer template — and the offer template was the one piece I had to copy out of
`libp2p-webrtc` verbatim.

One thing this makes visible: with both templates rendered inside the crate, `render_description`
no longer has any caller outside it. I left it `pub` since narrowing it would be a breaking change
unrelated to this PR, but happy to fold that in if you'd rather.

The changelog entries have placeholder PR numbers; I'll push the real one once this is assigned.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] A changelog entry has been made in the appropriate crates