### PR TITLE
fix(webrtc): preserve read half on STOP_SENDING frames

### DIFF
--- a/misc/webrtc-utils/src/stream.rs
+++ b/misc/webrtc-utils/src/stream.rs
@@ -63,6 +63,8 @@ pub struct Stream<T> {
     io: FramedDc<T>,
     state: State,
     read_buffer: Bytes,
+    /// An inbound FIN sharing a frame with data is applied after the data has been read.
+    pending_inbound_flag: Option<Flag>,
     /// Dropping this will close the oneshot and notify the receiver by emitting `Canceled`.
     drop_notifier: Option<oneshot::Sender<GracefullyClosed>>,
 }
@@ -80,6 +82,7 @@ where
             io: framed_dc::new(data_channel.clone()),
             state: State::Open,
             read_buffer: Bytes::default(),
+            pending_inbound_flag: None,
             drop_notifier: Some(sender),
         };
         let listener = DropListener::new(framed_dc::new(data_channel), receiver);
@@ -135,25 +138,56 @@ where
                 return Poll::Ready(Ok(n));
             }
 
+            if let Some(flag) = self.pending_inbound_flag.take() {
+                debug_assert_eq!(flag, Flag::Fin);
+                let Self {
+                    read_buffer,
+                    state,
+                    ..
+                } = &mut *self;
+                state.handle_inbound_flag(flag, read_buffer);
+
+                return Poll::Ready(Ok(0));
+            }
+
             let Self {
                 read_buffer,
                 io,
+                pending_inbound_flag,
                 state,
                 ..
             } = &mut *self;
 
             match ready!(io_poll_next(io, cx))? {
                 Some((flag, message)) => {
-                    if let Some(flag) = flag {
-                        state.handle_inbound_flag(flag, read_buffer);
-                    }
-
-                    debug_assert!(read_buffer.is_empty());
-                    match message {
-                        Some(msg) if !msg.is_empty() => {
-                            *read_buffer = msg.into();
+                    match (flag, message) {
+                        (Some(Flag::Fin), Some(message)) if !message.is_empty() => {
+                            *read_buffer = message.into();
+                            *pending_inbound_flag = Some(Flag::Fin);
                         }
-                        _ => {
+                        (Some(Flag::Fin), _) => {
+                            state.handle_inbound_flag(Flag::Fin, read_buffer);
+                            return Poll::Ready(Ok(0));
+                        }
+                        (Some(Flag::StopSending), message) => {
+                            state.handle_inbound_flag(Flag::StopSending, read_buffer);
+
+                            if let Some(message) = message.filter(|message| !message.is_empty()) {
+                                *read_buffer = message.into();
+                            } else {
+                                // STOP_SENDING only closes the write half. Keep waiting for data
+                                // from the peer instead of reporting EOF for the control frame.
+                                continue;
+                            }
+                        }
+                        (Some(Flag::Reset), _) => {
+                            state.handle_inbound_flag(Flag::Reset, read_buffer);
+                            return Poll::Ready(Err(io::ErrorKind::ConnectionReset.into()));
+                        }
+                        (None, Some(message)) if !message.is_empty() => {
+                            *read_buffer = message.into();
+                        }
+                        (None, _) => {
                             tracing::debug!("poll_read buffer is empty, received None");
                             return Poll::Ready(Ok(0));
                         }
@@ -278,6 +312,7 @@ where
 mod tests {
     use asynchronous_codec::Encoder;
     use bytes::BytesMut;
+    use futures::{executor::block_on, io::Cursor};
 
     use super::*;
     use crate::stream::framed_dc::codec;
@@ -300,5 +335,63 @@ mod tests {
         // Ensure the varint prefixed and protobuf encoded largest message is no longer than the
         // maximum limit specified in the libp2p WebRTC specification.
         assert_eq!(dst.len(), MAX_MSG_LEN);
+    }
+
+    #[test]
+    fn stop_sending_does_not_close_read_half() {
+        let mut stream = stream_with_messages([
+            Message {
+                flag: Some(Flag::StopSending as i32),
+                message: None,
+            },
+            Message {
+                flag: None,
+                message: Some(b"payload".to_vec()),
+            },
+        ]);
+
+        let mut buf = [0; 7];
+        block_on(stream.read_exact(&mut buf)).unwrap();
+
+        assert_eq!(&buf, b"payload");
+        assert!(matches!(stream.state, State::WriteClosed));
+    }
+
+    #[test]
+    fn reset_is_reported_immediately() {
+        let mut stream = stream_with_messages([Message {
+            flag: Some(Flag::Reset as i32),
+            message: None,
+        }]);
+
+        let error = block_on(stream.read(&mut [0; 1])).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::ConnectionReset);
+    }
+
+    #[test]
+    fn fin_payload_is_read_before_eof() {
+        let mut stream = stream_with_messages([Message {
+            flag: Some(Flag::Fin as i32),
+            message: Some(b"payload".to_vec()),
+        }]);
+
+        let mut buf = [0; 7];
+        block_on(stream.read_exact(&mut buf)).unwrap();
+        let eof = block_on(stream.read(&mut [0; 1])).unwrap();
+
+        assert_eq!(&buf, b"payload");
+        assert_eq!(eof, 0);
+    }
+
+    fn stream_with_messages(messages: impl IntoIterator<Item = Message>) -> Stream<Cursor<Vec<u8>>> {
+        let mut codec = codec();
+        let mut encoded = BytesMut::new();
+
+        for message in messages {
+            codec.encode(message, &mut encoded).unwrap();
+        }
+
+        Stream::new(Cursor::new(encoded.to_vec())).0
     }
 }


### PR DESCRIPTION
## Description

<!--
Please write a summary of your changes and why you made them.
This section will appear as the commit message after merging.
Please craft it accordingly.
For a quick primer on good commit messages, check out this blog post: https://cbea.ms/git-commit/

Please include any relevant issues here, for example:

Related https://github.com/libp2p/rust-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/rust-libp2p/issues/XYZ.
-->

Preserve WebRTC stream half-close semantics when processing control frames.

A payload-less `STOP_SENDING` frame previously caused `poll_read` to return `Ok(0)`, incorrectly signaling EOF even though `STOP_SENDING` only closes the local write half. Continue polling for inbound data after handling this flag.

Report `RESET` as `ConnectionReset` on the first read instead of initially returning normal EOF. When a `FIN` frame carries a payload, deliver the payload before reporting EOF.



## AI Assistance Disclosure

<!--
We ask every contributor to disclose AI assistance. This is not a filter — AI-assisted PRs
are accepted. We just need to know what was used and you need to vouch for what you submit.
We also ask contributors to be considerate of reviewer's time. Please keep AI-generated text brief and to the point.

Please do not delete this section.
-->

**Tools used** _(required — write `none` if no AI was used)_: OpenAI Codex

**Attestation** _(required)_:

- [x] I have read every line of this diff, understand what it does, and can explain it in review.

## Notes & open questions

<!--
Any notes, remarks, or open questions you have to make about the PR that don't need to go into the final commit message.
-->

The protobuf schema permits a flag and payload in the same frame. The implementation therefore delays handling a payload-carrying `FIN` until its payload has been consumed. `RESET` remains immediate and discards its payload.


## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
