### PR TITLE
fix(swarm-derive): allow unreachable_code on uninhabited ToSwarm fields

### DIFF
--- a/swarm-derive/src/lib.rs
+++ b/swarm-derive/src/lib.rs
@@ -398,7 +398,16 @@ fn build_struct(ast: &DeriveInput, data_struct: &DataStruct) -> syn::Result<Toke
 
             quote! {
                 match #trait_to_impl::poll(&mut self.#field, cx) {
-                    std::task::Poll::Ready(e) => return std::task::Poll::Ready(e.map_out(#map_out_event).map_in(#map_in_event)),
+                    std::task::Poll::Ready(e) => {
+                        // For a field whose `ToSwarm` is uninhabited (e.g. `Infallible`, as with
+                        // `connection_limits::Behaviour`), no `e` can ever reach this arm, so the
+                        // call below is unreachable in practice. Recent nightly lints that as
+                        // `unreachable_code` under `-D warnings`; the arm itself must still be
+                        // generated so this compiles for every other field whose `ToSwarm` is
+                        // inhabited.
+                        #[allow(unreachable_code)]
+                        return std::task::Poll::Ready(e.map_out(#map_out_event).map_in(#map_in_event));
+                    }
                     std::task::Poll::Pending => {},
                 }
             }

--- a/swarm/tests/swarm_derive.rs
+++ b/swarm/tests/swarm_derive.rs
@@ -613,6 +613,23 @@ fn custom_out_event_no_type_parameters() {
     require_net_behaviour::<Behaviour<()>>();
 }
 
+// Regression test for https://github.com/libp2p/rust-libp2p/issues/6600: a field whose
+// `NetworkBehaviour::ToSwarm` is uninhabited (`dummy::Behaviour`'s is `Infallible`) must not
+// make the generated `poll()` fail to compile under `-D warnings` on toolchains that lint the
+// resulting unreachable `Poll::Ready(e) => ...` arm as `unreachable_code`.
+#[test]
+fn uninhabited_to_swarm_field_compiles() {
+    #[allow(dead_code)]
+    #[derive(NetworkBehaviour)]
+    #[behaviour(prelude = "libp2p_swarm::derive_prelude")]
+    struct Foo {
+        ping: ping::Behaviour,
+        limits: dummy::Behaviour,
+    }
+
+    require_net_behaviour::<Foo>();
+}
+
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();


### PR DESCRIPTION
When a NetworkBehaviour field has a To Swarm type that's uninhabited like dummy Behaviour, whose ToSwarm = Infallible, the derive macro still generates a match arm for it in poll(). That arm can never actually run but it has to exist so the macro compiles when other fields do have real To Swarm types. Newer nightly compilers flag that dead arm as unreachable code, which fails the build for anyone compiling with D warnings.

The fix: "I Wrapped just that one generated call in #[allow(unreachable_code)]. This is the same fix the issue reporter suggested themselves  nothing else in the generated code changes."

Testing, I Added a test combining a real behaviour (ping, inhabited ToSwarm) with dummy.Behaviour (uninhabited ToSwarm) through the derive macro, to prove the mixed case still compiles. Full swarm,derive test suite- 20/20 pass. cargo fmt, clippyp libp2p,swarm,derive, and clippy -p libp2p,swarm features macros all clean.


